### PR TITLE
ci: one form for a commit subject and a branch name

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,82 @@
+#!/bin/sh
+#
+# Refuses a subject that is not in the form CONTRIBUTING describes, and a branch whose name is not
+# either. It runs at the commit, which is the only moment the repair is free: `git rebase -i` is not
+# available in the shells this repository is written from, so a malformed subject buried under nine
+# later commits costs a reconstruction of the branch rather than a reword.
+#
+# Install it once per clone. Worktrees share the same config file, so they need nothing of their own:
+#
+#     git config core.hooksPath .githooks
+#
+# This is also the whole of what `.github/workflows/commits.yml` runs, one message at a time over a
+# pull request's range, so the rule has a single home and cannot drift between the two ends of it.
+# Hence the second argument: a hook reads the branch off HEAD, but the workflow checks out a detached
+# merge commit and has to say which branch it means. An empty second argument checks no branch at
+# all, which is what the workflow passes for every commit after the first so the same complaint is
+# not printed once per commit.
+#
+#     .githooks/commit-msg <message-file> [branch]
+
+set -eu
+
+# Deliberately not a whitelist of the packages that exist today. A scope names a tree of code and the
+# trees move; CONTRIBUTING lists the ones in use, and this asks only that a scope look like one.
+types='feat|fix|perf|refactor|docs|test|build|ci|chore'
+subject_re="^($types)(\([a-z0-9-]+\))?!?: [a-z].*[^.]$"
+# `release` is a branch prefix and not a commit type: what lands from such a branch is the version
+# bump, which is a chore. The version itself is the name, so this is the one branch carrying dots.
+branch_re="^(($types)/[a-z0-9]+(-[a-z0-9]+)*|release/[0-9]+\.[0-9]+\.[0-9]+(-[0-9a-z.]+)?)$"
+
+die() {
+	echo "commit-msg: $1" >&2
+	echo >&2
+	echo "  <type>(<scope>)!: what the commit does" >&2
+	echo "  <type>/what-the-branch-does" >&2
+	echo >&2
+	echo "  type    feat fix perf refactor docs test build ci chore" >&2
+	echo "  scope   optional, a tree of code: pack glsl uniform render screen ..." >&2
+	echo "  !       marks what breaks a pack or a config that used to work" >&2
+	echo "  subject imperative, lower case, no full stop, 72 columns for the whole line" >&2
+	echo >&2
+	echo "The whole of it is in CONTRIBUTING.md, under Branches and Commits." >&2
+	exit 1
+}
+
+# What git will store, rather than what the file holds: it drops the comment lines the template
+# leaves behind and the blank lines above the subject, so the check has to drop them too.
+stored=$(sed '/^#/d' "$1" | sed '/./,$!d')
+subject=$(printf '%s\n' "$stored" | head -n 1)
+second=$(printf '%s\n' "$stored" | sed -n '2p')
+
+if [ -z "$subject" ]; then
+	die "the message is empty."
+fi
+
+if [ "${#subject}" -gt 72 ]; then
+	die "the subject is ${#subject} columns, and the limit is 72."
+fi
+
+if ! printf '%s' "$subject" | grep -Eq "$subject_re"; then
+	die "the subject is not in the form this repository uses: $subject"
+fi
+
+if [ -n "$second" ]; then
+	die "line 2 has to be blank, since it is what separates a subject from its body."
+fi
+
+# Absent under `git rebase` and anywhere else HEAD is detached, and there is nothing to check then.
+if [ "$#" -ge 2 ]; then
+	branch=$2
+else
+	branch=$(git symbolic-ref --short -q HEAD || true)
+fi
+
+case "$branch" in
+	'' | main | dev) ;;
+	*)
+		if ! printf '%s' "$branch" | grep -Eq "$branch_re"; then
+			die "the branch is not named the way this repository names one: $branch"
+		fi
+		;;
+esac

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,0 +1,66 @@
+# The subject of every commit and the name of the branch carrying them, checked against the one form
+# CONTRIBUTING describes. It matters more here than the same check does elsewhere, because a pull
+# request enters `dev` with the rebase button: subjects are replayed verbatim rather than collapsed
+# into the request's title, so what is written on a branch is what the public history keeps.
+#
+# It runs `.githooks/commit-msg`, the same file a contributor installs, one message at a time. The
+# rule therefore has a single home. A workflow rewriting the same regular expression would be a
+# second one, and the two would agree only until somebody changed one of them.
+#
+# What this adds over the hook is the case the hook cannot cover: whoever never ran the one command
+# that installs it, and a pull request from a fork, whose author has read nothing of this repository
+# except what is in front of them.
+#
+# Nothing older than the convention is ever read. The range is the branch's own commits, and the one
+# pull request that would carry the whole history, `dev` into `main`, is exempted below.
+
+name: commits
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commits:
+    # The release request, and it is the only exemption. It carries everything `dev` holds beyond
+    # `main`, which reaches back past the day this convention started; and it carries nothing of its
+    # own, every commit in it having already come through a request checked here.
+    if: github.base_ref != 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The range below asks what the branch holds that the base does not, so the base's history
+          # has to be there to answer it.
+          fetch-depth: 0
+
+      - name: Every subject on the branch, and the branch's own name
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+          failed=0
+          # The branch's name goes to the first commit alone. The hook would otherwise repeat the
+          # same complaint about it once per commit, and a branch has only one name.
+          branch=$BRANCH
+          for sha in $(git rev-list --reverse "origin/$BASE_REF..$HEAD_SHA"); do
+            git log -1 --format=%B "$sha" > "$RUNNER_TEMP/message"
+            if ! .githooks/commit-msg "$RUNNER_TEMP/message" "$branch"; then
+              echo "::error::$(git log -1 --format='%h %s' "$sha")"
+              failed=1
+            fi
+            branch=
+          done
+
+          exit $failed

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ replay_pid*.log
 /*.tsv
 /.*/
 !/.github/
