### PR TITLE
Take a report through a form that asks for its log

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,52 @@
+name: Something else is broken
+description: A crash, a game that will not start, or anything that is not a pack drawing wrongly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A world that looks entirely like vanilla is usually one of two things, and
+        [INSTALL.md](https://github.com/avpbynf/Vitrail-Shaders/blob/main/INSTALL.md) covers both:
+        the game came up on OpenGL, or Chloride is absent and the Vulkan surface never got a window
+        to draw into. Both say so in the log.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens
+      description: What you did, what happened, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: log
+    attributes:
+      label: The log
+      description: >
+        `logs/latest.log`, attached as a file. For a crash, the file under `crash-reports/` as well.
+        The log's first line names the version that is actually running.
+    validations:
+      required: true
+
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: Vitrail and its loader, Minecraft, Sodium, Chloride, and anything else in `mods/`.
+      placeholder: Vitrail 0.3.0-alpha.1 for NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: without
+    attributes:
+      label: Does it still happen with Vitrail taken out?
+      description: >
+        Sodium and Chloride on their own, on the Vulkan backend, with the same pack folder in place.
+        It separates this engine from the two mods it cannot run without.
+      options:
+        - It stops when Vitrail is out
+        - It happens without Vitrail too
+        - Not tried
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Your pack does not look right
+    url: https://github.com/avpbynf/Vitrail-Shaders/blob/main/docs/compatibility.md
+    about: Start from what you are seeing. Most of the shapes people report are named there, with the cause and how to confirm it rather than guess.
+  - name: The game will not start, or the world looks vanilla
+    url: https://github.com/avpbynf/Vitrail-Shaders/blob/main/INSTALL.md
+    about: The versions this needs, the two Chloride settings that have to come off, and what the absence of either looks like.
+  - name: What is already known to be missing
+    url: https://github.com/avpbynf/Vitrail-Shaders/issues?q=is%3Aissue+is%3Aopen+label%3A%22known+limitation%22
+    about: The gaps this engine already knows about are open as issues. A symptom that matches one is worth a comment there rather than a new report.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,44 @@
+name: Something the engine does not do yet
+description: A family the game still draws, a value a pack is not served, a pack that is refused.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Work here is ordered by risk rather than by request, and the picture changes from one release
+        to the next, so what this asks for is the pack that needs it and what the reference does with
+        it. That is what decides where a thing lands in the order.
+
+        If you mean to write it yourself, say so: the README asks for an issue before anything
+        substantial, and the reason is that code arriving ahead of what can be verified is hard to
+        accept however good it is.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What is missing
+      description: What the engine does today, and what it would do instead.
+    validations:
+      required: true
+
+  - type: input
+    id: pack
+    attributes:
+      label: Which pack needs it
+      description: >
+        A pack that visibly wants this, and what it does without it. A gap nothing asks for is
+        cheaper to leave open.
+      placeholder: Complementary Unbound r5.8.1
+    validations:
+      required: true
+
+  - type: textarea
+    id: reference
+    attributes:
+      label: What Iris does with it
+      description: >
+        Iris is the reference this is measured against, so how it handles the same thing is half of
+        the answer. A file and a line in its tree is ideal, a description is fine, and "unknown" is
+        an honest answer.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/pack-report.yml
+++ b/.github/ISSUE_TEMPLATE/pack-report.yml
@@ -1,0 +1,99 @@
+name: A pack does not draw as it should
+description: An image that is wrong, missing, or unlike the same pack elsewhere.
+labels: ["pack compatibility"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two things close most of these, and both are quicker than this form.
+
+        [Pack compatibility](https://github.com/avpbynf/Vitrail-Shaders/blob/main/docs/compatibility.md)
+        starts from what you are seeing and names the cause. Several of the shapes that get reported
+        are the game's own behaviour or the pack's default settings rather than this engine, and that
+        page says how to tell which.
+
+        And what this engine is known to be missing is
+        [open as issues already](https://github.com/avpbynf/Vitrail-Shaders/issues?q=is%3Aissue+is%3Aopen+label%3A%22known+limitation%22).
+        A symptom that matches one of them is worth a comment there, where it will be read against
+        the rest of that gap, rather than a report of its own.
+
+        The log matters more here than the description does. The engine says at load what it refused,
+        what it could not serve, and which program it chose for each pass, so most of what you are
+        about to write is already in it, in words, at the moment it happened.
+
+  - type: input
+    id: pack
+    attributes:
+      label: The pack, and its version
+      placeholder: BSL v10.1.3
+    validations:
+      required: true
+
+  - type: textarea
+    id: symptom
+    attributes:
+      label: What you see
+      description: >
+        What the picture does, and where it does it: a dimension, a time of day, standing under
+        water, whatever it takes for somebody else to stand where you are standing. Screenshots go
+        here, and one of the same spot with the pack running on Iris is worth more than any
+        description of the difference.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: reference
+    attributes:
+      label: Does the same pack do this on Iris?
+      description: >
+        Iris on the OpenGL backend is what this engine is measured against, so a pack behaving the
+        same way there is behaving as it was written to, and the answer is in the pack rather than
+        here. Not having tried is a fine answer.
+      options:
+        - It draws correctly on Iris
+        - It does the same on Iris
+        - Not tried
+    validations:
+      required: true
+
+  - type: textarea
+    id: log
+    attributes:
+      label: The log
+      description: >
+        `logs/latest.log` from the session you saw it in, attached as a file rather than pasted. Its
+        first line names the version that is actually running, which is not always the one you meant
+        to install.
+    validations:
+      required: true
+
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: Vitrail and its loader, Minecraft, Sodium, Chloride, and anything else in `mods/`.
+      placeholder: Vitrail 0.3.0-alpha.1 for NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before reporting
+      description: Every one of these has produced a report that turned out not to be a defect.
+      options:
+        - label: >
+            The log says the game came up on the Vulkan backend. A failed Vulkan start drops the
+            setting back to OpenGL and the dying process rewrites `options.txt` over any edit, so
+            what you typed there is not evidence of what ran.
+          required: true
+        - label: >
+            The pack's own setting for the effect is on. Depth of field, motion blur and custom sun
+            discs are routinely shipped switched off, and a pass that never ran is not a pass that
+            failed.
+          required: true
+        - label: >
+            The world was rebuilt after the pack changed, and not merely reloaded. Block numbers
+            travel on the vertex and no two packs number them alike, so nothing seen before that
+            rebuild means anything.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,34 @@ already pushed to is replaced by one on the new name, GitHub having no way to mo
 one branch to another. `main` and `dev` are exempt from the name, and so is a detached HEAD, which
 is why a rebase replays a branch without ever asking.
 
+## Labels
+
+Everything carries one, requests and issues alike, and neither set is decoration: a list of a dozen
+open things has to say what each one is before any of them is opened.
+
+**A pull request carries the type of its branch, and only that.** The nine are the ones in the table
+above, so the label is not a second opinion about the change: it is the word already in the branch
+name and at the head of every subject the branch carries. `docs/correct-a-page` is labelled `docs`,
+and a branch whose commits are mostly `fix` with a `refactor` among them is labelled `fix`, the same
+way its name was settled.
+
+**An issue carries what it is about instead**, being a report rather than a change:
+
+| label | what it marks |
+| --- | --- |
+| `known limitation` | a gap this engine already knows about, opened here rather than waited for |
+| `pack compatibility` | a pack does not draw as it should |
+| `upstream` | the cause is in another project or in the backend, and nothing here closes it |
+
+beside GitHub's own `bug`, `enhancement` and `question`, which the issue forms set themselves. The
+two sets do not overlap and are not meant to: a type says what a change does, and these say what a
+report is about.
+
+**A request that closes an issue says so in its body**, `Closes #31` on a line of its own, so that
+the issue goes with the merge rather than being noticed weeks later. That is the whole reason the
+known limitations are open as issues rather than living in a file somewhere: a branch can point at
+one, and a reader can see that somebody is on it.
+
 ## Encoding and text
 
 UTF-8 without BOM everywhere, accents included. A BOM breaks several tools in this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,10 @@ carry no prefix, being the only two that are not about one thing.
 name: such a branch carries the version bump and nothing else, so there is nothing else to say
 about it.
 
-Nothing in a name records who wrote the branch or when, and none of them carries an issue number,
-there being nothing here that numbers them.
+Nothing in a name records who wrote the branch or when, and none of them carries an issue number
+either. That second one is a choice rather than an absence, now that there are issues to number: a
+request points at the one it closes from its body, where `Closes #31` really closes it, and a name
+carrying the number would say the same thing in the one place nothing reads it back from.
 
 **The history is linear and carries no merge commit anywhere, which is not a preference.** A tree
 that forks is a tree nobody reads once it is public, and this one is public. A topic branch is


### PR DESCRIPTION
## What changes

Three issue forms and a config, where the repository took reports through a blank box, plus the convention that labels them. The pack report asks for the pack and its version, what is seen and where, whether the same pack does it on Iris, the log as a file rather than pasted, and the versions of everything in `mods/`. It makes three checks compulsory, and each of the three has already produced a report here that was not a defect: the log saying the game came up on the Vulkan backend, since a failed start drops the setting back and rewrites `options.txt` over any edit; the pack's own setting for the effect being on, since two packs out of two ship their showcase effects off; and the world rebuilt rather than reloaded after a pack change, since block numbers travel on the vertex. A second form takes what is not a pack drawing wrongly and asks whether it still happens with Vitrail out, and a third takes what the engine does not do yet and asks which pack needs it and what Iris does with it. Blank issues are off, and the three contact links send a reader to the compatibility page, to `INSTALL.md`, and to the known limitations before anything is opened.

`CONTRIBUTING.md` gains the section for the labels themselves, and it buys the convention rather than inventing one: a request carries the type of its branch, which is a word it already has in its name and at the head of every subject it carries, so the nine types have one home and are read in one more place. It also corrects the sentence under Branches that said no branch name carries an issue number "there being nothing here that numbers them", which stopped being true the moment the known limitations were opened: a request points at the issue it closes from its body, where the pointer really closes it.

## How it differs from the reference, and for what obstacle

It does not. Nothing here reaches the engine.

## What proves it

- `gradlew build` green, which runs the text gate over `.github/**`.
- The four files are ASCII, no BOM, LF.
- A form is only really exercised the first time somebody opens an issue through it, and none has been yet.

## What it leaves owing

Nothing. The twelve labels are created and the seven known limitations the config links to are open, #26 to #32.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees. This changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
