### PR TITLE
Take the chunk pipeline back only when it fits the mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ plus, because each of them files an upload per loader and has nowhere else to pu
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Fixed
+
+- Picking None while a pack is drawing no longer leaves the terrain in stretched coloured spikes
+  until the game is restarted. The world was being drawn through a pipeline built for the wider
+  vertex the pack needs, over a mesh that had already gone back to the narrower one.
+
 ## 0.2.0-alpha.1
 
 ### Added

--- a/common/src/main/java/dev/vitrail/mixin/MixinShaderChunkRenderer.java
+++ b/common/src/main/java/dev/vitrail/mixin/MixinShaderChunkRenderer.java
@@ -15,15 +15,19 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Map;
 
 /**
  * Hands Sodium the pack's own programs in place of its chunk shader, one per pass.
  * <p>
  * The head of {@code compileProgram} is the whole hook: it is one point, it has no state of its own,
  * and short circuiting it there leaves Sodium's memo untouched, so nothing of ours is ever handed
- * back once this is turned off.
+ * back once this is turned off. What that memo answers when the pass is left to Sodium is a question
+ * of its own, and {@link #vitrail$ofThisFormat} is where it is asked.
  * <p>
  * The three passes are told apart by identity against {@code DefaultTerrainRenderPasses}, and a pass
  * that is none of the three is left to Sodium. That is not defensive: {@code TerrainRenderPass} is a
@@ -79,5 +83,59 @@ public abstract class MixinShaderChunkRenderer {
 		if (pipeline != null) {
 			callback.setReturnValue(pipeline);
 		}
+	}
+
+	/**
+	 * Hands the renderer its own memoised pipeline back only when that pipeline was built for the
+	 * format this renderer binds, and reports a miss otherwise so that it is built again.
+	 * <p>
+	 * <strong>The memo is static and keyed by the render pass alone.</strong> The three passes are
+	 * immortal instances of {@code DefaultTerrainRenderPasses}, the map is a static field, and what
+	 * it holds declares the vertex format of whichever renderer built it,
+	 * {@code withVertexBinding(0, this.vertexFormat)}. Nothing ever empties it, and the renderer's own
+	 * {@code delete} is not an oversight either: what it frees is the index buffer and the draw context
+	 * it owns, and the half it inherits is a plain return.
+	 * <p>
+	 * Everything else that holds a stride is rebuilt when the format moves - the section manager, the
+	 * chunk renderer it constructs from the format in force, the mesh of every section - so this memo
+	 * is the one thing that survives the rebuild carrying the old one. And it is handed to the game's
+	 * own chunk shader, which draws the terrain wherever this engine gives a pass back, warm up
+	 * included. A pipeline declaring 44 bytes a vertex over a mesh written at 20 reads every position
+	 * out of the middle of some other vertex: the terrain comes out as stretched coloured spikes while
+	 * the sky, the entities and the interface stay right. That is what dropping a pack to {@code none}
+	 * in a running game did, and the same mechanism says the first frames after picking one are drawn
+	 * from a pipeline left over at Sodium's own stride.
+	 * <p>
+	 * <strong>The Sodium this could not happen on says what the key is missing.</strong> Its memo was
+	 * one per renderer and keyed by {@code ChunkShaderOptions}, which carries the
+	 * {@code ChunkVertexType} itself, so an entry built for one format could not answer for another.
+	 * This asks the same question where the answer is used rather than rekeying a map that is not
+	 * ours, and it costs one reference comparison per pass and frame.
+	 * <p>
+	 * <strong>What building one again costs is real and bounded.</strong> The device keeps the
+	 * compiled pipeline in an identity map from the description it was compiled from, and only a
+	 * resource reload empties it, so the one left behind by a switch lives until the next reload:
+	 * three at most for each time the format moves. The alternative is the wrong picture.
+	 * <p>
+	 * <strong>{@code require = 1}, and what it guards is the lookup being there at all.</strong> A
+	 * Sodium that put the format back in its key would go on asking the same map the same way, so
+	 * this would go on applying and its comparison would simply never refuse anything. What fails the
+	 * injection is the memo being dropped or reached by some other road, and refusing to load then
+	 * names the one thing that moved. Failing quietly is the other way round: a world destroyed a
+	 * pack switch later, and nothing on screen pointing anywhere near here.
+	 */
+	@Redirect(method = "compileProgram",
+			at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;"),
+			require = 1)
+	private Object vitrail$ofThisFormat(Map<?, ?> memo, Object pass) {
+		Object found = memo.get(pass);
+		// A pipeline binding nothing at nought is no more usable than one binding another format, and
+		// the renderer builds none: every road into this map goes through its own vertex binding.
+		if (found instanceof RenderPipeline pipeline
+				&& !this.vertexFormat.equals(pipeline.getVertexFormatBinding(0))) {
+			return null;
+		}
+
+		return found;
 	}
 }

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -29,7 +29,7 @@ The first two are what lets a pack's program run at all, and they are the ones a
 The rest are what makes what it draws correct, and leaving them out of a mental model of this area
 is how a program that compiles ends up drawing the wrong picture.
 