+!/.githooks/
 
 # Pages being written. A page moves out of here and into docs/ when it has been read back
 # against the source and stops moving; until then it is a draft, and publishing a draft is how

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,26 @@ Two long-lived branches, and the difference between them is one question: has th
 So `main` is always an exact prefix of `dev`, which is what makes the two readable side by side:
 whatever `dev` holds beyond `main` is precisely what is written and not yet published.
 
+Every other branch is a topic branch, and it is named for what it does:
+
+    <type>/what-the-branch-does
+
+The type is one of the nine a commit subject uses, listed under [Commits](#commits), and it is
+whatever the branch mostly is. After the slash come two to five words in lower case joined by
+dashes, saying what the branch does rather than which class it opens. The two long-lived branches
+carry no prefix, being the only two that are not about one thing.
+
+    feat/entity-color-from-overlay
+    fix/hand-bob-frame
+    ci/commit-and-branch-format
+
+`release/0.3.0-alpha.1` is the one shape that departs from it, and the version is the whole of the
+name: such a branch carries the version bump and nothing else, so there is nothing else to say
+about it.
+
+Nothing in a name records who wrote the branch or when, and none of them carries an issue number,
+there being nothing here that numbers them.
+
 **The history is linear and carries no merge commit anywhere, which is not a preference.** A tree
 that forks is a tree nobody reads once it is public, and this one is public. A topic branch is
 rebased onto `dev` and enters by a pull request, merged with the rebase button. If that button
@@ -109,16 +129,72 @@ is what the release body and both stores are handed.
 
 ## Commits
 
-One logical change per commit. Short imperative subject, no trailing period, 72 columns
-or less. A body only when the reason is not obvious from the diff, and then it explains
-why rather than what.
+One logical change per commit, and a subject in the form the wider ecosystem calls a conventional
+commit:
+
+    <type>(<scope>)!: what the commit does
+
+That form is worth more here than it is in most repositories, because of how a branch lands. The
+rebase button replays every subject verbatim into the public history instead of collapsing them
+into the request's title, so a subject is not a note to a reviewer: it is the line somebody reads
+two years later, in a log where `git log --oneline` is the only thing they will look at.
+
+| type | what it carries |
+| --- | --- |
+| `feat` | geometry served, a uniform provided, a screen opened: something the engine did not do |
+| `fix` | a defect corrected, in the image or in what a pack is allowed to say |
+| `perf` | the same behaviour for less |
+| `refactor` | no change of behaviour at all, dead code removed included |
+| `docs` | `docs/`, the changelog, this file, javadoc on its own |
+| `test` | the out-of-game harness and the corpus it runs over |
+| `build` | Gradle, the JDK, loader versions, what the build refuses |
+| `ci` | `.github/workflows` |
+| `chore` | whatever none of the others is, and the version bump, which is `chore(release):` |
+
+The scope is optional and names a tree of code: `pack`, `glsl`, `uniform`, `render`, `screen`,
+`settings`, `sodium`, `mixin`, `platform`, or `neoforge` and `fabric` for a whole module. It is left
+out where the type already says everything, which `docs` and `ci` usually do.
+
+The subject is imperative and therefore starts on a verb, in lower case, and it carries no full
+stop. The whole line is 72 columns or fewer with the prefix counted in, and the prefix is not free:
+`feat(render): ` is fourteen of them. What used to fit in a subject running to a hundred columns
+goes in the body now, which is where it reads better anyway. A body is for the reason, when the
+reason is not in the diff, and a blank line separates it from the subject.
+
+A `!` before the colon marks a change that breaks a pack or a configuration that used to work. What
+breaks is written in the body, and there is no `BREAKING CHANGE:` footer: there are no trailers here
+at all, and nothing in this repository reads one, the changelog being written by hand and the
+version typed by a human.
 
 ```
-Add fullscreen pass hook for the Vulkan backend
-Fix binding allocation colliding on location 7
+feat(render): read entityColor off the entity mesh overlay
+fix(pack)!: refuse a customTexture path that leaves the pack
+docs: correct five sentences against the source
+chore(release): raise the version to 0.3.0-alpha.1
 ```
 
-No trailers.
+A commit that changes a mechanism and the paragraph describing it is one commit under the type of
+the mechanism rather than two, since a changelog entry and a doc line belong with the change that
+made them true. `docs` is for the batch that is documentation and nothing else.
+
+None of this is retroactive, and what was written before the convention is left as it was. Rewriting
+a public history to tidy the shape of its subjects would cost every reference anybody holds to it
+and buy a uniformity nobody reads for.
+
+### Both ends of the rule are one file
+
+`.githooks/commit-msg` refuses a subject or a branch name that is not in the form above. Install it
+once per clone, worktrees sharing the same config:
+
+    git config core.hooksPath .githooks
+
+`.github/workflows/commits.yml` runs that same file over every commit of a pull request, for
+whoever never ran that command and for anything arriving from a fork. It is deliberately the same
+file: a workflow rewriting the same expression would be a second home for the rule, and the two
+would agree only until one of them changed.
+
+Catch it at the commit rather than at the request. A subject is amended in one gesture while it is
+still the last one, and rebuilt by hand once nine commits stand on top of it.
 
 ## Encoding and text
 

--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ tasks.register("checkText") {
 	// listing them, so a new icon does not have to be remembered here.
 	def texts = fileTree(rootDir) {
 		include "*.md", "*.gradle", "*.properties", ".gitattributes", ".gitignore"
-		include "common/src/**", "neoforge/src/**", "fabric/src/**", ".github/**"
+		include "common/src/**", "neoforge/src/**", "fabric/src/**", ".github/**", ".githooks/**"
 		// docs/ is prose rather than code, which is exactly why it needs this: a curly quote
 		// pasted from a browser is invisible in a diff and reaches the published page.
 		include "docs/**"


### PR DESCRIPTION
## What changes

Commit subjects and branch names take one form from here on, the one the wider ecosystem calls a
conventional commit: `<type>(<scope>)!: what the commit does`, and `<type>/what-the-branch-does`
for the branch carrying them. Nine types, an optional scope naming a tree of code, an imperative
subject under 72 columns with the prefix counted in. It is worth more here than in most
repositories because of how a branch lands: the rebase button replays every subject verbatim into
the public history rather than collapsing them into this request's title, so a subject is the line
somebody reads in a `--oneline` two years from now. The `worktree-` prefix goes with it, having
said nothing that was not true of every branch. Nothing older is rewritten.

`.githooks/commit-msg` refuses what does not fit, and `.github/workflows/commits.yml` runs that
same file over a request's range for whoever never installed it and for anything from a fork. One
file rather than two copies of one expression, which would agree until somebody changed one of
them. `.gitignore` gains the allow-list line the new directory needs, since root dot-directories
are denied by default there, and `checkText` gains it too.

## How it differs from the reference, and for what obstacle

It does not. Nothing here reaches the engine, a pack or a frame.

## What proves it

- `gradlew build` green locally, `checkText` included.
- The hook was installed while this branch was written, so both of its commits went through it.
- Sixteen messages tested against it by hand, valid and not: a prose subject, a capital after the
  colon, a full stop, a subject at 84 columns, a body with no blank line above it, an old
  `worktree-` name, a capital in a branch. This request is the seventeenth case, the workflow
  running on the branch that adds it.

## What it leaves owing

**An ordering constraint, and it is the whole of what this owes.** The three requests open today
carry subjects written before the convention, so `commits.yml` refuses them: this one merges after
them, or they go red. Their branches would also have to be renamed to pass, and a rename closes a
request, GitHub having no way to follow a head ref that moved.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] No `CHANGELOG.md` entry: this changes nothing a player sees.
- [x] `CONTRIBUTING.md` is the one home for the rule, and nothing else states it.