### PR TITLE
fix(glsl): stop handing on a varying the next stage never declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,14 @@ what the next one holds.
   saw was the game with no shader on it at all. The value is now handed over rather than the pass
   being thrown away. Mellow is the pack it cost, on one of its lighting passes, and it draws now.
 
+- **A pass reading its neighbour's value, which showed as a shader that simply looks wrong.** The
+  other half of the same pairing, and the half that said nothing: a value a pass sends on and the
+  next one never asks for used to push everything sent after it one place along, so the pass read
+  the wrong value under the right name. Nothing was refused and nothing was logged, which is what
+  made it hard to see. Sixteen passes across Bliss and Mellow were reading at least one value that
+  way: the enchantment shine under Mellow, and under Bliss the block-breaking crack along with the
+  post-processing steps that carry the sun's direction and the exposure, in every dimension.
+
 ## 0.3.0-alpha.1
 
 ### Changed

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -289,6 +289,12 @@ public final class GlslTranslator {
 	/** Varyings this stage hands the next one, which is what says whether an input is provided. */
 	private final Set<String> declaredOutputs = new LinkedHashSet<>();
 
+	/** The same, as the declarations they came from, so that one can be taken back out whole. */
+	private final List<FileScope> declaredOutputScopes = new ArrayList<>();
+
+	/** Inputs {@link #dropUnprovidedInputs} took out, which this stage no longer declares. */
+	private final Set<String> droppedInputs = new LinkedHashSet<>();
+
 	/**
 	 * Inputs nothing before this stage writes and that the body reads anyway, so that they could not
 	 * be taken back out: by the name, the interpolation qualifier and the type it was declared
@@ -623,6 +629,32 @@ public final class GlslTranslator {
 		/** The varyings this stage hands on, which is what says whether the next one is provided. */
 		public Set<String> provides() {
 			return Set.copyOf(this.translator.declaredOutputs);
+		}
+
+		/**
+		 * The varyings this stage still takes in, which is what says whether the stage before it is
+		 * handing on one nobody declares.
+		 * <p>
+		 * What {@link #dropUnprovidedInputs} took out is left out here, and has to be: it is no
+		 * longer in the text, so the game will not count it either.
+		 */
+		public Set<String> requires() {
+			Set<String> names = new LinkedHashSet<>();
+			this.translator.declaredInputs.forEach(declared -> names.addAll(declared.names()));
+			names.removeAll(this.translator.droppedInputs);
+
+			return Set.copyOf(names);
+		}
+
+		/**
+		 * Stops this stage handing on the varyings the next one does not declare.
+		 * See {@link GlslTranslator#withholdUndeclaredOutputs}.
+		 * <p>
+		 * After {@link #owe}, which adds to what this stage hands on, and before anything is
+		 * rendered: it changes both the text and the answer {@link #provides} gives.
+		 */
+		public void withhold(Set<String> declared) {
+			this.translator.withholdUndeclaredOutputs(declared);
 		}
 
 		/**
@@ -1983,6 +2015,7 @@ public final class GlslTranslator {
 				FileScope declared = fileScopeDeclaration(index);
 				if (declared != null) {
 					this.declaredOutputs.addAll(declared.names());
+					this.declaredOutputScopes.add(declared);
 				}
 			} else if (token.identifier("in") && this.stage != ProgramStage.VERTEX) {
 				FileScope declared = fileScopeDeclaration(index);
@@ -2028,6 +2061,7 @@ public final class GlslTranslator {
 		for (FileScope declared : unprovided) {
 			if (declared.names().stream().noneMatch(read::contains)) {
 				blankRange(declared.start(), declared.end());
+				this.droppedInputs.addAll(declared.names());
 				dropped = true;
 				continue;
 			}
@@ -2059,6 +2093,72 @@ public final class GlslTranslator {
 		if (dropped) {
 			this.used = usedNames();
 			this.declaredAfter = declaredUnderAType();
+		}
+	}
+
+	/**
+	 * Stops this stage handing on every varying the stage after it does not declare, by taking the
+	 * {@code out} off the declaration and leaving a plain global of the same name and type behind.
+	 * <p>
+	 * <strong>The other way round from {@link #dropUnprovidedInputs}, and it is the way that says
+	 * nothing at all.</strong> {@code rebind:151-163} numbers the fragment stage over the vertex
+	 * stage's output list and advances its counter only on the names the fragment declares, while
+	 * {@code createFromSpirv:114-116} had numbered that same list {@code 0..n-1} with nothing
+	 * skipped. One name the fragment does not declare therefore drops every name after it in the
+	 * list by a location, with no exception raised and no line logged, and the fragment reads its
+	 * neighbour's value. Measured over the corpus before this: 39 pairs handing on a varying the
+	 * fragment never declares, and 16 of them landing at least one location on the neighbour.
+	 * <p>
+	 * <strong>Demoted rather than deleted, because the body writes them.</strong> Deleting the
+	 * declaration would leave the assignments naming nothing, which is the pass lost. A global of
+	 * the same name and type keeps every assignment compiling and is simply not part of the
+	 * interface any more, which is the whole of what was wanted. The interpolation qualifier goes
+	 * with the {@code out}: {@code flat} on a plain global is a syntax error, and it means nothing
+	 * once there is nobody to interpolate for.
+	 * <p>
+	 * <strong>What Iris does here is nothing, and that is not an oversight on its part.</strong> It
+	 * links two stages the way OpenGL does, where an output nobody reads is legal and costs nothing;
+	 * there is no line of {@code CompatibilityTransformer} to follow because the language it targets
+	 * never asked the question. What forces the hand here is
+	 * {@code IntermediaryShaderModule.rebind:151-163}, which pairs by counting rather than by name.
+	 * The picture is unchanged either way: what is taken out of the interface is, by the condition
+	 * itself, a value no later stage could read.
+	 * <p>
+	 * <strong>A declaration is taken whole or left alone.</strong> {@code out vec3 a, b;} with the
+	 * fragment declaring {@code b} alone stays as it is, since demoting it would take {@code b} out
+	 * from under a fragment that reads it and that is the failure this exists to prevent. No pack
+	 * of the corpus writes one, the measurement below being zero, and the shape is worth naming
+	 * rather than reading as covered.
+	 * <p>
+	 * <strong>Only what the PACK declares is offered here, on both sides.</strong> The two varyings
+	 * the engine names itself are emitted into both headers off one union and are never in either
+	 * list, so neither can be withheld from under a stage that declares it. The shape that would
+	 * be a hazard is a pack writing {@code out vec4 entityColor} in its vertex stage against a
+	 * fragment that only gets the name from the header; it cannot arise, because a vertex stage
+	 * that reaches that union already receives the header's declaration of the same name and is
+	 * refused for the redefinition before this is ever asked.
+	 *
+	 * @param declared every name the stage after this one still declares as an input
+	 */
+	private void withholdUndeclaredOutputs(Set<String> declared) {
+		for (FileScope scope : this.declaredOutputScopes) {
+			if (scope.names().stream().anyMatch(declared::contains)) {
+				continue;
+			}
+
+			// From the start of the statement up to the type, which is the first token that is
+			// neither the keyword nor a qualifier. Either order has to be taken: GLSL accepts both,
+			// Mellow opens with flat, and fileScopeDeclaration already gathers them both ways.
+			for (int index : significantRange(scope.start(), scope.end())) {
+				String text = this.tokens.get(index).text();
+				if (!text.equals("out") && !LegacyGlsl.INTERPOLATION_QUALIFIERS.contains(text)) {
+					break;
+				}
+
+				blank(index);
+			}
+
+			this.declaredOutputs.removeAll(scope.names());
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -190,6 +190,10 @@ public final class ProgramTranslator {
 			// passes use, which declares eleven varyings; three of them are read by functions this
 			// pass never calls, and the game refused the whole module over exactly those three.
 			owed(prepared);
+
+			// And last, the other way round, because it reads what the two above have just settled:
+			// the first takes inputs out and the second adds outputs, and both change the answer.
+			withheld(prepared);
 		}
 
 		Map<String, TranslatedUnit.Uniform> uniforms = new LinkedHashMap<>();
@@ -279,6 +283,49 @@ public final class ProgramTranslator {
 			}
 
 			previous = stage;
+		}
+	}
+
+	/**
+	 * Stops each stage handing on the varyings the stage after it does not declare.
+	 * <p>
+	 * <strong>The same pairing as {@link #owed}, read from the other end, and the end that says
+	 * nothing.</strong> A varying the next stage declares and this one never wrote is a refusal,
+	 * loud, and the whole module goes with it. A varying this stage writes and the next one never
+	 * declares raises nothing: {@code rebind:151-163} counts only the names the next stage declares
+	 * while {@code createFromSpirv:114-116} numbered the whole list, so the two agree on nothing
+	 * after the first name that is missing. What the picture then shows is a fragment stage reading
+	 * its neighbour's varying, which looks like a shader that is merely wrong.
+	 * <p>
+	 * <strong>Last of the three, and the order is what makes it right.</strong> The drop takes
+	 * inputs out of the next stage, {@link #owed} puts outputs into this one, and both change the
+	 * two sets this compares. Running it first would withhold a name {@code owed} is about to make
+	 * the pair agree on.
+	 * <p>
+	 * <strong>A compute stage is stepped over, and it is not tidiness.</strong> It stands LAST in
+	 * the pipeline order, after the fragment stage, so pairing it with the stage before it would
+	 * make the fragment stage the one handing something on. What a fragment stage declares as
+	 * {@code out} is a colour attachment and not a varying, and one written without an explicit
+	 * {@code layout(location = n)} is still in the body here, {@code liftFragmentOutputs} only
+	 * taking out the ones that carry one. Demoting it would leave the pass compiling, drawing, and
+	 * writing to nothing. It costs nothing to step over: a compute stage is dispatched on its own,
+	 * and {@code GlslCompiler.compile:62-63} pairs one vertex module with one fragment module and
+	 * takes no third.
+	 *
+	 * @param prepared the stages of one program, keyed by stage, in pipeline order
+	 */
+	private static void withheld(Map<ProgramStage, GlslTranslator.Stage> prepared) {
+		GlslTranslator.Stage previous = null;
+		for (Map.Entry<ProgramStage, GlslTranslator.Stage> entry : prepared.entrySet()) {
+			if (entry.getKey() == ProgramStage.COMPUTE) {
+				continue;
+			}
+
+			if (previous != null) {
+				previous.withhold(entry.getValue().requires());
+			}
+
+			previous = entry.getValue();
 		}
 	}
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -136,13 +136,30 @@ the fragment declares without the vertex emitting it is refused loudly, while th
 and shifts the locations of everything after it.
 
 The two sides are reconciled in two different ways, and it is worth not confusing them. A varying
-the *engine* names (there is one, the fog coordinate) has to be declared by both stages or by
-neither, so it is decided at program assembly. The pack's own varyings are not unified that way:
-they are reconciled in the other direction, by striking from the later stage the inputs nothing
-upstream writes.
+the *engine* names (there are two, the fog coordinate and the colour a hurt mob flashes) has to be
+declared by both stages or by neither, so it is decided once at program assembly and written into
+both headers from the one answer. The pack's own varyings are not unified that way. They are
+brought into agreement by three passes over the pair, in this order, and the order matters because
+each one changes what the next one sees:
 
-A consequence for measurement: a per-unit check cannot see this class of defect at all, because it
-never pairs a vertex stage with its fragment stage.
+1. An input the later stage declares that nothing upstream writes is **struck out**, where its body
+   never reads it. That is the cheapest answer, because it changes nothing else.
+2. What the strike could not take, because the body does read it, is **owed by the stage before**,
+   which declares it and assigns it its zero. This is the reference's own patch, taken whole,
+   including the assignment: under the reference these varyings hold zero rather than whatever the
+   stage happened to leave in them.
+3. An output the earlier stage hands on that the later one never declares is **withheld**: the
+   `out` and its interpolation qualifier come off and a plain global of the same name and type is
+   left behind, so the body's own writes keep compiling. The reference does nothing here, and has
+   no reason to: it links two stages the way OpenGL does, where an output nobody reads is legal.
+   What forces it here is a backend that pairs the two lists by counting rather than by name.
+
+A consequence for measurement, and it is sharper than it looks: **a per-unit check cannot see this
+class of defect at all**, because it never pairs a vertex stage with its fragment stage. Neither
+can a check that compiles both stages in one invocation of a desktop GLSL compiler, which is the
+trap worth naming: that links them the OpenGL way, where both of these shapes are legal, so it
+reports the same clean number before and after either fix. Only compiling each stage on its own and
+pairing the two reflected interfaces answers.
 
 Two more rules on lifting. A declaration sitting in a dead branch must **not** be lifted out of it,
 because lifting makes it unconditional and can collide with a same-named ordinary global in the


### PR DESCRIPTION
## What changes

Each stage now stops handing on the varyings the stage after it does not declare. The other half of
this pairing was closed already: a varying the fragment declares and the vertex never writes is
refused outright, loudly, and the whole module goes with it. This way round raises nothing.
`IntermediaryShaderModule.rebind` numbers the fragment stage over the vertex stage's output list
and advances its counter only on the names the fragment declares, while `createFromSpirv` had
numbered that same list from zero with nothing skipped, so one name the fragment never asks for
drops every name after it by a location and the fragment reads its neighbour's value under the
right name. The declaration is demoted rather than deleted, keeping the name and the type as a
plain global, because the body writes it and deleting would cost the pass instead.

## How it differs from the reference, and for what obstacle

Iris does nothing here, and that is not an oversight on its part: it links two stages the way
OpenGL links them, where an output nobody reads is legal and costs nothing, so the question it
would answer is never asked. Checked rather than assumed, across `CompatibilityTransformer`,
`SodiumTransformer`, `CommonTransformer` and `EntityPatcher`: the only thing it prunes for being
unused is a function nobody calls. What forces the hand here is this backend pairing by COUNT
rather than by name, `IntermediaryShaderModule.rebind:151-163`. The picture is unchanged by the
demotion itself: what leaves the interface is, by the condition, a value no later stage could read.

## What proves it

- `gradlew build` green.
- The out-of-game harness, over the eight packs of the corpus. A new tool, `Varyings`, compiles each
  stage with shaderc and reflects it with SPIRV-Cross at the game's own option values, so the
  pairing it measures is the one `rebind` will make. 767 pairs: 39 handing on a varying the fragment
  never declares before this, 16 of them landing at least one location on the neighbour, and 0 and 0
  after. The 24 pairs that do not compile at all are the same 24 before and after.
- `Programmes`, `Terrain`, `Particules` and `Ciel` return exactly the same numbers before and after.
  `Programmes` returning 749 of 785 either way is the point rather than a reassurance: one
  glslangValidator invocation over both files links them the OpenGL way and cannot see this at all.
- **Not taken: anything in the game.** The test instance is holding another branch's jar for a
  check that has not happened yet, and installing this one over it is the wrong-jar mistake this
  repository has already paid for once. What a run would add is a smoke test, since the values that
  moved are read by post-processing and by the enchantment shine rather than shown as an obvious
  hole.

## What it leaves owing

An interface BLOCK is left alone. Demoting an `out` block to a struct would mean stripping the
interpolation qualifiers its members carry, which a struct cannot hold, and that is surgery inside
the braces for a shape one pack of the corpus writes on three passes with nothing declared after
it, on a pack this engine refuses at load for its required feature flags. The harness counts those
apart and would still catch them the day they cost something, since a block the fragment skips
moves the plain names after it and those are gated.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one. `docs/translation.md`
      described the pack side as reconciled in one direction and named one engine varying; it now
      names the three passes and the two. `Programmes` said in its own javadoc that it could see
      this pairing; it never could, and it now says so.
