### PR TITLE
Give the javadoc task the decisions the gate already made, and the parser its comment back

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,23 @@ subprojects {
 		options.errorprone.excludedPaths = ".*/vitrail/mixin/.*|.*/uniform/expr/kroppeb/.*"
 	}
 
+	// The javadoc task gates nothing the block above does not already gate: it runs the same doclint
+	// over the same sources, and a self-closing tag planted outside the vendored package fails
+	// `gradlew build` on its own, measured rather than reasoned about. So it is deliberately left out
+	// of `check`, where it would buy a second run of doclint and nothing else.
+	//
+	// What it cannot be left as is unconfigured, because then it disagrees with the gate on both of
+	// the decisions above. It reports the missing comments that -missing drops, a hundred of them
+	// before javadoc stops counting, and it fails on the vendored evaluator that -Xdoclint/package
+	// steps back from. Whoever runs it by hand reads a failure on borrowed code and a wall of
+	// warnings, and concludes the gate has a hole in exactly the place the gate made a decision. The
+	// two lines below are that decision said once more, to the only other tool that asks.
+	tasks.withType(Javadoc).configureEach {
+		options.encoding = "UTF-8"
+		options.addBooleanOption("Xdoclint:all,-missing", true)
+		options.addBooleanOption("Xdoclint/package:-dev.vitrail.uniform.expr.kroppeb.*", true)
+	}
+
 	tasks.withType(AbstractArchiveTask).configureEach {
 		preserveFileTimestamps = false
 		reproducibleFileOrder = true

--- a/common/src/main/java/dev/vitrail/uniform/expr/kroppeb/stareval/parser/Parser.java
+++ b/common/src/main/java/dev/vitrail/uniform/expr/kroppeb/stareval/parser/Parser.java
@@ -24,28 +24,28 @@ import java.util.List;
 /**
  * <p>
  * A parser for parsing expressions with operator precedences.
- * </p><p>
+ * <p/><p>
  * I can't actually find a parser type on wikipedia that matches this type of parser
- * </p><p>
+ * <p/><p>
  * The following parser is a bottom-up parser, meaning that the input tokens get combined into elements
  * which then get merged with other elements and tokens until a valid expression is formed, or an expression
  * is thrown.
- * </p><p>
+ * <p/><p>
  * The uniqueness of this parser lies in how it handles operator precedence without using any lookahead, instead any
  * binary operators trigger a simplification on the left-hand side of the operator until the left-hand side has a
  * precedence that is strictly higher than the new operator (assuming any expression that is not operator-based is the
  * highest possible precedence, eg: function calls, numbers and brackets). Note that making this relationship require
  * higher or equal, would make the operator right associative instead of left associative, in case that is ever needed.
- * </p><p>
+ * <p/><p>
  * Once the left-hand side of a binary operator has been sufficiently combined, the operator is combined with the
  * expression and is converted into a "partial binary expression" which acts like a unary operator with the precedence
  * level. The comments inside {@link #visitBinaryOperator} show a few cases on what this reduction does with a given
  * stack.
- * </p><p>
+ * <p/><p>
  * The parsing of brackets is a bit strange, and due to the fact this documentation has been written 5 months after I
  * made the design decision and 3 months after my latest code change, I can't fully explain why I put mutable state
  * inside one of the elements of the parser, as it does not provide any significant speedup that I could think of.
- * </p><p>
+ * <p/><p>
  * When an opening parenthesis is encountered, an "unfinished argument list" is pushed to the stack. Any comma will
  * fully combine the expression on the left of the comma and push it to that list. When a closing parenthesis is
  * encountered, a similar reduction is performed if the top of the stack is an expression. Then the parser checks if

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -136,6 +136,13 @@ There is one exemption, and it is a package: the vendored expression evaluator k
 javadoc. Bending borrowed code to this project's taste buys nothing and makes the next comparison
 with upstream harder. A contributor working in that package is not caught by this gate.
 
+That lint runs on the compiler, so it runs on every build, and the `javadoc` task is deliberately
+not part of `check`: it would run the same doclint over the same sources a second time and catch
+nothing the compile did not. It is configured all the same, with the missing-comment category off
+and the same package exempt, because a task left to its own defaults disagrees with the gate on
+both counts. It then fails on the vendored evaluator and reports the missing comments as a wall of
+warnings, and whoever ran it reads a hole in the gate where the gate made a decision.
+
 **Static analysis, contributing the checks it rates as errors** (the part of the catalogue meant to
 be a bug rather than a preference) **and two of its warnings promoted to join them.** The rest are
 worth reading and not worth blocking on, so a build flag prints them and lets the build through.


### PR DESCRIPTION
## What changes

Nothing in the engine. Two commits, and the second only makes sense after the first.

The `javadoc` task was never configured, so it disagreed with the quality gate on both of the
decisions the gate makes about doclint: it reported the missing comments that `-missing` drops, a
hundred of them before javadoc stops counting, and it failed on the vendored evaluator that
`-Xdoclint/package` steps back from. It is given the same two decisions, and `docs/developing.md`
says why it is still deliberately out of `check`.

That closes the six doclint errors where this repository had already decided they should be closed.
#6 had closed them the other way, by editing stareval's class comment, which is the diff against
upstream the exemption exists to prevent. It merged before this branch was pushed, so the second
commit here reverts it and gives that comment back to its author.

## How it differs from the reference, and for what obstacle

It does not. The only source change is a revert of a comment, and no behaviour rides on either.

## What proves it

- `gradlew build` green, `checkText` included, and `:common:compileJava --rerun-tasks` green so the
  reverted file really went back through the gate.
- `gradlew :common:javadoc --rerun-tasks` green at zero errors and zero warnings, with the six
  self-closing tags back in place. Before this branch it failed on those six and printed a hundred
  warnings.
- That the `javadoc` task adds no coverage was measured rather than reasoned about: a `<p/>` planted
  in `TranslatedUnit.java`, outside the exempt package, fails `gradlew build` on its own. That is
  why this branch configures the task instead of wiring it into `check`.

## What it leaves owing

Nothing. `uniform/expr/kroppeb/` is byte for byte what it was before #6.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
