### PR TITLE
Serve a mob's eyes with gbuffers_spidereyes, at the full light Iris gives them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ what the next one holds.
   read as a light rather than as a sticker. They are also drawn at full brightness whatever the mob
   is standing in, as the game draws them: handed the light of the spot instead, a pack that shades by
   that light would have put out the eyes of anything standing in the dark, which is where they matter
-  most. One pack of the eight tested reads that light in its eye program, so that one is where the
-  difference is visible.
+  most. Six of the eight packs tested ask for that light in the program that serves their eyes, and
+  one of them looks the game's light map up with it, which is where it shows on screen.
 - **The wind a breeze throws and the swirl over a charged creeper are painted by the pack now**,
   where the game kept its own shader for both. What held them back is a texture matrix of the
   game's own that scrolls them, and that matrix is answered out of the game's transforms now, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,16 @@ what the next one holds.
 
 ### Added
 
-- **The glowing eyes of a spider, an enderman, a phantom or a warden are painted by the pack now**,
-  where the game kept its own shader for them. They go through the program the format keeps for eyes
+- **Glowing eyes are painted by the pack now**, where the game kept its own shader for them: the eyes
+  of a spider, an enderman, a phantom, a breeze and the ender dragon, and the bioluminescent parts of
+  a warden, which the game draws the same way. They go through the program the format keeps for eyes
   alone, and they are added onto the mob's skin rather than laid over it, which is what makes an eye
   read as a light rather than as a sticker. They are also drawn at full brightness whatever the mob
   is standing in, as the game draws them: handed the light of the spot instead, a pack that shades by
   that light would have put out the eyes of anything standing in the dark, which is where they matter
   most. Six of the eight packs tested ask for that light in the program that serves their eyes, and
-  one of them looks the game's light map up with it, which is where it shows on screen.
+  one of them looks the game's light map up with it, which is where it shows on screen. What they do
+  not do yet is darken the mob's own shadow.
 - **The wind a breeze throws and the swirl over a charged creeper are painted by the pack now**,
   where the game kept its own shader for both. What held them back is a texture matrix of the
   game's own that scrolls them, and that matrix is answered out of the game's transforms now, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ what the next one holds.
 
 ### Added
 
+- **The glowing eyes of a spider, an enderman, a phantom or a warden are painted by the pack now**,
+  where the game kept its own shader for them. They go through the program the format keeps for eyes
+  alone, and they are added onto the mob's skin rather than laid over it, which is what makes an eye
+  read as a light rather than as a sticker. They are also drawn at full brightness whatever the mob
+  is standing in, as the game draws them: handed the light of the spot instead, a pack that shades by
+  that light would have put out the eyes of anything standing in the dark, which is where they matter
+  most. One pack of the eight tested reads that light in its eye program, so that one is where the
+  difference is visible.
 - **The wind a breeze throws and the swirl over a charged creeper are painted by the pack now**,
   where the game kept its own shader for both. What held them back is a texture matrix of the
   game's own that scrolls them, and that matrix is answered out of the game's transforms now, so a

