### PR TITLE
Say that dev reaches main by a fast-forward, not by the rebase button

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,17 @@ whatever `dev` holds beyond `main` is precisely what is written and not yet publ
 
 **The history is linear and carries no merge commit anywhere, which is not a preference.** A tree
 that forks is a tree nobody reads once it is public, and this one is public. A topic branch is
-rebased onto `dev` and enters by a pull request, merged with the rebase button; `dev` enters `main`
-the same way. If that button refuses, the rebase was not done, and the answer is to rebase rather
-than to merge.
+rebased onto `dev` and enters by a pull request, merged with the rebase button. If that button
+refuses, the rebase was not done, and the answer is to rebase rather than to merge.
+
+**`dev` reaches `main` by a fast-forward and NOT by that button**, and the difference is the whole
+of why `main` can be read as a prefix of `dev`. The rebase button always writes new commits: it
+re-applies each one under a fresh identity, which is what it is for on a topic branch and what makes
+it wrong here. `main` is already an ancestor of `dev`, so replaying `dev` onto it would give `main`
+a second copy of every commit under a different hash, and the two branches would then hold the same
+work under two histories. A pull request is still the right place to look at a release, for the
+record and for the checks it runs; what merges it is the fast-forward, and the pull request closes
+itself as merged once its commits are on `main`.
 
 **Every batch enters that way, including one written by whoever owns the repository.** Folding a
 branch in locally skips the one thing the pull request is for: `build.yml` runs on `pull_request`,


### PR DESCRIPTION
## What changes

`CONTRIBUTING.md` said `dev` entered `main` the same way a topic branch enters `dev`, at the rebase
button. It cannot: that button re-applies every commit under a fresh hash, which is what it is for
on a topic branch and what would hand `main` a second copy of everything `dev` already holds. The
prefix the two branches are read against only survives a fast-forward, so the section now says so
and says why a pull request is still worth opening for a release.

## How it differs from the reference, and for what obstacle

It does not. Nothing here touches the engine.

## What proves it

- `gradlew build` green, which is the gate for a text change: it refuses a BOM and typographic
  punctuation.
- Observed on this repository rather than read in a manual: merging pull request 1 with the rebase
  button rewrote its six commits under new hashes, which is what made pull request 2 unrebasable
  until it was replayed locally.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
