### PR TITLE
Name the image a pass really binds where it asks for the atlas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ what the next one holds.
 
 ## Unreleased
 
+### Changed
+
+- The line each program prints at its first draw now names the image it really samples where the
+  pack asks for the atlas, so a picture that disagrees with the wiring can be told apart from one
+  that agrees with it.
+
 ### Fixed
 
 - Picking None while a pack is drawing no longer leaves the terrain in stretched coloured spikes

--- a/common/src/main/java/dev/vitrail/mixin/TextureManagerAccessor.java
+++ b/common/src/main/java/dev/vitrail/mixin/TextureManagerAccessor.java
@@ -1,0 +1,30 @@
+package dev.vitrail.mixin;
+
+import net.minecraft.client.renderer.texture.AbstractTexture;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.resources.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
+
+/**
+ * Opens the game's own register of loaded textures, so that an image bound to a sampler can be
+ * named rather than described.
+ * <p>
+ * <strong>The label a texture carries is not an answer here.</strong> A texture loaded from a
+ * resource is created with its identifier as its label ({@code ReloadableTexture.java:42}), but the
+ * backend keeps it only while validation layers are on: {@code VulkanDevice.java:200} stores the
+ * empty string otherwise, and this engine runs against a device that has them off. Reading the
+ * label would print nothing at all and read as an image with no name.
+ * <p>
+ * This register is the other end of the same fact and holds under any device: it is what
+ * {@code RenderSetup.prepareTextures} looks a render type's texture up in
+ * ({@code RenderSetup.java:98}), so the view it hands a draw is one of the views held here.
+ */
+@Mixin(TextureManager.class)
+public interface TextureManagerAccessor {
+
+	@Accessor("byPath")
+	Map<Identifier, AbstractTexture> vitrail$byPath();
+}

--- a/common/src/main/java/dev/vitrail/render/GameImages.java
+++ b/common/src/main/java/dev/vitrail/render/GameImages.java
@@ -1,0 +1,75 @@
+package dev.vitrail.render;
+
+import dev.vitrail.mixin.TextureManagerAccessor;
+
+import com.mojang.blaze3d.textures.GpuTextureView;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.AbstractTexture;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.resources.Identifier;
+
+import java.util.Map;
+
+/**
+ * Names the image a draw really binds, by asking the game which of its own textures that view
+ * belongs to.
+ * <p>
+ * <strong>This exists because reading the wiring is not the same as reading the picture.</strong>
+ * The road from a render type to a sampler is four handovers long - the type names an identifier,
+ * the game resolves it to a view at prepare time, {@code EntityDraw} takes the view named
+ * {@code Sampler0} out of the prepared type, and {@link GeometryProgram} binds it wherever the pack
+ * asked for the atlas - and every one of them reads right while the screen says otherwise. A line
+ * that names the image closes that gap with an observation instead of a fifth reading.
+ * <p>
+ * Answered once per program at its first draw and never per draw: the map is the game's own and
+ * holds every texture it has loaded, so a lookup walks it whole.
+ */
+final class GameImages {
+
+	private GameImages() {
+	}
+
+	/**
+	 * What to call the image behind a view, which is its identifier wherever the game holds one.
+	 *
+	 * @param view the image bound, or null where the pass has none of its own
+	 */
+	static String name(GpuTextureView view) {
+		if (view == null) {
+			return "one white pixel, this pass having no image of its own";
+		}
+
+		String size = view.getWidth(0) + "x" + view.getHeight(0);
+		Minecraft minecraft = Minecraft.getInstance();
+		TextureManager manager = minecraft == null ? null : minecraft.getTextureManager();
+		if (manager == null) {
+			return "an unnamed " + size + " image";
+		}
+
+		Map<Identifier, AbstractTexture> loaded = ((TextureManagerAccessor) manager).vitrail$byPath();
+		for (Map.Entry<Identifier, AbstractTexture> entry : loaded.entrySet()) {
+			if (view.equals(viewOf(entry.getValue()))) {
+				return entry.getKey() + ", " + size;
+			}
+		}
+
+		// Every image of the pack's own is one of these, the colour targets first of all, so this is
+		// the ordinary answer for a sampler the chain fills rather than a fault.
+		return "an image the game does not hold, " + size;
+	}
+
+	/**
+	 * The view a loaded texture carries, or null before anything has uploaded one.
+	 * <p>
+	 * Caught rather than tested, and there is no test to make: a texture registered for the next
+	 * reload holds no view until that reload applies one, and the getter answers that with a throw.
+	 * A line that names an image is not worth a crash.
+	 */
+	private static GpuTextureView viewOf(AbstractTexture texture) {
+		try {
+			return texture.getTextureView();
+		} catch (IllegalStateException absent) {
+			return null;
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -735,8 +735,16 @@ final class GeometryProgram {
 		// to record a single command against it.
 		if (!this.drew) {
 			this.drew = true;
-			Vitrail.logger().info("The {} pass records its first draw with {}",
-					this.pass.name(), this.path);
+
+			// The image goes on this line and not on the one announce() prints, which is the only
+			// place it can go: the atlas belongs to the DRAW for two of the three families, so at
+			// the moment the program is announced this field holds nothing yet. Said for whoever
+			// reads the atlas and for nobody else, a pass with no such name having no image to name.
+			Vitrail.logger().info("The {} pass records its first draw with {}{}",
+					this.pass.name(), this.path,
+					this.samplers.stream().anyMatch(ATLAS::contains)
+							? ", reading " + GameImages.name(this.atlas) + " where it asks for the atlas"
+							: "");
 		}
 
 		pass.setUniform(UNIFORM_BLOCK, this.block.currentBuffer().slice(0, blockBytes()));

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -35,6 +35,7 @@
 		"MixinSodiumWorldRenderer",
 		"MixinSodiumWorldRendererInit",
 		"StagedVertexBufferDrawMixin",
+		"TextureManagerAccessor",
 		"VKDrawContextMixin",
 		"WeatherEffectRendererMixin"
 	]


### PR DESCRIPTION
## What changes

The line each geometry program prints at its first draw now names the image it really samples where
the pack asks for the atlas. It is named from the game's own register of loaded textures, which is
what `RenderSetup.prepareTextures` looks a render type's texture up in, rather than from the GPU
label: a texture loaded from a resource does carry its identifier as a label, but the backend keeps
that only under validation layers and stores the empty string otherwise, so the label would have
printed nothing at all and read as an image with no name. The register needs a mixin accessor,
which is the only other file this adds.

## How it differs from the reference, and for what obstacle

It does not. Nothing about the picture changes; this adds one line per program per load.

## What proves it

- `gradlew build` green.
- In the game, BSL v10.1.3 at a fixed point with a glinted golden apple held: the hand's glint pass
  prints `reading minecraft:textures/misc/enchanted_glint_item.png, 128x128`, the terrain passes
  print the block atlas, the sun and moon the celestials atlas, and a cloud pass, which has no image
  of its own, says so.

## What it leaves owing

Nothing. It was written to settle a question about the glint, and it settled it: the image bound is
the right one, and what looked like a wrong colour was the item under the glint rather than the
glint.
