### PR TITLE
Draw the breeze's wind and the energy swirl with the pack's own program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ plus, because each of them files an upload per loader and has nowhere else to pu
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Added
+
+- **The wind a breeze throws and the swirl over a charged creeper are painted by the pack now**,
+  where the game kept its own shader for both. What held them back is a texture matrix of the
+  game's own that scrolls them, and that matrix is answered out of the game's transforms now, so a
+  breeze scrolls rather than sitting frozen on one frame of its offset and two breezes on screen
+  keep their own. The swirl writes every image the pack declares for its entities: on five of the
+  eight packs tested that is between two and four images rather than the single one it would
+  otherwise have reached.
+
 ## 0.3.0-alpha.1
 
 ### Changed

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -119,7 +119,8 @@ public final class ChainPlan {
 					new NamedProgram("gbuffers_block", false, false, Families::entities),
 					// The blending half of those same two, on the far side of the stage: the game
 					// draws them among its translucent features, which is after the deferreds have
-					// run. Four entries and not two because the side is half the key.
+					// run. Five entries for four names because the side is half the key, and the
+					// entry below says which name is here twice and why.
 					//
 					// A name that never enters this list answers empty, and empty is the same word
 					// this table uses for a walk it REFUSED, so the caller cannot tell the two
@@ -128,6 +129,21 @@ public final class ChainPlan {
 					new NamedProgram("gbuffers_entities_translucent", true, false,
 							Families::entities),
 					new NamedProgram("gbuffers_block_translucent", true, false, Families::entities),
+					// The OPAQUE entity name on the far side, which reads like a contradiction and is
+					// the energy swirl over a charged creeper: Iris pins that row to ENTITIES_CUTOUT
+					// outright (pipeline/IrisPipelines.java:60) while the game blends it, so it is
+					// drawn among the translucent features and still asks for gbuffers_entities. It is
+					// the one row of render/EntityDraw whose name and side disagree, and no other walk
+					// reaches that pair: the two entries above ask for the blending names, and the
+					// opaque entry asks on the near side.
+					//
+					// Not counted, on the hand's argument rather than the entities': the family this
+					// key answers for is one row, and a swirl is drawn where somebody has charged a
+					// creeper or armoured a wither, which is a per frame answer no per place map may
+					// carry. Where a pack ships no gbuffers_entities_translucent of its own the
+					// blending name falls back on this very file, and that entry counts it; three
+					// packs of the corpus are in that case and this entry moves nothing for them.
+					new NamedProgram("gbuffers_entities", true, false, NOT_EVERYWHERE),
 					// The hand's two passes, which straddle the stage as the particles do and for the
 					// same kind of reason: the solid one is drawn among the game's opaque features and
 					// the blending one at the end of the level. Not counted, and not by a switch:
@@ -210,9 +226,10 @@ public final class ChainPlan {
 	 * <p>
 	 * One table for every family rather than one per family, which is what lets a family that does
 	 * not exist yet ask the same question: the terrain asks it three times, the sky three times, and
-	 * the entities once per FILE AND SIDE that serves them. Their pieces ask under four names, two
-	 * per side, and those four collapse onto fewer keys wherever the fallback tree lands two of them
-	 * on one program - but never across the sides, the side being half the key.
+	 * the entities once per FILE AND SIDE that serves them. Their pieces ask under four names, two on
+	 * the near side and three on the far one, {@code gbuffers_entities} being asked on both, and those
+	 * five collapse onto fewer keys wherever the fallback tree lands two of them on one program - but
+	 * never across the sides, the side being half the key.
 	 * What differs between families is only how they reach a key, and that is the two tables below
 	 * plus {@link #geometryOf} for whoever needs neither.
 	 * <p>
@@ -623,7 +640,8 @@ public final class ChainPlan {
 
 	/**
 	 * The same walk for every geometry program asked for by name, which is the sky's three, the four
-	 * entity names, the hand's two, the glint on both sides, the weather and the two particle halves.
+	 * entity names with the opaque one on both sides, the hand's two, the glint on both sides, the
+	 * weather and the two particle halves.
 	 * <p>
 	 * The names are the OptiFine split and they are not ours to choose: untextured sky geometry goes
 	 * to {@code gbuffers_skybasic}, the sun and the moon to {@code gbuffers_skytextured}, the clouds

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -486,8 +486,10 @@ public final class EntityDraw {
 	 * {@code pipeline/IrisPipelines.java:60,61,62}, all three {@code ShaderKey.ENTITIES_CUTOUT}. It is
 	 * the assignment being a CONSTANT that pins them: {@code getSolid}, {@code getCutout} and
 	 * {@code getTranslucent} are where the phase is consulted ({@code :191-218}), and a row that never
-	 * reaches one of the three cannot be moved by a phase. Two of them draw block entities in this
-	 * game, the end crystal beam and the offset cutout, and the third is the energy swirl.
+	 * reaches one of the three cannot be moved by a phase. ONE of them draws block entities in this
+	 * game, the offset cutout, which a skull reaches through {@code SkullBlockRenderer:140}; the end
+	 * crystal beam has only entity renderers ({@code EnderDragonRenderer.java:38}) and the swirl only
+	 * an entity layer ({@code EnergySwirlLayer.java:30}), so their twins are rows nobody selects.
 	 * <p>
 	 * <strong>Read as a list here and not as a blend, and the swirl is why.</strong> It is the one row
 	 * of the table that blends and still asks for the writing half's name; asking the blend first,
@@ -582,8 +584,9 @@ public final class EntityDraw {
 		put(new Element(RenderPipelines.END_CRYSTAL_BEAM, "crystal_beam", ENTITIES, CUTOUT));
 		put(new Element(RenderPipelines.ITEM_CUTOUT, "item", ENTITIES, CUTOUT));
 
-		// The blending run. Every one of them reaches Iris through getTranslucent, which is one
-		// function and not six rows: pipeline/IrisPipelines.java:35,36,38,39,55,83.
+		// The blending run. All of them but the swirl reach Iris through getTranslucent, which is one
+		// function and not seven rows: pipeline/IrisPipelines.java:35,36,38,39,55,56,83. The swirl is
+		// the exception and the comment on its own row says what it is pinned to instead.
 		put(new Element(RenderPipelines.ENTITY_TRANSLUCENT, "translucent", ENTITIES_TRANSLUCENT,
 				CUTOUT));
 		put(new Element(RenderPipelines.ENTITY_TRANSLUCENT_CULL, "translucent_cull",
@@ -665,8 +668,9 @@ public final class EntityDraw {
 	static {
 		// Derived from the table above, which Java has already run: static initialisers go in source
 		// order. One row per row and no filter, so this table cannot be missing the pipeline some
-		// block entity turns out to use. Two of the rows it makes are unreachable by any block entity
-		// renderer of the game, the item and the end crystal beam, and they are made anyway: a row
+		// block entity turns out to use. Four of the rows it makes are unreachable by any block entity
+		// renderer of the game - the item, the end crystal beam, the breeze's wind and the energy
+		// swirl, the last three having only entity renderers and layers - and they are made anyway: a row
 		// too many is a compiled module nobody selects, a row too few is the skull defect again, and
 		// only one of those two is visible on screen.
 		ELEMENTS.values().stream()
@@ -695,7 +699,6 @@ public final class EntityDraw {
 	 * ({@code pipeline/IrisPipelines.java:212-222}), so every other blending twin is
 	 * {@code gbuffers_block_translucent} and the tenth is already what its mob row carries.
 	 */
-	@SuppressWarnings("ReferenceEquality")
 	private static Element blockTwin(Element mob) {
 		if (PINNED.contains(mob.pipeline())) {
 			return new Element(mob.pipeline(), "block_" + mob.element(), mob.program(),
@@ -1142,7 +1145,7 @@ public final class EntityDraw {
 	 * Records one draw of a feature group with the pack's own program, or answers no and leaves it to
 	 * the game.
 	 * <p>
-	 * No is the ordinary answer and covers everything from text to particles: the table holds sixteen
+	 * No is the ordinary answer and covers everything from text to particles: the table holds eighteen
 	 * pipelines and the game has a hundred. What matters about a no is that it closes the pass this
 	 * was recording into, since the caller is about to open one of its own for the same draw and the
 	 * two would overlap.

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -105,9 +105,9 @@ import java.util.stream.Stream;
  * {@link FeatureLayer} carries it, with what Iris does instead and what it costs the image.
  * <p>
  * <strong>What is still the game's inside this window</strong>, and therefore still goes to that
- * layer, is the eyes ({@code EYES} and {@code ENTITY_TRANSLUCENT_EMISSIVE}), the beacon beam, the
- * text of a name plate or a sign, and the two pipelines {@link #WITHHELD} names. The shadow map is a
- * family of its own and is NOT in either window, a pass of its own that neither bracket reaches.
+ * layer, is the eyes ({@code EYES} and {@code ENTITY_TRANSLUCENT_EMISSIVE}), the beacon beam, and
+ * the text of a name plate or a sign. The shadow map is a family of its own and is NOT in either
+ * window, a pass of its own that neither bracket reaches.
  * <p>
  * <strong>An enchantment's glint comes in by this same door and is alone in it</strong>, in two ways
  * that are one: it is the only piece served here that is not drawn from an entity mesh, and the only
@@ -479,34 +479,31 @@ public final class EntityDraw {
 	private static final AlphaTest CUTOUT = AlphaTest.ONE_TENTH;
 
 	/**
-	 * The two pipelines of the blending half this engine leaves to the game, and the one reason it
-	 * leaves them.
+	 * The three pipelines Iris assigns a program to OUTRIGHT rather than through one of the three
+	 * functions the block entity and hand phases are read inside, and which therefore keep the entity
+	 * program whatever is being drawn.
 	 * <p>
-	 * Both are drawn with a render type carrying a {@code TextureTransform} of the game's own, an
-	 * {@code OffsetTextureTransform} built afresh per frame from the offsets the breeze and the swirl
-	 * are animated by ({@code rendertype/RenderTypes.java:524,536}); every other render type of this
-	 * family leaves it at {@code DEFAULT_TEXTURING}. That matrix is what a pack multiplies
-	 * {@code gl_MultiTexCoord0} by, and it is one of the six sites in the whole game that set one,
-	 * the four glints being the others.
+	 * {@code pipeline/IrisPipelines.java:60,61,62}, all three {@code ShaderKey.ENTITIES_CUTOUT}. It is
+	 * the assignment being a CONSTANT that pins them: {@code getSolid}, {@code getCutout} and
+	 * {@code getTranslucent} are where the phase is consulted ({@code :191-218}), and a row that never
+	 * reaches one of the three cannot be moved by a phase. Two of them draw block entities in this
+	 * game, the end crystal beam and the offset cutout, and the third is the energy swirl.
 	 * <p>
-	 * <strong>The matrix is no longer what withholds them.</strong> A pack's
-	 * {@code gl_TextureMatrix[0]} is answered from the game's own transforms, per draw, which is
-	 * Iris's answer as well ({@code transform/transformer/VanillaCoreTransformer.java:86}), so a
-	 * breeze served today would be animated rather than frozen and two breezes on screen would hold
-	 * their own offsets. What is left is the row, and it is not one row.
+	 * <strong>Read as a list here and not as a blend, and the swirl is why.</strong> It is the one row
+	 * of the table that blends and still asks for the writing half's name; asking the blend first,
+	 * which is what {@link #blockTwin} used to do, would give it {@code gbuffers_block_translucent}
+	 * where Iris keeps {@code gbuffers_entities}.
 	 * <p>
-	 * <strong>They are not one row when they come back.</strong> The breeze is a {@code getTranslucent}
-	 * row ({@code pipeline/IrisPipelines.java:56}), so it belongs with the six below; the swirl is
-	 * pinned to {@code ENTITIES_CUTOUT} ({@code :60}), which is {@code ProgramId.Entities}, so it asks
-	 * for the OPAQUE {@code gbuffers_entities} even though the game blends it. Whoever serves it will
-	 * be adding a blending row that asks for the writing half's name, which no row here does. That is
-	 * work not done, and it is the whole of what these two are still waiting on.
+	 * <strong>The hand does not read this list, and that is a divergence this engine already
+	 * had.</strong> Iris's hand override lives in the same three functions, so a pinned row keeps the
+	 * entity program in a hand pass too, where {@link #twins} gives every row a hand program. Nothing
+	 * of it reaches the screen: none of the three can be submitted by the hand, which carries the arm
+	 * and what it holds, so those twins are compiled modules nobody selects.
 	 */
-	private static final Map<RenderPipeline, String> WITHHELD = Map.of(
-			RenderPipelines.BREEZE_WIND, "it would be an ordinary translucent row, which is what Iris "
-					+ "makes of it, and that row has simply not been written",
-			RenderPipelines.ENERGY_SWIRL, "it needs a row no other one here has, asking for the "
-					+ "writing half's program while the game blends it, which is what Iris does with it");
+	private static final Set<RenderPipeline> PINNED = Set.of(
+			RenderPipelines.END_CRYSTAL_BEAM,
+			RenderPipelines.ENTITY_CUTOUT_Z_OFFSET,
+			RenderPipelines.ENERGY_SWIRL);
 
 	/**
 	 * Every pipeline the game draws entity geometry with, and nothing else.
@@ -520,8 +517,7 @@ public final class EntityDraw {
 	 * the EYES family, which Iris serves with {@code gbuffers_spidereyes} through
 	 * {@code ENTITIES_EYES} and {@code ENTITIES_EYES_TRANS}
 	 * ({@code pipeline/IrisPipelines.java:52,53}). That family is not here yet, so the game draws it
-	 * and {@link FeatureLayer} carries it in. {@link #WITHHELD} names the other two left out, for a
-	 * reason of their own. Each row that is here is a piece of
+	 * and {@link FeatureLayer} carries it in. Each row that is here is a piece of
 	 * its own even where two ask for the same program at the same threshold, which is how the sky is
 	 * six pieces out of three files: they differ in what {@link Element} reads off them, and a piece
 	 * is one compiled module.
@@ -556,7 +552,12 @@ public final class EntityDraw {
 	 * is clipped where it crosses it. Iris clips it too, and a pack writing its own
 	 * {@code alphaTest} directive settles it for both.
 	 * <p>
-	 * <strong>Two rows Iris serves are missing on purpose</strong> and are named in {@link #WITHHELD}.
+	 * <strong>The last two rows of that run are the only ones whose texture matrix is not the
+	 * identity</strong>, and they were withheld until it could be answered: the breeze's wind and the
+	 * energy swirl are animated by an {@code OffsetTextureTransform} built afresh per draw
+	 * ({@code rendertype/RenderTypes.java:524,536}), which is now read out of the game's own
+	 * transforms rather than replaced by an identity that would freeze them. The swirl is also the one
+	 * row here that blends and asks for the writing half's program, which {@link #PINNED} carries.
 	 * <p>
 	 * <strong>{@code ITEM_TRANSLUCENT} and {@code ENTITY_TRANSLUCENT_CULL} are here and are not
 	 * corner cases</strong>, though both of the game's render types for them name
@@ -596,6 +597,16 @@ public final class EntityDraw {
 		// for what it is rather than after that type: this class already draws into a shadow map, and
 		// an element called shadow would read as a piece of it in the log and in the identifier.
 		put(new Element(RenderPipelines.ENTITY_SHADOW, "ground_shadow", ENTITIES_TRANSLUCENT, CUTOUT));
+		// The wind a breeze throws, an ordinary row of this run: Iris sends it through the same
+		// getTranslucent as the six above (pipeline/IrisPipelines.java:56).
+		put(new Element(RenderPipelines.BREEZE_WIND, "breeze_wind", ENTITIES_TRANSLUCENT, CUTOUT));
+		// The swirl over a charged creeper or an armoured wither, and THE ONE ROW OF THIS TABLE THAT
+		// BLENDS AND ASKS FOR THE WRITING HALF'S PROGRAM. Iris pins it to ENTITIES_CUTOUT, which is
+		// ProgramId.Entities, rather than sending it through getTranslucent like its neighbours
+		// (pipeline/IrisPipelines.java:60), so the name is the opaque one while the pass is the
+		// blending one. Nothing here has to be told that twice: the side is read off the pipeline,
+		// which blends, and the name is what the row says.
+		put(new Element(RenderPipelines.ENERGY_SWIRL, "energy_swirl", ENTITIES, CUTOUT));
 	}
 
 	/**
@@ -672,27 +683,27 @@ public final class EntityDraw {
 	 * program and the tenth that comes with it. The phase itself is not a row of any table and does
 	 * not vary: it is what the origin of the draw says.
 	 * <p>
-	 * <strong>The blending run has no exception at all</strong>, and that is Iris's shape rather than
-	 * a simplification of it. Its three rows pinned to {@code ENTITIES_CUTOUT} whatever the phase are
-	 * the energy swirl, the end crystal beam and the offset cutout
-	 * ({@code pipeline/IrisPipelines.java:60,61,62}); the first of those three is withheld here and
-	 * the other two are opaque, so none of them is a blending row of ours. Every row that does reach
-	 * {@code getTranslucent} answers {@code BE_TRANSLUCENT} under the phase without the pipeline
-	 * being consulted at all ({@code pipeline/IrisPipelines.java:212-222}). So a blending twin is
-	 * always {@code gbuffers_block_translucent}, and the tenth is already what its mob row carries.
+	 * <strong>Three rows keep the entity program whatever the phase, and the blend has nothing to do
+	 * with which three.</strong> That is Iris's shape rather than a simplification of it: the energy
+	 * swirl, the end crystal beam and the offset cutout are assigned {@code ENTITIES_CUTOUT} outright
+	 * ({@code pipeline/IrisPipelines.java:60,61,62}), which is a constant and not one of the three
+	 * functions the phase is read inside, so no phase can move them. The swirl is the one of the
+	 * three that blends, which is why the test below is a list and not the blend: asking the blend
+	 * first would have given it {@code gbuffers_block_translucent} where Iris keeps
+	 * {@code gbuffers_entities}. Every row that does reach {@code getTranslucent} answers
+	 * {@code BE_TRANSLUCENT} under the phase without the pipeline being consulted at all
+	 * ({@code pipeline/IrisPipelines.java:212-222}), so every other blending twin is
+	 * {@code gbuffers_block_translucent} and the tenth is already what its mob row carries.
 	 */
 	@SuppressWarnings("ReferenceEquality")
 	private static Element blockTwin(Element mob) {
-		if (mob.blended()) {
-			return new Element(mob.pipeline(), "block_" + mob.element(), BLOCK_TRANSLUCENT, CUTOUT,
-					RenderStage.BLOCK_ENTITIES, false);
+		if (PINNED.contains(mob.pipeline())) {
+			return new Element(mob.pipeline(), "block_" + mob.element(), mob.program(),
+					mob.alphaTest(), RenderStage.BLOCK_ENTITIES, false);
 		}
 
-		boolean ownProgram = mob.pipeline() != RenderPipelines.END_CRYSTAL_BEAM
-				&& mob.pipeline() != RenderPipelines.ENTITY_CUTOUT_Z_OFFSET;
-
 		return new Element(mob.pipeline(), "block_" + mob.element(),
-				ownProgram ? BLOCK : mob.program(), ownProgram ? CUTOUT : mob.alphaTest(),
+				mob.blended() ? BLOCK_TRANSLUCENT : BLOCK, CUTOUT,
 				RenderStage.BLOCK_ENTITIES, false);
 	}
 
@@ -807,12 +818,11 @@ public final class EntityDraw {
 	 * <p>
 	 * Iris keys it on a CONSTANT, {@code p -> ShaderKey.GLINT}
 	 * ({@code pipeline/IrisPipelines.java:50}), where almost every row of {@link #ELEMENTS} reaches a
-	 * function that tests the hand and then the block entity phase. Two of them are pinned as well,
-	 * the end crystal beam and the offset cutout ({@code pipeline/IrisPipelines.java:61,62}), and
-	 * {@link #blockTwin} says what that costs them; what those two are pinned to is the key an entity
-	 * row reaches anyway, so the pin only keeps the phase off them. The glint's names a program no
-	 * other row of that table can reach. So a glint is a glint on a mob, on a chest and in the hand
-	 * alike, and the four pieces below differ in the MOMENT and never in the name.
+	 * function that tests the hand and then the block entity phase. Three of them are pinned as well,
+	 * which {@link #PINNED} names and {@link #blockTwin} reads; what those three are pinned to is the
+	 * key an entity row reaches anyway, so the pin only keeps the phase off them. The glint's names a
+	 * program no other row of that table can reach. So a glint is a glint on a mob, on a chest and in
+	 * the hand alike, and the four pieces below differ in the MOMENT and never in the name.
 	 */
 	private static final String ARMOR_GLINT = "gbuffers_armor_glint";
 
@@ -1185,9 +1195,6 @@ public final class EntityDraw {
 				: wanted && element != null && inWindow(element);
 		if (!inMoment || device == null || element == null) {
 			draw.end();
-			if (wanted && element == null && translucentFeatures) {
-				draw.withheld(prepared.pipeline());
-			}
 
 			return false;
 		}
@@ -1528,27 +1535,6 @@ public final class EntityDraw {
 				+ "dropped rather than handed back: inside the light's walk the game would open its "
 				+ "own pass on the target its render type names, which at that point in the frame "
 				+ "carries the finished picture", pipeline.getLocation());
-	}
-
-	/**
-	 * Says once, when one of the two pipelines {@link #WITHHELD} names is really drawn, that this
-	 * engine left it to the game and why.
-	 * <p>
-	 * Here and not at the load, because the load cannot know: a breeze and a guardian beam are things
-	 * a world may or may not contain, and a line said at every load about geometry nobody will meet
-	 * is a line a reader learns to skip. The rest of the table is silent on a miss for the opposite
-	 * reason, the game having a hundred pipelines this family was never asked about; these two were
-	 * asked about and answered no.
-	 */
-	private void withheld(RenderPipeline pipeline) {
-		String reason = WITHHELD.get(pipeline);
-		if (reason != null && this.refused.add("withheld:" + pipeline.getLocation())) {
-			Vitrail.logger().warn("The game keeps its own shader for {}, which this engine leaves to "
-					+ "it: {}. What it costs is that this geometry is lit by the game inside the "
-					+ "window the pack is drawing, so it carries none of the pack's material and its "
-					+ "colour makes one more trip through eight bits. It holds for as long as this "
-					+ "pack is loaded", pipeline.getLocation(), reason);
-		}
 	}
 
 	/**


### PR DESCRIPTION
## What changes

Serves the last two rows of the entity family the game still drew for itself: the wind a breeze
throws and the energy swirl over a charged creeper. Both are animated by a texture matrix of the
game's own, which is what withheld them, and that matrix is answered out of the game's transforms
now, so a breeze is animated rather than frozen on one frame of its offset. The swirl brings the one
shape the table had no room for, a row that blends and still asks for the writing half's program;
`PINNED` carries the three rows Iris assigns outright, and `blockTwin` reads that list instead of
reading the blend. `ChainPlan` gains the fifth entity entry that row needs, `gbuffers_entities` on
the far side of the deferred stage, without which the key it asks for would never have been walked.

## How it differs from the reference, and for what obstacle

It does not. The breeze goes through `getTranslucent` as Iris sends it
(`pipeline/IrisPipelines.java:56`), the swirl is pinned to `ENTITIES_CUTOUT` (`:60`).

## What proves it

`gradlew build` green locally. The out-of-game key gate over the eight-pack corpus, which asks
`gbuffers_entities` on both sides now: **15 mute keys before the entry, none after**, five packs of
eight in all three of their places - Bliss `[1, 8, 15, 2]`, both Complementary `[0, 3, 6, 4]`,
Reverie `[1, 2]`, Sildur's `[4, 1, 2]`, each of them one output on the game's target before. The
three that already answered do so because their blending entity name falls back on this very file.
The verdict pass over the same corpus is byte for byte what it was, which is what the entry not
being counted among the families a verdict may take for filled is meant to give.

In the game: a charged creeper under Complementary Unbound, on a bench world that stands one in
front of the camera.

## What it leaves owing

Nothing known. The counted statements of `EntityDraw` that these two rows made stale are corrected
in the same pass, along with one that was already wrong before them: the end crystal beam does not
draw block entities, `EnderDragonRenderer` being its only caller.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one.
