### PR TITLE
Carry a depth in the coverage mask, and let the entities, the hand and the glint write the pack's targets

### DIFF
--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -93,8 +93,15 @@ public final class GlslTranslator {
 	private static final String PACK_MAIN = "ofPackMain";
 
 	/**
-	 * The one output this engine adds itself: a byte saying that the pack's geometry covered this
-	 * pixel, so that whoever puts the game's own picture into the same target can leave it alone.
+	 * The one output this engine adds itself: the depth the pack's geometry left at this pixel, so
+	 * that whoever puts the game's own picture into the same target can tell whether anything has
+	 * been drawn in front of it since.
+	 * <p>
+	 * A depth and not a flag, and what it buys is the whole of what a flag could not answer: the
+	 * reader compares it with the world's depth as it stands, so a pixel nothing was drawn over
+	 * compares equal and belongs to the pack, and a pixel the game drew a feature onto does not.
+	 * The pixels the pack never wrote carry a value outside zero to one instead, which every real
+	 * depth is in front of, and the reader owes them no test of their own.
 	 */
 	private static final String COVERAGE = "ofCoverage";
 
@@ -299,6 +306,18 @@ public final class GlslTranslator {
 
 	/** Whether the mask was really given a rank of its own. {@link #planCoverage} says when it is not. */
 	private boolean covers;
+
+	/**
+	 * Whether the fragment stage names {@code gl_FragDepth} anywhere at all, live branch or not.
+	 * <p>
+	 * Anywhere at all, because what it decides is which value the mask is filled from, and a stage
+	 * that writes its own depth in one branch writes the attachment from that branch and from
+	 * {@code gl_FragCoord.z} in the others. The two have to be told apart by the text, since the
+	 * branch is the preprocessor's answer and not this pass's: Bliss writes it under {@code POM}
+	 * alone, and a mask filled from the interpolated depth there would say the geometry stands
+	 * where the surface was before the parallax moved it.
+	 */
+	private boolean namesFragDepth;
 
 	/** Where the fragment stage's own {@code main} stands, once the alpha test has claimed it. */
 	private int packMainName = -1;
@@ -1072,6 +1091,14 @@ public final class GlslTranslator {
 			Token token = this.tokens.get(index);
 			if (token.kind() != Kind.IDENTIFIER) {
 				continue;
+			}
+
+			// Above every skip below, and the bias is deliberate. A stage wrongly thought to write
+			// its own depth pays the early depth test and nothing else, since the wrapper then fills
+			// the mask from a value it wrote there itself; a stage wrongly thought not to fills the
+			// mask from a depth the attachment never received, and that is a picture.
+			if (this.stage == ProgramStage.FRAGMENT && token.identifier("gl_FragDepth")) {
+				this.namesFragDepth = true;
 			}
 
 			String directive = token.directive();
@@ -2976,17 +3003,48 @@ public final class GlslTranslator {
 			lines.add("void main() { "
 					+ (this.terrainPrologue ? SodiumVertex.PROLOGUE + "(); " : "")
 					+ (wrapsFragment() ? ORDER_OUTPUTS + "(); " : "")
+					+ coveragePrologue()
 					+ PACK_MAIN + "();"
 					+ (this.depthEpilogue ? " gl_Position.z = " + DEPTH_CONV
 							+ ".x * gl_Position.z + " + DEPTH_CONV + ".y * gl_Position.w;" : "")
 					+ (this.alphaEpilogue
 							? " " + this.alphaTest.discard(outputName(0, shadowed) + ".a")
 							: "")
-					+ (this.covers ? " " + COVERAGE + " = 1.0;" : "")
+					+ (this.covers ? " " + COVERAGE + " = " + writtenDepth() + ";" : "")
 					+ " }");
 		}
 
 		return String.join("\n", lines) + "\n";
+	}
+
+	/**
+	 * What the depth attachment of this draw receives, which is what the mask is filled from.
+	 * <p>
+	 * The interpolated depth for an ordinary stage, and the stage's own where it writes one: those
+	 * are the two values the hardware may write, and the mask exists to be compared with what was
+	 * written. Neither is converted. The pack's own reads of {@code gl_FragCoord.z} are put back
+	 * into the window it was written for, and its writes to {@code gl_FragDepth} are brought out of
+	 * it again, both by {@link #convertDepth}; this line is text of ours that pass never sees, so
+	 * both names here carry the value the target really holds.
+	 */
+	private String writtenDepth() {
+		return this.namesFragDepth ? "gl_FragDepth" : "gl_FragCoord.z";
+	}
+
+	/**
+	 * Gives {@code gl_FragDepth} the value the hardware would have written, before the pack's own
+	 * body runs and can write another.
+	 * <p>
+	 * <strong>Only where the mask is written and the stage names the builtin</strong>, and both
+	 * halves are paid for. A stage that names it may still leave it alone on the branch that runs -
+	 * Bliss writes it under {@code POM} and nowhere else ({@code dimensions/all_solid.fsh:359,394})
+	 * - and reading a builtin the stage never wrote is undefined, so the mask would carry whatever
+	 * the driver left there. Writing it costs the early depth test, which is why a stage that never
+	 * names it is left alone: it would pay that for a value the line below can read off
+	 * {@code gl_FragCoord} instead.
+	 */
+	private String coveragePrologue() {
+		return this.covers && this.namesFragDepth ? "gl_FragDepth = gl_FragCoord.z; " : "";
 	}
 
 	/** What output {@code slot} is called, which is the pack's own name when it declared one. */

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -597,9 +597,15 @@ public final class PackProgram {
 	 *                  piece, exactly as the chunk passes read it
 	 * @param inputs    where this piece's vertex stage takes its inputs from, which is the format the
 	 *                  pipeline drawing it binds
+	 * @param coverage  whether this piece's fragment stage writes the coverage mask on top of what
+	 *                  the pack asked for, which every piece drawn before the scene seed and into
+	 *                  the pack's own targets has to. It is part of what two pieces have to agree on
+	 *                  to share a translation, and not for tidiness: the mask is one more output,
+	 *                  and a piece whose pass attaches no image for it would be writing at a rank
+	 *                  its pipeline carries no state for
 	 */
 	public record GeometryElement(String element, String program, AlphaTest alphaTest,
-			VertexInputs inputs) {
+			VertexInputs inputs, boolean coverage) {
 	}
 
 	/**
@@ -700,12 +706,18 @@ public final class PackProgram {
 				// The format is in the key for the same reason and a harder one: it decides which
 				// names the vertex head declares as inputs, and two stages built from one text against
 				// two formats are two different modules.
+				//
+				// The mask is in the key as well, and it is the one answer here that is not a fact
+				// about the text: two pieces of one file are two texts as soon as one of them writes
+				// the mask, because the mask is an output the other one's pipeline carries no state
+				// for, and one module cannot be right for both.
 				VertexInputs inputs = element.inputs();
 				String key = path + "|" + alphaTest + "|" + LegacyGlsl.drawsEntities(element.program())
-						+ "|" + LegacyGlsl.bindsGameTransforms(element.program()) + "|" + inputs;
+						+ "|" + LegacyGlsl.bindsGameTransforms(element.program()) + "|" + inputs
+						+ "|" + element.coverage();
 				translated.computeIfAbsent(key, _ -> bind(source.packName(), path,
-						ProgramTranslator.translate(units, inputs, inputs.elements(), alphaTest, false,
-								element.program(), textures.volumes()),
+						ProgramTranslator.translate(units, inputs, inputs.elements(), alphaTest,
+								element.coverage(), element.program(), textures.volumes()),
 						targets, alphaTest, textures));
 				loaded.put(element.element(), translated.get(key));
 			}

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -113,11 +113,12 @@ public final class ProgramTranslator {
 	}
 
 	/**
-	 * The same, told whether the pass also writes the mask saying where it drew.
+	 * The same, told whether the pass also writes the mask carrying the depth it leaves.
 	 *
-	 * @param coverage whether the fragment stage also writes the mask saying where this pass drew.
-	 *                 A property of the pass, like the alpha test: the two opaque halves of the chunk
-	 *                 pass write it and no other pass of the engine does
+	 * @param coverage whether the fragment stage also writes the mask carrying the depth this pass
+	 *                 leaves. A property of the pass, like the alpha test: every pass drawn before
+	 *                 the scene seed and into the pack's own targets writes it, which is the two
+	 *                 opaque halves of the chunk pass, the sky's disc and the entities
 	 */
 	public static TranslatedProgram translate(Map<ProgramStage, ExpandedUnit> units,
 			VertexInputs inputs, AlphaTest alphaTest, boolean coverage, String program) {

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -111,12 +111,12 @@ public final class ChainPlan {
 			// to cost, where the verdicts are handed their map.
 			SKY_PROGRAMS.stream()
 					.map(program -> new NamedProgram(program, CLOUD_PROGRAM.equals(program),
-							NOT_EVERYWHERE)),
+							false, NOT_EVERYWHERE)),
 			Stream.of(
 					// The entity halves are the two the file has to ask for, and they are drawn in
 					// every place once it has: what decides them is the line and not the format.
-					new NamedProgram("gbuffers_entities", false, Families::entities),
-					new NamedProgram("gbuffers_block", false, Families::entities),
+					new NamedProgram("gbuffers_entities", false, false, Families::entities),
+					new NamedProgram("gbuffers_block", false, false, Families::entities),
 					// The blending half of those same two, on the far side of the stage: the game
 					// draws them among its translucent features, which is after the deferreds have
 					// run. Four entries and not two because the side is half the key.
@@ -125,8 +125,9 @@ public final class ChainPlan {
 					// this table uses for a walk it REFUSED, so the caller cannot tell the two
 					// apart: both make the family draw one output. That is why the entry matters
 					// more than it looks, and it is what the harness gate measures.
-					new NamedProgram("gbuffers_entities_translucent", true, Families::entities),
-					new NamedProgram("gbuffers_block_translucent", true, Families::entities),
+					new NamedProgram("gbuffers_entities_translucent", true, false,
+							Families::entities),
+					new NamedProgram("gbuffers_block_translucent", true, false, Families::entities),
 					// The hand's two passes, which straddle the stage as the particles do and for the
 					// same kind of reason: the solid one is drawn among the game's opaque features and
 					// the blending one at the end of the level. Not counted, and not by a switch:
@@ -138,8 +139,8 @@ public final class ChainPlan {
 					// gbuffers_hand, and that is exactly why they are two entries rather than one: a
 					// single walk would put one key in and leave the other side of the same file
 					// unanswered, which is the silence the head of this list is about.
-					new NamedProgram("gbuffers_hand", false, NOT_EVERYWHERE),
-					new NamedProgram("gbuffers_hand_water", true, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_hand", false, false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_hand_water", true, false, NOT_EVERYWHERE),
 					// An enchantment's glint, which straddles the stage for a reason of its own: what
 					// CARRIES it decides which half the game executes it in. An enchanted book is
 					// submitted among the solid features, foil and all, since the sort looks at the
@@ -151,22 +152,36 @@ public final class ChainPlan {
 					// Not counted, and on the hand's argument rather than the weather's: a glint is
 					// drawn where somebody is holding or wearing something enchanted, which is a per
 					// frame answer no per place map may carry.
-					new NamedProgram("gbuffers_armor_glint", false, NOT_EVERYWHERE),
-					new NamedProgram("gbuffers_armor_glint", true, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_armor_glint", false, false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_armor_glint", true, false, NOT_EVERYWHERE),
 					// Drawn, and still not counted: the game draws no rain and no snow where there is
 					// no weather, which is every place but the overworld.
-					new NamedProgram("gbuffers_weather", true, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_weather", true, false, NOT_EVERYWHERE),
 					// The one family that straddles the stage: the game submits every particle group
 					// twice, and the two land on either side of it. Counted wherever its line is on,
 					// and what earns it is that particles are drawn in every place there is.
-					new NamedProgram("gbuffers_particles", false, Families::particles),
-					new NamedProgram("gbuffers_particles_translucent", true, Families::particles)))
+					//
+					// And the last name of this list still riding on the seed: its opaque half never
+					// asks for a coverage mask, so its first output makes the trip through the game's
+					// own target and reaches the pack's picture through the seed and nowhere else.
+					new NamedProgram("gbuffers_particles", false, true, Families::particles),
+					new NamedProgram("gbuffers_particles_translucent", true, false,
+							Families::particles)))
 			.toList();
 
 	/**
 	 * One name of that list, the side of the deferred stage the family asking for it draws on, and
 	 * when a verdict may take its targets for filled.
 	 *
+	 * @param ridesTheSeed whether this name's FIRST output reaches the pack's picture through the
+	 *                   scene seed rather than being written into the pack's own target. It is what
+	 *                   holds a name to the seed's own target below, and it is a question about the
+	 *                   coverage mask and not about the side of the stage: a family drawn before the
+	 *                   seed that writes the mask keeps the seed off the pixels it wrote and takes
+	 *                   its first draw buffer outright, so the seed's target is no longer its
+	 *                   business. Only the opaque particles are left on that road, which
+	 *                   {@code render/ParticleDraw} says in the same words and {@code GeometryProgram}
+	 *                   lists among the halves that never asked for a mask
 	 * @param everywhere whether this engine draws that family, with the switches it was handed, in
 	 *                   EVERY place a plan is built for. Not simply whether it draws it: a plan is
 	 *                   per place, and a family drawn in the overworld alone would have a verdict
@@ -175,7 +190,7 @@ public final class ChainPlan {
 	 *                   about the verdicts, which are the one place that must not tell a reader a
 	 *                   target holds a clear colour when a family of ours has just written it
 	 */
-	private record NamedProgram(String program, boolean afterDeferred,
+	private record NamedProgram(String program, boolean afterDeferred, boolean ridesTheSeed,
 			Predicate<Families> everywhere) {
 	}
 
@@ -348,11 +363,12 @@ public final class ChainPlan {
 	 *                  programs
 	 * @param particles whether the game's quad particles are, both halves of them
 	 * @param seed      whether the game's finished frame is painted where the world would be. It is
-	 *                  the one road into the pack's picture for everything drawn BEFORE the deferred
-	 *                  stage, so off it takes the seed's own target with it and hands the entities
-	 *                  and the opaque particles back to the game, which is
-	 *                  {@code render/EntityDraw.writes} and {@code render/ParticleDraw.writes}
-	 *                  refusing on the same answer
+	 *                  the one road into the pack's picture for a family drawn BEFORE the deferred
+	 *                  stage that writes no coverage mask, so off it takes the seed's own target with
+	 *                  it and hands the opaque particles back to the game, which is
+	 *                  {@code render/ParticleDraw.writes} refusing on the same answer. The entities
+	 *                  are no longer on that road: they write the mask and take their first draw
+	 *                  buffer in the pack's own targets, so this switch moves nothing for them
 	 */
 	public record Families(boolean terrain, boolean entities, boolean particles, boolean seed) {
 
@@ -470,16 +486,32 @@ public final class ChainPlan {
 		// WHAT IT LEAVES OPEN, said rather than hidden: those overworld notes stay wrong, and the
 		// only honest way to close them is a per place answer rather than a per name one, which this
 		// record cannot carry.
-		// AND, on the near side, only where the draw is really taken. A family drawn before the
-		// deferred stage takes over a pass the renderer opened with one attachment of its own, so it
-		// can only be redirected when its first output is the seed's target and half; where it is not,
-		// the game keeps its own shader and nothing of the pack's is written. That is
-		// leadsWithSeed, and ParticleDraw refuses on the same answer. Bliss is why it is here: its
-		// seed is colortex1 against a first output of colortex2, so its opaque particles are handed
-		// back in all three places, and counting them would silence three notes that are true.
-		// Nothing on the corpus moves for it - Bliss's colortex9 is silenced by the translucent half,
-		// which carries no such condition - and that is the point: it costs no note and it stops the
-		// map claiming a draw that never happened.
+		// AND, on the near side, only where the draw is really taken. A family whose FIRST output
+		// reaches the pack's picture through the scene seed takes over a pass the renderer opened
+		// with one attachment of its own, so it can only be redirected when that output is the seed's
+		// target and half; where it is not, the game keeps its own shader and nothing of the pack's
+		// is written. That is leadsWithSeed, and ParticleDraw refuses on the same answer. Bliss is
+		// why it is here: its seed is colortex1 against a first output of colortex2, so its opaque
+		// particles are handed back in all three places, and counting them would silence three notes
+		// that are true. Nothing on the corpus moves for it - Bliss's colortex9 is silenced by the
+		// translucent half, which carries no such condition - and that is the point: it costs no note
+		// and it stops the map claiming a draw that never happened.
+		//
+		// IT IS THE SEED'S ROAD AND NOT THE SIDE OF THE STAGE, and the two parted company when the
+		// entities took their first draw buffer in the pack's own targets. A family drawn before the
+		// seed that writes the coverage mask keeps the seed off the pixels it wrote, so its first
+		// output never makes the trip and the seed's target says nothing about whether its draw was
+		// taken; render/EntityDraw stopped asking, and a map still asking would hand the entities
+		// back on any pack whose entity program leads with a target other than the seed's - and on
+		// every pack under seed=off, where the family is served all the same. ridesTheSeed carries
+		// which names are left on that road, and only the opaque particles are.
+		//
+		// WHAT THAT OVER-CLAIMS, said rather than hidden: this map cannot know whether the mask was
+		// really placed, which is the translation's answer and per FILE. A pack whose entity program
+		// declares eight outputs already, or more draw buffers than outputs, is drawn by the game's
+		// shader while these notes count it as drawn. That is the same shape as the per NAME against
+		// per FAMILY asymmetry below, it is the rarer of the two directions, and the engine says so
+		// by name in the log at the moment it happens.
 		//
 		// AND at the size of the screen, which is the same condition read off the other side: every
 		// family below shares the pass the renderer opened for the game's own target, one render pass
@@ -497,11 +529,11 @@ public final class ChainPlan {
 		// them refused here, would be counted half drawn while the family served nothing. No pack of
 		// the corpus reaches that case.
 		//
-		// WHAT THIS MAP DELIBERATELY DOES NOT FOLLOW: with chain=off the two families that ride on
-		// the seed are still drawn even with seed=off, which render/EntityDraw spells out - it is the
-		// one configuration that tells a wrong gbuffer from a wrong composite. This map has them
-		// handed back there. It costs nothing worth the branch: with the chain off, no pass of it
-		// draws, so every line these notes carry is about a frame that does not happen.
+		// WHAT THIS MAP DELIBERATELY DOES NOT FOLLOW: with chain=off the opaque particles are still
+		// drawn even with seed=off, which render/ParticleDraw spells out - it is the one
+		// configuration that tells a wrong gbuffer from a wrong composite. This map has them handed
+		// back there. It costs nothing worth the branch: with the chain off, no pass of it draws, so
+		// every line these notes carry is about a frame that does not happen.
 		Map<Key, Pass> world = new LinkedHashMap<>();
 		if (families.terrain()) {
 			terrainKeys.values().forEach(key -> world.put(key, attachments.get(key)));
@@ -511,7 +543,7 @@ public final class ChainPlan {
 			Key key = named.everywhere().test(families) ? namedKeys.get(named) : null;
 			Pass drawing = key == null ? null : attachments.get(key);
 			if (drawing != null && drawing.size().equals(TargetSize.ofScreen())
-					&& (named.afterDeferred() || leadsWithSeed(painted, drawing))) {
+					&& (!named.ridesTheSeed() || leadsWithSeed(painted, drawing))) {
 				world.put(key, drawing);
 			}
 		}

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -69,16 +69,11 @@ public final class EngineStages {
 	}
 
 	/**
-	 * With the opaque chunk passes done and not one entity drawn yet.
-	 * <p>
-	 * Keeps the world's depth as the pack's own geometry left it, the last moment at which it is
-	 * that and nothing else. The scene seed is cut against it, and what it buys is every entity the
-	 * game draws in front of a block.
+	 * With the opaque chunk passes done and not one entity drawn yet, which is where the window the
+	 * entities are served in opens.
 	 */
 	public static void afterOpaqueBlocks() {
-		PackChain.markGeometryDepth();
-
-		// And opens the one window the entities are served in. It has to be a window, because the
+		// Opens the one window the entities are served in. It has to be a window, because the
 		// screen is drawn by the same feature renderers, with the same pipelines and into the same
 		// target, out of a submit storage GameRenderer hands them after the level: nothing about one
 		// of those draws says it is not an entity, and only the moment does. The hand used to be the

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -10,6 +10,7 @@ import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.target.TargetSchedule;
 import dev.vitrail.pack.target.TargetSize;
 import dev.vitrail.pack.texture.TextureStage;
+import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.NoiseTexture;
 import dev.vitrail.Vitrail;
 
@@ -76,8 +77,30 @@ final class ColorTargets {
 	/** Enough for the three constants: they carry one pixel each and nothing samples their precision. */
 	private static final GpuFormat CONSTANT_FORMAT = GpuFormat.RGBA8_UNORM;
 
-	/** One byte a pixel, which is a yes or a no and nothing else. */
-	private static final GpuFormat COVERAGE_FORMAT = GpuFormat.R8_UNORM;
+	/**
+	 * One float a pixel, and no conversion: the mask carries the depth the pack's geometry left,
+	 * and it is compared with the game's own depth rather than read as one.
+	 * <p>
+	 * A float and nothing narrower because the comparison is for equality as much as for order. The
+	 * game's depth attachment is {@code D32_FLOAT} ({@code RenderTarget.createBuffers}), the mask is
+	 * filled from the very value the fragment stage hands that attachment, and both sides then carry
+	 * the same thirty two bits: a pixel nothing has been drawn over compares exactly equal. Rounded
+	 * into a narrower format it would not, and the seed would repaint the pack's own geometry
+	 * wherever the rounding fell the wrong way.
+	 */
+	private static final GpuFormat COVERAGE_FORMAT = GpuFormat.R32_FLOAT;
+
+	/**
+	 * What the mask holds where the pack's geometry has written nothing, which is outside the depth
+	 * range on the far side of the eye.
+	 * <p>
+	 * <strong>This is what makes the cut one comparison instead of two.</strong> Every real depth is
+	 * in front of it, so a pixel the pack never wrote answers "the game drew in front" through the
+	 * same test as a pixel it did write and something was drawn over, and the reader owes an empty
+	 * pixel no test of its own. The value follows {@link ClipSpace#REVERSED} rather than being
+	 * written out: the game rasterises reversed, so far is nought and this has to be below it.
+	 */
+	static final float COVERAGE_EMPTY = ClipSpace.REVERSED.z < 0.0F ? -1.0F : 2.0F;
 
 	/** The one target the format says starts at the fog colour. Every other one starts at a constant. */
 	private static final int FOG_TARGET = 0;
@@ -86,6 +109,10 @@ final class ColorTargets {
 	private static final Vector4fc OPAQUE_WHITE = new Vector4f(1.0F, 1.0F, 1.0F, 1.0F);
 	private static final Vector4fc MID_GREY = new Vector4f(0.5F, 0.5F, 0.5F, 1.0F);
 	private static final Vector4fc NOTHING = new Vector4f(0.0F, 0.0F, 0.0F, 0.0F);
+
+	/** The sentinel above as a clear colour: one channel, and the mask reads the first of them. */
+	private static final Vector4fc UNWRITTEN =
+			new Vector4f(COVERAGE_EMPTY, COVERAGE_EMPTY, COVERAGE_EMPTY, COVERAGE_EMPTY);
 
 	/** Past this much the log says so once. Refusing to allocate would trade a stutter for a black screen. */
 	private static final long LOUD_BYTES = 512L * 1024L * 1024L;
@@ -163,10 +190,12 @@ final class ColorTargets {
 	private TargetSurface white;
 	private TargetSurface grey;
 	private TargetSurface noise;
+	private TargetSurface unwritten;
 
 	/**
-	 * Where the pack's own opaque geometry has drawn this frame, one byte a pixel, so that whoever
-	 * puts the game's picture into the same target can leave those pixels alone.
+	 * The depth the pack's own opaque geometry left this frame, one float a pixel, so that whoever
+	 * puts the game's picture into the same target can tell a pixel that is still the pack's from
+	 * one the game has drawn a feature over since.
 	 * <p>
 	 * Emptied here at the head of every frame rather than by the pass that writes it, and that is
 	 * the whole safety of the thing. The frames where it is not written are exactly the frames
@@ -355,13 +384,16 @@ final class ColorTargets {
 			clear(encoder, this.black, OPAQUE_BLACK);
 			clear(encoder, this.white, OPAQUE_WHITE);
 			clear(encoder, this.grey, MID_GREY);
+			clear(encoder, this.unwritten, UNWRITTEN);
 			uploadNoise(encoder);
 			this.packSurfaces.forEach((image, surface) -> upload(encoder, surface, image.rgba()));
 		}
 
 		// Every frame and never conditionally: the mask answers a question about THIS frame, and an
-		// answer carried over from the last one is worse than no answer at all.
-		clear(encoder, this.coverage, NOTHING);
+		// answer carried over from the last one is worse than no answer at all. Left standing, last
+		// frame's depths would be compared with this frame's, the camera having moved between the
+		// two, and the seed would repaint the pack's geometry over most of the screen.
+		clear(encoder, this.coverage, UNWRITTEN);
 
 		for (int index : this.plan.ordered()) {
 			// A full clear ignores colortexNClear: a target that is kept from one frame to the
@@ -512,6 +544,15 @@ final class ColorTargets {
 		return this.black == null ? null : this.black.view();
 	}
 
+	/**
+	 * One pixel of the sentinel, which is a mask saying the pack wrote nowhere at all. Stands in
+	 * for the mask itself over the frames before it is allocated, so that the seed covers its
+	 * target whole there rather than being cut against a depth nothing wrote.
+	 */
+	GpuTextureView unwritten() {
+		return this.unwritten == null ? null : this.unwritten.view();
+	}
+
 	/** White, so a shadow lookup reads the far plane rather than putting the world in shadow. */
 	GpuTextureView white() {
 		return this.white == null ? null : this.white.view();
@@ -528,7 +569,7 @@ final class ColorTargets {
 	}
 
 	/**
-	 * Where the pack's opaque geometry has drawn this frame, or null until the first frame allocates
+	 * The depth the pack's opaque geometry left this frame, or null until the first frame allocates
 	 * it. Never held across a frame by anyone: it is looked up like every other view here.
 	 */
 	GpuTextureView coverage() {
@@ -592,6 +633,7 @@ final class ColorTargets {
 		this.white = release(this.white);
 		this.grey = release(this.grey);
 		this.noise = release(this.noise);
+		this.unwritten = release(this.unwritten);
 		this.coverage = release(this.coverage);
 		this.shadowMap.release();
 		this.depth.release();
@@ -613,6 +655,10 @@ final class ColorTargets {
 		this.black = new TargetSurface("Vitrail black", CONSTANT_FORMAT, false, 1, 1);
 		this.white = new TargetSurface("Vitrail white", CONSTANT_FORMAT, false, 1, 1);
 		this.grey = new TargetSurface("Vitrail grey", CONSTANT_FORMAT, false, 1, 1);
+		// The mask's own format and not the constants', because it stands in for the mask: what
+		// reads it compares it with a depth, and black would say the pack wrote the whole screen at
+		// the far plane rather than that it wrote nothing.
+		this.unwritten = new TargetSurface("Vitrail unwritten mask", COVERAGE_FORMAT, false, 1, 1);
 
 		if (this.noiseImage != null) {
 			this.noise = new TargetSurface("Vitrail noise", CONSTANT_FORMAT, false,

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -2,9 +2,11 @@ package dev.vitrail.render;
 
 import dev.vitrail.glsl.LegacyGlsl;
 import dev.vitrail.glsl.PackProgram;
+import dev.vitrail.glsl.TranslatedUnit;
 import dev.vitrail.glsl.VertexInputs;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.AlphaTest;
+import dev.vitrail.pack.program.ProgramStage;
 import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetName;
@@ -351,16 +353,28 @@ public final class EntityDraw {
 		 * game's target it would blend onto a clear, and the seed would then throw it away, its own
 		 * depth being the depth of the geometry it hangs on.
 		 * <p>
-		 * <strong>The hand is out, and not because a mask would be wrong for it.</strong> Its solid
-		 * pass is a change to the order of the frame rather than to this answer, which
-		 * {@link GeometryProgram} sets out where it demotes it: what that pass is waiting for is to
-		 * be drawn between the seed and the deferred stage, which is Iris's own moment for it.
+		 * <strong>The hand's solid pass is in, and the depth it is drawn with is the whole of why it
+		 * could not be before.</strong> That pass is drawn one line ahead of the seed
+		 * ({@code platform/EngineStages.java:115-116}) with its clip depth squeezed into the band
+		 * {@code 0.4375} to {@code 0.5625} ({@link HandDraw}), which is not the depth of anything it
+		 * stands in front of. Against a flag the cut asked whether the depth had moved closer since a
+		 * copy taken before the game's features, so every hand pixel answered yes whatever was marked
+		 * there. Against a depth it asks nothing of the sort: the mask is filled from what the
+		 * fragment hands the depth attachment, so the two hold one number at a hand pixel and the cut
+		 * compares it with itself.
+		 * <p>
+		 * <strong>A hand row that writes no depth is served by the same answer rather than in spite
+		 * of it</strong>, and a held banner's pattern is the one that is reachable ({@code
+		 * BANNER_PATTERN}, {@code RenderPipelines.java:319}). The mask takes the hand's own squeezed
+		 * depth and the attachment keeps what stands behind the hand, which is farther, so the cut
+		 * finds nothing in front and leaves the pixel alone. That is the piece the seed used to throw
+		 * away outright.
 		 * <p>
 		 * A piece drawn after the stage owes no mask, the seed having run long before, and a shadow
 		 * row is in neither position: it is drawn into the map, which no seed ever paints.
 		 */
 		boolean covers() {
-			return !shadow() && !afterStage() && !hand();
+			return !shadow() && !afterStage();
 		}
 
 		/** What the pack has to be read for to serve this piece, in terms the translation knows. */
@@ -1726,7 +1740,7 @@ public final class EntityDraw {
 				continue;
 			}
 
-			List<ChainPlan.Attachment> writes = writes(half);
+			List<ChainPlan.Attachment> writes = writes(half, one);
 			if (writes == null) {
 				return;
 			}
@@ -1795,16 +1809,26 @@ public final class EntityDraw {
 	 * buffer that is not the one it paints would have that output carried into a target the pack did
 	 * not ask for, which is a pack's albedo read as its normals.
 	 * <p>
+	 * <strong>Those two are asked of a half that will really be given the coverage mask, and it has
+	 * no seed to answer for.</strong> Every opaque piece of this door asks for one, {@link
+	 * Element#covers} saying so, and a piece that gets one writes the pack's target outright: nought
+	 * never makes the trip through the game's eight bit target, so what the seed paints and whether
+	 * it is painted at all stop being this half's business. What is left on the seed's road is the
+	 * half that asked for a mask and could not be given one, which {@code GeometryProgram.covers} is
+	 * the one reading of, and there the pack's own first draw buffer decides again.
+	 * <p>
 	 * <strong>The half drawn after the stage needs no seed and is not a relaxation of the rule but
 	 * the other side of it.</strong> It is drawn onto a colour target the chain has already
 	 * composed, so {@code GeometryProgram} gives it its own draw buffer nought: the output goes to
 	 * the pack outright rather than making the trip through the game's eight bit target. That is the
-	 * position the world's own water is in, and the translucent particles with it. The side of the
-	 * stage and not the blend is what earns it, and the hand is where the two part company: its
-	 * solid pass blends and is drawn one line before the seed, so it keeps draw buffer nought on the
-	 * game's target like the opaque halves.
+	 * position the world's own water is in, and the translucent particles with it.
+	 *
+	 * @param loaded the serving file as it came out of the translation, which is what says whether
+	 *               the mask was really placed. The same file rebound against another plan carries
+	 *               the same text and so the same answer, {@code PackProgram.Loaded.rebind} keeping
+	 *               the translated program and changing only what its samplers are bound to
 	 */
-	private List<ChainPlan.Attachment> writes(Half half) {
+	private List<ChainPlan.Attachment> writes(Half half, PackProgram.Loaded loaded) {
 		// A shadow half writes the map and nothing else. GeometryProgram gives a shadow pass no slots
 		// at all, so the list is never read for one, and asking the plan for it would ask about a
 		// name the plan's geometry table has no row for. Answered empty rather than left to fall
@@ -1815,17 +1839,38 @@ public final class EntityDraw {
 			return List.of();
 		}
 
-		// Before the plan is even asked, because it is not the plan's to answer: the scene seed is
-		// the ONLY road the opaque half's first output has into the pack's picture, so a run with the
-		// seed switched off would write every other draw buffer and no albedo at all. What that
-		// paints is a mob shaped hole of normals and specular over the terrain's own colours, which
-		// is exactly the plausible and wrong picture the switch exists to rule out.
+		Optional<ChainPlan.Pass> geometry = this.plan.geometryOf(half.servedBy(), half.afterStage());
+		if (geometry.isPresent() && !geometry.get().size().equals(TargetSize.ofScreen())) {
+			Vitrail.logger().warn("{} writes targets the pack asked to be scaled, so they cannot share "
+					+ "a pass with the game's own target and the game keeps its own shader for that "
+					+ "half of what it serves", half.servedBy());
+
+			return null;
+		}
+
+		List<ChainPlan.Attachment> attachments =
+				geometry.map(ChainPlan.Pass::attachments).orElse(List.of());
+		if (half.afterStage()) {
+			return attachments;
+		}
+
+		// Asked before either question about the seed, because it is what decides that neither of
+		// them is this half's to answer: with the mask placed, draw buffer nought is the pack's own
+		// target and the seed is kept off every pixel this half wrote.
+		if (GeometryProgram.covers(notes(loaded), attachments.size(), this.chainRuns)) {
+			return attachments;
+		}
+
+		// The scene seed is now the ONLY road this half's first output has into the pack's picture,
+		// so a run with it switched off would write every other draw buffer and no albedo at all.
+		// What that paints is a mob shaped hole of normals and specular over the terrain's own
+		// colours, which is exactly the plausible and wrong picture the switch exists to rule out.
 		// Only where the chain runs, and the condition is not a refinement. With chain=off nothing
 		// of the pack reaches the screen through a final, so draw buffer nought stays on the game's
 		// own target and is the picture: the seed has nothing to carry and is never even drawn.
 		// Refusing the family there would take away the one configuration that tells a wrong
 		// gbuffer from a wrong composite, which is what these switches exist for.
-		if (!half.afterStage() && this.chainRuns && !this.seeded) {
+		if (this.chainRuns && !this.seeded) {
 			Vitrail.logger().info("The scene seed is off, and it is the only way the first output of "
 					+ "an opaque piece reaches the pack's picture, so the game keeps its own shader "
 					+ "for what {} serves: served, it would write every other draw buffer and no "
@@ -1834,28 +1879,16 @@ public final class EntityDraw {
 			return null;
 		}
 
-		Optional<ChainPlan.Pass> geometry = this.plan.geometryOf(half.servedBy(), half.afterStage());
-		if (geometry.isEmpty()) {
-			return List.of();
+		if (attachments.isEmpty()) {
+			return attachments;
 		}
 
-		ChainPlan.Pass pass = geometry.get();
-		if (!pass.size().equals(TargetSize.ofScreen())) {
-			Vitrail.logger().warn("{} writes targets the pack asked to be scaled, so they cannot share "
-					+ "a pass with the game's own target and the game keeps its own shader for that "
-					+ "half of what it serves", half.servedBy());
-
-			return null;
-		}
-
-		if (half.afterStage()) {
-			return pass.attachments();
-		}
-
-		ChainPlan.Attachment first = pass.attachments().get(0);
+		// Asked of the plan's own predicate and not written out again here, which is the shape the
+		// rest of this method just took: the notes ChainPlan builds hold the same question for the
+		// families still riding on the seed, and two readings of it would be free to drift.
 		Optional<ChainPlan.Seed> seed = this.plan.seed();
-		if (seed.isEmpty() || seed.get().target() != first.target()
-				|| seed.get().side() != first.side()) {
+		if (!ChainPlan.leadsWithSeed(seed.orElse(null), geometry.orElse(null))) {
+			ChainPlan.Attachment first = attachments.get(0);
 			Vitrail.logger().warn("{} writes {} first and the scene seed paints {}, so the first output "
 					+ "of an opaque piece would be carried into a target the pack did not ask for: the "
 					+ "game keeps its own shader for that half", half.servedBy(),
@@ -1865,7 +1898,12 @@ public final class EntityDraw {
 			return null;
 		}
 
-		return pass.attachments();
+		return attachments;
+	}
+
+	/** What the fragment stage of a serving file came out of the translation carrying. */
+	private static TranslatedUnit.Notes notes(PackProgram.Loaded loaded) {
+		return loaded.program().stages().get(ProgramStage.FRAGMENT).notes();
 	}
 
 	/** The bare name of the file behind a loaded program, which is what the plan is keyed by. */

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -89,11 +89,11 @@ import java.util.stream.Stream;
  * ({@code feature/ShadowFeatureRenderer.java:19}), inheriting it.
  * <p>
  * <strong>What that costs the two halves is not the same thing, and it is the whole of why they
- * are two.</strong> The opaque half is drawn before the deferred stage, so its first draw buffer
- * stays on the game's target and reaches the pack through the scene seed. The blending half is
- * drawn after it, onto a colour target the chain has already composed, which is the position the
- * world's own water is in: it takes its first draw buffer outright, needs no seed, and reads the
- * far side of every target.
+ * are two.</strong> The opaque half is drawn before the deferred stage, so it takes its first draw
+ * buffer by writing the coverage mask, which is what keeps the scene seed off the pixels it wrote;
+ * {@link Element#covers} carries that. The blending half is drawn after the stage, onto a colour
+ * target the chain has already composed, which is the position the world's own water is in: it
+ * takes that buffer outright, owes no mask, and reads the far side of every target.
  * <p>
  * <strong>{@link FeatureLayer} is a second road into that same target and no draw takes both.</strong>
  * The layer catches what the game draws for itself during that window, by the game's own colour
@@ -333,10 +333,40 @@ public final class EntityDraw {
 			return (hand() || glint()) ? this.afterDeferred : blended();
 		}
 
+		/**
+		 * Whether this piece writes the coverage mask, which is the same question as whether it may
+		 * own draw buffer nought: a piece drawn before the scene seed keeps the pack's colour only
+		 * where the seed is kept off it, and the mask is what keeps it off.
+		 * <p>
+		 * <strong>Every piece of this door drawn before the stage, and that is what moves the
+		 * entities into the pack's own targets.</strong> The mask carries the depth its fragment
+		 * left, so the seed reads a mob's own depth back at every pixel of it, finds nothing drawn
+		 * in front, and leaves the pixel alone. Marking it was worth nothing while the mask was a
+		 * flag: the cut then compared the world's depth with one taken before a single feature was
+		 * drawn, and a mob standing in front of a block moved that depth by construction, so its
+		 * pixels answered "the game drew in front" whatever the flag said.
+		 * <p>
+		 * <strong>The glint is in and it could not be left out.</strong> It blends onto the pixels
+		 * the piece under it just wrote, and those pixels are the pack's target now; left on the
+		 * game's target it would blend onto a clear, and the seed would then throw it away, its own
+		 * depth being the depth of the geometry it hangs on.
+		 * <p>
+		 * <strong>The hand is out, and not because a mask would be wrong for it.</strong> Its solid
+		 * pass is a change to the order of the frame rather than to this answer, which
+		 * {@link GeometryProgram} sets out where it demotes it: what that pass is waiting for is to
+		 * be drawn between the seed and the deferred stage, which is Iris's own moment for it.
+		 * <p>
+		 * A piece drawn after the stage owes no mask, the seed having run long before, and a shadow
+		 * row is in neither position: it is drawn into the map, which no seed ever paints.
+		 */
+		boolean covers() {
+			return !shadow() && !afterStage() && !hand();
+		}
+
 		/** What the pack has to be read for to serve this piece, in terms the translation knows. */
 		private PackProgram.GeometryElement asked() {
 			return new PackProgram.GeometryElement(this.element, this.program, this.alphaTest,
-					inputs());
+					inputs(), covers());
 		}
 
 		/**

--- a/common/src/main/java/dev/vitrail/render/EntityProgram.java
+++ b/common/src/main/java/dev/vitrail/render/EntityProgram.java
@@ -39,18 +39,21 @@ import java.util.Set;
  * for the culling matters more than it looks: the entity pipelines split almost evenly on it, and a
  * cape drawn with the wrong answer is either a cape with no inside or a cape drawn twice.
  * <p>
- * <strong>The writing half's first draw buffer stays on the game's target, and the blending half's
- * does not.</strong> The writing half is the position the opaque chunk passes were in before the
- * coverage mask existed, and it is deliberate: the scene seed is cut against a depth taken before
- * the game draws a single feature, so an entity is by definition a pixel the seed repaints. Writing
- * the pack's colour target outright would put the picture there and have the seed paint over it a
- * frame later in the same frame. What that costs is the albedo making one trip through eight bits a
- * channel; what it buys is every other draw buffer, which is where a pack keeps the normal, the
- * specular map and the material it lights an entity by, and which is the whole of what
- * {@code the entities still come from the game} meant. The blending half is drawn after the seed has
- * run, onto a target that already holds the composed world, so it takes its first draw buffer
- * outright and pays nothing: {@code GeometryProgram} ties that to the pass blending at all, and the
- * blend it blends with is the game's own for the pipeline being served.
+ * <strong>Both halves take their first draw buffer in the pack's own targets, and they get there by
+ * two different routes.</strong> The blending half is drawn after the scene seed has run, onto a
+ * target that already holds the composed world, so it takes that buffer outright and owes nothing:
+ * {@code GeometryProgram} ties that to the pass blending at all, and the blend it blends with is
+ * the game's own for the pipeline being served. The writing half is drawn before the seed, so it
+ * takes the buffer by writing the coverage mask, which carries the depth its fragment left and is
+ * what the seed is cut against; {@link EntityDraw.Element#covers} is where that is decided and why.
+ * <p>
+ * <strong>That is what the trip through the game's target used to cost, and it is Bliss's
+ * albedo.</strong> The writing half was in the position the opaque chunk passes were in before the
+ * mask existed: its colour went to the game's target and reached the pack through the seed, eight
+ * bits a channel. A pack packing two values into each channel of a sixteen bit target loses the
+ * first of them there, and reads the second back as the albedo. What it always kept is every other
+ * draw buffer, which is where a pack keeps the normal, the specular map and the material it lights
+ * an entity by, and which is the whole of what {@code the entities still come from the game} meant.
  * <p>
  * <strong>Its namespace is ours and has no {@code sodium} in it</strong>, for the reason
  * {@link SkyProgram} gives: the word is what makes Sodium's mixin push twenty bytes of region offset
@@ -118,12 +121,12 @@ final class EntityProgram implements DumpedProgram {
 	 *               at
 	 * @param writes where this piece's outputs belong, in draw buffer order and each on the side the
 	 *               schedule gives it, the first one INCLUDED whichever half this is.
-	 *               {@code GeometryProgram} is what decides where that first one really goes, off
-	 *               the side of the stage and no longer off the blend: the pack's target for a piece
-	 *               drawn after the seed, the game's for one drawn before it, which is both entity
-	 *               writing rows and the whole of the hand's solid pass, the arm included although
-	 *               it blends. {@link EntityDraw} settles the list and refuses a whole half where
-	 *               the first one could not reach the pack
+	 *               {@code GeometryProgram} is what decides where that first one really goes: the
+	 *               pack's target for a piece drawn after the seed and for one that writes the mask,
+	 *               which is every entity row, and the game's for what is drawn before the seed
+	 *               without one, which is the whole of the hand's solid pass, the arm included
+	 *               although it blends. {@link EntityDraw} settles the list and refuses a whole half
+	 *               where the first one could not reach the pack
 	 */
 	static EntityProgram of(PackProgram.Loaded loaded, EntityDraw.Element element, PackValues values,
 			int load, List<ChainPlan.Attachment> writes, TargetPlan chainTargets,
@@ -162,22 +165,21 @@ final class EntityProgram implements DumpedProgram {
 				// what it wants of a translucent surface is the depth that surface stands at, not
 				// that depth mixed with the one behind it.
 				shadow ? Optional.<BlendFunction>empty() : game.getColorTargetState().blendFunction(),
-				// covers: no coverage mask on any of these passes. On a piece drawn before the seed,
-				// marking a pixel the seed is going to repaint anyway would only take the game's own
-				// picture away from whatever is drawn there next. On one drawn after it the question
-				// does not arise, the mask being cut against the seed and the seed having run long
-				// before. The two used to be one decision with draw buffer nought and are no longer:
-				// GeometryProgram asks the side of the stage first, so a pass can keep nought on the
-				// game's target for a reason that has nothing to do with a mask, which is what the
-				// hand's solid pass now does.
+				// covers: the mask on every piece drawn before the seed and on no other, which is
+				// Element.covers and is answered there, beside the question of which side of the
+				// stage a piece is drawn on. It is what takes draw buffer nought of those pieces off
+				// the game's target: the mask carries the depth the fragment left, so the seed reads
+				// a mob's own depth back at every pixel of it and leaves the pixel alone.
+				//
+				// The two are still not one decision with draw buffer nought: GeometryProgram asks
+				// the side of the stage first, so a pass can keep nought on the game's target for a
+				// reason that has nothing to do with a mask, which is what the hand's solid pass does.
 				//
 				// claimed: no opaque piece of this family stands over these pixels, and for the hand
 				// that is the whole of why its solid pass leaves draw buffer nought on the game's
 				// target although it blends. The sky's blending pieces have the disc and the horizon
-				// cone under them; the arm has no such sibling, and no mask could stand in for one -
-				// the seed's cut is a depth comparison and the hand's depth is squeezed into a band
-				// that answers it yes at every pixel a row writing depth drew.
-				false, false,
+				// cone under them; the arm has no such sibling.
+				element.covers(), false,
 				// afterDeferred: which side of the stage this piece is drawn on, which decides the
 				// half of every target it reads and whether a depth sampler may be answered with the
 				// opaque world's image. Asked of the row, Element.afterStage saying why that is not

--- a/common/src/main/java/dev/vitrail/render/EntityProgram.java
+++ b/common/src/main/java/dev/vitrail/render/EntityProgram.java
@@ -123,10 +123,10 @@ final class EntityProgram implements DumpedProgram {
 	 *               schedule gives it, the first one INCLUDED whichever half this is.
 	 *               {@code GeometryProgram} is what decides where that first one really goes: the
 	 *               pack's target for a piece drawn after the seed and for one that writes the mask,
-	 *               which is every entity row, and the game's for what is drawn before the seed
-	 *               without one, which is the whole of the hand's solid pass, the arm included
-	 *               although it blends. {@link EntityDraw} settles the list and refuses a whole half
-	 *               where the first one could not reach the pack
+	 *               which between them is every piece this door serves, and the game's for a piece
+	 *               that asked for a mask and could not be given one by the translation.
+	 *               {@link EntityDraw} settles the list and refuses a whole half where the first one
+	 *               could not reach the pack
 	 */
 	static EntityProgram of(PackProgram.Loaded loaded, EntityDraw.Element element, PackValues values,
 			int load, List<ChainPlan.Attachment> writes, TargetPlan chainTargets,
@@ -173,12 +173,13 @@ final class EntityProgram implements DumpedProgram {
 				//
 				// The two are still not one decision with draw buffer nought: GeometryProgram asks
 				// the side of the stage first, so a pass can keep nought on the game's target for a
-				// reason that has nothing to do with a mask, which is what the hand's solid pass does.
+				// reason that has nothing to do with a mask.
 				//
-				// claimed: no opaque piece of this family stands over these pixels, and for the hand
-				// that is the whole of why its solid pass leaves draw buffer nought on the game's
-				// target although it blends. The sky's blending pieces have the disc and the horizon
-				// cone under them; the arm has no such sibling.
+				// claimed: no opaque piece of this family stands over these pixels, which is true of
+				// every piece here including the arm. The sky's blending pieces have the disc and the
+				// horizon cone under them and are the one family that answers otherwise; what earns
+				// the hand's solid pass its own draw buffer nought is the mask it writes, not a
+				// sibling.
 				element.covers(), false,
 				// afterDeferred: which side of the stage this piece is drawn on, which decides the
 				// half of every target it reads and whether a depth sampler may be answered with the

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -111,8 +111,8 @@ final class GeometryProgram {
 	 *                     own answer for that pass and not a taste: the sun and the moon are drawn
 	 *                     over the sky and the chunk pass that is translucent is drawn over the
 	 *                     world. Empty for a pass that writes outright
-	 * @param covers       whether this pass is one of the opaque halves that write the mask the scene
-	 *                     seed is cut with
+	 * @param covers       whether this pass writes the mask the scene seed is cut with, which every
+	 *                     pass drawn before the seed and into the pack's own targets has to
 	 * @param claimed      whether this family draws opaque pieces of its OWN over the pixels its
 	 *                     blending pieces span, which is the sky and nothing else: its disc writes
 	 *                     outright and marks what it covers, and {@link HorizonCone}, drawn inside
@@ -209,7 +209,7 @@ final class GeometryProgram {
 		 */
 		UNUSED,
 
-		/** The mask saying where this pass drew, which is ours and not in the pack's draw buffers. */
+		/** The mask carrying the depth this pass left, which is ours and not in the pack's buffers. */
 		COVERAGE
 	}
 
@@ -365,20 +365,24 @@ final class GeometryProgram {
 		// drawn and then thrown away: the final overwrites that target with the image the chain
 		// composed out of a colortex the water never reached.
 		//
-		// The two opaque halves used to keep it on the game's target and reach the pack's colortex
-		// through the seed, which was one conversion too many. What a gbuffers_terrain puts in draw
+		// Every opaque half used to keep it on the game's target and reach the pack's colortex
+		// through the seed, which was one conversion too many. What a gbuffers program puts in draw
 		// buffer nought is not a colour but whatever the pack packed there, and the game's target is
 		// eight bits a channel: Bliss packs two values into each channel of a sixteen bit colortex1,
 		// and the trip through the game's target quantised its albedo away entirely, leaving the
 		// encoded normal to be read back as the albedo. So the opaque halves write their target
 		// outright, and the coverage mask below is what keeps the seed off the pixels they wrote.
+		// The entities came last of them, and only once the mask carried a DEPTH: while it was a
+		// flag, the cut compared the world's depth with one taken before a single feature was drawn,
+		// and a mob standing in front of a block moved that depth by construction, so no mask it
+		// wrote could have kept the seed off it.
 		//
 		// Everything that lands back on the game's target, and it is a list of reasons rather than a
 		// count. When the chain is not running there is no final to bring a colortex to the screen,
 		// so anything sent there would simply vanish; when the plan had no answer there is nowhere
 		// else to send it; when a half that ASKED for a mask could not be given one, the seed would
-		// repaint the whole target and take the terrain with it; when a half never asked for one,
-		// which is the entities and the opaque particles, the seed carries it in by design; and the
+		// repaint the whole target and take the geometry with it; when a half never asked for one,
+		// which is the opaque particles and the weather, the seed carries it in by design; and the
 		// last is what the statement after next is about, a blending pass drawn before the seed with
 		// nothing marking the pixels it blends onto. Either way the pass draws where Sodium would
 		// have, which is also what keeps the pipeline's one state the pass's.
@@ -400,13 +404,13 @@ final class GeometryProgram {
 		// over the same pixels, which is the sky alone and which claimed carries, with the two
 		// places it does not hold named where that field is declared.
 		//
-		// The hand's solid pass has none of the three, and no mask could give it the second: the
-		// seed's cut asks whether the depth moved closer since the pack's geometry was finished with
-		// it, and the hand is drawn with its clip depth squeezed into the band 0.4375 to 0.5625
-		// (render/HandDraw.java:93,362), which is not the depth of anything it stands in front of.
-		// A hand row that WRITES depth therefore answers that question yes at every pixel it drew,
-		// whatever mask is written there, so the seed repaints those pixels and a hand that owned
-		// draw buffer nought would have its colour painted over by a frame that never drew it.
+		// The hand's solid pass has none of the three today, and what used to make the second one
+		// impossible for it is gone. While the mask was a flag, the cut asked whether the depth had
+		// moved closer since a copy taken before the game's features, and the hand is drawn with its
+		// clip depth squeezed into the band 0.4375 to 0.5625 (render/HandDraw.java:93,362), which is
+		// not the depth of anything it stands in front of: every hand pixel answered that yes,
+		// whatever mask was written there. The mask carries the depth now, so a hand row would write
+		// that same squeezed value and the cut would compare it with itself.
 		//
 		// WHAT THIS COSTS AGAINST IRIS, AND IT IS NOT FORCED. Iris binds every gbuffers program to a
 		// framebuffer over the pack's own declared draw buffers, the hand included
@@ -414,21 +418,22 @@ final class GeometryProgram {
 		// pipeline/IrisPipelines.java:192,204,216), so its hand colour is written to the pack's
 		// target and never leaves it. Here it goes to the game's target and reaches the pack through
 		// the seed, which costs three things. The trip through eight bits a channel, which is the
-		// quantisation the Bliss paragraph above measured on the terrain. The blend, which now
-		// happens against the game's target: with the chain running the world is in the PACK's
-		// target, so a hand pixel of alpha under one blends against the clear rather than against
-		// what stands behind it. And a row that writes no depth with nothing of its own pass writing
-		// depth under it - a held banner's pattern is the reachable one (BANNER_PATTERN,
-		// RenderPipelines.java:318) - which the cut then answers no for and discards where the mask
-		// is set.
+		// quantisation the Bliss paragraph above measured on the terrain. The blend, which happens
+		// against the game's target: with the chain running the world is in the PACK's target, so a
+		// hand pixel of alpha under one blends against the clear rather than against what stands
+		// behind it. And a row that writes no depth with nothing of its own pass writing depth under
+		// it - a held banner's pattern is the reachable one (BANNER_PATTERN,
+		// RenderPipelines.java:318) - which the cut then discards, the mask and the world's depth
+		// both holding what the geometry behind the hand left.
 		//
-		// WHAT WOULD COST NOTHING, and it is not done here: draw the hand's solid pass BETWEEN the
-		// seed and the deferred stage. Iris's constraint is only that the hand precede the deferreds
+		// TWO WAYS OUT, and neither is taken here. The mask, which the paragraph above says is now
+		// open to it; or drawing the hand's solid pass BETWEEN the seed and the deferred stage, which
+		// Iris's own constraint allows - it asks only that the hand precede the deferreds
 		// (mixin/MixinLevelRenderer.java:280, deferredRenderer.renderAll at
 		// pipeline/IrisRenderingPipeline.java:1073), and the seed is ours and has no counterpart
-		// there, so that position keeps Iris's moment AND lets the pack own draw buffer nought. It
-		// is a change to the order of the frame rather than to this statement, so it is named here
-		// and not taken: what this file can decide is where nought goes given when the pass is drawn.
+		// there. The second is a change to the order of the frame rather than to this statement, and
+		// the two are alternatives rather than a pair: what this file can decide is where nought goes
+		// given when the pass is drawn.
 		this.ownsFirst = owns && (this.covers || pass.afterDeferred()
 				|| (pass.blended() && pass.claimed()));
 		// The demotion just above and none of the ones before it, which is why owns and the side are
@@ -577,7 +582,8 @@ final class GeometryProgram {
 				switch (one.bound()) {
 					case UNUSED -> builder.withUnusedColorTargetState(slot);
 					// The mask is written outright and never blended, whatever the pack asked for its
-					// own targets: a fragment either covered this pixel or it did not.
+					// own targets: what it carries is the depth the fragment left, and a depth mixed
+					// with the one behind it is the depth of nothing at all.
 					case COVERAGE -> builder.withColorTargetState(slot, new ColorTargetState(
 							Optional.empty(), one.format(), ColorTargetState.WRITE_ALL));
 					default -> builder.withColorTargetState(slot, state(one.format()));

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -278,8 +278,16 @@ final class GeometryProgram {
 
 	/**
 	 * Whether this pass blends and lost draw buffer nought all the same, which is the one demotion
-	 * that is a decision rather than the absence of anywhere to send it. Kept as a field because it
-	 * is answered where {@code owns} is in scope and said where it is not.
+	 * that says what it costs the BLEND rather than what it costs the colour. Kept as a field
+	 * because it is answered where {@code owns} is in scope and said where it is not.
+	 * <p>
+	 * <strong>It no longer has a cause of its own, and that is worth saying rather than leaving a
+	 * reader to work out.</strong> Every blending pass drawn before the seed either writes the mask
+	 * or has an opaque sibling of its own family marking those pixels, so what is left here is a
+	 * pass that asked for a mask and could not be given one, which the constructor has already
+	 * warned about by name. The line it prints is kept because it says a different thing: not that
+	 * the colour goes to the game's target, which the warning says, but that the blend is made
+	 * against a target the world is not in.
 	 */
 	private final boolean demoted;
 	private final ColorTargets targets;
@@ -391,49 +399,40 @@ final class GeometryProgram {
 		// of the same rule: the stage that could not be given one says so, and an engine that
 		// decided for itself would be attaching an image nothing fills.
 		boolean owns = chainRuns && !writes.isEmpty();
-		this.covers = owns && pass.covers() && notes.coverage() == 1 && writes.size() <= outputs
-				&& outputs < ColorTargetState.MAX_COLOR_TARGETS;
+		this.covers = pass.covers() && covers(notes, writes.size(), chainRuns);
 		// A blending pass may take draw buffer nought outright only where the seed will not repaint
 		// the pixels it blended onto, and blending is not that question: it was read as though it
 		// were, and every family answered the same either way until the hand arrived.
 		//
-		// Three ways the seed is kept off, and the hand has none of them. The pass is drawn AFTER
-		// the seed, which is the world's water, the weather, the clouds, the translucent particles,
-		// the blending half of the entities and the hand's own water pass. It writes the mask
-		// itself, which is what covers above answers. Or the family draws opaque pieces of its own
-		// over the same pixels, which is the sky alone and which claimed carries, with the two
-		// places it does not hold named where that field is declared.
+		// Three ways the seed is kept off. The pass is drawn AFTER the seed, which is the world's
+		// water, the weather, the clouds, the translucent particles, the blending half of the
+		// entities and the hand's own water pass. It writes the mask itself, which is what covers
+		// above answers, and which the hand's solid pass now does with the rest of the door. Or the
+		// family draws opaque pieces of its own over the same pixels, which is the sky alone and
+		// which claimed carries, with the two places it does not hold named where that field is
+		// declared.
 		//
-		// The hand's solid pass has none of the three today, and what used to make the second one
-		// impossible for it is gone. While the mask was a flag, the cut asked whether the depth had
-		// moved closer since a copy taken before the game's features, and the hand is drawn with its
-		// clip depth squeezed into the band 0.4375 to 0.5625 (render/HandDraw.java:93,362), which is
-		// not the depth of anything it stands in front of: every hand pixel answered that yes,
-		// whatever mask was written there. The mask carries the depth now, so a hand row would write
-		// that same squeezed value and the cut would compare it with itself.
+		// The hand came last of the three roads and by the second, and what had made it impossible
+		// there was the flag. The cut then asked whether the depth had moved closer since a copy
+		// taken before the game's features, and the hand is drawn with its clip depth squeezed into
+		// the band 0.4375 to 0.5625 (render/HandDraw.java:93,382), which is not the depth of anything
+		// it stands in front of: every hand pixel answered that yes, whatever mask was written there.
+		// The mask carries the depth now, so a hand row writes that same squeezed value and the cut
+		// compares it with itself.
 		//
-		// WHAT THIS COSTS AGAINST IRIS, AND IT IS NOT FORCED. Iris binds every gbuffers program to a
-		// framebuffer over the pack's own declared draw buffers, the hand included
+		// AND IT IS WHERE IRIS HAS IT. Iris binds every gbuffers program to a framebuffer over the
+		// pack's own declared draw buffers, the hand included
 		// (pipeline/IrisRenderingPipeline.java:686-687; the four keys its hand passes ask for are at
 		// pipeline/IrisPipelines.java:192,204,216), so its hand colour is written to the pack's
-		// target and never leaves it. Here it goes to the game's target and reaches the pack through
-		// the seed, which costs three things. The trip through eight bits a channel, which is the
-		// quantisation the Bliss paragraph above measured on the terrain. The blend, which happens
-		// against the game's target: with the chain running the world is in the PACK's target, so a
-		// hand pixel of alpha under one blends against the clear rather than against what stands
-		// behind it. And a row that writes no depth with nothing of its own pass writing depth under
-		// it - a held banner's pattern is the reachable one (BANNER_PATTERN,
-		// RenderPipelines.java:318) - which the cut then discards, the mask and the world's depth
-		// both holding what the geometry behind the hand left.
-		//
-		// TWO WAYS OUT, and neither is taken here. The mask, which the paragraph above says is now
-		// open to it; or drawing the hand's solid pass BETWEEN the seed and the deferred stage, which
-		// Iris's own constraint allows - it asks only that the hand precede the deferreds
-		// (mixin/MixinLevelRenderer.java:280, deferredRenderer.renderAll at
-		// pipeline/IrisRenderingPipeline.java:1073), and the seed is ours and has no counterpart
-		// there. The second is a change to the order of the frame rather than to this statement, and
-		// the two are alternatives rather than a pair: what this file can decide is where nought goes
-		// given when the pass is drawn.
+		// target and never leaves it. Three things were paid for the trip through the game's target
+		// while this pass was still making it, and they are what the mask buys back. The trip through
+		// eight bits a channel, which is the quantisation the Bliss paragraph above measured on the
+		// terrain. The blend, which happened against the game's target: with the chain running the
+		// world is in the PACK's target, so a hand pixel of alpha under one blended against the clear
+		// rather than against what stands behind it. And a row that writes no depth with nothing of
+		// its own pass writing depth under it - a held banner's pattern is the reachable one
+		// (BANNER_PATTERN, RenderPipelines.java:318) - which the cut discarded outright, the mask and
+		// the world's depth both holding what the geometry behind the hand left.
 		this.ownsFirst = owns && (this.covers || pass.afterDeferred()
 				|| (pass.blended() && pass.claimed()));
 		// The demotion just above and none of the ones before it, which is why owns and the side are
@@ -849,6 +848,38 @@ final class GeometryProgram {
 	 */
 	boolean covers() {
 		return this.covers;
+	}
+
+	/**
+	 * Whether a pass that asks for the coverage mask would really be given one, before there is a
+	 * program to ask. The constructor is one of the two callers and takes its own answer from here,
+	 * so the rule has one home.
+	 * <p>
+	 * <strong>The other caller has to know it a step earlier than the program exists</strong>, and
+	 * that is the whole reason this is not a field: {@link EntityDraw} settles where a serving file's
+	 * outputs go before it builds anything, and what it settles differs on this answer. A piece given
+	 * the mask writes the pack's target outright and owes the scene seed nothing; a piece that asked
+	 * for one and could not be given one falls back on the game's target and reaches the pack through
+	 * that seed, which is what makes the seed's own target its business again.
+	 * <p>
+	 * Three of the four terms are the translation's and one is the frame's. The stage says whether it
+	 * was really given a mask, {@code coverage} being one where the epilogue placed it; the mask sits
+	 * one rank above every output the stage declares, so a pack writing more draw buffers than it
+	 * declares outputs would have it land on a rank one of those draw buffers holds, and a stage
+	 * already at the eight a pipeline carries has no rank left for it. And with no attachment at all
+	 * there is nothing to keep the seed off, the pass drawing into the game's target as it always
+	 * did.
+	 *
+	 * @param attachments how many draw buffers the plan gives this pass, which is zero where it had
+	 *                    no answer for it. The chain is asked separately and not read off this
+	 *                    count: with the chain switched off the plan still hands its list over, and
+	 *                    what is missing is the final that would have brought a colortex to the
+	 *                    screen
+	 */
+	static boolean covers(TranslatedUnit.Notes notes, int attachments, boolean chainRuns) {
+		return chainRuns && attachments > 0 && notes.coverage() == 1
+				&& attachments <= notes.fragmentOutputs()
+				&& notes.fragmentOutputs() < ColorTargetState.MAX_COLOR_TARGETS;
 	}
 
 	/**
@@ -1499,11 +1530,13 @@ final class GeometryProgram {
 							.toList());
 		}
 
-		// Said outside the chain above, because neither branch that lands here names draw buffer
-		// nought and this is the one case where its going to the game's target is a decision rather
-		// than the ordinary answer. What it costs is a trip through eight bits a channel, a blend
-		// against the game's target instead of the world, and the rows that write no depth being
-		// discarded by the seed's cut - none of which a silent log would show.
+		// Said outside the chain above, and it is a second line about one cause rather than a line
+		// about a second cause: what lands here asked for a mask and was not given one, which the
+		// constructor has already named. What this adds is the half the warning does not carry, and
+		// it is the half a blending pass pays twice: the blend is made against the game's target
+		// instead of against the world, so a pixel of alpha under one is tinted by a clear rather
+		// than by what stands behind it, and a row that writes no depth is discarded outright by the
+		// seed's cut. Neither shows up as an error and neither is visible in a silent log.
 		if (this.demoted) {
 			Vitrail.logger().info("It blends and draw buffer nought still goes to the game's own "
 					+ "target: this pass is drawn before the scene seed and nothing marks the pixels "

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1133,12 +1133,6 @@ public final class PackChain {
 		// than with the frame, which is what the argument is.
 		this.targets.depth().forgetPreHand(HandDraw.diverted());
 
-		// The seed's kept depth is a per frame fact like the four above and belongs with them, the
-		// image itself outliving the frame only because nobody frees a texture every frame.
-		if (this.seed != null) {
-			this.seed.endFrame();
-		}
-
 		if (this.block != null) {
 			this.block.rotate();
 		}
@@ -1231,9 +1225,8 @@ public final class PackChain {
 		// The targets and the buffers first and the compilation second, which is not the order this
 		// had. What the warm up holds back is the drawing and not the frame, so the block ring and
 		// the targets are standing by the time the last program compiles rather than being allocated
-		// in that one frame on top of it. Not the quad, whatever an earlier reading of this line
-		// said: wherever the seed runs it is made earlier in the same frame, from markGeometryDepth,
-		// and quad() says why it cannot wait for this.
+		// in that one frame on top of it. The quad is made in prepare with them, and quad() says why
+		// it is asked for from elsewhere as well.
 		//
 		// Outside any render pass, both of them: creating a texture or a buffer records a barrier
 		// into the very command buffer a pass would be recording into, and the clears refuse
@@ -1368,44 +1361,6 @@ public final class PackChain {
 	}
 
 	/**
-	 * Keeps the world's depth as the pack's own geometry left it, which is what tells an entity the
-	 * game drew in front of a block from the block itself. Called once the opaque blocks are drawn
-	 * and before the game has drawn one feature over them.
-	 * <p>
-	 * Deliberately not on the road {@link #drawBeforeTranslucents} takes: nothing here warms a
-	 * pipeline, prepares a target or clears anything, because all of that belongs to the moment the
-	 * chain runs and moving it a step earlier in the frame would clear away what the chunk passes
-	 * have just written. This copies one image and answers for nothing else. The one thing it does
-	 * make is the quad it draws that copy with, which is a vertex buffer and clears nothing, and
-	 * {@link #quad} says why it cannot wait for the chain.
-	 */
-	public static void markGeometryDepth() {
-		PackChain chain = active;
-		GpuDevice device = RenderSystem.tryGetDevice();
-		Minecraft minecraft = Minecraft.getInstance();
-		if (disabled || chain == null || device == null || minecraft == null || !chainWanted
-				|| chain.seed == null || !chain.seedEnabled) {
-			return;
-		}
-
-		RenderTarget main = minecraft.gameRenderer.mainRenderTarget();
-		if (main == null) {
-			return;
-		}
-
-		// Caught like every other entry point this bus calls: an exception here reaches the game
-		// through an event handler and comes back on the very next frame.
-		try {
-			chain.seed.capture(device.createCommandEncoder(), device, chain.quad(device),
-					main.getDepthTextureView(), main.width, main.height);
-		} catch (RuntimeException e) {
-			disabled = true;
-			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
-			chain.release();
-		}
-	}
-
-	/**
 	 * Keeps the world's depth as it stands before the player's own hand is drawn, which is what the
 	 * pack reads as {@code depthtex2}. Called from the event the hand's solid half is drawn at and
 	 * one line ahead of it.
@@ -1434,9 +1389,9 @@ public final class PackChain {
 	 * {@link PackDepth} carries what that saves, and {@code GeometryProgram.depth} what it leaves
 	 * owing.
 	 * <p>
-	 * Deliberately not on the road {@link #drawBeforeTranslucents} takes, for the reason
-	 * {@link #markGeometryDepth} is not: nothing here warms a pipeline, prepares a target or clears
-	 * anything, all of which belong to the moment the chain runs.
+	 * Deliberately not on the road {@link #drawBeforeTranslucents} takes: nothing here warms a
+	 * pipeline, prepares a target or clears anything, all of which belong to the moment the chain
+	 * runs.
 	 */
 	public static void markPreHandDepth() {
 		PackChain chain = active;
@@ -1476,7 +1431,7 @@ public final class PackChain {
 	 * transparency chain, which is every setup this engine runs on.
 	 * <p>
 	 * Deliberately not on the road {@link #drawBeforeTranslucents} takes, for the same reason
-	 * {@link #markGeometryDepth} is not: nothing here warms a pipeline, prepares a target or clears
+	 * {@link #markPreHandDepth} is not: nothing here warms a pipeline, prepares a target or clears
 	 * anything, all of which belong to the moment the chain runs. This copies one image and answers
 	 * for nothing else.
 	 * <p>
@@ -1787,12 +1742,13 @@ public final class PackChain {
 	 * stands in for would have written.
 	 */
 	private void drawSeed(CommandEncoder encoder, GpuTextureView mainView, GpuTextureView depthView) {
-		// One pixel of black where no mask has been allocated yet, which reads as nought everywhere
-		// and hides nothing. The mask itself is emptied at the head of every frame, so a frame no
-		// terrain program drew in is served an empty one rather than the last one that was written.
+		// One pixel of the sentinel where no mask has been allocated yet, which reads as a screen the
+		// pack wrote nowhere on and hides nothing. The mask itself is emptied at the head of every
+		// frame, so a frame no program of the pack drew in is served an empty one rather than the
+		// last one that was written.
 		GpuTextureView covered = this.targets.coverage();
 		this.seed.draw(encoder, this.quad, mainView,
-				covered == null ? this.targets.black() : covered, depthView, this.targets);
+				covered == null ? this.targets.unwritten() : covered, depthView, this.targets);
 	}
 
 	/**
@@ -1919,12 +1875,10 @@ public final class PackChain {
 	/**
 	 * The quad every full screen pass of this engine draws, made the first time anything asks for it.
 	 * <p>
-	 * Its own method rather than a line of {@link #prepare}, because two moments of the frame need it
-	 * and they are not the same moment. The chain draws from AfterOpaqueFeatures on; the depth the
-	 * scene seed is cut against is kept at AfterOpaqueBlocks, which is strictly earlier. Built where
-	 * the chain draws alone, the first frame that ever gets that far kept no depth, and a frame with
-	 * no kept depth cuts its seed with the coverage mask alone, which throws away every one of the
-	 * game's opaque features standing in front of the pack's terrain.
+	 * Its own method rather than a line of {@link #prepare}, because the two depths a pack is served
+	 * are copied with it from entry points that never go through prepare at all:
+	 * {@link #markPreHandDepth} and {@link #markSceneDepth} answer events of their own, and a frame
+	 * reaches either of them whether or not the chain drew. Each asks here and gets the one buffer.
 	 */
 	private GpuBuffer quad(GpuDevice device) {
 		if (this.quad == null) {
@@ -2075,10 +2029,11 @@ public final class PackChain {
 			// that reads the world of this frame and one that reads what the clear left.
 			Vitrail.logger().info("It is painted where the world would be drawn, after {} passes of "
 					+ "the chain", where.get().at());
-			// The pair to the terrain's own line. A frame where no terrain program of the pack ran
-			// leaves the mask empty and this covers the target whole, which is what it always did.
-			Vitrail.logger().info("It paints only what the pack's own terrain has not written, which "
-					+ "the coverage mask says pixel by pixel");
+			// The pair to the terrain's own line. A frame where no program of the pack ran leaves
+			// the mask on its sentinel and this covers the target whole, which is what it always did.
+			Vitrail.logger().info("It paints where the world's depth stands in front of the one the "
+					+ "pack's own geometry left, which is what the coverage mask carries: everywhere "
+					+ "the pack wrote nothing, and everywhere the game has drawn over what it wrote");
 			// Named because it is the difference between a gbuffer that agrees with itself and one
 			// that carries the game's colour over the pack's normals, and neither shows as itself.
 			List<Integer> emptied = this.seed.emptied();
@@ -2176,10 +2131,6 @@ public final class PackChain {
 
 	private void release() {
 		this.targets.release();
-		if (this.seed != null) {
-			this.seed.release();
-		}
-
 		if (this.features != null) {
 			this.features.release();
 		}

--- a/common/src/main/java/dev/vitrail/render/ParticleDraw.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleDraw.java
@@ -96,10 +96,15 @@ public final class ParticleDraw {
 	 */
 	record Element(RenderPipeline pipeline, String element, String program, boolean afterDeferred) {
 
-		/** What the pack has to be read for to serve this half, in terms the translation knows. */
+		/**
+		 * What the pack has to be read for to serve this half, in terms the translation knows.
+		 * <p>
+		 * No coverage mask on either half, which {@link ParticleProgram} sets out where it decides
+		 * the same thing for the pass.
+		 */
 		private PackProgram.GeometryElement asked() {
 			return new PackProgram.GeometryElement(this.element, this.program, CUTOUT,
-					VertexInputs.PARTICLE);
+					VertexInputs.PARTICLE, false);
 		}
 
 		/**

--- a/common/src/main/java/dev/vitrail/render/SceneSeed.java
+++ b/common/src/main/java/dev/vitrail/render/SceneSeed.java
@@ -48,7 +48,7 @@ import java.util.Optional;
  * equal and is the pack's, and a pixel the game drew a feature onto compares closer and is the
  * game's to paint after all. That second case is the one a flag could not answer, and what it is
  * made of is every piece the game still draws for itself in front of a block: the eyes of a mob,
- * a beacon beam, a name plate, the hand.
+ * a beacon beam, a name plate, and the hand on the runs that hand it back.
  * <p>
  * <strong>Where the pack wrote nothing the mask carries a value outside zero to one</strong>, which
  * every real depth is in front of, so those pixels take the game's picture through the same

--- a/common/src/main/java/dev/vitrail/render/SceneSeed.java
+++ b/common/src/main/java/dev/vitrail/render/SceneSeed.java
@@ -35,20 +35,27 @@ import java.util.Optional;
  * every gbuffers stage that does not run: the entities, the particles and the weather.
  * <p>
  * It is cut around the pack's own geometry rather than painted over it. The opaque and cutout chunk
- * passes write that target themselves, and so do the two pieces of the sky that write outright, and
- * every one of them marks the pixels it covered as it goes, so what lands here is the game's picture
- * everywhere the pack answered for nothing. Without the cut the two would fight and the game would
- * win, because it is drawn second. The pieces that blend are different again, the translucent chunk
- * pass with them: they draw over what the others left and claim no pixel of their own.
+ * passes write that target themselves, and so do the two pieces of the sky that write outright and
+ * the opaque half of the entities, and every one of them records the depth it left as it goes, so
+ * what lands here is the game's picture everywhere the pack answered for nothing. Without the cut
+ * the two would fight and the game would win, because it is drawn second. The pieces that blend are
+ * different again, the translucent chunk pass with them: they draw over what the others left and
+ * claim no pixel of their own.
  * <p>
- * <strong>The mask alone cuts too much, and what it cuts is every entity standing in front of a
- * block.</strong> The game draws its opaque features after the chunk passes and into the same
- * picture, so a mob, an item frame or a block entity in front of a wall lands on a pixel the mask
- * says the pack answered for, and the cut throws the mob away with the wall. The mask is therefore
- * read against a depth taken the moment the pack's own geometry was finished with it: where the
- * depth has moved closer since, the game drew something in front, and that pixel is the game's to
- * paint after all. Where it has not, the pixel is the pack's and is cut as before. Nothing here
- * needs to know what was drawn, only that something was.
+ * <strong>The cut is one comparison, and it is the mask against the world's depth as it stands.</strong>
+ * The mask carries a depth and not a flag: what a program of the pack wrote into the depth
+ * attachment, at the moment it wrote it. So a pixel nothing has been drawn over since compares
+ * equal and is the pack's, and a pixel the game drew a feature onto compares closer and is the
+ * game's to paint after all. That second case is the one a flag could not answer, and what it is
+ * made of is every piece the game still draws for itself in front of a block: the eyes of a mob,
+ * a beacon beam, a name plate, the hand.
+ * <p>
+ * <strong>Where the pack wrote nothing the mask carries a value outside zero to one</strong>, which
+ * every real depth is in front of, so those pixels take the game's picture through the same
+ * comparison and owe no test of their own. That is the whole of why the mask is a depth: the two
+ * questions a flag needed - did the pack write here, and has anything moved closer since - are one
+ * number and one test, and the depth the pack's geometry left no longer has to be copied into an
+ * image of its own before the game's features overwrite it.
  * <p>
  * This is not a fallback and should not be read as one. The first draw buffer of the terrain pass
  * is, by the definition of the OptiFine model, where the world's colour ends up, so it is the one
@@ -95,40 +102,20 @@ final class SceneSeed {
 			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/seed_vertex");
 	private static final Identifier FRAGMENT_ID =
 			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/seed_fragment");
-	private static final Identifier KEEP_FRAGMENT_ID =
-			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/seed_keep_fragment");
 	private static final Identifier EMPTY_FRAGMENT_ID =
 			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/seed_empty_fragment");
 
 	private static final String SAMPLER = "InSampler";
 
-	/** Where the pack's own opaque geometry has already written, and where this must not paint. */
+	/** The depth the pack's own geometry left, and the value this whole class is cut against. */
 	private static final String COVERAGE = "CoverageSampler";
 
 	/** The world's depth as it stands, which by now carries the game's own features. */
 	private static final String DEPTH = "DepthSampler";
 
-	/** And as the pack's own geometry left it, before any of them was drawn. */
-	private static final String KEPT = "KeptSampler";
-
 	private static final String LABEL = "Vitrail scene seed";
 
 	private static final String EMPTY_LABEL = "Vitrail scene seed gbuffer";
-
-	private static final String KEEP_LABEL = "Vitrail depth before the features";
-
-	/**
-	 * The reason a frame kept no depth when nothing else took the blame, which is the reason worth
-	 * telling apart from the rest: the moment came and went without this class being asked at all,
-	 * so what to look at is the hook at AfterOpaqueBlocks rather than anything here.
-	 */
-	private static final String NEVER_ASKED = "nothing asked for it before the game's features";
-
-	/** How many times the cut may change answer before the log stops following it. */
-	private static final int CHANGES = 8;
-
-	/** One float a texel, and no conversion: this is compared with the game's depth, not read as one. */
-	private static final GpuFormat KEEP_FORMAT = GpuFormat.R32_FLOAT;
 
 	/**
 	 * Which way a depth grows towards the eye, taken from the one constant that holds the game's
@@ -137,6 +124,14 @@ final class SceneSeed {
 	 * the day the game stops reversing, this moves with it instead of quietly inverting the test.
 	 */
 	private static final String CLOSER = ClipSpace.REVERSED.z < 0.0F ? ">" : "<";
+
+	/**
+	 * How the mask says the pack wrote here at all, which is the sentinel of
+	 * {@link ColorTargets#COVERAGE_EMPTY} told from a real depth. Written from the same constant as
+	 * the sentinel itself, so the two cannot be moved apart: an empty pixel is on the far side of
+	 * the depth range and every depth in it satisfies this.
+	 */
+	private static final String WRITTEN = ClipSpace.REVERSED.z < 0.0F ? ">= 0.0" : "<= 1.0";
 
 	/** Two triangles, the same quad the pass itself draws, which is why it is passed in. */
 	private static final int VERTICES = 6;
@@ -155,51 +150,36 @@ final class SceneSeed {
 			}
 			""";
 
+	/**
+	 * The cut, and the whole of it: the game's picture goes in wherever the world's depth stands in
+	 * front of the depth the pack's geometry left.
+	 * <p>
+	 * Neither side is converted into the pack's window. The mask is filled by the fragment stage
+	 * from the value it hands the depth attachment, and this reads that attachment back, so the two
+	 * are the same number written by the same draw and a pixel nothing was drawn over compares
+	 * exactly equal however the game encodes its depth.
+	 */
 	private static final String FRAGMENT = String.format(Locale.ROOT, """
 			#version 460 core
 
 			uniform sampler2D InSampler;
 			uniform sampler2D CoverageSampler;
 			uniform sampler2D DepthSampler;
-			uniform sampler2D KeptSampler;
 
 			in vec2 ofTexCoord;
 
 			layout(location = 0) out vec4 ofFragData0;
 
 			void main() {
-				bool mine = texture(CoverageSampler, ofTexCoord).r > 0.5;
 				bool infront = texture(DepthSampler, ofTexCoord).r
-						%s texture(KeptSampler, ofTexCoord).r;
-				if (mine && !infront) {
+						%s texture(CoverageSampler, ofTexCoord).r;
+				if (!infront) {
 					discard;
 				}
 
 				ofFragData0 = texture(InSampler, ofTexCoord);
 			}
 			""", CLOSER);
-
-	/**
-	 * Keeps the depth as it stands, unconverted and one float a texel.
-	 * <p>
-	 * Not turned into the pack's window on the way, unlike {@link PackDepth}: nobody reads this as a
-	 * depth, it is only ever compared with the image it was copied from. Both sides then carry the
-	 * value the same way, and a fragment nothing was drawn over compares exactly equal however the
-	 * game encodes its depth.
-	 */
-	private static final String KEEP_FRAGMENT = """
-			#version 460 core
-
-			uniform sampler2D InSampler;
-
-			in vec2 ofTexCoord;
-
-			layout(location = 0) out vec4 ofFragData0;
-
-			void main() {
-				ofFragData0 = vec4(texture(InSampler, ofTexCoord).r);
-			}
-			""";
 
 	/**
 	 * One draw buffer of the geometry program the seed stands in for, past the first, that the seed
@@ -227,35 +207,10 @@ final class SceneSeed {
 	/** The pass that empties the rest of the gbuffer, or null when there is none to empty. */
 	private final RenderPipeline empties;
 
-	private final RenderPipeline keep;
 	private final ShaderSource source;
 
 	/** Built once with one output per target emptied, and handed back at every compile. */
 	private final String emptyFragment;
-
-	/** The depth the pack's own geometry left, or null until a frame has taken one. */
-	private TargetSurface kept;
-
-	/**
-	 * Whether the image above holds THIS frame's depth. Cleared at the frame boundary and set by a
-	 * capture that really ran, which is the only pair of moments that makes it true.
-	 * <p>
-	 * A frame that could not capture must fall back to the mask alone rather than to the depth of the
-	 * frame before. The image survives the boundary because it is a texture and nobody frees it every
-	 * frame, and the previous frame's depth is the worst answer available here: the camera has moved
-	 * since, so it differs at nearly every pixel of the screen, and the comparison then says that
-	 * something was drawn in front of the pack's terrain everywhere at once. The seed repaints the
-	 * whole target with the game's picture, which is the pack's geometry gone and nothing said.
-	 */
-	private boolean captured;
-
-	/** Which of the two cuts was last said, whether anything has been said, and how often. */
-	private boolean cutWithKept;
-	private boolean said;
-	private int changes;
-
-	/** Why this frame kept no depth, in the log's own words, or null when it kept one. */
-	private String refusal = NEVER_ASKED;
 
 	/** Whether {@link #empties} compiled, asked again every frame like the seed's own pipeline. */
 	private boolean emptying;
@@ -283,11 +238,7 @@ final class SceneSeed {
 					return FRAGMENT;
 				}
 
-				if (EMPTY_FRAGMENT_ID.equals(id)) {
-					return this.emptyFragment;
-				}
-
-				return KEEP_FRAGMENT_ID.equals(id) ? KEEP_FRAGMENT : null;
+				return EMPTY_FRAGMENT_ID.equals(id) ? this.emptyFragment : null;
 			}
 
 			return VERTEX_ID.equals(id) ? VERTEX : null;
@@ -302,7 +253,6 @@ final class SceneSeed {
 						.withSampler(SAMPLER)
 						.withSampler(COVERAGE)
 						.withSampler(DEPTH)
-						.withSampler(KEPT)
 						.build())
 				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
 				// The format of the target as the pack declared it, not the one of the main
@@ -315,19 +265,6 @@ final class SceneSeed {
 				.build();
 
 		this.empties = this.extras.isEmpty() ? null : emptiesPipeline(this.extras);
-
-		this.keep = RenderPipeline.builder()
-				.withLocation(Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pipeline/seed_keep"))
-				.withVertexShader(VERTEX_ID)
-				.withFragmentShader(KEEP_FRAGMENT_ID)
-				.withBindGroupLayout(BindGroupLayouts.GLOBALS)
-				.withBindGroupLayout(BindGroupLayout.builder().withSampler(SAMPLER).build())
-				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
-				.withColorTargetState(new ColorTargetState(Optional.empty(), KEEP_FORMAT,
-						ColorTargetState.WRITE_ALL))
-				.withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
-				.withCull(false)
-				.build();
 	}
 
 	/**
@@ -344,7 +281,6 @@ final class SceneSeed {
 				.withBindGroupLayout(BindGroupLayout.builder()
 						.withSampler(COVERAGE)
 						.withSampler(DEPTH)
-						.withSampler(KEPT)
 						.build())
 				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
 				.withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
@@ -364,6 +300,13 @@ final class SceneSeed {
 	/**
 	 * Its fragment stage: the cut of the seed turned the other way round, so that what it writes is
 	 * exactly what the seed painted over, and one output an emptied target.
+	 * <p>
+	 * The mask is asked one thing more than the seed asks it, and it is the question the sentinel
+	 * answers: whether the pack wrote this pixel at all. The seed does not need it, an empty pixel
+	 * being one the game's picture goes into either way; here it is the difference between a pixel
+	 * the seed painted OVER the pack's geometry, whose gbuffer no longer belongs with the colour,
+	 * and one the pack never touched, whose targets hold a prepare's or a clear's and are none of
+	 * this pass's business.
 	 */
 	private static String emptyFragmentOf(List<Extra> extras) {
 		StringBuilder outputs = new StringBuilder();
@@ -380,21 +323,20 @@ final class SceneSeed {
 
 				uniform sampler2D CoverageSampler;
 				uniform sampler2D DepthSampler;
-				uniform sampler2D KeptSampler;
 
 				in vec2 ofTexCoord;
 
 				%s
 				void main() {
-					bool mine = texture(CoverageSampler, ofTexCoord).r > 0.5;
-					bool infront = texture(DepthSampler, ofTexCoord).r
-							%s texture(KeptSampler, ofTexCoord).r;
+					float mask = texture(CoverageSampler, ofTexCoord).r;
+					bool mine = mask %s;
+					bool infront = texture(DepthSampler, ofTexCoord).r %s mask;
 					if (!mine || !infront) {
 						discard;
 					}
 				%s
 				}
-				""", outputs, CLOSER, empties);
+				""", outputs, WRITTEN, CLOSER, empties);
 	}
 
 	/**
@@ -409,84 +351,6 @@ final class SceneSeed {
 	/** The draw buffers past the first that the seed really empties, for the log. In pack order. */
 	List<Integer> emptied() {
 		return this.extras.stream().map(Extra::target).toList();
-	}
-
-	/**
-	 * Keeps the world's depth as the pack's own geometry left it, before the game draws a single
-	 * feature over it. Must run on the render thread and outside any render pass.
-	 * <p>
-	 * The moment is the whole value of the image and it is not the moment anything else here is
-	 * taken: {@link PackDepth} takes its opaque world once the features are drawn, because that is
-	 * what a pack means by {@code depthtex1}. This one has to be older than they are, or the
-	 * comparison it exists for compares a thing with itself.
-	 *
-	 * @param live the game's depth as it stands, which the caller has to take before the features
-	 * @return false when nothing could be kept, in which case the cut falls back to the mask alone,
-	 *         which is what it did before this image existed
-	 */
-	boolean capture(CommandEncoder encoder, GpuDevice device, GpuBuffer quad, GpuTextureView live,
-			int width, int height) {
-		this.captured = false;
-		if (live == null) {
-			this.refusal = "the game's main target carries no depth";
-
-			return false;
-		}
-
-		if (quad == null || width <= 0 || height <= 0) {
-			this.refusal = "there was nothing to draw the copy with, at " + width + "x" + height;
-
-			return false;
-		}
-
-		if (!device.precompilePipeline(this.keep, this.source).isValid()) {
-			this.refusal = "the copy did not compile";
-
-			return false;
-		}
-
-		if (this.kept == null) {
-			this.kept = new TargetSurface("Vitrail depth before the features", KEEP_FORMAT, false,
-					width, height);
-		} else {
-			this.kept.resize(width, height);
-		}
-
-		if (this.kept.view() == null) {
-			this.refusal = "the image to keep it in could not be allocated";
-
-			return false;
-		}
-
-		// Loaded rather than cleared: the draw covers the image whole.
-		try (RenderPass pass = encoder.createRenderPass(() -> KEEP_LABEL, this.kept.view(), Optional.empty())) {
-			pass.setPipeline(this.keep);
-			RenderSystem.bindDefaultUniforms(pass);
-			pass.setVertexBuffer(0, quad.slice());
-			// NEAREST, so one texel of the copy is one texel of the depth and the two compare as
-			// the same number rather than as a neighbourhood of it.
-			pass.bindTexture(SAMPLER, live,
-					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
-			pass.draw(VERTICES, 1, 0, 0);
-		}
-
-		this.captured = true;
-		this.refusal = null;
-
-		return true;
-	}
-
-	/**
-	 * Forgets the depth this frame kept, at the frame boundary and nowhere else, so that the next
-	 * frame answers for itself. See {@link #captured} for what carrying it over would look like.
-	 * <p>
-	 * The reason goes back to the one that costs nothing to name: a frame in which the capture was
-	 * never even reached. Every other reason is written where it happens, so the one left standing
-	 * here is the one nothing wrote.
-	 */
-	void endFrame() {
-		this.captured = false;
-		this.refusal = NEVER_ASKED;
 	}
 
 	/** Called every frame: a resource reload empties the pipeline cache. */
@@ -525,12 +389,10 @@ final class SceneSeed {
 	 * them where it landed on top of that geometry. Only worth calling once {@link #prepare} has
 	 * said the pipeline is usable.
 	 *
-	 * @param covered the mask, which is read and never judged: an image of nought everywhere is a
-	 *                mask that hides nothing and the seed then covers the target whole, which is
-	 *                what the frames with no terrain of the pack's in them have to look like
-	 * @param live    the world's depth as it stands, features included. Given the kept image as
-	 *                well when nothing kept one, so that the two compare equal everywhere and the
-	 *                cut is the mask alone, which is what it was before either existed
+	 * @param covered the mask, which is read and never judged: an image of the sentinel everywhere
+	 *                is a mask that hides nothing and the seed then covers the target whole, which
+	 *                is what the frames with no geometry of the pack's in them have to look like
+	 * @param live    the world's depth as it stands, features included
 	 * @param targets where the pack's colour targets are looked up, every frame and never held: a
 	 *                resize replaces the images and keeping one across it draws into a texture that
 	 *                has been closed
@@ -542,15 +404,10 @@ final class SceneSeed {
 	 */
 	boolean draw(CommandEncoder encoder, GpuBuffer quad, GpuTextureView scene,
 			GpuTextureView covered, GpuTextureView live, ColorTargets targets) {
-		boolean held = this.captured && this.kept != null;
-		GpuTextureView before = held ? this.kept.view() : live;
 		GpuTextureView into = targets.view(this.seed.target(), this.seed.side());
-		if (quad == null || scene == null || covered == null || live == null || before == null
-				|| into == null) {
+		if (quad == null || scene == null || covered == null || live == null || into == null) {
 			return false;
 		}
-
-		say(held);
 
 		// Loaded rather than cleared: the clears have already run, and the draw no longer covers the
 		// target whole in any case.
@@ -560,32 +417,24 @@ final class SceneSeed {
 			pass.setVertexBuffer(0, quad.slice());
 			pass.bindTexture(SAMPLER, scene,
 					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
-			// NEAREST, and the mask is the size of the screen, so a texel is a pixel and the answer
-			// is the one the geometry wrote. Filtered, the edge of every block would read as half
-			// covered and the threshold would move it by half a pixel.
+			// NEAREST on both, and it matters more here than anywhere: the mask is the size of the
+			// screen, so a texel is a pixel and the answer is the one the geometry wrote, and the
+			// two depths are compared for having moved. Filtered, either read would move by a
+			// fraction of a texel along every silhouette in the picture, and the pack's own geometry
+			// would be repainted along all of them.
 			pass.bindTexture(COVERAGE, covered,
 					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
-			// NEAREST for the same reason again, and it matters more here than anywhere: the two
-			// depths are compared for having moved, and a filtered read of either would move them
-			// both by a fraction of a texel along every silhouette in the picture.
 			pass.bindTexture(DEPTH, live,
-					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
-			pass.bindTexture(KEPT, before,
 					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
 			pass.draw(VERTICES, 1, 0, 0);
 		}
 
-		return !this.emptying || empty(encoder, quad, covered, live, before, targets);
+		return !this.emptying || empty(encoder, quad, covered, live, targets);
 	}
 
 	/**
 	 * Empties the rest of the gbuffer over the pixels the draw above painted on top of the pack's
-	 * own geometry, which are the ones its cut let through with the mask set.
-	 * <p>
-	 * Nothing at all is written when the seed was cut against the mask alone: {@code infront} is
-	 * then false at every pixel, so this discards the whole screen. That is right rather than a gap.
-	 * The seed threw away every one of those pixels in that mode, the pack's terrain still shows
-	 * there, and its gbuffer is the one that belongs with it.
+	 * own geometry, which are the ones its cut let through where the mask holds a depth of its own.
 	 *
 	 * @return false when a target is missing or is no longer the size of the first one, which is a
 	 *         frame in the middle of a resize. The gbuffer then keeps what it held for that frame,
@@ -593,7 +442,7 @@ final class SceneSeed {
 	 *         target and the pass refuses to bind against any other count
 	 */
 	private boolean empty(CommandEncoder encoder, GpuBuffer quad, GpuTextureView covered,
-			GpuTextureView live, GpuTextureView before, ColorTargets targets) {
+			GpuTextureView live, ColorTargets targets) {
 		RenderPassDescriptor descriptor = RenderPassDescriptor.create(() -> EMPTY_LABEL);
 		int width = 0;
 		int height = 0;
@@ -619,13 +468,11 @@ final class SceneSeed {
 			pass.setPipeline(this.empties);
 			RenderSystem.bindDefaultUniforms(pass);
 			pass.setVertexBuffer(0, quad.slice());
-			// NEAREST on all three, and for the reasons the draw above gives: a texel of the mask is
-			// a pixel, and the two depths are compared for having moved.
+			// NEAREST on both, and for the reason the draw above gives: a texel of the mask is a
+			// pixel, and the two depths are compared for having moved.
 			pass.bindTexture(COVERAGE, covered,
 					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
 			pass.bindTexture(DEPTH, live,
-					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
-			pass.bindTexture(KEPT, before,
 					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
 			pass.draw(VERTICES, 1, 0, 0);
 		}
@@ -633,63 +480,4 @@ final class SceneSeed {
 		return true;
 	}
 
-	/**
-	 * Says which of the two cuts a frame drew with, the first time and at every change of answer
-	 * afterwards. A steady session therefore says it once.
-	 * <p>
-	 * <strong>Neither answer shows on screen as itself, and they are a whole defect apart.</strong>
-	 * Cut against the kept depth, everything the game drew in front of the pack's terrain comes back
-	 * around it; cut against the mask alone, every villager, every item frame and every block entity
-	 * standing in front of a block is thrown away with the block, and what the player sees is not a
-	 * cut but an empty village. <strong>Worse, and differently, once an entity is drawn with the
-	 * pack's own program</strong>: that entity has written the pack's other targets already, so what
-	 * the fallback throws away is its colour alone, and the normals and the material it left behind
-	 * are lit over the wall it stood in front of.
-	 * The fallback was silent, so a frame that took it read exactly like a
-	 * frame that never had the depth in the first place, and there was no way to tell the two apart
-	 * from the picture. This is the line that tells them apart.
-	 * <p>
-	 * Bounded, because the answer changing every frame is a real possibility and a line a frame at
-	 * sixty frames a second is a log nobody can read and a game nobody can play. The bound is said
-	 * when it is reached, so that a reader is never left thinking the answer settled.
-	 */
-	private void say(boolean held) {
-		if (this.said && held == this.cutWithKept) {
-			return;
-		}
-
-		this.said = true;
-		this.cutWithKept = held;
-		if (this.changes++ >= CHANGES) {
-			if (this.changes == CHANGES + 1) {
-				Vitrail.logger().warn("The scene seed has changed which cut it draws with {} times, so "
-						+ "it stops saying: the answer is not settling and the first lines above say "
-						+ "what the two are", CHANGES);
-			}
-
-			return;
-		}
-
-		if (held) {
-			Vitrail.logger().info("The scene seed is cut against the depth the pack's own geometry left,"
-					+ " so what the game drew in front of it is kept");
-		} else {
-			Vitrail.logger().warn("The scene seed is cut against the coverage mask alone, because {}: "
-					+ "every entity standing in front of the pack's terrain is thrown away with the "
-					+ "terrain", this.refusal);
-		}
-	}
-
-	/**
-	 * Frees the kept depth. A pipeline is not a resource this class owns: the compiled form lives
-	 * in the device cache, which the game empties on its own at every resource reload.
-	 */
-	void release() {
-		if (this.kept != null) {
-			this.kept.close();
-			this.kept = null;
-		}
-
-		this.captured = false;
-	}
 }

--- a/common/src/main/java/dev/vitrail/render/WeatherDraw.java
+++ b/common/src/main/java/dev/vitrail/render/WeatherDraw.java
@@ -98,10 +98,15 @@ public final class WeatherDraw {
 	 */
 	record Element(RenderPipeline pipeline, String element, RenderStage stage) {
 
-		/** What the pack has to be read for to serve this piece, in terms the translation knows. */
+		/**
+		 * What the pack has to be read for to serve this piece, in terms the translation knows.
+		 * <p>
+		 * No coverage mask, which {@link WeatherProgram} sets out where it decides the same thing
+		 * for the pass.
+		 */
 		private PackProgram.GeometryElement asked() {
 			return new PackProgram.GeometryElement(this.element, PROGRAM, CUTOUT,
-					VertexInputs.PARTICLE);
+					VertexInputs.PARTICLE, false);
 		}
 	}
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -186,15 +186,18 @@ The engine squeezes the hand's depth the way the reference does, and a pack that
 with `MC_HAND_DEPTH` gets the same eighth it expects. What blends in the hand goes through the water
 pass with the arm, a held translucent block included, so both are the pack's.
 
-**Where the SOLID hand pass is not what the reference makes of it**, the water pass being unaffected:
-its colour reaches the pack's picture through the same road everything the game draws takes, rather
-than being written into the pack's target directly. What that looks like: colour banding on a hand
-held against a smooth gradient; a sleeve or any half-transparent layer tinted by the fog colour
-rather than by what is behind it; a held banner's pattern missing over ground the pack drew; and a
-pack that writes a normal or a specular map from `gbuffers_hand` unable to light the hand from them
-anywhere the pack's own terrain stands behind it. A `gbuffers_hand` that samples scene depth is
-handed a constant rather than a depth image. The hand is lit and it moves with the pack's world;
-what a pack cannot do here is treat it as material of its own.
+**Both passes write the pack's own draw buffers, the first one included**, which is what the
+reference does with them. The solid pass earns that the way the world's opaque geometry does, by
+writing the coverage mask that keeps the scene seed off the pixels it drew; the water pass is drawn
+after the deferred stage, onto a picture the chain has already composed, and takes the buffer
+outright. So a pack that writes a normal or a specular map from `gbuffers_hand` can light the hand
+from them, and a sleeve or any half-transparent layer blends against what stands behind it.
+
+What a `gbuffers_hand` does not get is this frame's scene depth. `depthtex0` and `depthtex1` are
+answered with the far plane, the image of the opaque world not having been taken when the pass is
+drawn, and handing it the previous frame's would be wrong by one frame of camera movement.
+`depthtex2` is the exception and is a real copy, taken one line before the pass is drawn, which is
+the name a pack reads to see what the hand it is holding stands in front of.
 
 **The mobs and the block entities are drawn into the pack's own shadow map**, so they cast as well
 as receive, and the log names the shadow passes one by one when a place first draws. Two things
@@ -224,21 +227,19 @@ rather than reporting as separate bugs:
   entity can be treated as a surface to fog. The held hand shows whatever the mobs show, since it
   arrives by the same door and in the same vertex format, with the identifier that names what is
   held among the constants too.
-- **Flat wrong colours on the hand, oranges and greens that belong nowhere in the scene**, on a
-  pack that packs two values into each channel of a wide target. The hand's first draw buffer is
-  the one still making the trip through the game's eight-bit target, where such a value loses one
-  of its two halves and the other is read back as the albedo. The mobs and the block entities are
-  no longer in that position, and the frame page says what earned it: they write the coverage mask
-  and take that buffer in the pack's own targets.
 - A pack can allocate a colour target for a family that is not drawn through it. BSL allocates one
   for glowing entities alone, and its deferred pass samples that target, so the chain reads a clear
   across a whole target.
 
 The engine names the families that still come from the game, in the log, when a place first draws.
 That line is the authority; this page does not duplicate it. A place drawn without a seed does not
-print it, and says so on a line of its own instead, and there the mobs stay with the game whatever
-the switch says, the seed being the only road their colour has into the pack's picture, which the
-log also names when it happens.
+print it, and says so on a line of its own instead.
+
+What can still send one of these families back to the game for the seed's sake is narrower than it
+was, and the log names it by program: a fragment stage the translation could not place the coverage
+mask in falls back on the game's target, and there its own first draw buffer has to be the one the
+seed paints, or the game keeps its shader for that half rather than carry the pack's albedo into a
+target it never asked for.
 
 ## The sky goes flat
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -220,13 +220,16 @@ rather than reporting as separate bugs:
 - **The identifiers a pack reads off it are constants rather than this entity's own**: the material
   id it carries, and the ones a pack compares against a mob type, a block entity type or the item
   in hand. A pack that branches on any of them takes the same branch for every draw, and what that
-  looks like is entirely the pack's business:
-  where the water composites sort by material, an entity can be treated as a surface to fog; on
-  Bliss, mobs and the held arm come out in flat wrong colours, oranges and greens that belong
-  nowhere in the scene. Which of them a given pack lands on is not established here, and they are
-  all the same lot to close. The held hand shows whatever the mobs show, since it arrives by the
-  same door and in the same vertex format, with the identifier that names what is held among the
-  constants too.
+  looks like is entirely the pack's business: where the water composites sort by material, an
+  entity can be treated as a surface to fog. The held hand shows whatever the mobs show, since it
+  arrives by the same door and in the same vertex format, with the identifier that names what is
+  held among the constants too.
+- **Flat wrong colours on the hand, oranges and greens that belong nowhere in the scene**, on a
+  pack that packs two values into each channel of a wide target. The hand's first draw buffer is
+  the one still making the trip through the game's eight-bit target, where such a value loses one
+  of its two halves and the other is read back as the albedo. The mobs and the block entities are
+  no longer in that position, and the frame page says what earned it: they write the coverage mask
+  and take that buffer in the pack's own targets.
 - A pack can allocate a colour target for a family that is not drawn through it. BSL allocates one
   for glowing entities alone, and its deferred pass samples that target, so the chain reads a clear
   across a whole target.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -274,30 +274,28 @@ blends before the seed and keeps the buffer all the same, because it draws opaqu
 cone comes with two conditions of its own, set out under
 [the horizon gap](sky-and-shadows.md#the-horizon-gap), and where it is not drawn the seed repaints
 whatever stands in the band it would have closed: the lower half of the stars, the sunrise, a rising
-or setting sun. The hand's solid pass has no such sibling at all, and writes no mask of its own
-either, so its first draw buffer stays on the game's target and reaches the picture through the
-seed. That last one is the only piece drawn before the seed still in that position.
+or setting sun. The hand's solid pass has no such sibling at all and keeps the buffer by the other
+road, the one every opaque piece of the world takes: it writes the mask.
 
-That last one is a **divergence**, and it is the seed's price rather than a reading of Iris: Iris
-binds every gbuffers program to the pack's own draw buffers, the hand included, so the hand's colour
-never leaves the pack's target there. Here it makes the trip through the game's eight-bit target,
-which is a quantisation and not a loss of the picture. Three things do cost the picture, and none of
-them shows up as an error: a half-transparent hand pixel blends against the game's target, which
-holds no world while the chain is running, so it is tinted by the clear rather than by what stands
-behind it; a hand piece drawn with a pipeline that writes no depth, with nothing of its own pass
-writing depth under it, is discarded by the seed's cut, the mask and the world's depth both holding
-what the geometry behind the hand left; and the hand's *other* draw buffers still go straight to the
-pack, where the seed empties the ones its terrain program shares, so a pack whose hand program
-writes a normal or a specular map cannot light the hand from them over its own terrain.
+**The hand was the last piece that could have taken the mask and did not**, and what had kept it
+there was the flag the mask used to be. It is not the last piece drawn before the seed making the
+trip through the game's target, and the difference is worth keeping: the opaque particles never ask
+for a mask at all, so the seed carries them in by design, and so does anything whose fragment stage
+the translation could not place a mask in. The hand is drawn with its clip depth squeezed into the
+middle eighth of the range, which is not the depth of anything it stands in front of, so against a
+flag the cut asked whether the depth had moved closer since a copy taken before the game's features
+and every hand pixel answered yes. Against a depth it asks nothing of the sort: the mask is filled
+from the value the fragment hands the depth attachment, so at a hand pixel the two hold one number
+and the cut compares it with itself.
 
-**And it is not forced**, which is worth writing down rather than discovering twice. There are two
-ways out and neither has been taken. The mask is open to the hand now that it carries a depth: a
-hand row would write the same squeezed value the depth attachment receives, and the cut would
-compare it with itself, where the flag it used to be could not have helped. Or the reference's only
-constraint is that the hand precede the deferred stage, and the seed is this engine's own with no
-counterpart there, so drawing the hand's solid pass *between* the seed and the deferred stage would
-keep the reference's moment and let the pack own the first draw buffer. The second is a change to
-the order of the frame rather than to this rule.
+Three things the trip cost, and they are what moving it back buys, each of them a symptom that never
+showed up as an error: a half-transparent hand pixel blended against the game's target, which holds
+no world while the chain is running, so it was tinted by the clear rather than by what stands behind
+it; a hand piece drawn with a pipeline that writes no depth, with nothing of its own pass writing
+depth under it, was discarded by the seed's cut, the mask and the world's depth both holding what
+the geometry behind the hand left; and the albedo went through eight bits a channel like every other
+seeded family. It is also where the reference has it, which is the point: it binds every gbuffers
+program to the pack's own draw buffers, the hand included.
 
 ## Reading the plan before running it
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -174,18 +174,25 @@ applies to a family only for as long as the seed is its road in: a mob served by
 program takes a different one, with a fault of its own described in
 [pack compatibility](compatibility.md).
 
-**A pixel the pack's own terrain has covered must not be seeded over.** That is what the coverage
-mask is for: it is compared against the depth left by the pack's own geometry, so a pixel the pack
-drew belongs to the pack and a pixel it did not belongs to the seed. Comparing against the wrong
-depth (one the game has since cleared) makes the mask wrong everywhere, and things the game drew
-in front of the terrain vanish.
+**A pixel the pack's own geometry has covered must not be seeded over.** That is what the coverage
+mask is for, and it carries a **depth** rather than a flag: every program of the pack drawn before
+the seed writes into it the value it handed the depth attachment, and the seed compares that with
+the world's depth as it stands. A pixel nothing has been drawn over since compares equal and is the
+pack's; a pixel the game has drawn a feature onto compares closer and is the seed's. Where the pack
+wrote nothing at all the mask holds a value outside zero to one, which every real depth is in front
+of, so those pixels take the game's picture through the same comparison.
 
-**The entities are the exception, and it is deliberate rather than a gap.** They write no mask, so
-their pixels are seeded over on purpose: the seed is cut against a depth taken before the game draws
-a single feature, and an entity is by definition in front of that depth, so a mask claiming those
-pixels would take them from the very image that carries the entity's colour. What that costs is one
-trip through eight bits a channel for the albedo, and what it buys is every other draw buffer, which
-is where a pack keeps the normal and the material it lights an entity by.
+That is one comparison for two questions, and the second one is what a flag could not answer. The
+game still draws pieces of its own in front of the pack's geometry, and they have to arrive; the
+pack's own geometry must not be repainted. Only a depth tells those two pixels apart.
+
+**The entities used to be the exception and are not any more.** Their first draw buffer went to the
+game's target and reached the pack through the seed, which cost the albedo one trip through eight
+bits a channel: a pack that packs two values into each channel of a wider target lost the first of
+them there. They write the mask now and take that buffer in the pack's own targets, which was not
+open to them while the mask was a flag - the cut then compared the world's depth with one taken
+before a single feature was drawn, and a mob standing in front of a block moves that depth by
+construction, so every pixel of it answered "the game drew in front" whatever mask it wrote.
 
 So a flat, unlit mob is not a mask bug, and before reading it as one, check which of two things you
 are looking at. The family goes through the pack out of the box, so the first question is whether
@@ -267,11 +274,9 @@ blends before the seed and keeps the buffer all the same, because it draws opaqu
 cone comes with two conditions of its own, set out under
 [the horizon gap](sky-and-shadows.md#the-horizon-gap), and where it is not drawn the seed repaints
 whatever stands in the band it would have closed: the lower half of the stars, the sunrise, a rising
-or setting sun. The hand's solid pass has no such sibling at all, and no mask could stand in for one:
-the seed's cut asks whether the depth moved closer since the pack's geometry was finished with it,
-and the hand is drawn with its clip depth squeezed into a band of its own, so the answer is yes at
-every pixel it covers. Its first draw buffer therefore stays on the game's target and reaches the
-picture through the seed.
+or setting sun. The hand's solid pass has no such sibling at all, and writes no mask of its own
+either, so its first draw buffer stays on the game's target and reaches the picture through the
+seed. That last one is the only piece drawn before the seed still in that position.
 
 That last one is a **divergence**, and it is the seed's price rather than a reading of Iris: Iris
 binds every gbuffers program to the pack's own draw buffers, the hand included, so the hand's colour
@@ -280,17 +285,19 @@ which is a quantisation and not a loss of the picture. Three things do cost the 
 them shows up as an error: a half-transparent hand pixel blends against the game's target, which
 holds no world while the chain is running, so it is tinted by the clear rather than by what stands
 behind it; a hand piece drawn with a pipeline that writes no depth, with nothing of its own pass
-writing depth under it, is discarded by the seed's cut where the mask is set rather than carried in;
-and the hand's *other* draw buffers still go straight to the pack, where the seed empties the ones
-its terrain program shares, so a pack whose hand program writes a normal or a specular map cannot
-light the hand from them over its own terrain.
+writing depth under it, is discarded by the seed's cut, the mask and the world's depth both holding
+what the geometry behind the hand left; and the hand's *other* draw buffers still go straight to the
+pack, where the seed empties the ones its terrain program shares, so a pack whose hand program
+writes a normal or a specular map cannot light the hand from them over its own terrain.
 
-**And it is not forced**, which is worth writing down rather than discovering twice. The reference's
-only constraint is that the hand precede the deferred stage; the seed is this engine's own and has
-no counterpart there, so drawing the hand's solid pass *between* the seed and the deferred stage
-would keep the reference's moment and let the pack own the first draw buffer, at none of the three
-costs above. That is a change to the order of the frame rather than to this rule, and it has not
-been made.
+**And it is not forced**, which is worth writing down rather than discovering twice. There are two
+ways out and neither has been taken. The mask is open to the hand now that it carries a depth: a
+hand row would write the same squeezed value the depth attachment receives, and the cut would
+compare it with itself, where the flag it used to be could not have helped. Or the reference's only
+constraint is that the hand precede the deferred stage, and the seed is this engine's own with no
+counterpart there, so drawing the hand's solid pass *between* the seed and the deferred stage would
+keep the reference's moment and let the pack own the first draw buffer. The second is a change to
+the order of the frame rather than to this rule.
 
 ## Reading the plan before running it
 


### PR DESCRIPTION
## What changes

The coverage mask carries the depth a fragment handed the depth attachment instead of a one byte
flag, so the cut the scene seed is made with becomes one comparison. That opens the same door to
three families in turn, and this branch walks all three: the entities and block entities, the hand's
solid pass, and an enchantment's glint. Each of them used to send its first draw buffer to the
game's eight bit target and reach the pack's picture through the seed; each of them now writes the
pack's own target outright.

## How it differs from the reference, and for what obstacle

It does not, and on the hand it closes a divergence: Iris binds every gbuffers program to the pack's
own draw buffers, the hand included (`pipeline/IrisRenderingPipeline.java:686-687`), where this
engine was still going through the game's target.

The one place a reading of Iris had to be translated rather than copied is the direction of "in
front", Iris running against an OpenGL volume where this engine rasterises in reversed z. The
comparison and the sentinel are both written from `ClipSpace.REVERSED` so they cannot be moved
apart.

## What proves it

- `gradlew build` green.
- Harness over the eight pack corpus: `Terrain` 192/192, `Entites` 264/264, `Chaine` seven
  invariants including the one that replays the engine's own plan. Negative control done: forcing
  the wrong depth builtin into the epilogue makes Bliss fail four cases.
- `Verdicts` byte identical before and after, so the second reading of the seed's road was closed
  without moving anything on this corpus.
- In the game, same point, same pack, two clean launches with nothing changed but the jar: item
  frames go from flat panels to textured wood, and a golden apple held in hand from a black block
  with green and yellow facets to its own colours.

## What it leaves owing

- The glint is drawn by the pack now and comes out far too strong under Bliss, erasing the item
  rather than shimmering over it. The side the engine reads its exposure from is verified correct;
  the brightness the pack computes from it is not explained. Tracked.
- `gbuffers_armor_glint` is swept by no harness. Its mesh is not the entity one, so it needs a tool
  of its own.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [ ] `CHANGELOG.md` entry under `Unreleased`. Not yet: no release until a defect found while this
      branch was open is fixed, and the entry is better written beside it.
- [x] Every place that states a fact this branch changed now states the new one. A targeted
      adversarial review found four and all four are corrected here.
