### PR TITLE
fix(render): keep the casters in the map while the chain compiles

### DIFF
--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -1448,10 +1448,20 @@ public final class EntityDraw {
 	}
 
 	/**
-	 * Whether what this family writes still reaches the screen this frame, which is the question
+	 * Whether what a camera row writes still reaches the screen this frame, which is the question
 	 * {@code TerrainDraw.shown} and {@code SkyDraw.shown} both ask and the same answer: the chain
 	 * draws nothing at all while it is still compiling, so a frame that wrote the pack's targets then
 	 * would be a frame with no entity in it.
+	 * <p>
+	 * <strong>The shadow rows do not ask, and their reason is not the one {@code TerrainDraw} gives
+	 * for its own shadow half.</strong> There the refusal would be unsafe: with nothing handed back,
+	 * Sodium opens its own pass on the finished picture. Here it is safe, {@link #draw} turning a no
+	 * into a drop. What rules it out instead is that the question does not reach a caster at all: it
+	 * is written into the map and never into a colour target, so the chain's final is not the road it
+	 * takes back, and the state of the chain settles nothing about it. Whether the map is worth
+	 * filling on those frames is the separate question, and the terrain half of the very same map
+	 * answers it by filling throughout: a map holding the world and nothing alive in it is the worse
+	 * of the two to leave standing.
 	 */
 	private boolean shown() {
 		return !this.chainRuns || this.owner.drawable();
@@ -1529,23 +1539,26 @@ public final class EntityDraw {
 			PreparedRenderType prepared) {
 		end();
 
-		// NEITHER OF THESE inside the light's walk, and TerrainDraw already guards the same pair for
-		// the same reason, in the same words. The walk stands after the
-		// chain has closed the frame, so both per frame guards are down again: opening here advances
-		// the value store a SECOND time, which turns every gbufferPrevious* of the next frame
-		// into the current one, and clears the pack's colour targets over what the chain has just
-		// written into them. Neither call has anything to give a caster: it is drawn into the map,
-		// which the stage ensured and emptied before any of this, and it reads no colour target.
+		// NONE OF THESE THREE inside the light's walk, and TerrainDraw skips the same three there.
+		// The walk stands after the chain has closed the frame, so both per frame guards are down
+		// again: opening here advances the value store a SECOND time, which turns every
+		// gbufferPrevious* of the next frame into the current one, and clears the pack's colour
+		// targets over what the chain has just written into them. Neither call has anything to give a
+		// caster either: it is drawn into the map, which the stage ensured and emptied before any of
+		// this, and it reads no colour target.
 		if (!element.shadow()) {
 			this.owner.beginFrame();
 			if (!this.owner.openTargets(device)) {
 				return refuse(element, "targets", "the colour targets could not be opened this frame");
 			}
-		}
 
-		if (!shown()) {
-			return refuse(element, "warming", "the chain is still compiling, so nothing written to the pack's targets "
-					+ "would reach the screen yet");
+			// The third asks about the road a colour target takes back to the screen, and a caster
+			// takes no such road. What that turns on, and why the answer here is not the one
+			// TerrainDraw gives for its own shadow half, is in shown().
+			if (!shown()) {
+				return refuse(element, "warming", "the chain is still compiling, so nothing written to "
+						+ "the pack's targets would reach the screen yet");
+			}
 		}
 
 		// The matrix belongs to the RUN and not to the draw, which is what makes it settleable here:


### PR DESCRIPTION
## What changes

The guard that asks whether what a draw writes still reaches the screen this frame was being asked
of every row of the entity door, the shadow ones among them, and it does not reach a caster: a
caster is written into the shadow map and never into a colour target, so the chain's final is not
the road it takes back and the state of the chain settles nothing about it. It is now asked of the
camera's rows alone. `TerrainDraw` skips the same three guards inside the light's walk, for a reason
of its own (a refusal there would be unsafe, Sodium opening its own pass on the finished picture),
and `shown()` sets the two reasons side by side rather than claiming they are one.

What it cost is the warm up that follows every load, every resource reload and every portal, which
is one chain program a frame and `programs.size()` frames long: every caster was dropped out of the
map while the terrain half of that same map went on being filled.

## How it differs from the reference, and for what obstacle

It does not. The warm up is this engine's own answer to compiling a chain a program at a time, and
Iris has nothing in that position, building every program in its pipeline constructor. What the
branch does is stop one consequence of that warm up reaching a half of the frame it was never about.
The one-frame lag of the map, and the vanilla-lit stretch the warm up itself shows, are older
divergences and are argued in `docs/sky-and-shadows.md`.

## What proves it

- `gradlew build` green, and `-PlintReport` adds no warning in the file this touches.
- In the game, on Bliss and on the same world twice a minute apart, entering the world at the same
  place. Before: `entity_solid`, `entity_translucent` and `item_cutout` each left a line saying the
  caster cast no shadow that frame. After: none of the three, and the light's walk records the
  player's cape and skin, a chicken, a bat and an enderman's eyes into the map instead. The pack was
  loaded from a zip and the engine's three switches were left where they were.
- Not proven, and not claimed: any change on screen. Nothing of the pack reads the map on the frames
  in question, the chain composing nothing and every camera pass being refused for the same warm up,
  so what this fixes is a map that disagreed with itself and the log lines that said so.
- The reproduction depends on the pack: it is a race between the chain compiling and the light's
  walk finding a caster, and Mellow and Complementary do not show it where Bliss does.

## What it leaves owing

Nothing of this defect. The lines that remain on a launch are the deliberate ones, which name a
pipeline no shadow table anywhere carries a row for: a name plate, text, an end portal.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
