### PR TITLE
Give the hand the bob it was really drawn with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ what the next one holds.
 - Picking None while a pack is drawing no longer leaves the terrain in stretched coloured spikes
   until the game is restarted. The world was being drawn through a pipeline built for the wider
   vertex the pack needs, over a mesh that had already gone back to the narrower one.
+- The item in your hand no longer swims inside a nether portal or under nausea while the arm
+  holding it stays put. The pack was being handed the whole screen distortion as the hand's walk
+  bob, and the hand is drawn without it.
 
 ## 0.2.0-alpha.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ what the next one holds.
 - Picking None while a pack is drawing no longer leaves the terrain in stretched coloured spikes
   until the game is restarted. The world was being drawn through a pipeline built for the wider
   vertex the pack needs, over a mesh that had already gone back to the narrower one.
-- The item in your hand no longer swims inside a nether portal or under nausea while the arm
-  holding it stays put. The pack was being handed the whole screen distortion as the hand's walk
-  bob, and the hand is drawn without it.
+- Your hand no longer turns and stretches along with the screen inside a nether portal or under
+  nausea, where it should hold still in front of the camera. The pack was being handed the whole
+  screen distortion as the hand's walk bob, and it is the hand's clip position a pack writes
+  through that. Walking and being hit were already right.
 
 ## 0.2.0-alpha.1
 

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -970,9 +970,17 @@ public final class GlslTranslator {
 	 * {@code iris_ModelViewMatInverse} and {@code iris_NormalMat}
 	 * ({@code transform/transformer/VanillaTransformer.java:168-178}), both filled from
 	 * {@code RenderSystem.getModelViewMatrix()} at program setup
-	 * ({@code pipeline/programs/ExtendedShader.java:181-189}), which is the stack and carries no
-	 * nudge. So a pack that multiplies the matrix by its own inverse is a hair off in both engines,
-	 * by the same hair.
+	 * ({@code pipeline/programs/ExtendedShader.java:183} and {@code :188}), which is the stack and
+	 * carries no nudge. So a pack that multiplies the matrix by its own inverse is a hair off in both
+	 * engines, by the same hair.
+	 * <p>
+	 * <strong>On the hand it is not a hair, and it is the same difference twice rather than two
+	 * findings.</strong> Both derived names come off one matrix,
+	 * {@code dev.vitrail.uniform.ViewSource#passModelView}, so what separates them from the
+	 * reference's separates them together: the hand's carries that pass's bob and Iris's stack does
+	 * not. {@code dev.vitrail.render.EntityDraw.Element.modelView} carries the whole argument and
+	 * what it costs the image; it is written down as a divergence rather than closed, because the
+	 * answer that would close it is Iris's number against this engine's placement of the bob.
 	 *
 	 * @return whether the name was one this rewrites, false leaving it to the ordinary rename
 	 */

--- a/common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java
+++ b/common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java
@@ -254,6 +254,15 @@ public final class LegacyGlsl {
 	 * <p>
 	 * It is the very matrix {@code dev.vitrail.render.ViewMatrices#passModelView} multiplies by,
 	 * published rather than rebuilt, so that the two roads cannot end up with two different bobs.
+	 * <p>
+	 * <strong>Four effects for three of the four families and TWO for the hand, and that is a
+	 * property of where each is drawn.</strong> What this name means is the left factor that really
+	 * placed the geometry of the pass reading it. The entities, the block entities and the glint are
+	 * placed by the level's matrix, which carries all four; the hand is drawn under a projection this
+	 * engine builds out of the walk bob and the damage tilt alone, the nausea and the portal being a
+	 * distortion of the world rather than of the arm.
+	 * {@code dev.vitrail.render.ViewMatrices.passBob} carries what handing it the frame's four would
+	 * cost, and it is not small: a hand program writes its clip position through this factor.
 	 */
 	public static final String CAMERA_BOB = "of_CameraBob";
 

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -416,18 +416,26 @@ public final class EntityDraw {
 		 * HandDraw} putting the whole of the hand's transform in the projection, so what is read
 		 * here is what the game itself would have read at that draw.
 		 * <p>
-		 * <strong>What the hand's normal matrix comes to is a DIVERGENCE, and it is this engine's
-		 * placement of the bob translated rather than Iris's line copied.</strong> Iris answers the
-		 * identity there, filling {@code iris_NormalMat} from {@code RenderSystem.getModelViewMatrix()}
-		 * ({@code pipeline/programs/ExtendedShader.java:187}) while its own hand leaves the stack at a
-		 * fresh pose ({@code pathways/HandRenderer.java:104,114-115}). What stops that answer from
-		 * being right here is where the two engines keep the hand's bob: Iris multiplies it into the
-		 * projection it binds ({@code pathways/HandRenderer.java:64-70}), and a normal matrix is never
-		 * derived from a projection, so the identity is consistent with its own geometry. This engine
-		 * publishes the bob in the model view for every family, {@link CameraBob} saying why, so the
-		 * matrix a hand program reads carries it and a normal matrix that did not would contradict the
-		 * very matrix beside it. Copying the identity across would buy Iris's number and a pair that
-		 * no longer multiplies back.
+		 * <strong>What the two names DERIVED from it come to on the hand is a DIVERGENCE, and it is
+		 * this engine's placement of the bob translated rather than Iris's line copied.</strong> Two
+		 * names and not one: {@code gl_NormalMatrix} and {@code gl_ModelViewMatrixInverse} both come
+		 * off this one matrix, {@code of_NormalMatrix} and {@code of_ModelViewMatrixInverse} in
+		 * {@link dev.vitrail.uniform.values.GeometryValues}, so whatever separates one from the
+		 * reference's separates the other by the same thing. Iris answers the identity to both,
+		 * filling {@code iris_ModelViewMatInverse} and {@code iris_NormalMat} from
+		 * {@code RenderSystem.getModelViewMatrix()} ({@code pipeline/programs/ExtendedShader.java:183}
+		 * and {@code :188}) while its own hand leaves the stack at a fresh pose
+		 * ({@code pathways/HandRenderer.java:104,114-115}, out of the {@code new PoseStack()} at
+		 * {@code :73}).
+		 * <p>
+		 * What stops that answer from being right here is where the two engines keep the hand's bob.
+		 * Iris multiplies it into the projection it binds ({@code pathways/HandRenderer.java:65-70},
+		 * the damage tilt always and the walk bob under the player's own option), and a normal matrix
+		 * is never derived from a projection, so the identity is consistent with its own geometry.
+		 * This engine publishes the bob in the model view for every family, {@link CameraBob} saying
+		 * why, so the matrix a hand program reads carries it and a pair derived from it that did not
+		 * would contradict the very matrix beside it. Copying the identity across would buy Iris's
+		 * number and a pair that no longer multiplies back.
 		 * <p>
 		 * What it costs the image, measured out of game rather than argued: the hand's normals are
 		 * turned against the reference's by up to half a degree while the player walks, the walk

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -415,6 +415,26 @@ public final class EntityDraw {
 		 * frame's camera. What the stack holds while a hand pass runs is the identity, {@link
 		 * HandDraw} putting the whole of the hand's transform in the projection, so what is read
 		 * here is what the game itself would have read at that draw.
+		 * <p>
+		 * <strong>What the hand's normal matrix comes to is a DIVERGENCE, and it is this engine's
+		 * placement of the bob translated rather than Iris's line copied.</strong> Iris answers the
+		 * identity there, filling {@code iris_NormalMat} from {@code RenderSystem.getModelViewMatrix()}
+		 * ({@code pipeline/programs/ExtendedShader.java:187}) while its own hand leaves the stack at a
+		 * fresh pose ({@code pathways/HandRenderer.java:104,114-115}). What stops that answer from
+		 * being right here is where the two engines keep the hand's bob: Iris multiplies it into the
+		 * projection it binds ({@code pathways/HandRenderer.java:64-70}), and a normal matrix is never
+		 * derived from a projection, so the identity is consistent with its own geometry. This engine
+		 * publishes the bob in the model view for every family, {@link CameraBob} saying why, so the
+		 * matrix a hand program reads carries it and a normal matrix that did not would contradict the
+		 * very matrix beside it. Copying the identity across would buy Iris's number and a pair that
+		 * no longer multiplies back.
+		 * <p>
+		 * What it costs the image, measured out of game rather than argued: the hand's normals are
+		 * turned against the reference's by up to half a degree while the player walks, the walk
+		 * amplitude topping out at a tenth and the two rotations it carries being three and five
+		 * degrees of that; and by fourteen at the peak of a damage tilt, which is a handful of
+		 * frames and the widest this ever gets. Nothing at all at rest, and nothing carried over
+		 * from a portal or nausea, {@link HandDraw#bob()} keeping those two out.
 		 */
 		private Matrix4fc modelView() {
 			return hand() ? RenderSystem.getModelViewMatrixCopy() : null;
@@ -1327,10 +1347,11 @@ public final class EntityDraw {
 		// The matrix belongs to the RUN and not to the draw, which is what makes it settleable here:
 		// what varies with the draw is read out of the game's own block instead, Element.modelView
 		// saying what is left for this one. Null for everything but the hand, and written into the
-		// block a few lines down. The volume goes in beside it and comes from the same place, the
-		// pass being drawn; it is asked of HandDraw rather than carried on the row, so that the two
-		// cannot be two answers: it holds nothing between its passes.
-		RenderPipeline pipeline = program.prepare(device, element.modelView(), HandDraw.volume());
+		// block a few lines down. The bob and the volume go in beside it and come from the same
+		// place, the pass being drawn; they are asked of HandDraw rather than carried on the row, so
+		// that the two cannot be two answers: it holds neither between its passes.
+		RenderPipeline pipeline = program.prepare(device, element.modelView(), HandDraw.bob(),
+				HandDraw.volume());
 		if (pipeline == null) {
 			// Lasting, and it took a review to see it: a program that would not compile, or that
 			// declares a storage block, latches broken in GeometryProgram and never unlatches, so

--- a/common/src/main/java/dev/vitrail/render/EntityProgram.java
+++ b/common/src/main/java/dev/vitrail/render/EntityProgram.java
@@ -263,14 +263,19 @@ final class EntityProgram implements DumpedProgram {
 	 *                   piece but the hand's and null for those. It is what the derived uniforms are
 	 *                   built from and no longer what places the geometry: {@code EntityDraw.Element}
 	 *                   says why the depth nudge of a render type is not in it
+	 * @param bob        the bob that placed this piece, or null for the frame's. Only the hand passes
+	 *                   one, and it must: the projection above is built with the walk bob and the
+	 *                   damage tilt alone, so the frame's four would publish a spin the arm was never
+	 *                   drawn with
 	 * @param projection the volume the piece is drawn in, or null for the frame's. Only the hand
 	 *                   passes one, and it must: it is drawn under the head-up field of view and a
 	 *                   clip depth squeezed to an eighth, which is a matrix of its own rather than a
 	 *                   nudge of the frame's
 	 * @see GeometryProgram#prepare
 	 */
-	RenderPipeline prepare(GpuDevice device, Matrix4fc modelView, Matrix4fc projection) {
-		return this.body.prepare(device, null, modelView, null, projection);
+	RenderPipeline prepare(GpuDevice device, Matrix4fc modelView, Matrix4fc bob,
+			Matrix4fc projection) {
+		return this.body.prepare(device, null, modelView, bob, null, projection);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -260,8 +260,8 @@ public final class FrameState implements WorldState {
 	 * the pass beside its convention, and for the same reason: both are properties of where the pass
 	 * draws rather than of the frame.
 	 */
-	public void passModelView(Matrix4fc matrix) {
-		this.view.passModelView(matrix);
+	public void passModelView(Matrix4fc matrix, Matrix4fc bob) {
+		this.view.passModelView(matrix, bob);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -338,6 +338,9 @@ final class GeometryProgram {
 	/** The matrix the game pushed for this pass, or null for the frame's camera. */
 	private Matrix4fc modelView;
 
+	/** The bob that placed this pass's geometry, or null for the frame's. Only the hand sets one. */
+	private Matrix4fc bob;
+
 	/** The volume this pass is drawn in, or null for the frame's. Only the hand sets one. */
 	private Matrix4fc projection;
 
@@ -664,7 +667,7 @@ final class GeometryProgram {
 	 * @return the pipeline to draw with, or null to leave the game's own shader alone
 	 */
 	RenderPipeline prepare(GpuDevice device, GpuTextureView atlas) {
-		return prepare(device, atlas, null, null, null);
+		return prepare(device, atlas, null, null, null, null);
 	}
 
 	/**
@@ -673,13 +676,18 @@ final class GeometryProgram {
 	 * @param modelView  the matrix the game pushed for this pass, or null for the frame's camera.
 	 *                   Kept until the block is written rather than applied here: it is one value of
 	 *                   the block among the rest, and the block is written a few lines below
+	 * @param bob        the left factor that placed this pass's geometry, or null for the frame's.
+	 *                   The hand is the one family that sets it, and it sets it because it is drawn
+	 *                   under a projection built here rather than under the level's;
+	 *                   {@code ViewMatrices.passBob} says what the frame's would cost it
 	 * @param projection the volume this pass is drawn in, or null for the frame's. The hand is the
 	 *                   one family that sets it, and it is not a nudge of the frame's but a matrix
 	 *                   of its own; {@link dev.vitrail.uniform.ViewSource#passProjection} says why
 	 */
 	RenderPipeline prepare(GpuDevice device, GpuTextureView atlas, Matrix4fc modelView,
-			Vector4fc passColour, Matrix4fc projection) {
+			Matrix4fc bob, Vector4fc passColour, Matrix4fc projection) {
 		this.modelView = modelView;
+		this.bob = bob;
 		this.passColour = passColour;
 		this.projection = projection;
 		if (this.broken) {
@@ -1103,7 +1111,7 @@ final class GeometryProgram {
 		// frame now that the shadow map is ours and the game's targets are not, and what a vertex
 		// stage does with its clip depth on the way out comes from this pair.
 		this.values.convention(this.pass.shadow() ? ClipSpace.FORWARD : ClipSpace.REVERSED);
-		this.values.modelView(this.modelView);
+		this.values.modelView(this.modelView, this.bob);
 		this.values.projection(this.projection);
 		this.values.passColour(this.passColour);
 		this.values.renderStage(this.pass.stage());

--- a/common/src/main/java/dev/vitrail/render/HandDraw.java
+++ b/common/src/main/java/dev/vitrail/render/HandDraw.java
@@ -140,13 +140,24 @@ public final class HandDraw {
 	 * <strong>Without, and that is not the same as Iris's matrix.</strong> Iris multiplies the bob
 	 * into the projection it binds and leaves its model view at the identity; this engine publishes
 	 * the bob in the model view for every family, {@link CameraBob} saying why, so the hand puts it
-	 * in the same place as its neighbours. The product a pack computes,
-	 * {@code gl_ProjectionMatrix * gl_ModelViewMatrix}, is the same matrix either way for the walk
-	 * bob, which is all the device's matrix takes in. The nausea roll and the portal scale are
-	 * carried by {@code CameraBob.taken()} into the model view alone, so under those two the pack's
-	 * product bears transforms the drawn geometry does not, and with the bob untrusted it loses the
-	 * bob outright: the matrix the geometry is really drawn with is the device's, and the product
-	 * only approximates it in those states.
+	 * in the same place as its neighbours.
+	 * <p>
+	 * <strong>The product a pack computes lands on the device's matrix all the same, and the route
+	 * is not the one it looks like.</strong> A hand program does not read this engine's pass model
+	 * view at all: {@code gbuffers_hand} is one of the families
+	 * {@code LegacyGlsl.readsDrawModelView} answers for, so its {@code gl_ModelViewMatrix} is
+	 * rewritten to {@code of_CameraBob * of_GameModelView}, the second factor being what the game
+	 * wrote for that draw. That member is the identity here, {@code RenderType.writeDynamicTransforms}
+	 * copying the model view stack this class has just set to the identity, so the product comes to
+	 * {@code volume * bob} - which is {@link #drawn}, exactly. Measured out of game over eight states
+	 * of the player, and exact in every one of them.
+	 * <p>
+	 * That holds because {@link #bob()} hands the pack the same pose this class draws with, and it is
+	 * the same field: the frame's bob would carry the nausea roll and the portal scale besides, and
+	 * the arm is drawn without them. It holds on a frame this engine could not split as well, which
+	 * no other family manages: {@link CameraBob#pose()} is answered whatever the split says, so the
+	 * hand keeps a product that multiplies back while the rest of the frame falls back on the drawn
+	 * projection.
 	 */
 	private final Matrix4f volume = new Matrix4f();
 
@@ -226,6 +237,23 @@ public final class HandDraw {
 	 */
 	static Matrix4fc volume() {
 		return half == null || instance == null ? null : instance.volume;
+	}
+
+	/**
+	 * The bob the volume above was built against, or null when the hand is not being drawn, which is
+	 * the left factor a hand program is handed as {@code of_CameraBob}.
+	 * <p>
+	 * <strong>The walk bob and the damage tilt, and not the frame's four.</strong> A hand program
+	 * reads its model view out of the game's per draw block and multiplies this by it, so this factor
+	 * and {@link #drawn} have to be built from the same pose or the pack's
+	 * {@code gl_ProjectionMatrix * gl_ModelViewMatrix} stops being the matrix the device was given.
+	 * The frame's is all four effects, the nausea and the portal included, and those two are a
+	 * distortion of the world rather than of the arm: {@link CameraBob#pose()} carries why the game
+	 * leaves them out of its own hand, and Iris leaves them out of its hand's projection too
+	 * ({@code pathways/HandRenderer.java:64-70}).
+	 */
+	static Matrix4fc bob() {
+		return half == null || instance == null ? null : CameraBob.pose();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/HandDraw.java
+++ b/common/src/main/java/dev/vitrail/render/HandDraw.java
@@ -152,12 +152,14 @@ public final class HandDraw {
 	 * {@code volume * bob} - which is {@link #drawn}, exactly. Measured out of game over eight states
 	 * of the player, and exact in every one of them.
 	 * <p>
-	 * That holds because {@link #bob()} hands the pack the same pose this class draws with, and it is
-	 * the same field: the frame's bob would carry the nausea roll and the portal scale besides, and
-	 * the arm is drawn without them. It holds on a frame this engine could not split as well, which
-	 * no other family manages: {@link CameraBob#pose()} is answered whatever the split says, so the
-	 * hand keeps a product that multiplies back while the rest of the frame falls back on the drawn
-	 * projection.
+	 * That holds because {@link #bob()} hands the pack the pose this class draws with: the frame's
+	 * bob would carry the nausea roll and the portal scale besides, and the arm is drawn without
+	 * them. The two read {@link CameraBob#pose()} at two moments rather than sharing one copy, and
+	 * what makes them the same matrix is that nothing writes it in between: it is written once per
+	 * level render, from the mixin on the game's own multiplication, and both moments fall after it.
+	 * It holds on a frame this engine could not split as well, which no other family manages:
+	 * {@link CameraBob#pose()} is answered whatever the split says, so the hand keeps a product that
+	 * multiplies back while the rest of the frame falls back on the drawn projection.
 	 */
 	private final Matrix4f volume = new Matrix4f();
 
@@ -250,7 +252,8 @@ public final class HandDraw {
 	 * The frame's is all four effects, the nausea and the portal included, and those two are a
 	 * distortion of the world rather than of the arm: {@link CameraBob#pose()} carries why the game
 	 * leaves them out of its own hand, and Iris leaves them out of its hand's projection too
-	 * ({@code pathways/HandRenderer.java:64-70}).
+	 * ({@code pathways/HandRenderer.java:65-70}, the damage tilt always and the walk bob under the
+	 * player's own option, which is the game's own pair of conditions).
 	 */
 	static Matrix4fc bob() {
 		return half == null || instance == null ? null : CameraBob.pose();

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1939,7 +1939,7 @@ public final class PackChain {
 		// decoded dump beside it. The frame boundary drops them as
 		// well and that is not the same guard: it drops them at the head of the frame, and every one
 		// of those families writes after it and before this.
-		this.values.modelView(null);
+		this.values.modelView(null, null);
 		this.values.passColour(null);
 		this.values.projection(null);
 

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -195,9 +195,15 @@ public final class PackValues {
 	 * varies with the DRAW there, the depth nudge of a render type included, is read out of the
 	 * game's own per draw block instead, {@code LegacyGlsl.readsDrawModelView} saying which passes
 	 * and why.
+	 * <p>
+	 * The bob comes with it rather than beside it, and the hand is again the one family that hands
+	 * one in: it is drawn under a projection this engine builds, and built with the walk bob and the
+	 * damage tilt alone. See {@code ViewMatrices.passBob}.
+	 *
+	 * @param bob the left factor this pass's geometry was really placed by, or null for the frame's
 	 */
-	public void modelView(Matrix4fc matrix) {
-		this.state.passModelView(matrix);
+	public void modelView(Matrix4fc matrix, Matrix4fc bob) {
+		this.state.passModelView(matrix, bob);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ParticleProgram.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleProgram.java
@@ -117,7 +117,7 @@ final class ParticleProgram implements DumpedProgram {
 		// No model view of its own and no colour: the renderer writes its transform from
 		// RenderSystem.getModelViewMatrixCopy(), which is the frame's camera, and through the one
 		// argument overload, whose modulator is white.
-		return this.body.prepare(device, null, null, null, null);
+		return this.body.prepare(device, null, null, null, null, null);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/SkyProgram.java
+++ b/common/src/main/java/dev/vitrail/render/SkyProgram.java
@@ -115,7 +115,7 @@ final class SkyProgram implements DumpedProgram {
 	 * @see GeometryProgram#prepare
 	 */
 	RenderPipeline prepare(GpuDevice device, Matrix4fc modelView, Vector4fc colour) {
-		return this.body.prepare(device, null, modelView, colour, null);
+		return this.body.prepare(device, null, modelView, null, colour, null);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -105,6 +105,25 @@ public final class ViewMatrices implements ViewSource {
 	 */
 	private final Matrix4f bob = new Matrix4f();
 
+	/**
+	 * The bob of the pass being drawn, for the one family whose geometry is not placed by the
+	 * frame's, standing empty until a pass sets one and dropped at the same boundary the pass matrix
+	 * is.
+	 * <p>
+	 * <strong>The hand, and only the hand, and the difference is the nausea and the portal.</strong>
+	 * The frame's bob is all four effects, since all four are in the projection the level was drawn
+	 * with; the hand is drawn under a projection this engine builds itself, and it builds it with
+	 * {@link CameraBob#pose()}, the walk bob and the damage tilt alone, because that is the pose the
+	 * game gives its own hand and the pose Iris gives its own
+	 * ({@code pathways/HandRenderer.java:64-70}, a bob stack of {@code bobHurt} and {@code bobView}
+	 * multiplied into the hand's projection and nothing else). Handing the frame's four to a hand
+	 * program would publish a spin the arm was never drawn with: measured out of game, the product
+	 * a hand program forms lands 0.34 away from the matrix the device was given under a full portal,
+	 * where the walk and the tilt leave it exact.
+	 */
+	private final Matrix4f passBob = new Matrix4f();
+	private boolean passBobSet;
+
 	/** The colour the pass modulates its draw by, white until a pass says otherwise. */
 	private final Vector4f passColour = new Vector4f(1.0F, 1.0F, 1.0F, 1.0F);
 	private float far;
@@ -170,6 +189,7 @@ public final class ViewMatrices implements ViewSource {
 		// the only reader left holding a stale one being the decoded dump, and that is said where
 		// the dump is taken.
 		this.passSet = false;
+		this.passBobSet = false;
 		this.passProjectionSet = false;
 		this.passColour.set(1.0F, 1.0F, 1.0F, 1.0F);
 
@@ -269,11 +289,29 @@ public final class ViewMatrices implements ViewSource {
 	 * <p>
 	 * The frame that could not be split is right for free: {@link CameraBob#taken()} answers the
 	 * identity then, and the projection published is the one the level was drawn with, bob included.
+	 * <p>
+	 * <strong>Which bob goes on the front is the pass's to say</strong>, and the two arrive in one
+	 * call so that neither can be read against the other one's. {@link #passBob} carries why the
+	 * hand's is not the frame's; every other pass hands in nothing and is multiplied by the frame's,
+	 * as it always was.
+	 * <p>
+	 * A bob without a matrix is dropped rather than kept, and that is the conservative half of the
+	 * pair: a pass with no matrix of its own is drawn under the frame's camera, which the frame's own
+	 * bob is the left factor of. Taking one there would publish a bob against a matrix it did not
+	 * place.
+	 *
+	 * @param matrix the matrix the game drew this pass with, or null for the frame's camera
+	 * @param bob    the left factor that geometry was really placed by, or null for the frame's
 	 */
-	void passModelView(Matrix4fc matrix) {
+	void passModelView(Matrix4fc matrix, Matrix4fc bob) {
 		this.passSet = matrix != null;
+		this.passBobSet = this.passSet && bob != null;
+		if (this.passBobSet) {
+			this.passBob.set(bob);
+		}
+
 		if (this.passSet) {
-			this.passModelView.set(this.bob).mul(matrix);
+			this.passModelView.set(cameraBob()).mul(matrix);
 			this.passModelView.invert(this.passModelViewInverse);
 		}
 	}
@@ -349,16 +387,17 @@ public final class ViewMatrices implements ViewSource {
 	}
 
 	/**
-	 * The bob on its own, which is the left factor {@link #passModelView(Matrix4fc)} multiplies every
-	 * pass matrix onto.
+	 * The bob on its own, which is the left factor {@link #passModelView(Matrix4fc, Matrix4fc)}
+	 * multiplies every pass matrix onto.
 	 * <p>
 	 * The same field that multiplication reads, so the two cannot say different things: a shader
 	 * forming {@code cameraBob() * m} gets exactly what handing {@code m} in would have stored, which
-	 * is the whole point of publishing it.
+	 * is the whole point of publishing it. The pass's own when it set one, {@link #passBob} saying
+	 * which pass that is.
 	 */
 	@Override
 	public Matrix4fc cameraBob() {
-		return this.bob;
+		return this.passBobSet ? this.passBob : this.bob;
 	}
 
 	@Override

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -115,10 +115,11 @@ public final class ViewMatrices implements ViewSource {
 	 * with; the hand is drawn under a projection this engine builds itself, and it builds it with
 	 * {@link CameraBob#pose()}, the walk bob and the damage tilt alone, because that is the pose the
 	 * game gives its own hand and the pose Iris gives its own
-	 * ({@code pathways/HandRenderer.java:64-70}, a bob stack of {@code bobHurt} and {@code bobView}
-	 * multiplied into the hand's projection and nothing else). Handing the frame's four to a hand
-	 * program would publish a spin the arm was never drawn with: measured out of game, the product
-	 * a hand program forms lands 0.34 away from the matrix the device was given under a full portal,
+	 * ({@code pathways/HandRenderer.java:65-70}, a bob stack of {@code bobHurt} and, under the
+	 * player's own option, {@code bobView}, multiplied into the hand's projection and nothing else).
+	 * Handing the frame's four to a hand program would publish a spin the arm was never drawn with,
+	 * and a hand program writes its clip position through this factor: measured out of game, the
+	 * product it forms lands 0.34 away from the matrix the device was given under a full portal,
 	 * where the walk and the tilt leave it exact.
 	 */
 	private final Matrix4f passBob = new Matrix4f();

--- a/common/src/main/java/dev/vitrail/render/WeatherProgram.java
+++ b/common/src/main/java/dev/vitrail/render/WeatherProgram.java
@@ -118,7 +118,7 @@ final class WeatherProgram implements DumpedProgram {
 		// No model view of its own and no colour: the renderer writes its transform from
 		// RenderSystem.getModelViewMatrixCopy(), which is the frame's camera, and through the one
 		// argument overload, whose modulator is white.
-		return this.body.prepare(device, null, null, null, null);
+		return this.body.prepare(device, null, null, null, null, null);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/uniform/ViewSource.java
+++ b/common/src/main/java/dev/vitrail/uniform/ViewSource.java
@@ -58,7 +58,12 @@ public interface ViewSource {
 	 * {@link dev.vitrail.glsl.LegacyGlsl#CAMERA_BOB} carries why the factor has to be a name.
 	 * <p>
 	 * The identity on a frame this engine could not split, exactly as the pass matrix is then the
-	 * game's own.
+	 * game's own. <strong>The hand is the exception to that sentence and to the one above.</strong>
+	 * It is not placed by the frame's matrix at all, being drawn under a projection this engine
+	 * builds, so it hands in the pose that projection was built with and is answered that;
+	 * {@code dev.vitrail.render.ViewMatrices.passBob} carries which effects that pose leaves out and
+	 * why. It is answered whatever the split says, too, so a hand program keeps a product that
+	 * multiplies back on a frame where nothing else does.
 	 */
 	Matrix4fc cameraBob();
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -236,6 +236,10 @@ is already mid-frame at both of those moments and refuses to be re-entered. And 
 copy above in two, since from the moment the hand is in the world's depth a pack asking what lies
 behind it has to be given the depth from before it was drawn.
 
+A projection of its own also means a walk bob of its own, since the bob a pack reads is the one that
+placed the geometry and the hand's is not the frame's. That is
+[in the bob's own section](internals/terrain.md#the-view-bob-is-in-the-projection-and-packs-expect-it-in-the-model-view).
+
 ## Why a family cannot simply be switched over
 
 There is a trap here that looks like an easy win and is a regression, and it explains the shape of

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -337,6 +337,19 @@ interception has no counterpart here, which is just as well: the method it wraps
 shape in this version of the game, and a patch descriptor that no longer matches its target fails
 silently when injectors are not required.
 
+One family is not placed by that matrix and therefore does not read it: the player's own hand, which
+is drawn under a projection the engine builds rather than under the level's. The game builds the
+hand's pose out of the walk bob and the damage tilt alone, leaving the nausea and the portal out on
+purpose, since those two distort the world and not the arm; so the hand is handed that pose as its
+bob, and everything else the frame's. Handed the frame's, a hand program would form a product
+carrying a spin the arm was never drawn with, and the item in the player's grip would swim inside a
+portal while the arm holding it stayed put. What the hand's normals then come to is the one place
+this engine is knowingly not the reference's number, and the reason is the placement above rather
+than a choice: the reference keeps the hand's bob in a projection, where a normal matrix never
+reaches, and here it is in the model-view the same program reads, so a normal matrix ignoring it
+would contradict the matrix beside it. The gap is a fraction of a degree while walking and its
+widest at the peak of a damage tilt.
+
 Because the whole thing rests on having intercepted *every* operation that touches the projection,
 it carries its own witness. Each frame, the clean projection is multiplied back by the accumulated
 bob and compared against the matrix captured on its way to the device. If the game ever multiplies in

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -341,14 +341,17 @@ One family is not placed by that matrix and therefore does not read it: the play
 is drawn under a projection the engine builds rather than under the level's. The game builds the
 hand's pose out of the walk bob and the damage tilt alone, leaving the nausea and the portal out on
 purpose, since those two distort the world and not the arm; so the hand is handed that pose as its
-bob, and everything else the frame's. Handed the frame's, a hand program would form a product
-carrying a spin the arm was never drawn with, and the item in the player's grip would swim inside a
-portal while the arm holding it stayed put. What the hand's normals then come to is the one place
-this engine is knowingly not the reference's number, and the reason is the placement above rather
-than a choice: the reference keeps the hand's bob in a projection, where a normal matrix never
-reaches, and here it is in the model-view the same program reads, so a normal matrix ignoring it
-would contradict the matrix beside it. The gap is a fraction of a degree while walking and its
-widest at the peak of a damage tilt.
+bob, and everything else the frame's. Handed the frame's, a hand program forms a product carrying a
+spin the arm was never drawn with, and that product is what a pack writes the hand's clip position
+through: the whole hand turns and stretches with the screen inside a portal, where it should hold
+still in front of the camera.
+
+What the two quantities *derived* from the hand's model-view then come to, its inverse and its
+normal matrix, is the one place this engine is knowingly not the reference's number. The reason is
+the placement above rather than a choice: the reference keeps the hand's bob in a projection, where
+neither of those two ever reaches, and here it is in the model-view the same program reads, so a
+pair derived from it that ignored the bob would contradict the matrix beside it. The gap is a
+fraction of a degree while walking and at its widest at the peak of a damage tilt.
 
 Because the whole thing rests on having intercepted *every* operation that touches the projection,
 it carries its own witness. Each frame, the clean projection is multiplied back by the accumulated


### PR DESCRIPTION
## What changes

The player's hand is drawn under a projection this engine builds itself, and it builds it with the
walk bob and the damage tilt alone, leaving the nausea roll and the portal skew out because those
distort the world and not the arm. What a hand program was handed as `of_CameraBob` was the frame's
bob instead, which carries all four. That factor is not decoration: a hand program writes its clip
position through it, so inside a portal or under nausea the whole hand turned and stretched along
with the screen where it should have held still in front of the camera, and everything derived from
the hand's model view turned with it. A pass now hands in its bob beside its matrix, in one call so
neither can be read against the other one's, and the hand is the only family that hands one in.

## How it differs from the reference, and for what obstacle

The two quantities derived from the hand's model view do: `gl_ModelViewMatrixInverse` and
`gl_NormalMatrix`. They are one divergence and not two, both coming off the same matrix through
`of_ModelViewMatrixInverse` and `of_NormalMatrix` in `GeometryValues`. Iris answers the identity to
both, filling `iris_ModelViewMatInverse` and `iris_NormalMat` from
`RenderSystem.getModelViewMatrix()` (`pipeline/programs/ExtendedShader.java:183` and `:188`) while
its own hand leaves a fresh pose on the stack (`pathways/HandRenderer.java:104,114-115`). What makes
that answer wrong here is where each engine keeps the hand's bob. Iris multiplies it into the
projection it binds (`pathways/HandRenderer.java:65-70`), and neither of those two is ever derived
from a projection, so its identity is consistent with its own geometry. This engine publishes the
bob in the model view for every family (`common/src/main/java/dev/vitrail/render/CameraBob.java`),
so the matrix a hand program reads carries it and a pair derived from it that did not would
contradict the matrix beside it; `EntityDraw.Element.modelView` holds the argument. It costs up to
half a degree of normal while walking and 14.4 at the peak of a damage tilt, which is a handful of
frames, and nothing at rest.

## What proves it

- `gradlew build` green.
- The out-of-game harness, `Bloc`, over eight states of the player with the bob built by the game's
  own formula. The two-engine bench cannot answer this at all: it pins the camera every tick, so its
  bob is the identity and both readings collapse onto what they are compared with. Before: the
  product stood 0.16 and 0.34 from the device's matrix under nausea and a portal, and the normals
  turned 27 and 36 degrees. After: the product is exact in all eight, and the normal matrix agrees
  with the model view published beside it in all eight.
- One reviewer against Iris and the game's own source, on every claim the branch makes. Four of them
  were wrong and the last commit is the correction, the symptom above included.
- Not looked at in the game. It only shows while walking, hurt or in a portal.

## What it leaves owing

Nothing on this family. The divergence above is written down rather than left open.