-Two properties of the format substitution are constraints, not details.
+Three properties of the format substitution are constraints, not details.
 
 **The format may only change where nothing holds the old one.** Every caller of the accessor (the
 section manager, the mesh builder, the per-region device resources) keeps whatever it was handed
@@ -39,6 +39,18 @@ meshes built at one stride land in an arena sized for another, and nothing in th
 notice. So the engine takes the answer at the single instant the chunk renderer is being built again
 from nothing, and merely repeats it everywhere else. Turning the terrain switch on or off asks the
 game to rebuild the world, which is the same door F3+A uses; it does not ask for a restart.
+
+**One thing outlives that rebuild, and it is a pipeline.** The chunk renderer memoises its own
+pipeline in a map keyed by render pass, the map is static and the three passes are immortal, and a
+pipeline declares the vertex format of whichever renderer built it. Nothing ever empties it, so the
+entry made during one session's warm up goes on answering for every renderer built afterwards, at
+whatever stride it was born with. What it is handed to is the game's own chunk shader, which draws
+the terrain on every road where a pass is given back: a pipeline declaring 44 bytes a vertex over a
+mesh written at 20 reads every position out of the middle of some other vertex, and the terrain comes
+out as stretched coloured spikes while the sky, the entities and the interface stay right. So the
+engine compares that pipeline's own vertex binding against the format the renderer binds, and calls a
+disagreement a miss. An older Sodium asked the same question in the key itself, its memo being one
+per renderer and keyed by a record carrying the vertex type.
 
 **Everything the pipeline declares must be bound.** Descriptor flushing walks the entries of the
 bound pipeline, so uniform and texture bindings the chunk renderer emits unconditionally for its own


### PR DESCRIPTION
## What changes

Picking None while a pack is drawing used to leave the terrain in stretched coloured spikes until
the game was restarted, the sky and the interface staying right. The mesh goes back to Sodium's own
twenty bytes and everything holding a stride is rebuilt with it, but the renderer memoises its chunk
pipeline in a static map keyed by the render pass alone, the three passes are immortal, and nothing
empties it: the pipeline built during one warm up, declaring forty-four bytes a vertex, went on
being handed to the game's own chunk shader. This branch makes that lookup compare the pipeline's
own vertex binding against the format the renderer binds, and treat a disagreement as a miss.

## How it differs from the reference, and for what obstacle

It does not. Iris cannot meet this: the Sodium it runs against memoises per renderer and keys on
`ChunkShaderOptions`, which carries the `ChunkVertexType` itself, so an entry built for one format
cannot answer for another. This asks the same question where the answer is used, because the key is
not ours to change.

## What proves it

- `gradlew build` green.
- In the game, same world, same viewpoint, same pack, two clean launches with only the jar changing.
  BSL drawing, then None, then BSL again, all without leaving the game. On the jar without this the
  world is coloured spikes the moment None takes effect; with it the terrain is untouched through
  both switches. The switch itself is driven from the disk, `pack.txt` plus a dimension change,
  which is the same road the settings screen takes into `PackChain.load`.
- The log carries the format moving both ways at each switch, 44 to 20 and back.

## What it leaves owing

The pipeline abandoned by a switch stays in the device's own cache until the next resource reload,
three at most each time the format moves. Bounded, and the alternative is the wrong picture.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one: the terrain page
      carries the third constraint on the format substitution, beside the two it already had.
