### PR TITLE
Raise the version to 0.3.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,19 @@ what the next one holds.
 
 ### Changed
 
+- **Mobs, block entities, the enchantment shine and the player's hand are now painted into the
+  pack's own images**, where before their colour reached the pack through the game's, eight bits a
+  channel. Packs that pack two values into each channel of a wider image were reading one back in
+  place of the other: under Bliss an enderman came out lit instead of black.
 - The line each program prints at its first draw now names the image it really samples where the
   pack asks for the atlas, so a picture that disagrees with the wiring can be told apart from one
   that agrees with it.
 
 ### Fixed
 
+- The enchantment shine is no longer dropped by packs that draw it into an image of their own. It
+  was being refused outright, on a question that only applies to the pieces whose colour still
+  travels through the game.
 - Picking None while a pack is drawing no longer leaves the terrain in stretched coloured spikes
   until the game is restarted. The world was being drawn through a pipeline built for the wider
   vertex the pack needs, over a mesh that had already gone back to the narrower one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ plus, because each of them files an upload per loader and has nowhere else to pu
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.3.0-alpha.1
 
 ### Changed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.2.0-alpha.1
+mod_version=0.3.0-alpha.1
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

Nothing the engine does. The changelog gains the three batches that moved the mobs, the block
entities, the enchantment shine and the hand into the pack's own images and left no line behind,
which is the largest visible change since the second loader; then `Unreleased` becomes
`0.3.0-alpha.1` and `mod_version` follows it.

## How it differs from the reference, and for what obstacle

It does not. No engine line is touched.

## What proves it

- `gradlew build` green, and both jars come out under the new name,
  `vitrail-neoforge-0.3.0-alpha.1+mc26.2.jar` and `vitrail-fabric-0.3.0-alpha.1+mc26.2.jar`.
- The tag and `mod_version` are compared by `release.yml` before anything is uploaded, so the pair
  above is what makes `v0.3.0-alpha.1` publishable at all.

## What it leaves owing

Nothing. The tag is pushed after this reaches `main`, and it is the tag that publishes.
