### PR TITLE
Give the release its own template, and check the prefix after the fact

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,65 @@
+<!--
+The template for the ONE pull request that targets `main`. Open it with
+
+    gh pr create --base main --head dev --template release.md
+
+or by adding `?template=release.md` to the compare URL. Every other pull request targets `dev` and
+uses the default template, which asks what a batch changes; this one asks nothing of the sort,
+because a release changes nothing. Everything in it has already entered `dev` through a pull request
+of its own, and been reviewed there.
+
+**DO NOT PRESS A MERGE BUTTON ON THIS ONE.** All three rewrite, and `main` is already an ancestor of
+`dev`, so replaying `dev` onto it hands `main` a second copy of every commit under a fresh hash.
+What merges this is a fast-forward from a terminal,
+
+    git push origin origin/dev:main
+
+and the pull request closes itself as merged once its commits are on `main`. The tag goes on after
+that and never before it, because the tag is what publishes.
+-->
+
+## What this publishes
+
+<!--
+One paragraph, for somebody reading the release later and not for the reviewer: what a player gets
+that they did not have. Not a commit list, the changelog already is one.
+-->
+
+## The version
+
+- Tag: `v`
+- `mod_version` in `gradle.properties`:
+- The changelog section is named after it, and `Unreleased` is gone or empty.
+
+<!--
+The tag and `mod_version` are one number written twice, and `release.yml` compares them before it
+uploads anything. A disagreement stops the run, which is the one mistake that would otherwise ship a
+jar under a version nothing inside it agrees with.
+-->
+
+## What the release carries that no changelog entry names
+
+<!--
+The question this template exists for. Read `git log origin/main..origin/dev` against the section
+you just named, batch by batch. A batch that changed the picture and left no line here ships mute,
+and the entity door did exactly that: three batches moved the mobs, the shine and the hand into the
+pack's own images without a single line, and it was caught by looking at the range and not at the
+last branch. "Nothing" is the answer you want, and it is worth having checked.
+-->
+
+## What proves it
+
+<!--
+- `gradlew build` green on `dev` at the commit being tagged, not on a branch before it.
+- Anything looked at in the game since the last release, with the pack and the place.
+- Say plainly what has NOT been looked at. A pre-release is allowed to carry that; a silent one is
+  not.
+-->
+
+---
+
+- [ ] `main` is an ancestor of `dev`, so this merges by fast-forward.
+- [ ] `gradlew build` green locally on the commit being tagged.
+- [ ] The changelog section is named after the tag, and the range was read against it.
+- [ ] Merged by fast-forward from a terminal, and by no button.
+- [ ] The tag is pushed only once its commits are on `main`, because the tag is what publishes.

--- a/.github/workflows/prefix.yml
+++ b/.github/workflows/prefix.yml
@@ -1,0 +1,56 @@
+# `main` is an exact prefix of `dev`, and this is what says so out loud when it stops being one.
+#
+# The rule it guards is in CONTRIBUTING: everything enters `dev` by a pull request merged with the
+# rebase button, and `dev` reaches `main` by a FAST-FORWARD and by no button. The reason is that all
+# three merge buttons rewrite. `main` is already an ancestor of `dev`, so replaying `dev` onto it
+# would give `main` a second copy of every commit under a fresh hash, and the two branches would
+# then hold the same work under two histories.
+#
+# **Nothing on GitHub can prevent that press.** Which merge buttons a repository offers is a
+# repository-wide setting, not a per-target one, and the button `dev` needs for a topic branch is
+# the very button that is wrong here. So this is detection and not prevention: the wrong gesture is
+# caught within a minute of the push rather than at the next release, while the branch can still be
+# reset onto `dev` without anything having been built on top of it.
+#
+# The gesture it is guarding is one line, `git push origin origin/dev:main`, and the pull request
+# closes itself as merged once its commits are there.
+
+name: prefix
+
+on:
+  push:
+    branches:
+      - main
+  # For a state settled by hand, so the answer can be asked again without an empty commit.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Take both long-lived branches
+        uses: actions/checkout@v4
+        with:
+          # The whole history, since the question is about an ancestry that reaches back to the
+          # first commit. A shallow clone answers "not an ancestor" for a graft it simply cannot see.
+          fetch-depth: 0
+
+      - name: main is an ancestor of dev
+        run: |
+          git fetch --no-tags origin +refs/heads/dev:refs/remotes/origin/dev
+          if git merge-base --is-ancestor "$GITHUB_SHA" origin/dev; then
+            echo "main is contained in dev, so it is still an exact prefix of it."
+            exit 0
+          fi
+
+          echo "::error::main carries commits that dev does not, so it has stopped being an exact"
+          echo "::error::prefix of dev. That is what a merge button does to this pair: it replays"
+          echo "::error::dev's commits under fresh hashes instead of moving the pointer. Reset main"
+          echo "::error::onto dev with a fast-forward before anything else lands on it."
+          echo
+          echo "On main and not on dev:"
+          git log --oneline origin/dev.."$GITHUB_SHA"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,22 @@ work under two histories. A pull request is still the right place to look at a r
 record and for the checks it runs; what merges it is the fast-forward, and the pull request closes
 itself as merged once its commits are on `main`.
 
+    git push origin origin/dev:main
+
+**That pull request has a template of its own**, `.github/PULL_REQUEST_TEMPLATE/release.md`, opened
+with `gh pr create --base main --head dev --template release.md`. It asks nothing the default one
+asks: a release changes nothing by itself, everything in it having entered `dev` through a pull
+request of its own. What it asks instead is the version in both the places it is written, and one
+question no command can answer, whether the range about to be published carries a batch that changed
+the picture and left no changelog line. That is not hypothetical.
+
+**Nothing on GitHub can refuse the wrong press**, which is worth knowing rather than assuming: the
+merge buttons a repository offers are a repository-wide setting, and the rebase button this forbids
+here is the one a topic branch needs. So `prefix.yml` checks after the fact instead, on every push
+to `main`, that `main` is still contained in `dev`, and fails loudly within a minute when it is not.
+Recovering from it is a reset of `main` back onto `dev`, and it is cheap for exactly as long as
+nothing has been built on top.
+
 **Every batch enters that way, including one written by whoever owns the repository.** Folding a
 branch in locally skips the one thing the pull request is for: `build.yml` runs on `pull_request`,
 so a batch that goes in by hand is built only once it is already in `dev`, and a red build then


### PR DESCRIPTION
## What changes

Nothing the engine does. A second pull request template, for the one pull request that targets `main`, and a workflow that checks after every push to `main` that it is still contained in `dev`. `CONTRIBUTING.md` names both and says why the check is after the fact rather than before.

## How it differs from the reference, and for what obstacle

It does not. No engine line is touched.

## What proves it

- `gradlew build` green.
- The gesture the template describes is the one that merged 0.3.0-alpha.1 an hour ago, and the pull request closed itself as merged, which is the behaviour the template relies on.
- `prefix.yml` carries a `workflow_dispatch`, so its answer can be asked without waiting for a release.

## What it leaves owing

Prevention. GitHub offers merge buttons per repository and not per target branch, so the wrong press stays possible and is caught within a minute instead of being refused.