### PR TITLE
Close an issue from the commit, not from the request

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,10 @@ name: such a branch carries the version bump and nothing else, so there is nothi
 about it.
 
 Nothing in a name records who wrote the branch or when, and none of them carries an issue number
-either. That second one is a choice rather than an absence, now that there are issues to number: a
-request points at the one it closes from its body, where `Closes #31` really closes it, and a name
-carrying the number would say the same thing in the one place nothing reads it back from.
+either. That second one is a choice rather than an absence, now that there are issues to number: the
+commit that does the work names the issue it closes, and a name carrying the number would say the
+same thing in the one place nothing reads it back from. Commits says where that line goes and why it
+is not the request's body.
 
 **The history is linear and carries no merge commit anywhere, which is not a preference.** A tree
 that forks is a tree nobody reads once it is public, and this one is public. A topic branch is
@@ -164,9 +165,23 @@ goes in the body now, which is where it reads better anyway. A body is for the r
 reason is not in the diff, and a blank line separates it from the subject.
 
 A `!` before the colon marks a change that breaks a pack or a configuration that used to work. What
-breaks is written in the body, and there is no `BREAKING CHANGE:` footer: there are no trailers here
-at all, and nothing in this repository reads one, the changelog being written by hand and the
-version typed by a human.
+breaks is written in the body, and there is no `BREAKING CHANGE:` footer: the changelog is written
+by hand and the version typed by a human, so nothing here would read one. The `Closes` line below is
+the single exception, and what reads it is GitHub rather than anything in this repository.
+
+**An issue is closed from the COMMIT that closes it and never from the pull request**, on a line of
+its own at the foot of the body:
+
+    Closes #30
+
+That is the shape of this repository rather than a taste. A closing keyword fires when the request
+it is written in merges into the DEFAULT branch, which here is `main`, and every request here merges
+into `dev`: written in a request's body it links the issue and then leaves it open for good. Written
+on the commit it travels with the commit, and it lands on `main` the day `dev` does.
+
+**Check the issue really closed once `dev` has landed on `main`, and close it by hand if it did
+not.** This is the one rule in this file whose far end is a service rather than a script, so it is
+the one that can quietly stop being true without anything here changing.
 
 ```
 feat(render): read entityColor off the entity mesh overlay


### PR DESCRIPTION
## What changes

`CONTRIBUTING.md` said that a request points at the issue it closes from its body, "where
`Closes #31` really closes it". It does not, and the shape of this repository is why: GitHub fires a
closing keyword only when the request it is written in merges into the DEFAULT branch, which here is
`main`, while every request merges into `dev`. Written in a request's body the keyword links the
issue and leaves it open. It goes on the COMMIT now, on a line of its own at the foot of the body,
where it travels with the commit and reaches `main` the day `dev` does. Branches points at Commits
for the rule, and the sentence in Commits saying nothing here reads a footer is narrowed to what is
still true of it.

## How it differs from the reference, and for what obstacle

It does not. Nothing here is about the engine.

## What proves it

- `gradlew build` green, which is what checks the punctuation and the encoding of this file.
- Measured rather than reasoned: #30 carried `Closes #30` in the body of #34, #34 merged into `dev`,
  and the issue stayed open. It was closed by hand.
- `.githooks/commit-msg` reads the subject and the branch name only, so a `Closes` line at the foot
  of a body passes it, and so does the workflow that runs the same script.

## What it leaves owing

The far end of this rule is a service and not a script: nothing in the repository can check that
GitHub really closed an issue when `dev` landed on `main`. The file says so, and says to close by
hand when it did not. The two issues open against merged work today, if any, are not swept up here.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees:
      nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. The claim lived in
      two paragraphs of this one file, and the pull request and issue templates never made it.
