### PR TITLE
Put a mob's glowing eyes in the shadow map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,11 @@ what the next one holds.
   is standing in, as the game draws them: handed the light of the spot instead, a pack that shades by
   that light would have put out the eyes of anything standing in the dark, which is where they matter
   most. Six of the eight packs tested ask for that light in the program that serves their eyes, and
-  one of them looks the game's light map up with it, which is where it shows on screen. What they do
-  not do yet is darken the mob's own shadow.
+  one of them looks the game's light map up with it, which is where it shows on screen. They reach
+  the pack's shadow map as well, where every draw of them used to be dropped, on the light of the
+  spot rather than at that full brightness. What that puts into the map is colour and not depth, so
+  an eye lays no shadow of its own; what it changes is what a pack reading the map's colour finds
+  there.
 - **The wind a breeze throws and the swirl over a charged creeper are painted by the pack now**,
   where the game kept its own shader for both. What held them back is a texture matrix of the
   game's own that scrolls them, and that matrix is answered out of the game's transforms now, so a

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -841,6 +841,11 @@ public final class EntityDraw {
 	 * outright, which is what a shadow map wants: the depth a surface stands at, not that depth mixed
 	 * with the one behind it.
 	 * <p>
+	 * <strong>Two tables feed it, {@link #ELEMENTS} and {@link #FIXED}</strong>, the second being what
+	 * puts a mob's glowing eyes in the map. The hand's two tables do not, and cannot: their rows are
+	 * the mob rows again under a moment of the camera's, and no hand is submitted inside the light's
+	 * walk.
+	 * <p>
 	 * The stage is {@code ENTITIES} for the whole table, including the rows the camera draws under
 	 * {@code NONE}. Iris poses it once for the whole stretch its feature renderers are drawn in
 	 * ({@code shadows/ShadowRenderer.java:521} up to the copy), the two chunk groups of the same
@@ -850,7 +855,19 @@ public final class EntityDraw {
 	private static final Map<RenderPipeline, Element> SHADOW_ELEMENTS = new LinkedHashMap<>();
 
 	static {
-		ELEMENTS.values().stream()
+		shadowTwins(ELEMENTS);
+	}
+
+	/**
+	 * Files one table's rows into {@link #SHADOW_ELEMENTS}, one shadow row each.
+	 * <p>
+	 * Taken a table at a time rather than over one stream of both, because {@link #FIXED} is declared
+	 * below this point: a static initialiser here would read it while it is still empty, and the two
+	 * rows that put a mob's eyes in the map would be missing with nothing said. Its call sits under
+	 * its own block instead.
+	 */
+	private static void shadowTwins(Map<RenderPipeline, Element> from) {
+		from.values().stream()
 				.filter(mob -> mob.pipeline() != RenderPipelines.ENTITY_SHADOW)
 				.map(mob -> new Element(mob.pipeline(), "shadow_" + mob.element(), SHADOW_ENTITIES,
 						CUTOUT, RenderStage.ENTITIES, false))
@@ -955,7 +972,7 @@ public final class EntityDraw {
 	 * three rows and not about these two. The two rows below reach a CONSTANT,
 	 * {@code p -> ShaderKey.ENTITIES_EYES} and
 	 * {@code p -> ShaderKey.ENTITIES_EYES_TRANS} ({@code pipeline/IrisPipelines.java:52,53}), which
-	 * consults nothing. Derived into the other three tables they would ask for
+	 * consults nothing. Derived into the block table or either hand one they would ask for
 	 * {@code gbuffers_block_translucent} inside a chest's draw and {@code gbuffers_hand_water} inside
 	 * the hand's, and Iris asks for neither: an eye is an eye wherever it is drawn.
 	 * <p>
@@ -1000,14 +1017,20 @@ public final class EntityDraw {
 	 * and no animation to read out of the game's own transforms, which the last two rows of
 	 * {@link #ELEMENTS} do need.
 	 * <p>
-	 * <strong>Neither casts a shadow, and that is work not done rather than a choice.</strong> Iris
-	 * puts both pipelines in its shadow table as {@code SHADOW_ENTITIES_CUTOUT}
-	 * ({@code pipeline/IrisPipelines.java:105,107}); {@link #SHADOW_ELEMENTS} is derived from
-	 * {@link #ELEMENTS} alone, so a row here has no shadow twin and the draw is dropped inside the
-	 * light's walk, which the engine prints at the moment it happens. Nothing here makes it
-	 * impossible: it is named rather than argued for, and what it costs the image is the sliver of a
-	 * mob's shadow its eyes would have darkened, an eye being a decal on geometry the mob's own rows
-	 * already cast.
+	 * <strong>Both reach the shadow map, and what they reach of it is its COLOUR and never its
+	 * depth.</strong> Iris puts both pipelines in its shadow table as {@code SHADOW_ENTITIES_CUTOUT}
+	 * ({@code pipeline/IrisPipelines.java:105,107}), so {@link #shadowTwins} files them beside the mob
+	 * rows and the load is asked for their programs there. Neither pipeline writes depth, which the
+	 * paragraph above says of the plain one and {@code RenderPipelines.java:295} says of the emissive
+	 * one, and {@code EntityProgram.intoMap} keeps the write exactly. So an eye paints into
+	 * {@code shadowcolor} and lays nothing under itself: it is not an occluder and it darkens no
+	 * shadow, which is the same reading this file gives the ground oval. What the row buys is a pack
+	 * that reads the map's colour seeing the eyes where it used to see a dropped draw.
+	 * <p>
+	 * <strong>Nor at full light, and that side of it is the camera's alone.</strong> The shadow key is
+	 * declared {@code LightingModel.LIGHTMAP} ({@code pipeline/programs/ShaderKey.java:79}) where the
+	 * two the camera reaches are {@code FULLBRIGHT} ({@code :44,45}), so the twins take the row every
+	 * other caster gets rather than the full light of their own side.
 	 */
 	private static final Map<RenderPipeline, Element> FIXED = new LinkedHashMap<>();
 
@@ -1017,6 +1040,12 @@ public final class EntityDraw {
 		FIXED.put(RenderPipelines.ENTITY_TRANSLUCENT_EMISSIVE,
 				new Element(RenderPipelines.ENTITY_TRANSLUCENT_EMISSIVE, "eyes_emissive", SPIDER_EYES,
 						CUTOUT, RenderStage.NONE, false, true));
+	}
+
+	static {
+		// Here and not beside the call for the mob table: this one is declared below it, so a block up
+		// there would read it while it is still empty and lose both rows without a word.
+		shadowTwins(FIXED);
 	}
 
 	/**
@@ -1658,9 +1687,10 @@ public final class EntityDraw {
 		// gives them.
 		if (pipeline == RenderPipelines.ENTITY_SHADOW) {
 			Vitrail.logger().info("The ground oval under a mob is left out of the shadow map, which "
-					+ "is what Iris does: it has no shadow row for that pipeline either, and the "
-					+ "pipeline writes no depth, so a row for it would put nothing into the depth a "
-					+ "pack reads its shadows from");
+					+ "is what Iris does: it has no shadow row for that pipeline either. What a row "
+					+ "would add is worth knowing and is not the obvious answer: the pipeline writes "
+					+ "no depth, so it would lay no occluder under anything and would only paint into "
+					+ "the map's colour, which is what a mob's eyes do there");
 
 			return;
 		}
@@ -1777,6 +1807,11 @@ public final class EntityDraw {
 		// the frame that share no target, so one of them can be served while the other is not. Five
 		// where every switch is on, the eyes being a group of their own for the reason given below.
 		List<List<Element>> groups = new ArrayList<>();
+
+		// Asked once and held, because it is asked for twice: once as a group of the picture and once
+		// as the rows the shadow table takes from it. Calling fixed() again would send a format this
+		// engine cannot decode to the log a second time, and read as two defects.
+		List<Element> eyes = wanted ? fixed() : List.of();
 		if (wanted) {
 			List<Element> family = Stream.concat(served.stream(),
 							served.stream().map(element -> BLOCK_ELEMENTS.get(element.pipeline())))
@@ -1791,7 +1826,7 @@ public final class EntityDraw {
 			// buffers; put in with the entities, a place that could not answer for that one file
 			// would take every mob and every chest down with it. Apart, the worst it can paint is a
 			// mob the pack lit wearing eyes the game drew, which is the smaller of the two pictures.
-			groups.add(fixed());
+			groups.add(eyes);
 		}
 
 		if (HandDraw.wanted()) {
@@ -1827,7 +1862,8 @@ public final class EntityDraw {
 		// can ever select. The ground shadow is not in the table, so this really is empty for such a
 		// pack rather than nearly empty.
 		if (wanted && TerrainDraw.shadowsAsked() && this.values.shadowCasters().anyFeature()) {
-			groups.add(twinsOf(served, SHADOW_ELEMENTS));
+			groups.add(twinsOf(Stream.concat(served.stream(), eyes.stream()).toList(),
+					SHADOW_ELEMENTS));
 		}
 
 		List<Element> asked = groups.stream().flatMap(List::stream).toList();
@@ -1883,11 +1919,14 @@ public final class EntityDraw {
 	}
 
 	/**
-	 * One table's row for each served mob row, for the tables derived from the mob one.
+	 * One table's row for each row handed in, for the tables derived from another.
 	 * <p>
 	 * A missing row is dropped rather than carried as a null, and only one table has any: the shadow
 	 * one leaves the ground shadow out, because Iris leaves it out. The two hand tables and the block
 	 * one are derived row for row and cannot lose one here.
+	 * <p>
+	 * What is handed in is the mob rows for three of the four tables and the mob rows plus the eyes
+	 * for the shadow one, which is the same pair {@link #SHADOW_ELEMENTS} is filled from.
 	 */
 	private static List<Element> twinsOf(List<Element> served, Map<RenderPipeline, Element> table) {
 		return served.stream()

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -199,17 +199,19 @@ drawn, and handing it the previous frame's would be wrong by one frame of camera
 `depthtex2` is the exception and is a real copy, taken one line before the pass is drawn, which is
 the name a pack reads to see what the hand it is holding stands in front of.
 
-**The mobs and the block entities are drawn into the pack's own shadow map**, so they cast as well
-as receive, and the log names the shadow passes one by one when a place first draws. Two things
-take that back: a pack can ask for fewer casters than the default and is given what it asks for,
-and a draw whose pipeline this engine has no shadow row for is left out of the map rather than
-guessed at: the log says so, by name, for each one. **The rain, the snow, the particles, the hand,
-a mob's glowing eyes and the glint of an enchantment are never in it**: they have the pack's light
-on them and nothing under them. Two of the six cost less than the list suggests, the eyes and the
-glint both sitting on a body that fills the map on its own, so what is missing there is a tint on a
-shape the map already has; and the glint is the one where the reference does the same thing for its
-own reason, cancelling the foil while the map is filled. Receiving and casting are two different
-things here, and the second is the shorter list.
+**The mobs and the block entities are drawn into the pack's own shadow map**, so they cast as
+well as receive, and the log names the shadow passes one by one when a place first draws. A mob's
+glowing eyes are drawn into it too and are the one thing there that casts nothing: neither pipeline
+the game gives them writes depth, so what they reach is the map's colour and not the depth a pack
+reads its shadows from. Two things take that back: a pack can ask for fewer casters than the
+default and is given what it asks for, and a draw whose pipeline this engine has no shadow row for
+is left out of the map rather than guessed at: the log says so, by name, for each one. **The rain,
+the snow, the particles, the hand and the glint of an enchantment are never in it**: they have the
+pack's light on them and nothing under them. The glint costs less than the list suggests, sitting
+on a body that fills the map on its own, so what is missing there is a tint on a shape the map
+already has; and it is the one where the reference does the same thing for its own reason,
+cancelling the foil while the map is filled. Receiving and casting are two different things here,
+and the second is the shorter list.
 
 **Turn the game's improved transparency off if the rain or the translucent particles do not change.**
 It is a video setting of its own, which the Fabulous preset turns on everywhere except macOS. With


### PR DESCRIPTION
## What changes

A mob's glowing eyes go into the pack's shadow map. The shadow table was derived from the mob table
alone, so the two rows the eyes are served by had no twin there and every draw of them was dropped
for the length of the light's walk; both are filed now, and the load is asked for their programs
beside the mob ones. What the rows reach of the map is its COLOUR and never its depth: neither
pipeline the game gives the eyes writes any (`RenderPipelines.java:363` and `:295`) and
`EntityProgram.intoMap` keeps the write exactly, so an eye paints into `shadowcolor` and lays no
occluder. It casts nothing, and what changes is what a pack reading the map's colour finds there.

## How it differs from the reference, and for what obstacle

It does not. Iris assigns both pipelines to `SHADOW_ENTITIES_CUTOUT`
(`pipeline/IrisPipelines.java:105,107`), and that key is declared `LightingModel.LIGHTMAP`
(`pipeline/programs/ShaderKey.java:79`) where the two keys its camera reaches are `FULLBRIGHT`
(`:44,45`). The twins take the same row every other caster gets: one program, a tenth for a
threshold, no blend, the light map off the mesh.

## What proves it

- `gradlew build` green.
- In the game: Complementary Unbound, the night bench with a spider, an enderman and a warden in
  front of the camera, one clean launch per jar and only the jar changing. Against `dev`, the whole
  shadow section of the log is identical but for two rows added,
  `Drawing the shadow_eyes entity pass with world0/shadow` and
  `Drawing the shadow_eyes_emissive entity pass`, whose first draws read
  `enderman_eyes.png` and `warden_bioluminescent_layer.png`. No other shadow line moved.
- The line saying the two pipelines cast no shadow is still printed once on the warm-up frame,
  before the programs are ready, and so is the one for `entity_solid`, which has had a row all
  along. It is the load settling and not a row missing.

## What it leaves owing

The rain, the snow, the particles, the hand and an enchantment's glint are still out of the map, the
glint being the one the reference leaves out on purpose. And what this adds to the picture is small
and worth saying so: an eye writes no depth, so it lays no shadow of its own, and it is a decal on
geometry the mob's own rows already put in the map.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, folded into the one the eyes already have
      there rather than added beside it, neither having shipped.
- [x] Every place that states a fact this branch changed now states the new one:
      `docs/compatibility.md` took the eyes out of the list of what is never in the map, and the
      javadoc that called this work not done says what it does now.

Closes #30.
