### PR TITLE
Correct what the public pages claim about entities and Sulkan

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,9 +7,8 @@ installed on one.
 
 Built jars are attached to the [releases](https://github.com/avpbynf/Vitrail-Shaders/releases),
 one per tag, built by the tag itself rather than uploaded by hand, and mirrored to
-[CurseForge](https://www.curseforge.com/minecraft/mc-mods/vitrail-shaders) and
-[Modrinth](https://modrinth.com/project/vitrail-shaders) by that same run, so
-whichever of the three you take is the same file. A version
+[CurseForge](https://www.curseforge.com/minecraft/mc-mods/vitrail-shaders) by that
+same run, so whichever of the two you take is the same file. A version
 carrying an identifier after a dash is marked as a pre-release, which is what it
 is. Building from source is below and gives the same thing for whatever commit you
 are on.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 <p align="center">
   <a href="https://www.curseforge.com/minecraft/mc-mods/vitrail-shaders"><img src="https://img.shields.io/badge/download-CurseForge-F16436?style=flat-square&logo=curseforge&logoColor=white" alt="Vitrail on CurseForge"></a>
-  <a href="https://modrinth.com/project/vitrail-shaders"><img src="https://img.shields.io/badge/download-Modrinth-00AF5C?style=flat-square&logo=modrinth&logoColor=white" alt="Vitrail on Modrinth"></a>
   <img src="https://img.shields.io/badge/status-experimental-C1440E?style=flat-square" alt="Experimental">
 </p>
 
@@ -91,9 +90,9 @@ and will trade image quality for it in the meantime.
 
 There is one jar per loader, NeoForge and Fabric. Both are on
 [CurseForge](https://www.curseforge.com/minecraft/mc-mods/vitrail-shaders) and
-[Modrinth](https://modrinth.com/project/vitrail-shaders), and attached to every
-[release](https://github.com/avpbynf/Vitrail-Shaders/releases) here. One run
-builds them and uploads them to all three, so the three carry the same files.
+attached to every [release](https://github.com/avpbynf/Vitrail-Shaders/releases)
+here, put there by the same run, so whichever of the two you take is the same
+file.
 
 Put the one for your loader in `mods/` next to Sodium and Chloride, and switch
 the game to Vulkan: `preferredGraphicsBackend:"vulkan"` in `options.txt`, or

--- a/common/src/main/java/dev/vitrail/render/SceneSeed.java
+++ b/common/src/main/java/dev/vitrail/render/SceneSeed.java
@@ -48,8 +48,8 @@ import java.util.Optional;
  * attachment, at the moment it wrote it. So a pixel nothing has been drawn over since compares
  * equal and is the pack's, and a pixel the game drew a feature onto compares closer and is the
  * game's to paint after all. That second case is the one a flag could not answer, and what it is
- * made of is every piece the game still draws for itself in front of a block: the eyes of a mob,
- * a beacon beam, a name plate, and the hand on the runs that hand it back.
+ * made of is every piece the game still draws for itself in front of a block: a beacon beam, a
+ * bolt of lightning, a name plate, and the hand on the runs that hand it back.
  * <p>
  * <strong>Where the pack wrote nothing the mask carries a value outside zero to one</strong>, which
  * every real depth is in front of, so those pixels take the game's picture through the same

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -167,14 +167,14 @@ go out of date between two of them. What follows is what each family that IS ser
 own programs out of the box, both halves of the particles, and `weather=off` or `particles=off` in
 `vitrail/options.txt` hands either family back to the game if you need to compare.
 
-**The mobs and the block entities go through the pack out of the box.** The opaque half of them
-(the body of a mob, a chest, a conduit, an armour piece) is drawn with the pack's own program: it is
-lit as the pack lights the world, and the shadows the terrain casts fall on it. What stays behind is
-everything that blends, and the player's own body is in that half, so third person still shows the
-symptom this section describes. `entities=off` in `vitrail/options.txt` hands the whole family back
-to the game if you need to compare, and with it the glint an enchantment puts over what a mob holds
-or wears. What is left is named in the log rather than on this page, by the line the close of this
-section points at.
+**The mobs and the block entities go through the pack out of the box, both halves of them.** The
+body of a mob, a chest, a conduit, an armour piece and everything that blends over one of those is
+drawn with the pack's own program: they are lit as the pack lights the world, and the shadows the
+terrain casts fall on them. The player's own body in third person is drawn by the same rows, so it
+is the pack's too. `entities=off` in `vitrail/options.txt` hands the whole family back to the game
+if you need to compare, and with it the glint an enchantment puts over what a mob holds or wears.
+What is left is named in the log rather than on this page, by the line the close of this section
+points at.
 
 **The hand you are holding has a switch of its own, and it goes through the pack out of the box
 too.** It is drawn inside the level, in two passes, served by `gbuffers_hand` and
@@ -203,12 +203,13 @@ the name a pack reads to see what the hand it is holding stands in front of.
 as receive, and the log names the shadow passes one by one when a place first draws. Two things
 take that back: a pack can ask for fewer casters than the default and is given what it asks for,
 and a draw whose pipeline this engine has no shadow row for is left out of the map rather than
-guessed at: the log says so, by name, for each one. **The rain, the snow, the particles, the hand
-and the glint of an enchantment are never in it**: they have the pack's light on them and nothing
-under them. The glint is the one of the five where the reference does the same thing for its own
-reason, cancelling the foil while the map is filled, so what is missing there is a tint on a shadow
-whose shape the item already casts. Receiving and casting are two different things here, and the
-second is the shorter list.
+guessed at: the log says so, by name, for each one. **The rain, the snow, the particles, the hand,
+a mob's glowing eyes and the glint of an enchantment are never in it**: they have the pack's light
+on them and nothing under them. Two of the six cost less than the list suggests, the eyes and the
+glint both sitting on a body that fills the map on its own, so what is missing there is a tint on a
+shape the map already has; and the glint is the one where the reference does the same thing for its
+own reason, cancelling the foil while the map is filled. Receiving and casting are two different
+things here, and the second is the shorter list.
 
 **Turn the game's improved transparency off if the rain or the translucent particles do not change.**
 It is a video setting of its own, which the Fabulous preset turns on everywhere except macOS. With

--- a/docs/why.md
+++ b/docs/why.md
@@ -39,9 +39,7 @@ the projects below.
 - **[Sulkan](https://github.com/mravatins/sulkanShaders)** is an open source Vulkan shader engine
   for Minecraft, GPLv3, built as a Fabric mod. It was already running on the Vulkan renderer when
   this project started, and reading where it hooks into the game was useful. None of its code is
-  reused here: its licence would not allow it without relicensing all of Vitrail. A mechanical line
-  comparison of the two sources is what keeps that claim honest rather than a promise, and it is
-  re-run whenever this engine takes on a part of the frame Sulkan also touches.
+  reused here: its licence would not allow it without relicensing all of Vitrail.
 - **[Aperture](https://github.com/IrisShaders/Aperture-Example-Pack)**, from the Iris team, is a
   newer engine whose packs are written in Slang. Its example pack is public. It is a clean break
   from the OptiFine format rather than a way to keep running what already exists.


### PR DESCRIPTION
## What changes

Four claims the code had outgrown, plus a dead link. `docs/compatibility.md` said the blending half of an entity stayed with the game and that third person still showed the symptom, where every row of the entity table has had a translucent twin since the hand's own half landed, so the player's body is the pack's like the rest of it; and its list of what is never in the shadow map predates the glowing eyes, which have no shadow row either. `SceneSeed`'s javadoc still counted those eyes among the pieces the game draws in front of a block, where the class beside it says they are served. `docs/why.md` still promised a mechanical line comparison with Sulkan, re-run whenever this engine takes on a part of the frame that mod also touches, on the one subject where being ahead of the file costs the most. And the Modrinth badge and both its links leave `README.md` and `INSTALL.md` while that page sits in the store's moderation queue and answers "Project not found" to every reader of a public repository.

## How it differs from the reference, and for what obstacle

It does not. No behaviour changes.

## What proves it

- `gradlew build` green.
- Each corrected sentence was read against the class that answers for it: `EntityDraw:636-651` for the translucent rows, `EntityDraw:1005-1017` for the shadow twins the eyes have not got, `FeatureLayer:60-63` for what is left to the game.
- The Modrinth page was opened and answers "Project not found"; every other link and image path of the README resolves.
- The rest of `docs/`, fifteen pages, was read against the code in the same pass. Only `why.md` came back with anything.

## What it leaves owing

Modrinth comes back, badge and both sentences, the day the page is listed.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees. Nothing here changes what the engine does.
- [x] Every place that states a fact this branch changed now states the new one.
