### PR TITLE
Hand a kept input over from the stage before, as Iris does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ what the next one holds.
   eight packs tested that is between two and four images rather than the single one it would
   otherwise have reached.
 
+### Fixed
+
+- **Mellow draws instead of showing you the game's own picture.** A pass may read a value that the
+  step before it never sends, which a pack gets away with elsewhere and this engine refused: the
+  refusal cost the pass, and a pack cannot lose a pass without losing the whole picture, so what you
+  saw was the game with no shader on it at all. The value is now handed over rather than the pass
+  being thrown away. Mellow is the pack it cost, on one of its lighting passes, and it draws now.
+
 ## 0.3.0-alpha.1
 
 ### Changed

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -1755,6 +1755,7 @@ public final class GlslTranslator {
 		if (this.stage == ProgramStage.FRAGMENT) {
 			if (wrapsFragment()) {
 				replace(this.packMainName, PACK_MAIN);
+				this.mainWrapped = true;
 			}
 
 			return;
@@ -1955,12 +1956,20 @@ public final class GlslTranslator {
 
 			// Read by the body, so it stays, and the stage before it has to hand it over instead.
 			// Every name of the declaration and not only the ones read: they share one statement,
-			// so the stage before writes the whole of it or the locations no longer line up.
+			// and a name left out of it is one the module is still refused for.
 			for (String name : declared.names()) {
-				// An array is left where it is, as Iris leaves everything it cannot write an
-				// initialiser for: CompatibilityTransformer.java:473-480 bails on a type its
-				// getInitializer has no default value for, and says so. The declarator carrying
-				// brackets is what tells one here, the type name alone never doing so.
+				// A DIVERGENCE, and an array is the whole of it. Iris patches one:
+				// CompatibilityTransformer.java:467-497 bails only on a type with no numeric
+				// specifier (:473-480), and its declarationTemplate at :68-70 is "out __type
+				// __name;", which carries no array specifier at all. What makes that impossible
+				// here is that the two sides would then disagree on the type, the fragment stage
+				// holding "in float x[4]" against a vertex stage holding "out float x", and this
+				// backend compiles each stage to its own module rather than linking them, so the
+				// disagreement lands as a compile error naming neither stage. What it costs the
+				// image is nothing: the pass is lost either way, here through the refusal it
+				// already had and there through a module that does not build, and no pack of the
+				// corpus declares a varying array. The declarator carrying brackets is what tells
+				// one, the type name alone never doing so.
 				if (declared.declarators().getOrDefault(name, "").equals(declared.type() + " " + name)) {
 					this.unprovidedInputs.put(name, declared.qualifier().isEmpty()
 							? declared.type()
@@ -1992,9 +2001,12 @@ public final class GlslTranslator {
 
 	/**
 	 * What the stage assigns an owed varying, which is the type's zero, exactly as Iris writes it at
-	 * {@code CompatibilityTransformer.java:494} out of {@code getInitializer:351-359}. Every type
-	 * that reaches here spells its own zero the same way, {@link LegacyGlsl#TYPE_NAMES} holding
-	 * nothing but the numeric ones.
+	 * {@code CompatibilityTransformer.java:494} out of {@code getInitializer:351-359}.
+	 * <p>
+	 * {@code type(0)} spells the zero of every type that can reach here. {@link LegacyGlsl#TYPE_NAMES}
+	 * holds the scalars, the vectors and the matrices, and the constructor of each takes a single
+	 * zero; {@code bool} and {@code bvec} are in it too and take one just as well. {@code void} is
+	 * the one member no constructor answers for, and a varying cannot be declared under it.
 	 */
 	private static String initialiser(String name, String qualified) {
 		int type = qualified.lastIndexOf(' ');
@@ -2100,10 +2112,11 @@ public final class GlslTranslator {
 	/**
 	 * One declaration at file scope, and the tokens that would go with it if it were taken out.
 	 *
-	 * @param qualifier   the interpolation qualifier the declaration opens with, empty where it has
-	 *                    none. Kept because a varying handed to the other stage has to be declared
-	 *                    there under the same one, and {@code flat} is the one that matters: an
-	 *                    integer varying is flat or it is nothing
+	 * @param qualifier   the interpolation qualifiers of the declaration, from either side of the
+	 *                    storage keyword, empty where it has none. Kept because a varying handed to
+	 *                    the other stage has to be declared there under the same ones, and
+	 *                    {@code flat} is the one that matters: an integer varying is flat or it is
+	 *                    nothing
 	 * @param declarators each name with the text that declares it, array brackets included, which is
 	 *                    what lets a declaration be written again rather than described
 	 */
@@ -3120,11 +3133,6 @@ public final class GlslTranslator {
 			lines.add((this.stage == ProgramStage.VERTEX ? "out" : "in") + " float " + FOG_COORD + ";");
 		}
 
-		// The same rule read from the other end: a varying the NEXT stage declares and this one never
-		// wrote is not a silence but a refusal, so it is declared here rather than taken out there.
-		// The qualifier travels with it, since the two sides have to agree on that as well.
-		this.owedOutputs.forEach((name, qualified) -> lines.add(outDeclaration(name, qualified)));
-
 		// From zero up with no gaps, because a location the game finds nothing declared at is not
 		// left empty: it renumbers what is there and everything above the gap moves down one.
 		for (int slot = 0; slot <= this.maxFragmentOutput; slot++) {
@@ -3152,6 +3160,18 @@ public final class GlslTranslator {
 
 			lines.add(order.append(" }").toString());
 		}
+
+		// The same rule as the varying above, read from the other end: a varying the NEXT stage
+		// declares and this one never wrote is not a silence but a refusal, so it is declared here
+		// rather than taken out there. The qualifier travels with it, the two sides having to agree
+		// on that as well.
+		//
+		// BELOW the colour outputs and below the ascending function, for the reason the next block
+		// gives about itself: on a stage that has colour outputs, a plain out declaration met first
+		// would take location nought from the one the game writes back. Only the last stage of a
+		// pipeline has those and only a stage that is not last is ever owed anything, so the two do
+		// not meet today. They are ordered anyway rather than left to that argument holding.
+		this.owedOutputs.forEach((name, qualified) -> lines.add(outDeclaration(name, qualified)));
 
 		// Below the block, since it reads it, and below the outputs and the ascending function for a
 		// reason that decides the picture: a wrapper standing above them would be the first place the

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -266,8 +266,21 @@ public final class GlslTranslator {
 	/** Varyings this stage hands the next one, which is what says whether an input is provided. */
 	private final Set<String> declaredOutputs = new LinkedHashSet<>();
 
+	/**
+	 * Inputs nothing before this stage writes and that the body reads anyway, so that they could not
+	 * be taken back out: by the name, the interpolation qualifier and the type it was declared
+	 * under. What the stage before has to declare for the module to be built at all.
+	 */
+	private final Map<String, String> unprovidedInputs = new LinkedHashMap<>();
+
+	/** Declarations this stage owes the next one although its own body writes none of them. */
+	private final Map<String, String> owedOutputs = new LinkedHashMap<>();
+
 	private Set<String> declaredAfter = Set.of();
 	private Set<String> used = Set.of();
+
+	/** Whether the body's own main has been renamed, so that the header carries the one that runs. */
+	private boolean mainWrapped;
 
 	private int maxFragmentOutput = -1;
 	private boolean ordered;
@@ -547,6 +560,41 @@ public final class GlslTranslator {
 		 */
 		public void dropUnprovidedInputs(Set<String> provided) {
 			this.translator.dropUnprovidedInputs(provided);
+		}
+
+		/**
+		 * What {@link #dropUnprovidedInputs} could not take out, by name, each with the text that
+		 * declares it again. Empty until that has run.
+		 */
+		public Map<String, String> unprovided() {
+			return Map.copyOf(this.translator.unprovidedInputs);
+		}
+
+		/**
+		 * Makes this stage declare these as outputs and assign each one its zero, so that the stage
+		 * after it is provided for.
+		 * <p>
+		 * A name this stage already hands on is skipped, which is the test Iris makes at
+		 * {@code CompatibilityTransformer.java:467} against the out declarations it gathered at
+		 * :425-440. Compared against those and not against every name the stage declares: a vertex
+		 * stage that happens to call a function parameter {@code ViewPos} would otherwise make this
+		 * give up, and the pass would be lost for a name that clashes with nothing.
+		 * <p>
+		 * A name opening with {@code gl_} is skipped as well, as it is on both of Iris's sides at
+		 * :435 and :462. Redeclaring a built-in as a varying of ours is a compile error, and the
+		 * game provides them itself.
+		 */
+		public void owe(Map<String, String> declarations) {
+			declarations.forEach((name, qualified) -> {
+				if (!name.startsWith("gl_") && !this.translator.declaredOutputs.contains(name)) {
+					this.translator.owedOutputs.put(name, qualified);
+					this.translator.declaredOutputs.add(name);
+				}
+			});
+
+			if (!this.translator.owedOutputs.isEmpty()) {
+				this.translator.wrapMainForOwedOutputs();
+			}
 		}
 
 		public TranslatedUnit render(List<TranslatedUnit.Uniform> block,
@@ -1751,6 +1799,37 @@ public final class GlslTranslator {
 			takeDepthConv();
 			this.depthEpilogue = true;
 		}
+
+		this.mainWrapped = true;
+	}
+
+	/**
+	 * Wraps the body's own main so that the owed varyings can be assigned before it runs, where
+	 * nothing had wrapped it already.
+	 * <p>
+	 * After {@link #prepare} rather than inside it, and that is forced: which varyings are owed is a
+	 * property of the PROGRAM, decided once both stages have been read, and a stage prepared on its
+	 * own cannot know. The token indices are stable by then, which {@link #regions} relies on for
+	 * the same reason.
+	 * <p>
+	 * Before the pack's own main and not after, as Iris prepends it at
+	 * {@code CompatibilityTransformer.java:494}. It matters where a pack writes the name itself on
+	 * some path: the pack's own value has to win, so ours is what stands there before it runs.
+	 */
+	private void wrapMainForOwedOutputs() {
+		if (this.mainWrapped) {
+			return;
+		}
+
+		int name = mainName();
+		if (name < 0) {
+			// No main to wrap and so no place to assign from. The declarations still go out, which is
+			// what the pairing reads; the values are then whatever the stage leaves, as they were.
+			return;
+		}
+
+		replace(name, PACK_MAIN);
+		this.mainWrapped = true;
 	}
 
 	/**
@@ -1871,6 +1950,22 @@ public final class GlslTranslator {
 			if (declared.names().stream().noneMatch(read::contains)) {
 				blankRange(declared.start(), declared.end());
 				dropped = true;
+				continue;
+			}
+
+			// Read by the body, so it stays, and the stage before it has to hand it over instead.
+			// Every name of the declaration and not only the ones read: they share one statement,
+			// so the stage before writes the whole of it or the locations no longer line up.
+			for (String name : declared.names()) {
+				// An array is left where it is, as Iris leaves everything it cannot write an
+				// initialiser for: CompatibilityTransformer.java:473-480 bails on a type its
+				// getInitializer has no default value for, and says so. The declarator carrying
+				// brackets is what tells one here, the type name alone never doing so.
+				if (declared.declarators().getOrDefault(name, "").equals(declared.type() + " " + name)) {
+					this.unprovidedInputs.put(name, declared.qualifier().isEmpty()
+							? declared.type()
+							: declared.qualifier() + " " + declared.type());
+				}
 			}
 		}
 
@@ -1878,6 +1973,33 @@ public final class GlslTranslator {
 			this.used = usedNames();
 			this.declaredAfter = declaredUnderAType();
 		}
+	}
+
+	/**
+	 * An owed varying written as an output declaration, with {@code out} where GLSL wants it: after
+	 * the interpolation qualifier and before the type. Writing {@code out flat float} rather than
+	 * {@code flat out float} is a syntax error, so the two cannot simply be concatenated.
+	 *
+	 * @param qualified the qualifier and the type, {@code flat float} or {@code vec3}
+	 */
+	private static String outDeclaration(String name, String qualified) {
+		int type = qualified.lastIndexOf(' ');
+
+		return type < 0
+				? "out " + qualified + " " + name + ";"
+				: qualified.substring(0, type) + " out " + qualified.substring(type + 1) + " " + name + ";";
+	}
+
+	/**
+	 * What the stage assigns an owed varying, which is the type's zero, exactly as Iris writes it at
+	 * {@code CompatibilityTransformer.java:494} out of {@code getInitializer:351-359}. Every type
+	 * that reaches here spells its own zero the same way, {@link LegacyGlsl#TYPE_NAMES} holding
+	 * nothing but the numeric ones.
+	 */
+	private static String initialiser(String name, String qualified) {
+		int type = qualified.lastIndexOf(' ');
+
+		return name + " = " + qualified.substring(type + 1) + "(0);";
 	}
 
 	/**
@@ -1975,8 +2097,23 @@ public final class GlslTranslator {
 		return region;
 	}
 
-	/** One declaration at file scope, and the tokens that would go with it if it were taken out. */
-	private record FileScope(List<String> names, String type, int start, int end) {
+	/**
+	 * One declaration at file scope, and the tokens that would go with it if it were taken out.
+	 *
+	 * @param qualifier   the interpolation qualifier the declaration opens with, empty where it has
+	 *                    none. Kept because a varying handed to the other stage has to be declared
+	 *                    there under the same one, and {@code flat} is the one that matters: an
+	 *                    integer varying is flat or it is nothing
+	 * @param declarators each name with the text that declares it, array brackets included, which is
+	 *                    what lets a declaration be written again rather than described
+	 */
+	private record FileScope(List<String> names, String type, String qualifier,
+			Map<String, String> declarators, int start, int end) {
+
+		private FileScope {
+			names = List.copyOf(names);
+			declarators = Map.copyOf(declarators);
+		}
 	}
 
 	/**
@@ -2013,15 +2150,26 @@ public final class GlslTranslator {
 			return null;
 		}
 
+		// Gathered on both sides of the keyword, because GLSL takes the qualifier either way round
+		// and packs write both: Mellow opens with flat, and a pack writing "in flat" is as legal.
+		List<String> qualifiers = new ArrayList<>();
 		for (int before = 0; before < cursor; before++) {
-			if (!LegacyGlsl.INTERPOLATION_QUALIFIERS.contains(this.tokens.get(parts.get(before)).text())) {
+			String text = this.tokens.get(parts.get(before)).text();
+			if (!LegacyGlsl.INTERPOLATION_QUALIFIERS.contains(text)) {
 				return null;
 			}
+
+			qualifiers.add(text);
 		}
 
 		cursor++;
 		while (cursor < parts.size() && (isQualifier(this.tokens.get(parts.get(cursor)))
 				|| LegacyGlsl.INTERPOLATION_QUALIFIERS.contains(this.tokens.get(parts.get(cursor)).text()))) {
+			String text = this.tokens.get(parts.get(cursor)).text();
+			if (LegacyGlsl.INTERPOLATION_QUALIFIERS.contains(text)) {
+				qualifiers.add(text);
+			}
+
 			cursor++;
 		}
 
@@ -2039,7 +2187,8 @@ public final class GlslTranslator {
 			return null;
 		}
 
-		return new FileScope(List.copyOf(found.keySet()), type, start, end);
+		return new FileScope(List.copyOf(found.keySet()), type, String.join(" ", qualifiers), found,
+				start, end);
 	}
 
 	private boolean namesClipPosition() {
@@ -2971,6 +3120,11 @@ public final class GlslTranslator {
 			lines.add((this.stage == ProgramStage.VERTEX ? "out" : "in") + " float " + FOG_COORD + ";");
 		}
 
+		// The same rule read from the other end: a varying the NEXT stage declares and this one never
+		// wrote is not a silence but a refusal, so it is declared here rather than taken out there.
+		// The qualifier travels with it, since the two sides have to agree on that as well.
+		this.owedOutputs.forEach((name, qualified) -> lines.add(outDeclaration(name, qualified)));
+
 		// From zero up with no gaps, because a location the game finds nothing declared at is not
 		// left empty: it renumbers what is there and everything above the gap moves down one.
 		for (int slot = 0; slot <= this.maxFragmentOutput; slot++) {
@@ -3005,7 +3159,7 @@ public final class GlslTranslator {
 		// writes back. It has to be the ascending function that gets there first, so this goes last.
 		// The pack's body is concatenated after the header, so its own main is only a name here and
 		// has to be declared before it can be called.
-		if (this.depthEpilogue || this.terrainPrologue || wrapsFragment()) {
+		if (this.depthEpilogue || this.terrainPrologue || wrapsFragment() || owesInitialisers()) {
 			lines.add("void " + PACK_MAIN + "();");
 			// The mask goes last of all, after the discard: a fragment the alpha test threw away
 			// covered nothing, and marking it covered would leave a hole where a leaf was.
@@ -3013,6 +3167,7 @@ public final class GlslTranslator {
 					+ (this.terrainPrologue ? SodiumVertex.PROLOGUE + "(); " : "")
 					+ (wrapsFragment() ? ORDER_OUTPUTS + "(); " : "")
 					+ coveragePrologue()
+					+ owedPrologue()
 					+ PACK_MAIN + "();"
 					+ (this.depthEpilogue ? " gl_Position.z = " + DEPTH_CONV
 							+ ".x * gl_Position.z + " + DEPTH_CONV + ".y * gl_Position.w;" : "")
@@ -3024,6 +3179,24 @@ public final class GlslTranslator {
 		}
 
 		return String.join("\n", lines) + "\n";
+	}
+
+	/** Whether there is anything owed AND a wrapped main to assign it from. */
+	private boolean owesInitialisers() {
+		return this.mainWrapped && !this.owedOutputs.isEmpty();
+	}
+
+	/** The owed varyings set to their zero, ahead of the pack's own main. */
+	private String owedPrologue() {
+		if (!owesInitialisers()) {
+			return "";
+		}
+
+		StringBuilder assignments = new StringBuilder();
+		this.owedOutputs.forEach((name, qualified) ->
+				assignments.append(initialiser(name, qualified)).append(' '));
+
+		return assignments.toString();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -182,6 +182,14 @@ public final class ProgramTranslator {
 
 				provided.addAll(prepare.provides());
 			}
+
+			// What the drop would not take, handed back the other way. Taking it out was the first
+			// answer because it is the one that changes nothing; what is left is read by the body, so
+			// the only answers remaining are to have the stage before hand it over or to lose the
+			// pass. Mellow's deferred1 is drawn over a quad and includes the header its geometry
+			// passes use, which declares eleven varyings; three of them are read by functions this
+			// pass never calls, and the game refused the whole module over exactly those three.
+			owed(prepared);
 		}
 
 		Map<String, TranslatedUnit.Uniform> uniforms = new LinkedHashMap<>();
@@ -212,6 +220,48 @@ public final class ProgramTranslator {
 
 		return new TranslatedProgram(Map.copyOf(translated), block, bound, Map.copyOf(synthesized),
 				inputs);
+	}
+
+	/**
+	 * Makes each stage declare the varyings the stage after it kept, and assign each one its zero.
+	 * <p>
+	 * <strong>This is Iris's own patch, and it is taken whole rather than adapted.</strong>
+	 * {@code CompatibilityTransformer.java:442-504} does exactly this: same condition, the input
+	 * having to be referenced somewhere (:469); same interpolation qualifier carried over (:485-488);
+	 * same pairing with the stage before; and the declaration is followed by an initialiser
+	 * prepended to that stage's main (:494). <strong>The initialiser is not decoration.</strong>
+	 * Under Iris these varyings hold ZERO, deterministically, and dropping it would leave them
+	 * holding whatever the stage happens to leave in them. Packs are written against Iris, so the
+	 * value they see here has to be the value they see there.
+	 * <p>
+	 * <strong>Why this cannot shift a location.</strong> {@code GlslCompiler.compile:69-86} hands the
+	 * fragment stage the vertex stage's output list in order; {@code createFromSpirv:114-116} had
+	 * numbered that list {@code 0..n-1} with nothing skipped; {@code rebind:151-163} then numbers the
+	 * fragment stage over the same list, counting only the names the fragment declares. The two agree
+	 * for every name that has no undeclared one before it in the list, so declaring MORE on the
+	 * fragment side is always safe, and what is added here is by construction a name the fragment
+	 * already declares.
+	 * <p>
+	 * <strong>The stage before is the vertex stage, and in this game it can be nothing else.</strong>
+	 * {@code GlslCompiler.compile:62-63} takes one vertex module and one fragment module and pairs
+	 * those two at :86; 26.2 compiles no geometry stage at all. The walk is written over the pipeline
+	 * order anyway rather than reaching for the vertex stage by name, so that a stage appearing
+	 * between them is paired correctly rather than silently skipped.
+	 *
+	 * @param prepared the stages of one program, keyed by stage, in pipeline order
+	 */
+	private static void owed(Map<ProgramStage, GlslTranslator.Stage> prepared) {
+		GlslTranslator.Stage previous = null;
+		for (GlslTranslator.Stage stage : prepared.values()) {
+			if (previous != null) {
+				Map<String, String> declarations = stage.unprovided();
+				if (!declarations.isEmpty()) {
+					previous.owe(declarations);
+				}
+			}
+
+			previous = stage;
+		}
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -238,9 +238,15 @@ public final class ProgramTranslator {
 	 * fragment stage the vertex stage's output list in order; {@code createFromSpirv:114-116} had
 	 * numbered that list {@code 0..n-1} with nothing skipped; {@code rebind:151-163} then numbers the
 	 * fragment stage over the same list, counting only the names the fragment declares. The two agree
-	 * for every name that has no undeclared one before it in the list, so declaring MORE on the
-	 * fragment side is always safe, and what is added here is by construction a name the fragment
-	 * already declares.
+	 * on every name with no undeclared one before it in the list. What is added here is a name the
+	 * fragment already declares, so it is counted on both sides and opens no such gap. A name the
+	 * fragment does NOT declare is what would open one, and nothing here adds one of those.
+	 * <p>
+	 * <strong>What this does not reach.</strong> A declaration whose names are only PARTLY provided,
+	 * {@code in vec3 a, b;} with a stage before writing {@code a} alone, is neither dropped nor owed:
+	 * it is offered only when nothing before writes any of its names. The module is then refused as
+	 * it was. No pack of the corpus writes one, and the shape is worth naming rather than reading as
+	 * covered.
 	 * <p>
 	 * <strong>The stage before is the vertex stage, and in this game it can be nothing else.</strong>
 	 * {@code GlslCompiler.compile:62-63} takes one vertex module and one fragment module and pairs


### PR DESCRIPTION
## What changes

A fragment stage that declares an input no earlier stage writes is refused outright by the game,
and a refused program takes the whole pack with it. Such an input was already dropped where the
body never read it; this branch answers the ones the body does read, by having the stage before
declare the varying and assign it its zero. Mellow is the pack it cost: its `deferred1` is drawn
over a quad and includes the header its geometry passes use, so it asked for `material`,
`LightmapCoords` and `ViewPos`, all three read only by functions that pass never calls. It showed
the game's own picture with no shader on it at all, and it draws now.

## How it differs from the reference, and for what obstacle

It does not. This is Iris's own patch, `CompatibilityTransformer.java:442-504`, taken whole rather
than adapted: same condition on the input being referenced, same interpolation qualifier carried
over, same pairing with the stage before, and the same initialiser prepended to that stage's main.
The initialiser is the half that is easy to drop and must not be: under Iris these varyings hold
zero rather than whatever the stage happens to leave in them.

## What proves it

- `gradlew build` green.
- The out-of-game harness over the eight packs of the corpus. No fullscreen pass of any of them
  declares an unprovided input any more, where Mellow declared three in each of its four dimension
  folders. `Programmes` links 749 of 785 programs, identical pack by pack before and after: glslang
  does not see this refusal, only `rebind` does, so that number is the no-regression control and not
  the proof.
- Read rather than measured, since no local tool reaches it: `GlslCompiler.compile:69-86` hands the
  fragment stage the vertex stage's output list in order, `createFromSpirv:114-116` had numbered
  that list from zero with nothing skipped, and `rebind:151-163` numbers the fragment stage over the
  same list counting only what it declares. Declaring more on the fragment side therefore never
  shifts a location, and every name added here is one the fragment already declared.
- Not in the game. The test instance is held by another branch.

## What it leaves owing

The same mechanism read the other way round, which refuses nothing and is therefore worse: a
varying the vertex writes and the fragment never declares shifts every location after it in the
list, silently. Bliss is the only pack of the corpus affected, on three passes. It is written up in
the backlog rather than fixed here, so that one branch carries one gesture.
