### PR TITLE
Close the vendored parser's javadoc paragraphs

### DIFF
--- a/common/src/main/java/dev/vitrail/uniform/expr/kroppeb/stareval/parser/Parser.java
+++ b/common/src/main/java/dev/vitrail/uniform/expr/kroppeb/stareval/parser/Parser.java
@@ -24,28 +24,28 @@ import java.util.List;
 /**
  * <p>
  * A parser for parsing expressions with operator precedences.
- * <p/><p>
+ * </p><p>
  * I can't actually find a parser type on wikipedia that matches this type of parser
- * <p/><p>
+ * </p><p>
  * The following parser is a bottom-up parser, meaning that the input tokens get combined into elements
  * which then get merged with other elements and tokens until a valid expression is formed, or an expression
  * is thrown.
- * <p/><p>
+ * </p><p>
  * The uniqueness of this parser lies in how it handles operator precedence without using any lookahead, instead any
  * binary operators trigger a simplification on the left-hand side of the operator until the left-hand side has a
  * precedence that is strictly higher than the new operator (assuming any expression that is not operator-based is the
  * highest possible precedence, eg: function calls, numbers and brackets). Note that making this relationship require
  * higher or equal, would make the operator right associative instead of left associative, in case that is ever needed.
- * <p/><p>
+ * </p><p>
  * Once the left-hand side of a binary operator has been sufficiently combined, the operator is combined with the
  * expression and is converted into a "partial binary expression" which acts like a unary operator with the precedence
  * level. The comments inside {@link #visitBinaryOperator} show a few cases on what this reduction does with a given
  * stack.
- * <p/><p>
+ * </p><p>
  * The parsing of brackets is a bit strange, and due to the fact this documentation has been written 5 months after I
  * made the design decision and 3 months after my latest code change, I can't fully explain why I put mutable state
  * inside one of the elements of the parser, as it does not provide any significant speedup that I could think of.
- * <p/><p>
+ * </p><p>
  * When an opening parenthesis is encountered, an "unfinished argument list" is pushed to the stack. Any comma will
  * fully combine the expression on the left of the comma and push it to that list. When a closing parenthesis is
  * encountered, a similar reduction is performed if the top of the stack is an expression. Then the parser checks if


### PR DESCRIPTION
## What changes

Nothing in the engine. The class comment of the vendored stareval `Parser` separated its paragraphs
with `<p/>`, and HTML has no self-closing `<p>`, so `:common:javadoc` failed on six errors. Each one
becomes the `</p><p>` the comment already meant. That task is not part of `gradlew build`, which is
why the quality gate stayed green over it and why this is latent debt rather than a regression.

## How it differs from the reference, and for what obstacle

It does not. The file is vendored third-party code and nothing outside its comment is touched, so
the parser behaves exactly as before.

## What proves it

- `gradlew build` green.
- `gradlew :common:javadoc --rerun-tasks` green, where it previously failed on six errors. It still
  prints 100 warnings, all of them missing `@param` tags elsewhere in `common`, untouched here.

## What it leaves owing

Those 100 warnings, and the fact that `:common:javadoc` is still not wired into `build`, so nothing
stops the next `<p/>` from landing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