--- a/common/src/main/java/dev/vitrail/glsl/EntityVertex.java
+++ b/common/src/main/java/dev/vitrail/glsl/EntityVertex.java
@@ -45,10 +45,13 @@ public final class EntityVertex {
 	 * What the light map names read on a piece the game draws at full light, which is the value a
 	 * block at the brightest light level would have carried on the element.
 	 * <p>
-	 * Iris's own constant, {@code transform/transformer/VanillaCoreTransformer.java:117-121}, and the
-	 * number is the game's rather than a round one: {@code LightTexture.pack} puts each of the two
-	 * levels on the element shifted four bits up, so the brightest of the sixteen is fifteen times
-	 * sixteen. Handing a pack anything larger would send it off its own light map.
+	 * Iris's own constant, {@code transform/transformer/VanillaCoreTransformer.java:117-118}, and the
+	 * number is the game's rather than a round one. {@code LightCoordsUtil.pack} shifts the block level
+	 * up by four and the sky level up by twenty ({@code util/LightCoordsUtil.java:13-14}), so each of
+	 * the two lands on its own short with the brightest of the sixteen levels at fifteen times sixteen.
+	 * The game names that value twice itself, {@code FULL_BRIGHT = 0xF000F0} at {@code :9} and
+	 * {@code MAX_SMOOTH_LIGHT_LEVEL = 240} at {@code :11}. Handing a pack anything larger would send it
+	 * off its own light map.
 	 */
 	public static final String FULL_LIGHT = "vec4(240.0, 240.0, 0.0, 1.0)";
 
@@ -80,7 +83,7 @@ public final class EntityVertex {
 		// Still declared under full light, and it has to be: the element is in the format whatever
 		// the piece does with it, and rebind matches by name over the whole format, so a head that
 		// dropped it would move every name after it one location down without a word. Iris keeps it
-		// for the same reason, renaming vaUV2 in both branches (VanillaCoreTransformer.java:118,123).
+		// for the same reason, renaming vaUV2 in both branches (VanillaCoreTransformer.java:115,119).
 		String light = fullbright ? FULL_LIGHT : "vec4(UV2, 0.0, 1.0)";
 
 		lines.add("#define of_Vertex vec4(Position, 1.0)");

--- a/common/src/main/java/dev/vitrail/glsl/EntityVertex.java
+++ b/common/src/main/java/dev/vitrail/glsl/EntityVertex.java
@@ -41,6 +41,17 @@ public final class EntityVertex {
 	public static final List<String> ATTRIBUTES =
 			List.of("Position", "Color", "UV0", "UV1", "UV2", "Normal");
 
+	/**
+	 * What the light map names read on a piece the game draws at full light, which is the value a
+	 * block at the brightest light level would have carried on the element.
+	 * <p>
+	 * Iris's own constant, {@code transform/transformer/VanillaCoreTransformer.java:117-121}, and the
+	 * number is the game's rather than a round one: {@code LightTexture.pack} puts each of the two
+	 * levels on the element shifted four bits up, so the brightest of the sixteen is fifteen times
+	 * sixteen. Handing a pack anything larger would send it off its own light map.
+	 */
+	public static final String FULL_LIGHT = "vec4(240.0, 240.0, 0.0, 1.0)";
+
 	private EntityVertex() {
 	}
 
@@ -52,21 +63,33 @@ public final class EntityVertex {
 	 *                    pack that never asks
 	 * @param synthesized the vertex inputs the pack declared for itself and that were taken out of
 	 *                    the body, by name and with the type the pack gave them
+	 * @param fullbright  whether the light map names are answered with {@link #FULL_LIGHT} rather
+	 *                    than out of the element, which is a fact about the PIECE being drawn and not
+	 *                    about the mesh: {@code UV2} is bound and carries a real light map either
+	 *                    way. {@link VertexInputs#ENTITY_FULLBRIGHT} says which pieces and why the
+	 *                    sampler has to follow
 	 */
-	public static List<String> prologue(Set<String> used, Map<String, String> synthesized) {
+	public static List<String> prologue(Set<String> used, Map<String, String> synthesized,
+			boolean fullbright) {
 		List<String> lines = new ArrayList<>();
 
 		for (String attribute : ATTRIBUTES) {
 			lines.add("in " + VertexPrologue.elementType(attribute) + " " + attribute + ";");
 		}
 
+		// Still declared under full light, and it has to be: the element is in the format whatever
+		// the piece does with it, and rebind matches by name over the whole format, so a head that
+		// dropped it would move every name after it one location down without a word. Iris keeps it
+		// for the same reason, renaming vaUV2 in both branches (VanillaCoreTransformer.java:118,123).
+		String light = fullbright ? FULL_LIGHT : "vec4(UV2, 0.0, 1.0)";
+
 		lines.add("#define of_Vertex vec4(Position, 1.0)");
 		lines.add("#define of_Color Color");
 		lines.add("#define of_MultiTexCoord0 vec4(UV0, 0.0, 1.0)");
-		lines.add("#define of_MultiTexCoord1 vec4(UV2, 0.0, 1.0)");
+		lines.add("#define of_MultiTexCoord1 " + light);
 		// Unit two is a second name for the light map and not a unit of its own, which is what Iris
 		// makes of it as well, VanillaTransformer.java:77 renaming one into the other.
-		lines.add("#define of_MultiTexCoord2 vec4(UV2, 0.0, 1.0)");
+		lines.add("#define of_MultiTexCoord2 " + light);
 		lines.addAll(VertexPrologue.blankTexCoords());
 
 		lines.add("#define of_Normal Normal.xyz");

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -2880,7 +2880,8 @@ public final class GlslTranslator {
 				}
 				case TERRAIN, TERRAIN_SEPARATE_AO -> lines.addAll(
 						SodiumVertex.prologue(this.used, this.synthesized, this.inputs.separateAo()));
-				case ENTITY -> lines.addAll(EntityVertex.prologue(this.used, this.synthesized));
+				case ENTITY, ENTITY_FULLBRIGHT -> lines.addAll(
+						EntityVertex.prologue(this.used, this.synthesized, this.inputs.fullbright()));
 				case GLINT -> lines.addAll(GlintVertex.prologue(this.used, this.synthesized));
 				case PARTICLE -> lines.addAll(ParticleVertex.prologue(this.used, this.synthesized));
 				case SKY -> lines.addAll(SkyVertex.prologue(this.bound, this.used, this.synthesized));

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -107,6 +107,27 @@ public final class PackProgram {
 		}
 
 		/**
+		 * Whether this program was translated for a piece the game draws at full light, and therefore
+		 * whether the name {@code lightmap} is bound to one white texel rather than to the game's own
+		 * image.
+		 * <p>
+		 * <strong>Read off the translation and not tabulated beside it</strong>, which is
+		 * {@link #readsGameTransforms}'s reason with a different consequence: full light is TWO
+		 * answers, the constant the vertex head hands the light map names and the texture the fragment
+		 * stage samples, and a pack multiplies one by the other. Given the constant alone the piece
+		 * comes out with whatever light the mob is standing in; given the texture alone it comes out
+		 * at the light the mesh carries. Both are darker than the game would have drawn it, and
+		 * neither says anything.
+		 * <p>
+		 * Iris answers both off one field for the same reason, {@code ShaderKey}'s lighting model
+		 * reaching the head through {@code gl/state/ShaderAttributeInputs.java:42} and the sampler
+		 * through {@code samplers/IrisSamplers.java:202-206}.
+		 */
+		public boolean fullbright() {
+			return this.program.inputs().fullbright();
+		}
+
+		/**
 		 * Whether any stage of this program reads the game's own per draw transforms, and therefore
 		 * whether the pipeline has to carry the bind group that block is bound through.
 		 * <p>

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -64,10 +64,15 @@ public final class ProgramTranslator {
 	 * @param synthesized vertex inputs the mesh has not got, answered with a constant, by name and
 	 *                    with the type the pack declared them under. Empty for every pass drawn over
 	 *                    a quad, which is every pass this engine drew before milestone six
+	 * @param inputs      where the vertex stage was translated to take its inputs from. Carried out
+	 *                    of the translation rather than tabulated again beside it, so that whoever
+	 *                    binds the samplers reads the very value that wrote the vertex head: the
+	 *                    light map is answered in the head AND behind a sampler, and a piece given
+	 *                    one half without the other is served an image neither authority asked for
 	 */
 	public record TranslatedProgram(Map<ProgramStage, TranslatedUnit> stages,
 			List<TranslatedUnit.Uniform> uniforms, List<TranslatedUnit.Uniform> samplers,
-			Map<String, String> synthesized) {
+			Map<String, String> synthesized, VertexInputs inputs) {
 	}
 
 	/**
@@ -205,7 +210,8 @@ public final class ProgramTranslator {
 			translated.put(stage, prepare.render(block, bound, varyings, shadowed));
 		});
 
-		return new TranslatedProgram(Map.copyOf(translated), block, bound, Map.copyOf(synthesized));
+		return new TranslatedProgram(Map.copyOf(translated), block, bound, Map.copyOf(synthesized),
+				inputs);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/VertexInputs.java
+++ b/common/src/main/java/dev/vitrail/glsl/VertexInputs.java
@@ -63,7 +63,7 @@ public enum VertexInputs {
 	 * in this position walking the fallback tree like any other.
 	 * <p>
 	 * <strong>It is half of what Iris means by full light, and the other half is the sampler.</strong>
-	 * The constant here is {@code transform/transformer/VanillaCoreTransformer.java:117-121}, taken
+	 * The constant here is {@code transform/transformer/VanillaCoreTransformer.java:117-118}, taken
 	 * where {@code gl/state/ShaderAttributeInputs.java:42} refused {@code UV2}; the white pixel bound
 	 * behind {@code lightmap} is {@code samplers/IrisSamplers.java:202-206}, and
 	 * {@code PackProgram.Loaded#fullbright} is what carries this answer there. A piece given one half

--- a/common/src/main/java/dev/vitrail/glsl/VertexInputs.java
+++ b/common/src/main/java/dev/vitrail/glsl/VertexInputs.java
@@ -53,6 +53,26 @@ public enum VertexInputs {
 	ENTITY,
 
 	/**
+	 * The same mesh read by a piece the game draws at full light: {@code UV2} is bound and carries a
+	 * real light map, and the two names a pack reads it under are answered with the brightest value
+	 * instead. {@link EntityVertex} carries the constant.
+	 * <p>
+	 * A second contract over one format, which is what {@link #TERRAIN_SEPARATE_AO} is over
+	 * {@link #TERRAIN}: same elements, same order, same stride, and only the two lines that fill the
+	 * light map names differ. It is a property of the piece and not of the file, the one program name
+	 * in this position walking the fallback tree like any other.
+	 * <p>
+	 * <strong>It is half of what Iris means by full light, and the other half is the sampler.</strong>
+	 * The constant here is {@code transform/transformer/VanillaCoreTransformer.java:117-121}, taken
+	 * where {@code gl/state/ShaderAttributeInputs.java:42} refused {@code UV2}; the white pixel bound
+	 * behind {@code lightmap} is {@code samplers/IrisSamplers.java:202-206}, and
+	 * {@code PackProgram.Loaded#fullbright} is what carries this answer there. A piece given one half
+	 * without the other is served darker than the game would have drawn it, a pack multiplying the
+	 * two.
+	 */
+	ENTITY_FULLBRIGHT,
+
+	/**
 	 * The game's own particle mesh: the four elements of {@code DefaultVertexFormat.PARTICLE}, out of
 	 * which the names a pack reads are made. Two families bind it, the quad particles and the
 	 * weather. {@link ParticleVertex} carries the renaming and says what a particle has not got.
@@ -113,6 +133,15 @@ public enum VertexInputs {
 	}
 
 	/**
+	 * Whether the light map names are answered with the brightest value rather than with the element
+	 * the mesh really carries, which is Iris's full light and is asked of the piece rather than of
+	 * the mesh.
+	 */
+	public boolean fullbright() {
+		return this == ENTITY_FULLBRIGHT;
+	}
+
+	/**
 	 * The names the head declares for itself, which the pack may therefore not use for anything of
 	 * its own.
 	 * <p>
@@ -137,7 +166,7 @@ public enum VertexInputs {
 		return switch (this) {
 			case FULLSCREEN -> LegacyGlsl.FULLSCREEN_ELEMENTS;
 			case TERRAIN, TERRAIN_SEPARATE_AO -> SodiumVertex.ATTRIBUTES;
-			case ENTITY -> EntityVertex.ATTRIBUTES;
+			case ENTITY, ENTITY_FULLBRIGHT -> EntityVertex.ATTRIBUTES;
 			case GLINT -> GlintVertex.ATTRIBUTES;
 			case PARTICLE -> ParticleVertex.ATTRIBUTES;
 			case SKY -> SkyVertex.ATTRIBUTES;

--- a/common/src/main/java/dev/vitrail/pack/program/ProgramFallbacks.java
+++ b/common/src/main/java/dev/vitrail/pack/program/ProgramFallbacks.java
@@ -19,7 +19,12 @@ import java.util.Set;
  * as this project. The original is the enum
  * {@code net.irisshaders.iris.shaderpack.loading.ProgramId}, read on 1 August 2026. Adapted in
  * 2026: the enum became a name to parent map, and the public API mapping the original also
- * carried was left out. It is reproduced rather than guessed because there is no other
+ * carried was left out, as were seven of its eight blend mode overrides. Those seven are the
+ * {@code BlendModeOverride.OFF} the shadow programs each carry
+ * ({@code shaderpack/loading/ProgramId.java:13-19}), and {@code EntityProgram} answers them for the
+ * whole shadow family at once rather than name by name; {@link #blendOverride} carries the eighth,
+ * which is the only one that is not a refusal. It is reproduced rather than guessed because there is
+ * no other
  * authority for it: the format's own documentation does not spell the chain out, and getting
  * an edge wrong means a pack renders something with the wrong program and nothing reports it.
  *

--- a/common/src/main/java/dev/vitrail/pack/program/ProgramFallbacks.java
+++ b/common/src/main/java/dev/vitrail/pack/program/ProgramFallbacks.java
@@ -18,17 +18,18 @@ import java.util.Set;
  * copyright the Iris contributors and licensed under the GNU LGPL version 3, the same licence
  * as this project. The original is the enum
  * {@code net.irisshaders.iris.shaderpack.loading.ProgramId}, read on 1 August 2026. Adapted in
- * 2026: the enum became a name to parent map, and the blend mode overrides and the public API
- * mapping the original also carried were left out. It is reproduced rather than guessed
- * because there is no other authority for it: the format's own documentation does not spell
- * the chain out, and getting an edge wrong means a pack renders something with the wrong
- * program and nothing reports it.
+ * 2026: the enum became a name to parent map, and the public API mapping the original also
+ * carried was left out. It is reproduced rather than guessed because there is no other
+ * authority for it: the format's own documentation does not spell the chain out, and getting
+ * an edge wrong means a pack renders something with the wrong program and nothing reports it.
  *
  * @see <a href="https://github.com/IrisShaders/Iris">Iris, LGPL-3.0</a>
  */
 public final class ProgramFallbacks {
 
 	private static final Map<String, String> PARENTS = buildParents();
+
+	private static final Map<String, BlendMode> BLEND_OVERRIDES = buildBlendOverrides();
 
 	private ProgramFallbacks() {
 	}
@@ -94,6 +95,42 @@ public final class ProgramFallbacks {
 		// Not Map.copyOf: the roots of the tree map to null, and the immutable factories reject
 		// a null value rather than storing it.
 		return Collections.unmodifiableMap(parents);
+	}
+
+	/**
+	 * What a program name blends with when the pack names no blending of its own for it.
+	 * <p>
+	 * One entry, and the table exists rather than the constant because the shape is Iris's: the
+	 * override hangs off the program NAME in the same enum the parents above come from
+	 * ({@code shaderpack/loading/ProgramId.java:47-48}), so a second one would be another row here
+	 * and not another special case at a call site.
+	 * <p>
+	 * <strong>It is keyed by the name ASKED FOR and not by the file that ends up serving it</strong>,
+	 * which is the whole reason it cannot live beside the pack's own directive. Iris reads the two
+	 * from two different places on purpose: the pack's {@code blend.<program>} is looked up under the
+	 * resolved source's name and this default under the asked-for id
+	 * ({@code pipeline/programs/ShaderCreator.java:71}), so a pack shipping no
+	 * {@code gbuffers_spidereyes} at all still draws its eyes additively through whatever
+	 * {@code gbuffers_textured} it fell back on.
+	 */
+	private static Map<String, BlendMode> buildBlendOverrides() {
+		Map<String, BlendMode> overrides = new LinkedHashMap<>();
+
+		// Additive, and it is what makes an eye a light rather than a decal: the source is weighted by
+		// its own alpha and the destination is kept whole, so the pupil adds to the mob's skin instead
+		// of replacing it. The game's own pipeline blends the ordinary translucent way, which is the
+		// value this one displaces; alpha keeps ZERO, ONE for the same reason Iris gives it that.
+		overrides.put("gbuffers_spidereyes", new BlendMode(false, "SRC_ALPHA", "ONE", "ZERO", "ONE"));
+
+		return Collections.unmodifiableMap(overrides);
+	}
+
+	/**
+	 * What the pack falls back to for this program when it names no blending of its own, or null
+	 * where the caller's own default stands.
+	 */
+	public static BlendMode blendOverride(String program) {
+		return BLEND_OVERRIDES.get(program);
 	}
 
 	/** Every program name that takes part in the fallback tree. */

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -150,10 +150,10 @@ public final class ChainPlan {
 					// the deferreds.
 					//
 					// Not counted, and it is the hand's reason rather than the entities': the line
-					// being on does not put a spider, an enderman, a phantom or the dragon in front
-					// of the camera, and nothing else in the game draws with these pipelines. A
-					// verdict that took the eyes for drawn would report targets as written in every
-					// place a plan is built for, which is every place those four mobs are not.
+					// being on does not put one of the six mobs that reach these two pipelines in
+					// front of the camera. A verdict that took the eyes for drawn would report
+					// targets as written in every place a plan is built for, which is every place
+					// none of the six is standing.
 					new NamedProgram("gbuffers_spidereyes", true, false, NOT_EVERYWHERE),
 					// The hand's two passes, which straddle the stage as the particles do and for the
 					// same kind of reason: the solid one is drawn among the game's opaque features and

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -144,6 +144,17 @@ public final class ChainPlan {
 					// blending name falls back on this very file, and that entry counts it; three
 					// packs of the corpus are in that case and this entry moves nothing for them.
 					new NamedProgram("gbuffers_entities", true, false, NOT_EVERYWHERE),
+					// The glowing eyes of a mob, drawn among the translucent features beside the two
+					// above and on the same side of the stage. One entry and not two: its two
+					// pipelines ask for the one name, both blend, and neither is ever drawn before
+					// the deferreds.
+					//
+					// Not counted, and it is the hand's reason rather than the entities': the line
+					// being on does not put a spider, an enderman, a phantom or the dragon in front
+					// of the camera, and nothing else in the game draws with these pipelines. A
+					// verdict that took the eyes for drawn would report targets as written in every
+					// place a plan is built for, which is every place those four mobs are not.
+					new NamedProgram("gbuffers_spidereyes", true, false, NOT_EVERYWHERE),
 					// The hand's two passes, which straddle the stage as the particles do and for the
 					// same kind of reason: the solid one is drawn among the game's opaque features and
 					// the blending one at the end of the level. Not counted, and not by a switch:

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -233,13 +233,31 @@ public final class EntityDraw {
 	 *                      and never with {@link #blended()}, its pipeline being the mob's and its
 	 *                      moment its pass's; an entity row answers with {@link #blended()}, and
 	 *                      carries false here
+	 * @param fullbright    whether the game draws this piece at full light, so that the light map
+	 *                      names are answered with a constant and the sampler behind them with one
+	 *                      white texel. True for the two rows of {@link #FIXED} and no other so far.
+	 *                      <strong>A column of the row and not a reading of the program name</strong>,
+	 *                      which is where Iris keeps it as well: its lighting model hangs off the
+	 *                      {@code ShaderKey} ({@code pipeline/programs/ShaderKey.java:44,45}), and
+	 *                      three of its program names carry keys of both kinds, one row drawn at the
+	 *                      light it stands in and one of the same geometry lit whole
+	 *                      ({@code :38,40} for {@code gbuffers_entities} alone)
 	 */
 	record Element(RenderPipeline pipeline, String element, String program, AlphaTest alphaTest,
-			RenderStage stage, boolean afterDeferred) {
+			RenderStage stage, boolean afterDeferred, boolean fullbright) {
 
 		/** A piece of the mob half, which is every row of the table above. */
 		Element(RenderPipeline pipeline, String element, String program, AlphaTest alphaTest) {
-			this(pipeline, element, program, alphaTest, RenderStage.NONE, false);
+			this(pipeline, element, program, alphaTest, RenderStage.NONE, false, false);
+		}
+
+		/**
+		 * A piece whose moment or whose side of the stage is its own, which is the hand's rows, the
+		 * glint's four and the shadow table. None of them is drawn at full light.
+		 */
+		Element(RenderPipeline pipeline, String element, String program, AlphaTest alphaTest,
+				RenderStage stage, boolean afterDeferred) {
+			this(pipeline, element, program, alphaTest, stage, afterDeferred, false);
 		}
 
 		/**
@@ -286,9 +304,24 @@ public final class EntityDraw {
 			return glint() ? DefaultVertexFormat.POSITION_TEX : DefaultVertexFormat.ENTITY;
 		}
 
-		/** Where the vertex stage of this piece takes its inputs from, which is the same answer. */
+		/**
+		 * Where the vertex stage of this piece takes its inputs from, which is the same answer plus
+		 * one: the entity mesh is read under two contracts, and a piece the game draws at full light
+		 * takes the one that answers the light map names with a constant.
+		 * <p>
+		 * <strong>Two contracts and not two formats</strong>, which is why {@link #format} does not
+		 * split with it and must not: the mesh is the same thirty-six bytes and {@code UV2} is bound
+		 * and declared either way. What changes is one line of the vertex head and the texture behind
+		 * one sampler. It reaches the translation because this constant is part of the key a program
+		 * is translated under, so the two contracts are two modules and neither is handed the other's
+		 * text.
+		 */
 		VertexInputs inputs() {
-			return glint() ? VertexInputs.GLINT : VertexInputs.ENTITY;
+			if (glint()) {
+				return VertexInputs.GLINT;
+			}
+
+			return this.fullbright ? VertexInputs.ENTITY_FULLBRIGHT : VertexInputs.ENTITY;
 		}
 
 		/** One word for the log, which has to say which of the four families a line is about. */
@@ -935,6 +968,18 @@ public final class EntityDraw {
 	 * is not read off the pipeline: Iris hangs an additive override on the program name itself, which
 	 * {@link EntityProgram} takes from {@code ProgramFallbacks} rather than from the pipeline.
 	 * <p>
+	 * <strong>Both are drawn at FULL LIGHT, and it is the answer that decides whether they are worth
+	 * serving at all.</strong> Iris marks both keys {@code LightingModel.FULLBRIGHT}
+	 * ({@code pipeline/programs/ShaderKey.java:44,45}), which reaches its shaders as two things: the
+	 * light map names are answered with a constant rather than out of the mesh
+	 * ({@code gl/state/ShaderAttributeInputs.java:42} into
+	 * {@code transform/transformer/VanillaCoreTransformer.java:117-121}) and the name {@code lightmap}
+	 * is bound to one white texel ({@code samplers/IrisSamplers.java:202-206}). {@link Element#inputs} is
+	 * where the row hands that on, and both halves come back off the translation so that they cannot
+	 * part company. A pack whose {@code gbuffers_spidereyes} multiplies by the light map would
+	 * otherwise draw an enderman's eyes as dark as the block it stands on, and the additive blend
+	 * above is what would make that darkness the thing being added.
+	 * <p>
 	 * <strong>Both bind {@code DefaultVertexFormat.ENTITY}</strong> ({@code RenderPipelines.java:361}
 	 * and the {@code ENTITY_EMISSIVE_SNIPPET} at {@code :64}), which is why this family could be
 	 * served at all and the four beside it could not: the door decodes that one format.
@@ -948,10 +993,10 @@ public final class EntityDraw {
 
 	static {
 		FIXED.put(RenderPipelines.EYES, new Element(RenderPipelines.EYES, "eyes", SPIDER_EYES,
-				AlphaTest.NON_ZERO));
+				AlphaTest.NON_ZERO, RenderStage.NONE, false, true));
 		FIXED.put(RenderPipelines.ENTITY_TRANSLUCENT_EMISSIVE,
 				new Element(RenderPipelines.ENTITY_TRANSLUCENT_EMISSIVE, "eyes_emissive", SPIDER_EYES,
-						CUTOUT));
+						CUTOUT, RenderStage.NONE, false, true));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -105,9 +105,14 @@ import java.util.stream.Stream;
  * {@link FeatureLayer} carries it, with what Iris does instead and what it costs the image.
  * <p>
  * <strong>What is still the game's inside this window</strong>, and therefore still goes to that
- * layer, is the eyes ({@code EYES} and {@code ENTITY_TRANSLUCENT_EMISSIVE}), the beacon beam, and
- * the text of a name plate or a sign. The shadow map is a family of its own and is NOT in either
- * window, a pass of its own that neither bracket reaches.
+ * layer, is the beacon beam, the lightning, and the text of a name plate or a sign. All three of
+ * those families bind a mesh this door cannot decode, which {@link #decodable} says and which is why
+ * none of them is a row here. The shadow map is a family of its own and is NOT in either window, a
+ * pass of its own that neither bracket reaches.
+ * <p>
+ * <strong>The eyes were among them and are not any more</strong>: they alone of the four bind
+ * {@code DefaultVertexFormat.ENTITY}, so they come in by this door with a table of their own,
+ * {@link #FIXED}, which says why it is not the mob table.
  * <p>
  * <strong>An enchantment's glint comes in by this same door and is alone in it</strong>, in two ways
  * that are one: it is the only piece served here that is not drawn from an entity mesh, and the only
@@ -473,6 +478,12 @@ public final class EntityDraw {
 	private static final String BLOCK_TRANSLUCENT = "gbuffers_block_translucent";
 
 	/**
+	 * What the glowing eyes of a mob ask for, and the one name of this class that answers whatever
+	 * else is going on.
+	 */
+	private static final String SPIDER_EYES = "gbuffers_spidereyes";
+
+	/**
 	 * What a cutout entity discards at, which is a tenth and not the half the terrain uses. Named
 	 * here so that the table below reads as a table.
 	 */
@@ -518,8 +529,9 @@ public final class EntityDraw {
 	 * {@code ENTITY_TRANSLUCENT_EMISSIVE} ({@code :287-297}) bind that format and blend, and both are
 	 * the EYES family, which Iris serves with {@code gbuffers_spidereyes} through
 	 * {@code ENTITIES_EYES} and {@code ENTITIES_EYES_TRANS}
-	 * ({@code pipeline/IrisPipelines.java:52,53}). That family is not here yet, so the game draws it
-	 * and {@link FeatureLayer} carries it in. Each row that is here is a piece of
+	 * ({@code pipeline/IrisPipelines.java:52,53}). They are served here too and are in {@link #FIXED}
+	 * rather than in this table, because a row here is a row that gets a block entity twin and two
+	 * hand twins and theirs must get none. Each row that is here is a piece of
 	 * its own even where two ask for the same program at the same threshold, which is how the sky is
 	 * six pieces out of three files: they differ in what {@link Element} reads off them, and a piece
 	 * is one compiled module.
@@ -896,6 +908,53 @@ public final class EntityDraw {
 	}
 
 	/**
+	 * The pieces whose program does not depend on what else is going on, which is the eyes and
+	 * nothing else so far.
+	 * <p>
+	 * <strong>A table of its own because Iris keys these rows differently, and the difference is
+	 * exactly what a twin would destroy.</strong> Every row of {@link #ELEMENTS} reaches Iris through
+	 * {@code getSolid}, {@code getCutout} or {@code getTranslucent}, which is why each of them has a
+	 * block entity twin and two hand twins: those three functions test the hand, then the block entity
+	 * phase, then fall through ({@code pipeline/IrisPipelines.java:188-222}). The two rows below reach
+	 * a CONSTANT instead, {@code p -> ShaderKey.ENTITIES_EYES} and
+	 * {@code p -> ShaderKey.ENTITIES_EYES_TRANS} ({@code pipeline/IrisPipelines.java:52,53}), which
+	 * consults nothing. Derived into the other three tables they would ask for
+	 * {@code gbuffers_block_translucent} inside a chest's draw and {@code gbuffers_hand_water} inside
+	 * the hand's, and Iris asks for neither: an eye is an eye wherever it is drawn.
+	 * <p>
+	 * Both keys are {@code ProgramId.SpiderEyes}
+	 * ({@code pipeline/programs/ShaderKey.java:44,45}), so both ask for one name and differ only in
+	 * what they discard at, {@code NON_ZERO_ALPHA} for the plain eyes and {@code ONE_TENTH_ALPHA} for
+	 * the emissive one. That tenth is the game's own {@code ALPHA_CUTOUT} for that pipeline
+	 * ({@code RenderPipelines.java:290}) and the plain eyes pipeline declares none
+	 * ({@code :351-364}), so here the two authorities agree row for row.
+	 * <p>
+	 * <strong>Both blend, so both belong to the translucent window</strong>, the game declaring
+	 * {@code BlendFunction.TRANSLUCENT} on each ({@code RenderPipelines.java:360,293}). What they are
+	 * blended WITH is not the game's answer though, and that is the one thing about this family that
+	 * is not read off the pipeline: Iris hangs an additive override on the program name itself, which
+	 * {@link EntityProgram} takes from {@code ProgramFallbacks} rather than from the pipeline.
+	 * <p>
+	 * <strong>Both bind {@code DefaultVertexFormat.ENTITY}</strong> ({@code RenderPipelines.java:361}
+	 * and the {@code ENTITY_EMISSIVE_SNIPPET} at {@code :64}), which is why this family could be
+	 * served at all and the four beside it could not: the door decodes that one format.
+	 * <p>
+	 * Neither render type carries a layering transform or a texture transform
+	 * ({@code rendertype/RenderTypes.java:190-198,242-244}), so there is no depth nudge to reproduce
+	 * and no animation to read out of the game's own transforms, which the last two rows of
+	 * {@link #ELEMENTS} do need.
+	 */
+	private static final Map<RenderPipeline, Element> FIXED = new LinkedHashMap<>();
+
+	static {
+		FIXED.put(RenderPipelines.EYES, new Element(RenderPipelines.EYES, "eyes", SPIDER_EYES,
+				AlphaTest.NON_ZERO));
+		FIXED.put(RenderPipelines.ENTITY_TRANSLUCENT_EMISSIVE,
+				new Element(RenderPipelines.ENTITY_TRANSLUCENT_EMISSIVE, "eyes_emissive", SPIDER_EYES,
+						CUTOUT));
+	}
+
+	/**
 	 * Which piece answers for a draw of this pipeline, which is the block entity one only where the
 	 * draw came from a block entity renderer AND that pipeline has one. Null for a pipeline this
 	 * engine does not serve at all, which is most of them.
@@ -913,6 +972,14 @@ public final class EntityDraw {
 	 * chest had just been submitted must not be given the block program, and no more must a glint.
 	 * After the hand, because which of its four pieces answers is a question about the MOMENT, and
 	 * the hand's two passes are two of the four moments.
+	 * <p>
+	 * <strong>{@link #FIXED} is asked before all three, and that is the same fidelity read from the
+	 * other end.</strong> Those rows are constants in Iris's own table rather than calls into the
+	 * three functions that test anything ({@code pipeline/IrisPipelines.java:52,53}), so no mark of
+	 * ours may reach them either. Asked after the hand, an eye drawn while the arm was up would be
+	 * served {@code gbuffers_hand_water}; asked after the block entity mark, an eye on a mob standing
+	 * where a chest had just been submitted would be served {@code gbuffers_block_translucent}. Iris
+	 * answers {@code gbuffers_spidereyes} to both.
 	 */
 	@SuppressWarnings("ReferenceEquality")
 	private static Element element(RenderPipeline pipeline) {
@@ -922,8 +989,18 @@ public final class EntityDraw {
 		// map. Iris has no such order to keep, its shadow table being a second table consulted
 		// instead of the main one rather than a branch inside it (pipeline/IrisPipelines.java:85-134
 		// against :25-83).
+		//
+		// Ahead of FIXED as well, and for that same reason rather than against it: FIXED is a row of
+		// the MAIN table, and under Iris the main table is not the one consulted while the map is
+		// drawn. The marks FIXED stands in front of are ours and are the hand's and the block
+		// entity's; the shadow table is a table and not a mark.
 		if (shadowFeatures) {
 			return SHADOW_ELEMENTS.get(pipeline);
+		}
+
+		Element fixed = FIXED.get(pipeline);
+		if (fixed != null) {
+			return fixed;
 		}
 
 		if (HandDraw.drawing()) {
@@ -1194,7 +1271,16 @@ public final class EntityDraw {
 		// entities live inside the two windows the level's features are drawn in; the hand is
 		// submitted by this engine itself, twice, and both of those moments fall outside the
 		// windows. Each family is guarded by its own switch and neither borrows the other's.
-		boolean inMoment = HandDraw.drawing() ? HandDraw.wanted()
+		//
+		// Asked of the ROW and no longer of the moment, which is what carrying a fixed table costs:
+		// an eyes row is the answer even inside a hand pass, and it is not a hand row, so it may not
+		// take the hand's switch. What it does take is its own window, and inside a hand pass that
+		// window is shut, so the game keeps that draw. Iris would serve it, gbuffers_spidereyes being
+		// its constant there too; the obstacle is that this engine binds a piece to one side of the
+		// deferred stage at the LOAD, and an eyes row is bound to the side its window is on. No
+		// renderer of the game can reach it: the four callers of the eyes render type are the ender
+		// dragon and the ender, phantom and spider eye layers, none of which draws in a hand pass.
+		boolean inMoment = (element != null && element.hand()) ? HandDraw.wanted()
 				: wanted && element != null && inWindow(element);
 		if (!inMoment || device == null || element == null) {
 			draw.end();
@@ -1626,6 +1712,15 @@ public final class EntityDraw {
 					.toList();
 			groups.add(family.stream().filter(element -> !element.afterStage()).toList());
 			groups.add(family.stream().filter(Element::afterStage).toList());
+
+			// A group of its own and not part of the blending half above, for the reason the
+			// particles are two groups: what stands or falls together is what shares a picture. The
+			// eyes ask for a name of their own that walks its own chain, gbuffers_spidereyes through
+			// the textured pair, so it commonly resolves to a different file with different draw
+			// buffers; put in with the entities, a place that could not answer for that one file
+			// would take every mob and every chest down with it. Apart, the worst it can paint is a
+			// mob the pack lit wearing eyes the game drew, which is the smaller of the two pictures.
+			groups.add(fixed());
 		}
 
 		if (HandDraw.wanted()) {
@@ -1696,6 +1791,13 @@ public final class EntityDraw {
 	 * picture and reads its texture coordinates out of the light map. Two formats come in by this door
 	 * now, the entity mesh and the glint's two elements, so the claim is the piece's and the check is
 	 * against the game's own binding.
+	 * <p>
+	 * It is also what keeps the three families beside the eyes out of these tables, and that is a
+	 * fact about this engine rather than about them: the beacon beam binds
+	 * {@code DefaultVertexFormat.BLOCK}, the lightning and the dragon rays {@code POSITION_COLOR} and
+	 * the world text {@code POSITION_TEX_LIGHTMAP_COLOR}, and {@code VertexInputs} has a decoder for
+	 * none of the three. A row added for any of them would be caught here and reported, rather than
+	 * drawn out of the wrong offsets.
 	 */
 	private static boolean decodable(Element element) {
 		VertexFormat format = element.pipeline().getVertexFormatBinding(0);
@@ -1721,6 +1823,11 @@ public final class EntityDraw {
 				.map(element -> table.get(element.pipeline()))
 				.filter(Objects::nonNull)
 				.toList();
+	}
+
+	/** The fixed rows this engine can decode the mesh of, which today is both of them. */
+	private static List<Element> fixed() {
+		return FIXED.values().stream().filter(EntityDraw::decodable).toList();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -220,7 +220,8 @@ public final class EntityDraw {
 	 * @param alphaTest what this piece discards at when the pack says nothing. It is the game's own
 	 *                  {@code ALPHA_CUTOUT} define for that pipeline, a tenth where there is one and
 	 *                  no test at all where there is none, and Iris gives the entity programs the
-	 *                  same tenth
+	 *                  same tenth. <strong>One row of {@link #FIXED} takes Iris's answer where the
+	 *                  game has none</strong>, and that javadoc says why
 	 * @param stage         what the pack is told it is drawing. {@code NONE} for a mob, which is not a
 	 *                      reading of what the pass is but Iris's answer, and {@link EntityProgram}
 	 *                      has the four places it was read from; {@code BLOCK_ENTITIES} for a block
@@ -945,11 +946,14 @@ public final class EntityDraw {
 	 * nothing else so far.
 	 * <p>
 	 * <strong>A table of its own because Iris keys these rows differently, and the difference is
-	 * exactly what a twin would destroy.</strong> Every row of {@link #ELEMENTS} reaches Iris through
-	 * {@code getSolid}, {@code getCutout} or {@code getTranslucent}, which is why each of them has a
-	 * block entity twin and two hand twins: those three functions test the hand, then the block entity
-	 * phase, then fall through ({@code pipeline/IrisPipelines.java:188-222}). The two rows below reach
-	 * a CONSTANT instead, {@code p -> ShaderKey.ENTITIES_EYES} and
+	 * exactly what a twin would destroy.</strong> Most rows of {@link #ELEMENTS} reach Iris through
+	 * {@code getSolid}, {@code getCutout} or {@code getTranslucent}, which is why the table is twinned
+	 * at all: those three functions test the hand, then the block entity phase, then fall through
+	 * ({@code pipeline/IrisPipelines.java:188-222}). Three of its rows reach constants there instead,
+	 * the swirl, the crystal beam and the offset cutout ({@code :60,61,62}), and are twinned along with
+	 * the rest by a table built with no filter; whether that costs anything is a question about those
+	 * three rows and not about these two. The two rows below reach a CONSTANT,
+	 * {@code p -> ShaderKey.ENTITIES_EYES} and
 	 * {@code p -> ShaderKey.ENTITIES_EYES_TRANS} ({@code pipeline/IrisPipelines.java:52,53}), which
 	 * consults nothing. Derived into the other three tables they would ask for
 	 * {@code gbuffers_block_translucent} inside a chest's draw and {@code gbuffers_hand_water} inside
@@ -958,9 +962,16 @@ public final class EntityDraw {
 	 * Both keys are {@code ProgramId.SpiderEyes}
 	 * ({@code pipeline/programs/ShaderKey.java:44,45}), so both ask for one name and differ only in
 	 * what they discard at, {@code NON_ZERO_ALPHA} for the plain eyes and {@code ONE_TENTH_ALPHA} for
-	 * the emissive one. That tenth is the game's own {@code ALPHA_CUTOUT} for that pipeline
-	 * ({@code RenderPipelines.java:290}) and the plain eyes pipeline declares none
-	 * ({@code :351-364}), so here the two authorities agree row for row.
+	 * the emissive one. <strong>The two authorities agree on one of those rows and not on the
+	 * other</strong>, and this is the place {@link #ELEMENTS} calls the one where the two halves are
+	 * read differently. The tenth is the game's own {@code ALPHA_CUTOUT} for that pipeline
+	 * ({@code RenderPipelines.java:290}), so the emissive row is both answers at once. The plain eyes
+	 * pipeline declares no {@code ALPHA_CUTOUT} at all ({@code :351-364}), which by the letter of
+	 * {@link Element#alphaTest} would be no test, and the row carries Iris's threshold instead, for the
+	 * reason that settles every such tie here: a pack is written against Iris. What it is worth in the
+	 * picture is not claimed, and the honest answer is that it may be nothing, since a texel this test
+	 * discards adds nothing under the additive blend either and the pipeline writes no depth. A pack
+	 * that writes its own {@code alphaTest} directive settles it for both.
 	 * <p>
 	 * <strong>Both blend, so both belong to the translucent window</strong>, the game declaring
 	 * {@code BlendFunction.TRANSLUCENT} on each ({@code RenderPipelines.java:360,293}). What they are
@@ -973,7 +984,7 @@ public final class EntityDraw {
 	 * ({@code pipeline/programs/ShaderKey.java:44,45}), which reaches its shaders as two things: the
 	 * light map names are answered with a constant rather than out of the mesh
 	 * ({@code gl/state/ShaderAttributeInputs.java:42} into
-	 * {@code transform/transformer/VanillaCoreTransformer.java:117-121}) and the name {@code lightmap}
+	 * {@code transform/transformer/VanillaCoreTransformer.java:117-118}) and the name {@code lightmap}
 	 * is bound to one white texel ({@code samplers/IrisSamplers.java:202-206}). {@link Element#inputs} is
 	 * where the row hands that on, and both halves come back off the translation so that they cannot
 	 * part company. A pack whose {@code gbuffers_spidereyes} multiplies by the light map would
@@ -988,6 +999,15 @@ public final class EntityDraw {
 	 * ({@code rendertype/RenderTypes.java:190-198,242-244}), so there is no depth nudge to reproduce
 	 * and no animation to read out of the game's own transforms, which the last two rows of
 	 * {@link #ELEMENTS} do need.
+	 * <p>
+	 * <strong>Neither casts a shadow, and that is work not done rather than a choice.</strong> Iris
+	 * puts both pipelines in its shadow table as {@code SHADOW_ENTITIES_CUTOUT}
+	 * ({@code pipeline/IrisPipelines.java:105,107}); {@link #SHADOW_ELEMENTS} is derived from
+	 * {@link #ELEMENTS} alone, so a row here has no shadow twin and the draw is dropped inside the
+	 * light's walk, which the engine prints at the moment it happens. Nothing here makes it
+	 * impossible: it is named rather than argued for, and what it costs the image is the sliver of a
+	 * mob's shadow its eyes would have darkened, an eye being a decal on geometry the mob's own rows
+	 * already cast.
 	 */
 	private static final Map<RenderPipeline, Element> FIXED = new LinkedHashMap<>();
 
@@ -1021,10 +1041,12 @@ public final class EntityDraw {
 	 * <strong>{@link #FIXED} is asked before all three, and that is the same fidelity read from the
 	 * other end.</strong> Those rows are constants in Iris's own table rather than calls into the
 	 * three functions that test anything ({@code pipeline/IrisPipelines.java:52,53}), so no mark of
-	 * ours may reach them either. Asked after the hand, an eye drawn while the arm was up would be
-	 * served {@code gbuffers_hand_water}; asked after the block entity mark, an eye on a mob standing
-	 * where a chest had just been submitted would be served {@code gbuffers_block_translucent}. Iris
-	 * answers {@code gbuffers_spidereyes} to both.
+	 * ours may reach them either. What being asked LATER would cost is not the wrong program but no
+	 * program at all: the three tables the marks select are each derived from {@link #ELEMENTS} alone,
+	 * which has no eyes row, so an eye drawn while the arm was up or on a mob standing where a chest
+	 * had just been submitted would find nothing, go back to the game, and be painted flat through
+	 * {@link FeatureLayer}. Iris answers {@code gbuffers_spidereyes} in both moments, so this order is
+	 * the only one that serves them at all.
 	 */
 	@SuppressWarnings("ReferenceEquality")
 	private static Element element(RenderPipeline pipeline) {
@@ -1323,8 +1345,12 @@ public final class EntityDraw {
 		// window is shut, so the game keeps that draw. Iris would serve it, gbuffers_spidereyes being
 		// its constant there too; the obstacle is that this engine binds a piece to one side of the
 		// deferred stage at the LOAD, and an eyes row is bound to the side its window is on. No
-		// renderer of the game can reach it: the four callers of the eyes render type are the ender
-		// dragon and the ender, phantom and spider eye layers, none of which draws in a hand pass.
+		// renderer of the game can reach it, and that is read off both pipelines rather than one: the
+		// eyes render type is asked for by the ender dragon and by the ender, phantom and spider eye
+		// layers (EnderDragonRenderer:37, EnderEyesLayer:14, PhantomEyesLayer:14, SpiderEyesLayer:14),
+		// and the emissive one by the warden's five emissive layers and the breeze's eyes
+		// (WardenRenderer:34,44,54,60,65 and BreezeEyesLayer:19 through RenderTypes:515). None of the
+		// ten draws in a hand pass.
 		boolean inMoment = (element != null && element.hand()) ? HandDraw.wanted()
 				: wanted && element != null && inWindow(element);
 		if (!inMoment || device == null || element == null) {
@@ -1745,11 +1771,11 @@ public final class EntityDraw {
 		// cannot decode has already been reported once and saying it four times would read as four
 		// defects.
 		//
-		// Four GROUPS and not one list, because what stands or falls together is not the same in
-		// each. The entity names walk one picture and hold together WITHIN a half, and the two
-		// halves settle apart, which is the particles' position; the hand's two passes are two
-		// moments of the frame that share no target, so one of them can be served while the other
-		// is not.
+		// GROUPS and not one list, because what stands or falls together is not the same in each.
+		// The entity names walk one picture and hold together WITHIN a half, and the two halves
+		// settle apart, which is the particles' position; the hand's two passes are two moments of
+		// the frame that share no target, so one of them can be served while the other is not. Five
+		// where every switch is on, the eyes being a group of their own for the reason given below.
 		List<List<Element>> groups = new ArrayList<>();
 		if (wanted) {
 			List<Element> family = Stream.concat(served.stream(),

--- a/common/src/main/java/dev/vitrail/render/EntityProgram.java
+++ b/common/src/main/java/dev/vitrail/render/EntityProgram.java
@@ -1,6 +1,7 @@
 package dev.vitrail.render;
 
 import dev.vitrail.glsl.PackProgram;
+import dev.vitrail.pack.program.ProgramFallbacks;
 import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
@@ -164,7 +165,17 @@ final class EntityProgram implements DumpedProgram {
 				// (shaderpack/loading/ProgramId.java:13-19), and the reason is what a map is for:
 				// what it wants of a translucent surface is the depth that surface stands at, not
 				// that depth mixed with the one behind it.
-				shadow ? Optional.<BlendFunction>empty() : game.getColorTargetState().blendFunction(),
+				//
+				// Off the map, the game's own blending for this pipeline, unless the name asked for
+				// is one Iris gives a default of its own; the pack's own blend directive still
+				// displaces either, GeometryProgram looking that one up under the file that really
+				// served the piece. Only the eyes have one, and for them the game's translucent
+				// blend is the wrong answer rather than a duller one: an eye is drawn additively or
+				// it is a decal. The two questions are asked in this order and not folded together:
+				// the map's refusal is about the target, the lookup is about the program name.
+				shadow ? Optional.<BlendFunction>empty()
+						: BlendFunctions.of(ProgramFallbacks.blendOverride(element.program()),
+								game.getColorTargetState().blendFunction()),
 				// covers: the mask on every piece drawn before the seed and on no other, which is
 				// Element.covers and is answered there, beside the question of which side of the
 				// stage a piece is drawn on. It is what takes draw buffer nought of those pieces off

--- a/common/src/main/java/dev/vitrail/render/FeatureLayer.java
+++ b/common/src/main/java/dev/vitrail/render/FeatureLayer.java
@@ -51,17 +51,18 @@ import java.util.Optional;
  * divergence from Iris and it is written out in the three parts one owes.</strong>
  * <p>
  * What Iris does: it replaces the SHADER of a draw and never the target it goes to, keying the
- * replacement on the pipeline ({@code pipeline/IrisPipelines.java:52} for the eyes, {@code :66,67}
- * for the beacon beam, {@code :72} for the text), so the text, the eyes, the beams and the served
- * entities are all drawn into the same attachments in the order the game walks its phases, each one
- * depth tested against the last. It composes nothing, so the question cannot arise there.
+ * replacement on the pipeline ({@code pipeline/IrisPipelines.java:66,67} for the beacon beam,
+ * {@code :72} for the text, {@code :63} for the lightning), so the text, the beams, the bolts and
+ * the served entities are all drawn into the same attachments in the order the game walks its
+ * phases, each one depth tested against the last. It composes nothing, so the question cannot arise
+ * there.
  * <p>
- * What stops that here: {@link EntityDraw} serves the blending half of the entities inside this same
- * bracket and the families nobody serves yet stay the game's - the eyes, the beacon beam, the text
- * and the lightning, plus the one glint that is addressed away from the main target and handed back
- * with them. No draw takes both roads, but the ones left here are drawn into a
- * layer of this class's own and that layer is composed ONCE, at {@code PackChain.closeFeatures}, over
- * a full screen quad carrying no depth attachment and therefore no depth test.
+ * What stops that here: {@link EntityDraw} serves the blending half of the entities and the eyes
+ * inside this same bracket and the families nobody serves yet stay the game's, the beacon beam, the
+ * text and the lightning, plus the one glint that is addressed away from the main target and handed
+ * back with them. No draw takes both roads, but the ones left here are drawn into a layer of this
+ * class's own and that layer is composed ONCE, at {@code PackChain.closeFeatures}, over a full
+ * screen quad carrying no depth attachment and therefore no depth test.
  * <p>
  * What it costs the image: everything still left to the game is painted in front of everything
  * served, however far behind it stands. The game draws the shadows, then the translucent models,

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -1174,6 +1174,16 @@ final class GeometryProgram {
 		}
 
 		if (LIGHTMAP.equals(sampler)) {
+			// One white texel for a piece the game draws at full light, which is the other half of what
+			// the vertex head did with the light map names and is read off the same field so that the
+			// two cannot part company (PackProgram.Loaded.fullbright). Iris binds its own white pixel
+			// here (samplers/IrisSamplers.java:202-206). White is what leaves the piece alone: a pack
+			// multiplies its albedo by what it reads out of this image, and every texel of the game's
+			// own is darker than one except at the brightest level.
+			if (this.loaded.fullbright()) {
+				return this.white.getColorTextureView();
+			}
+
 			Minecraft minecraft = Minecraft.getInstance();
 			GpuTextureView lightmap = minecraft == null ? null : minecraft.gameRenderer.lightmap();
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -204,22 +204,28 @@ not reach: the log names the reason at the moment it happens. Neither case is th
 
 `entities=on` covers more than mobs. Block entities come in by the same door and are asked for
 `gbuffers_block` rather than `gbuffers_entities`, the hand rides its own switch, and a mob's glowing
-eyes are asked for `gbuffers_spidereyes` - blended additively, which is what makes an eye a light
-rather than a decal, and which the pack overrides with `blend.gbuffers_spidereyes` like any other.
+eyes are asked for `gbuffers_spidereyes`, and an enchantment's shine for `gbuffers_armor_glint`.
+
+The eyes answer two things differently from every other piece here, and both come from the game
+drawing them as a light rather than as a surface. They are **blended additively**, which is what
+makes an eye add to the skin under it instead of replacing it, and the pack displaces that with
+`blend.gbuffers_spidereyes` like any other. And they are drawn at **full light**: the light map
+coordinate the pack reads is the brightest one whatever the mob is standing in, and the light map
+image itself is one white texel, so a pack that multiplies by it is left where it started. Given
+only one of those two, an eye comes out darker than the game would have drawn it, and the additive
+blend then adds that darkness.
 
 What decides whether a family can come in at all is **the mesh the game binds for it**, not how
 interesting the family is. The door reads one vertex layout, the game's entity format, and names the
 attributes a pack expects out of its elements. A pipeline binding anything else would have every
 attribute read from the wrong offset - a picture, and a wrong one, with nothing to say so - so it is
-refused and named in the log instead.
+refused and named in the log instead. The glint is the one exception and it is a narrow one: it is
+drawn from a two-element quad the door decodes as well.
 
-That is the whole reason the beacon beam, the lightning bolt, the enchantment glint and the text of
-a sign or a name plate still come from the game's own shader: they bind the block, position-colour,
-position-texture and glyph layouts respectively. They reach the pack's image through the layer
-described below, which means they are visible but flat, and drawn in front of what should hide them.
-The glint has a second reason of its own: its render type animates by moving its texture matrix
-every frame, and a pack reading that matrix here would be handed the identity, so the scroll that is
-the entire effect would be frozen on one frame.
+That is the whole reason the beacon beam, the lightning bolt and the text of a sign or a name plate
+still come from the game's own shader: they bind the block, position-colour and glyph layouts. They
+reach the pack's image through the layer described below, which means they are visible but flat, and
+drawn in front of what should hide them.
 
 Which target is seeded is the first draw buffer of the pass that draws the terrain, resolved through
 the fallback tree, and it is not always target zero: one pack of the corpus serves its terrain

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -208,8 +208,11 @@ eyes are asked for `gbuffers_spidereyes`, and an enchantment's shine for `gbuffe
 
 The eyes answer two things differently from every other piece here, and both come from the game
 drawing them as a light rather than as a surface. They are **blended additively**, which is what
-makes an eye add to the skin under it instead of replacing it, and the pack displaces that with
-`blend.gbuffers_spidereyes` like any other. And they are drawn at **full light**: the light map
+makes an eye add to the skin under it instead of replacing it. A pack displaces that with a `blend`
+directive like any other, with one catch worth knowing: that directive is read under the name of the
+file that really serves the piece, so a pack shipping no `gbuffers_spidereyes` of its own has to
+write the line under whatever the fallback tree lands its eyes on. And they are drawn at
+**full light**: the light map
 coordinate the pack reads is the brightest one whatever the mob is standing in, and the light map
 image itself is one white texel, so a pack that multiplies by it is left where it started. Given
 only one of those two, an eye comes out darker than the game would have drawn it, and the additive

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -200,6 +200,27 @@ somebody wrote `entities=off` in `vitrail/options.txt`, which hands every entity
 the game's shader. Failing that, an entity that still looks flat is one the pack's own program did
 not reach: the log names the reason at the moment it happens. Neither case is the coverage mask.
 
+### What the entity door can carry, and what the mesh keeps out
+
+`entities=on` covers more than mobs. Block entities come in by the same door and are asked for
+`gbuffers_block` rather than `gbuffers_entities`, the hand rides its own switch, and a mob's glowing
+eyes are asked for `gbuffers_spidereyes` - blended additively, which is what makes an eye a light
+rather than a decal, and which the pack overrides with `blend.gbuffers_spidereyes` like any other.
+
+What decides whether a family can come in at all is **the mesh the game binds for it**, not how
+interesting the family is. The door reads one vertex layout, the game's entity format, and names the
+attributes a pack expects out of its elements. A pipeline binding anything else would have every
+attribute read from the wrong offset - a picture, and a wrong one, with nothing to say so - so it is
+refused and named in the log instead.
+
+That is the whole reason the beacon beam, the lightning bolt, the enchantment glint and the text of
+a sign or a name plate still come from the game's own shader: they bind the block, position-colour,
+position-texture and glyph layouts respectively. They reach the pack's image through the layer
+described below, which means they are visible but flat, and drawn in front of what should hide them.
+The glint has a second reason of its own: its render type animates by moving its texture matrix
+every frame, and a pack reading that matrix here would be handed the identity, so the scroll that is
+the entire effect would be frozen on one frame.
+
 Which target is seeded is the first draw buffer of the pass that draws the terrain, resolved through
 the fallback tree, and it is not always target zero: one pack of the corpus serves its terrain
 through the textured gbuffers program, whose draw buffers start at the fifth target.


### PR DESCRIPTION
## What changes

Serves the glowing eyes of a mob with `gbuffers_spidereyes`, on two rows that get no block entity twin
and no hand twin, and gives them the two things Iris means by full light. The blend is a default hung
on the program NAME rather than read off the pipeline, and the pack's own `blend` directive still
displaces it. The light is a second contract over the entity mesh, `ENTITY_FULLBRIGHT`, which answers
the light map names with the brightest coordinate and binds one white texel behind `lightmap`; both
halves are read off the translation, so they cannot part company. The contract is keyed on the ROW and
not on the program name, which is where Iris keeps it too: one pack of the corpus serves its eyes and
its mobs out of a single `gbuffers_textured`, and the two want different answers.

## How it differs from the reference, and for what obstacle

It does not, on any of that. Two rows, `ENTITIES_EYES` and `ENTITIES_EYES_TRANS`
(`pipeline/IrisPipelines.java:52,53`); one additive default
(`shaderpack/loading/ProgramId.java:47-48`); full light in its two halves
(`gl/state/ShaderAttributeInputs.java:42` into `transformer/VanillaCoreTransformer.java:117-118`, and
`samplers/IrisSamplers.java:202-206`). One threshold is Iris's where the game declares none, and
`FIXED` writes out why.

## What proves it

- `gradlew build` green after the rebase onto `dev`, which took two conflicts resolved by composition.
- The off-game harness over the eight packs: 150 programs, 300 stages compiled out of 300, and a new
  section that asks the question the way the engine asks it, through `loadGeometry`, fallback tree
  included. 24 rows served, the two eye rows at full light everywhere and the ordinary mob row off the
  mesh. Six packs name that coordinate in the file serving their eyes; one samples the light map with
  it. Forcing the constant back to the mesh makes the gate fall on every pack.
- In the game, Complementary Unbound, a night bench with a spider, an enderman and a warden: both rows
  draw with `world0/gbuffers_spidereyes`, reading `enderman_eyes.png`, and the spider's eyes come out
  lit on a body left black.
- One adversarial review: no defect of behaviour, thirteen written claims that did not hold, all
  verified in the game's own source and in Iris and corrected in the last commit.

## What it leaves owing

**Neither row casts a shadow.** Iris puts both pipelines in its shadow table
(`pipeline/IrisPipelines.java:105,107`) and `SHADOW_ELEMENTS` is derived from the mob table alone, so
the draw is dropped inside the light's walk. Named in `FIXED` and printed by the engine at the moment
it happens.

**The full light half was not seen by eye.** The only pack of the corpus whose eye program samples the
light map is Reverie, which this engine refuses for four unrelated features, so that half rests on the
harness.

`entityId`, `blockEntityId` and `currentRenderedItemId` are withheld from this chain, latent: no pack
of the corpus names them there.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one. `docs/frame.md` is
      the one that listed families; `README.md` defers to the line the engine prints.
