### PR TITLE
File the store uploads as beta, not alpha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,9 +238,14 @@ jobs:
       # number itself the one this job checked the tag against. CurseForge has no version object at
       # all, only files, so there the line changes nothing and `name` is what a reader sees.
       #
-      # The version type is still left to the action, and still reads the jar rather than this file:
-      # it tells an alpha from a beta from a release by the word in the version, and `+neoforge`
-      # appended to `0.1.0-alpha.1` leaves that word exactly where it was.
+      # The version type is the one thing NOT left to the action, which would read the word out of
+      # the version and file an alpha. CurseForge hides an alpha behind a filter its own navigation
+      # sets, `showAlphaFiles=hide` on the Files link of every project page, so this one sat behind
+      # an empty page: five files uploaded and in place, and a reader who clicked Files told there
+      # were no results. Nothing is lost by saying beta here. The word is still in the version
+      # number, in the tag, in the GitHub release marked as a prerelease, and in the first paragraph
+      # of both store pages, which is where it informs somebody; as a file type it described nothing
+      # those do not say and hid the files themselves.
       #
       # `java` is CurseForge's alone. Modrinth has no field for it and the action never sends it
       # there, so the line is not the pair of a missing one.
@@ -257,6 +262,7 @@ jobs:
           files: ${{ steps.jars.outputs.neoforge }}
           name: ${{ steps.which.outputs.tag }} (NeoForge)
           version: ${{ steps.version.outputs.version }}+neoforge
+          version-type: beta
           changelog-file: changelog.md
           loaders: neoforge
           game-versions: "26.2"
@@ -283,6 +289,7 @@ jobs:
           files: ${{ steps.jars.outputs.fabric }}
           name: ${{ steps.which.outputs.tag }} (Fabric)
           version: ${{ steps.version.outputs.version }}+fabric
+          version-type: beta
           changelog-file: changelog.md
           loaders: fabric
           game-versions: "26.2"


### PR DESCRIPTION
## What changes

The two store uploads are filed as beta rather than left to the action, which reads the word out of the version and files an alpha. CurseForge hides an alpha behind a filter its own navigation sets, `showAlphaFiles=hide` on the Files link of every project page, so this project's Files tab answered "No Results" while five files stood on it, and the launcher did not offer them either. Nothing about how early this is goes unsaid by that: the word is still in the version number, in the tag, in the GitHub release marked as a prerelease, and in the first paragraph of the store page, which is where it informs somebody.

## How it differs from the reference, and for what obstacle

It does not. Nothing here reaches the engine.

## What proves it

- `gradlew build` green.
- `version-type` is an input of mc-publish v3.3 and takes alpha, beta or release.
- The behaviour worked around was read off the live page rather than assumed: the project's own Files link carries `showAlphaFiles=hide`, and forcing it to `show` lists all five files.

## What it leaves owing

The five files already uploaded stay alpha; this reaches the next release and the ones after it.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees. Nothing about a version changes; what changes is how the store files it.
- [x] Every place that states a fact this branch changed now states the new one. The comment that said the type was left to the action is rewritten beside the parameter.
