### PR TITLE
perf(sodium): carry only the chunk elements the pack reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@ what the next one holds.
 
 ### Changed
 
+- **A chunk vertex only carries what the pack loaded actually reads.** Every vertex of every section
+  used to carry the block id, the middle of the sprite, the offset to the middle of the block, the
+  normal, the tangent and a second copy of the colour, whichever of those the pack asked for: forty
+  four bytes each, whether four of them were read or none. The pack's own chunk programs are now read
+  first and the mesh is built from what they name, so a vertex costs between twenty four and forty
+  four bytes. Of the eight packs tested, one drops twelve bytes a vertex, one drops eight and one
+  drops four. It is video memory and the bandwidth of every chunk draw, so it is paid twice a frame
+  as soon as a shadow map is being filled. Switching between two packs that read different names
+  rebuilds the world, as switching the terrain off already did.
+
 - **The settings screen is the one pack authors already know.** It is the screen of the engine packs
   are written against, ported rather than approximated: the same list of packs with the shaders
   toggle at its head, the same pages of settings with the value of each in a sunken box beside its

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -607,6 +607,23 @@ public final class GlslTranslator {
 			return Map.copyOf(this.translator.synthesized);
 		}
 
+		/**
+		 * Which elements of the mesh this stage really reads, out of the ones its family may leave
+		 * off. Empty for every family that carries one format for all packs, which is all of them
+		 * but the chunk mesh.
+		 * <p>
+		 * Asked between {@link #prepare} and {@link #render}, and that is the whole reason it is a
+		 * method of this class: the answer is what the format is built from, and the format is what
+		 * the header then declares. Nothing here reads {@code bound}, so the value handed to
+		 * {@code prepare} for a stage that will only ever be asked this is not yet settled.
+		 */
+		public Set<String> reads() {
+			return this.translator.inputs.terrain()
+					? SodiumVertex.reads(this.translator.used, this.translator.synthesized,
+							this.translator.inputs.separateAo())
+					: Set.of();
+		}
+
 		/** Varyings the engine names, which both sides of a program have to declare or neither. */
 		public Set<String> varyings() {
 			Set<String> named = new LinkedHashSet<>();
@@ -3283,8 +3300,8 @@ public final class GlslTranslator {
 					lines.addAll(LegacyGlsl.FULLSCREEN_ATTRIBUTES);
 					lines.addAll(VertexPrologue.tail(this.used, this.synthesized));
 				}
-				case TERRAIN, TERRAIN_SEPARATE_AO -> lines.addAll(
-						SodiumVertex.prologue(this.used, this.synthesized, this.inputs.separateAo()));
+				case TERRAIN, TERRAIN_SEPARATE_AO -> lines.addAll(SodiumVertex.prologue(this.bound,
+						this.used, this.synthesized, this.inputs.separateAo()));
 				case ENTITY, ENTITY_FULLBRIGHT -> lines.addAll(
 						EntityVertex.prologue(this.used, this.synthesized, this.inputs.fullbright()));
 				case GLINT -> lines.addAll(GlintVertex.prologue(this.used, this.synthesized));

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -365,6 +366,14 @@ public final class PackProgram {
 	 * A pass the pack serves no program for is simply absent from the answer, and the chunk renderer
 	 * keeps the game's own shader for it. That is a normal thing for a pack to do rather than a
 	 * failure: nothing in the format obliges a pack to ship a {@code gbuffers_water}.
+	 * <p>
+	 * <strong>The passes are walked twice, and that is what settles the mesh.</strong> The chunk
+	 * mesh carries what the pack reads and no more, so the first walk rewrites each vertex stage and
+	 * asks it what it reads, and only the union of the six is enough to say what any of them may
+	 * declare. The second walk is the translation proper, against that answer. What the two walks
+	 * cost is one extra rewrite per vertex stage; what a single walk would cost is either a mesh
+	 * built before it is known or six programs each declaring its own idea of the format, which
+	 * shifts every location after the first difference and says nothing.
 	 *
 	 * @param place  where the entry points are read from, {@code world0} or the root, already
 	 *               settled by the chain
@@ -377,7 +386,7 @@ public final class PackProgram {
 	 *               for another mesh, which declares other names and would be found out by nothing
 	 *               short of the picture
 	 */
-	public static Map<TerrainPass, Loaded> loadTerrain(Path packPath, String place,
+	public static Terrain loadTerrain(Path packPath, String place,
 			Map<String, OptionValue> chosen, String profile, VertexInputs inputs)
 			throws IOException {
 		if (!inputs.terrain()) {
@@ -400,7 +409,15 @@ public final class PackProgram {
 			ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
 					dimensions);
 
-			Map<TerrainPass, Loaded> loaded = new LinkedHashMap<>();
+			// What each pass is served by, read once and kept, because the passes are walked twice:
+			// the mesh is built out of what ALL of them ask for, and every one of them then declares
+			// that whole mesh. Expanding the includes a second time would be the same files read
+			// again for the same answer.
+			record Served(String path, Map<ProgramStage, ExpandedUnit> units, AlphaTest alphaTest) {
+			}
+
+			Map<TerrainPass, Served> served = new LinkedHashMap<>();
+			Set<String> reads = new LinkedHashSet<>();
 			for (TerrainPass pass : TerrainPass.values()) {
 				Optional<ProgramResolver.Resolution> resolution = resolver.lookup(place, pass.program());
 				if (resolution.isEmpty()) {
@@ -418,15 +435,53 @@ public final class PackProgram {
 				}
 
 				AlphaTest alphaTest = pass.alphaTest(properties, servedBy);
-				// The pass's own program and not the file that serves it, for the reason the alpha
-				// test is taken that way: what the engine supplies belongs to what is being drawn.
-				loaded.put(pass, bind(source.packName(), path,
-						ProgramTranslator.translate(units, inputs, inputs.elements(), alphaTest,
-								pass.covers(), pass.program(), textures.volumes()),
-						targets, alphaTest, textures));
+				served.put(pass, new Served(path, units, alphaTest));
+				reads.addAll(ProgramTranslator.reads(units.get(ProgramStage.VERTEX), inputs,
+						alphaTest, pass.covers(), pass.program(), textures.volumes()));
 			}
 
-			return loaded;
+			// Nothing to draw and therefore nothing to carry, which is not the same answer as a mesh
+			// whose pack reads none of the six: the caller leaves Sodium's own format alone either
+			// way, and this is the road where it also has no program to leave it alone for.
+			if (served.isEmpty()) {
+				return new Terrain(Map.of(), List.of());
+			}
+
+			List<String> carried = SodiumVertex.carried(reads);
+			Map<TerrainPass, Loaded> loaded = new LinkedHashMap<>();
+			for (Map.Entry<TerrainPass, Served> entry : served.entrySet()) {
+				TerrainPass pass = entry.getKey();
+				Served one = entry.getValue();
+				// The pass's own program and not the file that serves it, for the reason the alpha
+				// test is taken that way: what the engine supplies belongs to what is being drawn.
+				loaded.put(pass, bind(source.packName(), one.path(),
+						ProgramTranslator.translate(one.units(), inputs, carried, one.alphaTest(),
+								pass.covers(), pass.program(), textures.volumes()),
+						targets, one.alphaTest(), textures));
+			}
+
+			return new Terrain(loaded, carried);
+		}
+	}
+
+	/**
+	 * The pack's chunk programs and the mesh they were written against.
+	 * <p>
+	 * The two travel together because neither is worth anything without the other. A vertex stage
+	 * declares exactly the elements listed here, so a caller that took these programs and bound a
+	 * format built from anything else would be shifting the location of every element after the
+	 * first difference, in silence.
+	 *
+	 * @param programs one per pass the pack serves, absent for a pass it does not
+	 * @param carried  the elements the chunk mesh has to carry, Sodium's own four first and then
+	 *                 whatever the union of the six programs reads. Empty when there is no program
+	 *                 at all, where the mesh keeps Sodium's own format
+	 */
+	public record Terrain(Map<TerrainPass, Loaded> programs, List<String> carried) {
+
+		public Terrain {
+			programs = Map.copyOf(programs);
+			carried = List.copyOf(carried);
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -131,6 +131,25 @@ public final class ProgramTranslator {
 	}
 
 	/**
+	 * Which elements of its mesh one program's vertex stage really reads, without a line of it being
+	 * written.
+	 * <p>
+	 * The chunk mesh is the one family whose format follows the pack, so its caller has to know what
+	 * every one of the pack's chunk programs asks for before it can settle what any of them
+	 * declares. This is the half of the translation that answers that: the stage is rewritten, its
+	 * names are read off it, and the header it would have been given is never built.
+	 * <p>
+	 * <strong>The elements handed in here are not the ones the head will declare</strong>, and they
+	 * cannot be: the format is what this call is being asked for. Nothing between here and
+	 * {@code render} reads them, which is what makes the two halves separable at all.
+	 */
+	public static Set<String> reads(ExpandedUnit vertex, VertexInputs inputs, AlphaTest alphaTest,
+			boolean coverage, String program, Map<String, VolumeAtlas> volumes) {
+		return GlslTranslator.prepare(vertex, ProgramStage.VERTEX, inputs, inputs.elements(),
+				alphaTest, coverage, program, volumes).reads();
+	}
+
+	/**
 	 * The same, for a family that binds more than one vertex format.
 	 * <p>
 	 * Only {@link VertexInputs#SKY} is one today: {@code SkyRenderer} binds four formats between its

--- a/common/src/main/java/dev/vitrail/glsl/SodiumVertex.java
+++ b/common/src/main/java/dev/vitrail/glsl/SodiumVertex.java
@@ -3,6 +3,7 @@ package dev.vitrail.glsl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -30,9 +31,15 @@ import java.util.Set;
  * <strong>Every name a pack reads of this geometry is now in the mesh.</strong> The block id, the
  * middle of the sprite, the offset to the middle of the block, the normal and the tangent are five
  * elements of this engine's own; {@link #TINT_AND_AO} is a sixth, and the one that answers no name
- * of the pack's but the shape of a name it already reads. Twenty bytes of Sodium's, twenty-four of
- * ours. The facing that used to stand in for a normal, in the spare bits of the material byte, is
- * gone with the last thing that read it.
+ * of the pack's but the shape of a name it already reads. The facing that used to stand in for a
+ * normal, in the spare bits of the material byte, is gone with the last thing that read it.
+ * <p>
+ * <strong>Which of the six a mesh really carries follows the pack</strong>, and the format is
+ * therefore anything from twenty bytes to forty-four. {@link #reads} says what one vertex stage
+ * needs, {@link #carried} turns the union over the pack's six chunk programs into the format, and
+ * {@link #prologue} declares that list and nothing besides. The union and not each program's own
+ * answer: an element the format carries that a stage does not declare shifts the location of every
+ * element after it without a word, so what one pass reads is paid for on every vertex by all six.
  * <p>
  * The region offset arrives through push constants, which is the one thing here that has to be got
  * right or nothing else matters. blaze3d never declares a push constant range; Sodium adds one, and
@@ -133,10 +140,33 @@ public final class SodiumVertex {
 					MID_BLOCK, NORMAL, TANGENT, TINT_AND_AO);
 
 	/**
-	 * The ones of {@link VertexPrologue#SYNTHESIZED} this mesh answers for real, out of an element
-	 * under another name. What is left of that set is what the log has to call a constant.
+	 * The ones of {@link #ATTRIBUTES} this engine appends, which are also the only ones a pack may
+	 * be spared. Sodium's own four are never dropped: its encoder writes all four whatever this
+	 * engine is doing, and its own chunk shader reads all four.
 	 */
-	public static final Set<String> ANSWERED = Set.of("mc_Entity", "mc_midTexCoord", "at_midBlock", "at_tangent");
+	private static final Set<String> OURS =
+			Set.of(BLOCK_ID, MID_TEX_COORD, MID_BLOCK, NORMAL, TANGENT, TINT_AND_AO);
+
+	/**
+	 * What the translation has turned {@code gl_Normal} into by the time a head is written. The one
+	 * name the mesh answers that is a spelling of neither the pack's nor an element's.
+	 */
+	private static final String OWN_NORMAL = "of_Normal";
+
+	/**
+	 * The ones of {@link VertexPrologue#SYNTHESIZED} this mesh answers for real, and the element
+	 * each of them is made out of. What is left of that set is what the log has to call a constant,
+	 * and so is any of these whose element the pack was not asked to carry.
+	 * <p>
+	 * A {@link LinkedHashMap} and not a literal, for the reason {@link VertexPrologue#SYNTHESIZED}
+	 * gives about its own set: this is walked to write a head, and a literal hands its names back in
+	 * an order the runtime picks afresh on every start, which is the same text to a reader and a
+	 * different shader to the game.
+	 */
+	private static final Map<String, String> OUT_OF = outOf();
+
+	/** The names of {@link #OUT_OF}, for a caller asking whether the mesh answers one of them. */
+	public static final Set<String> ANSWERED = OUT_OF.keySet();
 
 	/**
 	 * Every texture unit above the light map. Declared whether the pack mentions them or not costs
@@ -150,23 +180,93 @@ public final class SodiumVertex {
 	}
 
 	/**
-	 * The head of a terrain vertex stage: every element of the format, the region push constants, the
-	 * names the mesh answers out of them, and whatever the pack reads that no element carries.
+	 * Which of the elements this engine appends one vertex stage really reads.
+	 * <p>
+	 * The question {@link #prologue} answers for one stage, asked before any text exists so that the
+	 * mesh can be built out of the union over the pack's chunk programs. The two walk the same
+	 * globals and have to go on doing so: an element left out that a head then names is a stage
+	 * declaring an input the format has not got, and {@code IntermediaryShaderModule.rebind:205-207}
+	 * refuses the whole module for it.
+	 * <p>
+	 * <strong>A divergence, and it is one of ORDER rather than of taste.</strong> Iris asks the same
+	 * question of the LINKED program, {@code getAttribLocation} on its handle at
+	 * {@code pipeline/programs/SodiumPrograms.java:174-177}, so an attribute the compiler eliminated
+	 * for being named only in a dead branch costs it nothing. Nothing is compiled where this is
+	 * asked: {@code TerrainMesh.settle} is called from the head of Sodium's {@code initRenderer} and
+	 * the format has to be settled there, before the chunk renderer that meshes at that stride
+	 * exists, and each stage becomes a module of its own here rather than a linked program there
+	 * would be anything to query. So the names the rewritten text mentions are what is read. The
+	 * format can therefore only be LARGER than Iris's, never smaller, which costs four bytes a vertex
+	 * for such a name and nothing at all to the picture.
 	 *
+	 * @param used        every name the rewritten body mentions
+	 * @param synthesized the vertex inputs the pack declared for itself and that were taken out of
+	 *                    the body, by name and with the type the pack gave them
+	 * @param separateAo  whether the pack asked for the terrain's ambient occlusion to be kept out
+	 *                    of its vertex colour. The one answer here that is the PACK's rather than
+	 *                    this stage's: it decides which of the two colour elements every chunk
+	 *                    program reads, so it decides whether the mesh carries the second one at all
+	 */
+	public static Set<String> reads(Set<String> used, Map<String, String> synthesized,
+			boolean separateAo) {
+		Set<String> reads = new LinkedHashSet<>();
+		for (String name : VertexPrologue.globals(used, synthesized, FIXED).keySet()) {
+			String element = OUT_OF.get(name);
+			if (element != null) {
+				reads.add(element);
+			}
+		}
+
+		// Not one of the four, because it answers no name the pack writes: a body reads gl_Normal,
+		// and the translation has already turned that into of_Normal by the time this is asked.
+		if (used.contains(OWN_NORMAL)) {
+			reads.add(NORMAL);
+		}
+
+		// Nor is this, for the other reason: it is a second shape for a word the mesh already
+		// carries, and what decides whether a stage reads it is the directive and not the body.
+		if (separateAo) {
+			reads.add(TINT_AND_AO);
+		}
+
+		return reads;
+	}
+
+	/**
+	 * The whole format for a pack whose chunk programs read those elements: Sodium's own four, then
+	 * ours in {@link #ATTRIBUTES}'s order and only the ones asked for.
+	 * <p>
+	 * The union over the pack's six chunk programs and never one program's own answer. Every one of
+	 * them declares every element the mesh carries, so an element one pass reads is paid for by all
+	 * six; declaring fewer is what shifts the location of everything after the gap.
+	 */
+	public static List<String> carried(Set<String> reads) {
+		return ATTRIBUTES.stream()
+				.filter(attribute -> !OURS.contains(attribute) || reads.contains(attribute))
+				.toList();
+	}
+
+	/**
+	 * The head of a terrain vertex stage: the elements the mesh carries, the region push constants,
+	 * the names the mesh answers out of them, and whatever the pack reads that no element carries.
+	 *
+	 * @param carried     the elements the mesh really carries, in the format's own order. Exactly
+	 *                    these are declared and no others, which is why it is the union of
+	 *                    {@link #reads} over the pack's chunk programs and not this stage's own
 	 * @param used        every name the rewritten body mentions, so that nothing is declared for a
 	 *                    pack that never asks
 	 * @param synthesized the vertex inputs the pack declared for itself and that were taken out of
 	 *                    the body, by name and with the type the pack gave them
 	 * @param separateAo  whether the pack asked for the terrain's ambient occlusion to be kept out
 	 *                    of its vertex colour, which decides which of the two colour elements this
-	 *                    stage reads. A property of the PACK and not of the mesh: every vertex
-	 *                    carries both, so nothing is rebuilt when it moves
+	 *                    stage reads. A property of the PACK and not of this stage, and the mesh
+	 *                    carries the second colour exactly when it is set
 	 */
-	public static List<String> prologue(Set<String> used, Map<String, String> synthesized,
-			boolean separateAo) {
+	public static List<String> prologue(List<String> carried, Set<String> used,
+			Map<String, String> synthesized, boolean separateAo) {
 		List<String> lines = new ArrayList<>();
 
-		for (String attribute : ATTRIBUTES) {
+		for (String attribute : carried) {
 			lines.add("in " + type(attribute) + " " + attribute + ";");
 		}
 
@@ -190,8 +290,10 @@ public final class SodiumVertex {
 
 		// A name the mesh answers is left uninitialised here and filled in the prologue below, like
 		// of_Vertex above it. A global initialiser that reads an attribute is not a constant
-		// expression, and the language does not allow one.
-		globals.forEach((name, type) -> lines.add(ANSWERED.contains(name)
+		// expression, and the language does not allow one. A name whose element this pack was not
+		// asked to carry takes the constant instead, which is the road every name outside ANSWERED
+		// has always taken.
+		globals.forEach((name, type) -> lines.add(answered(carried, name)
 				? type + " " + name + ";"
 				: VertexPrologue.declaration(name, type)));
 
@@ -234,9 +336,15 @@ public final class SodiumVertex {
 		// centres the sample on its level comes with it. Iris carries the raw pair too,
 		// SodiumTransformer.java:228, and every other family of this engine already did.
 		lines.add("\tof_MultiTexCoord1 = vec4(vec2(a_LightAndData.xy), 0.0, 1.0);");
-		lines.add("\tof_Normal = " + NORMAL + ".xyz;");
+		// Asked of the carried list and not of ANSWERED, this being the one name of the head that is
+		// no spelling of the pack's. A pack no chunk program of which reads gl_Normal leaves the
+		// element off the mesh, and what stands here is then the constant every other family hands
+		// back for a mesh with no normal in it.
+		lines.add("\tof_Normal = " + (carried.contains(NORMAL)
+				? NORMAL + ".xyz"
+				: VertexPrologue.value(OWN_NORMAL, "vec3")) + ";");
 		globals.forEach((name, type) -> {
-			if (ANSWERED.contains(name)) {
+			if (answered(carried, name)) {
 				lines.add("\t" + name + " = " + answer(name, type) + ";");
 			}
 		});
@@ -244,6 +352,13 @@ public final class SodiumVertex {
 		lines.add("}");
 
 		return List.copyOf(lines);
+	}
+
+	/** Whether the mesh answers this name AND was asked to carry the element it comes out of. */
+	private static boolean answered(List<String> carried, String name) {
+		String element = OUT_OF.get(name);
+
+		return element != null && carried.contains(element);
 	}
 
 	/** One of the names the mesh answers, in the shape the pack declared it under. */
@@ -373,6 +488,16 @@ public final class SodiumVertex {
 			case BLOCK_ID -> "uint";
 			default -> "vec4";
 		};
+	}
+
+	private static Map<String, String> outOf() {
+		Map<String, String> names = new LinkedHashMap<>();
+		names.put("mc_Entity", BLOCK_ID);
+		names.put("mc_midTexCoord", MID_TEX_COORD);
+		names.put("at_midBlock", MID_BLOCK);
+		names.put("at_tangent", TANGENT);
+
+		return Collections.unmodifiableMap(names);
 	}
 
 	private static Map<String, String> fixed() {

--- a/common/src/main/java/dev/vitrail/glsl/VertexPrologue.java
+++ b/common/src/main/java/dev/vitrail/glsl/VertexPrologue.java
@@ -151,8 +151,15 @@ public final class VertexPrologue {
 		};
 	}
 
-	/** What a name the mesh does not carry is worth, given the type the pack declared it under. */
-	private static String value(String name, String type) {
+	/**
+	 * What a name the mesh does not carry is worth, given the type the pack declared it under.
+	 * <p>
+	 * Public because a head may have to answer one of these names itself rather than through a
+	 * global: the chunk mesh carries a normal only while a pack reads one, and its head fills
+	 * {@code of_Normal} in the prologue where the other families fill it with a macro. Asking here
+	 * is what keeps the two answers one answer.
+	 */
+	public static String value(String name, String type) {
 		String better = BETTER_DEFAULTS.get(name);
 
 		return better != null && better.startsWith(type + "(") ? better : zero(type);

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -615,6 +615,10 @@ public final class PackChain {
 			announceRemoved(chain);
 			active = new PackChain(chain, values, world, engine.seed(), pack, chosen,
 					settings.profile());
+			// The one family read here rather than on demand, and the order is the whole reason: the
+			// chunk mesh carries what this pack's chunk programs read, and Sodium takes the format
+			// where it builds its chunk renderer, which is well before any pass asks for a shader.
+			active.terrain.read();
 			if (!chainWanted) {
 				EngineOptions.announceChainOff();
 			}

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -1,5 +1,6 @@
 package dev.vitrail.render;
 
+import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.TerrainPass;
 import dev.vitrail.pack.source.ShadowCasters;
@@ -20,6 +21,7 @@ import net.minecraft.client.Minecraft;
 
 import org.joml.Matrix4f;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -93,6 +95,18 @@ public final class TerrainDraw {
 	 */
 	private static boolean shadowing;
 
+	/**
+	 * What the chunk mesh has to carry for the pack in force: Sodium's own elements first, then the
+	 * ones this engine appends that the pack's chunk programs really read. Empty where no pack's
+	 * terrain program is wanted, and then the mesh keeps Sodium's own format.
+	 * <p>
+	 * <strong>Read by the mesh at the one instant it may change and written only by
+	 * {@link #carries}</strong>, which has the world rebuilt when the answer moves. Volatile because
+	 * the two sides are two threads: a pack is loaded off the render thread while the game starts up,
+	 * and Sodium builds its chunk renderer on the render thread.
+	 */
+	private static volatile List<String> carried = List.of();
+
 	private final PackChain owner;
 	private final Path packPath;
 	private final String place;
@@ -104,6 +118,15 @@ public final class TerrainDraw {
 	private final TargetPlan chainTargets;
 	private final boolean chainRuns;
 	private final ColorTargets targets;
+
+	/**
+	 * The pack's chunk programs as the translation left them, read when the pack was loaded. Empty
+	 * where the pack serves none, and where the reading threw.
+	 */
+	private Map<TerrainPass, PackProgram.Loaded> loaded = Map.of();
+
+	/** The elements those programs declare, which is what this pack published through {@link #carries}. */
+	private List<String> declares = List.of();
 
 	private Map<TerrainPass, TerrainProgram> programs = Map.of();
 	private boolean read;
@@ -127,12 +150,13 @@ public final class TerrainDraw {
 	/**
 	 * Whether a pack's terrain program takes over the opaque chunk pass, from the loaded options.
 	 * <p>
-	 * <strong>This answer decides what the chunk mesh carries</strong>, and the mesh only carries what
-	 * a pack reads while a pack wants it. So a change here is worth a rebuilt world: the sections
+	 * <strong>Switched off, this empties what the chunk mesh carries</strong>, the mesh only carrying
+	 * what a pack reads while a pack wants it. So a change here is worth a rebuilt world: the sections
 	 * standing at this instant were meshed at the other stride, and the renderer would bind a layout
 	 * that does not describe them. What that costs when it is skipped is a world drawn by the game
 	 * while the sky is drawn by the pack, which reads as the sky being in front of the world rather
-	 * than as a terrain program that never ran.
+	 * than as a terrain program that never ran. Switched on it empties nothing and settles nothing:
+	 * {@link #read()} is what fills the answer in, once the pack's own programs have been read.
 	 * <p>
 	 * The door is the one F3+A uses, {@code LevelExtractor.allChanged}, and it raises a flag the next
 	 * extract consumes rather than tearing sections down inside a frame. That extract calls
@@ -149,6 +173,13 @@ public final class TerrainDraw {
 	 * itself.
 	 */
 	static void wanted(boolean asked) {
+		if (!asked) {
+			// Whether or not the flag itself moved. A pack refused after this was raised leaves the
+			// flag standing with no chain behind it, and the elements are the half of the answer the
+			// mesh really reads.
+			carries(List.of());
+		}
+
 		if (wanted == asked) {
 			return;
 		}
@@ -163,6 +194,88 @@ public final class TerrainDraw {
 				+ "what it reads only while it does, so the sections are all built again",
 				asked ? "wanted" : "no longer wanted");
 		minecraft.levelExtractor.allChanged();
+	}
+
+	/**
+	 * Reads the pack's own chunk programs and publishes the mesh they were written against.
+	 * <p>
+	 * <strong>Here and not at the first chunk draw, and the reason is the ORDER.</strong> What the
+	 * mesh carries is the union of what those six programs read, and Sodium takes the format where it
+	 * builds its chunk renderer, which is long before any pass asks for a shader. Read late, the
+	 * format would be settled from the pack before it and every section would be meshed at a stride
+	 * these programs do not declare.
+	 * <p>
+	 * Nothing here touches the device, so it runs wherever the load runs, off the render thread while
+	 * the client starts up. What it costs a place that never draws a chunk is those six translations;
+	 * what the laziness bought was exactly that, and it cannot be had at the same time as a format
+	 * that follows the pack.
+	 * <p>
+	 * A reading that throws takes the terrain down rather than the pack: the sky and the entities are
+	 * read from the same archive and have their own answer about it, and a world drawn by the game
+	 * under a pack's sky is what this used to leave behind.
+	 */
+	void read() {
+		if (!wanted) {
+			return;
+		}
+
+		try {
+			PackProgram.Terrain read = TerrainProgram.read(this.packPath, this.place, this.chosen,
+					this.profile, this.values);
+			this.loaded = read.programs();
+			this.declares = read.carried();
+		} catch (IOException | RuntimeException e) {
+			wanted = false;
+			Vitrail.logger().error("Could not read the terrain programs of "
+					+ this.packPath.getFileName() + ", so the world keeps the game's own shader", e);
+		}
+
+		carries(this.declares);
+	}
+
+	/**
+	 * Takes the elements the mesh has to carry from here on, and has the world rebuilt when they
+	 * move.
+	 * <p>
+	 * The same door and the same reason as {@link #wanted(boolean)}: the sections standing at this
+	 * instant were meshed at the other stride and carry their words at the other offsets, so a
+	 * renderer binding the new layout over them reads each element out of its neighbour. It is
+	 * {@code LevelExtractor.allChanged}, which raises a flag the next extract consumes rather than
+	 * tearing sections down inside a frame, and that extract is where Sodium builds its chunk
+	 * renderer again and where {@code TerrainMesh.settle} takes this answer.
+	 * <p>
+	 * <strong>Two packs that both draw the terrain are the case this exists for.</strong> The flag
+	 * above does not move between them, and the ids moving is what used to rebuild the world;
+	 * two packs reading different names of the mesh with the same {@code block.properties} would have
+	 * left the sections at a stride nothing was writing.
+	 * <p>
+	 * Silent before a world is joined, where nothing has been meshed and the first reading answers
+	 * itself.
+	 */
+	private static void carries(List<String> asked) {
+		if (carried.equals(asked)) {
+			return;
+		}
+
+		carried = List.copyOf(asked);
+		Minecraft minecraft = Minecraft.getInstance();
+		if (minecraft == null || minecraft.level == null) {
+			return;
+		}
+
+		Vitrail.logger().info("The chunk mesh carries {} now, so the sections are all built again",
+				carried);
+		minecraft.levelExtractor.allChanged();
+	}
+
+	/**
+	 * The elements the chunk mesh has to carry, for the side that builds the format.
+	 * <p>
+	 * Read at one instant of that side's own choosing and not per frame, for the reason
+	 * {@link #asked()} gives: the format may only change where nothing is left holding the old one.
+	 */
+	public static List<String> carried() {
+		return carried;
 	}
 
 	/** Whether the shadow map is drawn, from the loaded options. */
@@ -623,15 +736,19 @@ public final class TerrainDraw {
 	private RenderPipeline prepare(TerrainPass pass, VertexFormat format, GpuTextureView atlas) {
 		if (!this.read) {
 			this.read = true;
-			if (!TerrainProgram.carries(format)) {
+			// Asked of the programs and not of the mesh, because a pack that serves no chunk program
+			// at all declares nothing and asked for nothing: the mesh was never extended for it, and
+			// comparing an empty list against Sodium's own four would put the whole pack away over a
+			// chunk pass it never wanted. It keeps the game's own shader for the six passes, which is
+			// a normal thing for a pack to do, and its sky and its chain go on being drawn.
+			if (!this.loaded.isEmpty() && !TerrainProgram.carries(format, this.declares)) {
 				this.owner.putAway("the chunk mesh does not carry what a terrain program reads");
 
 				return null;
 			}
 
-			this.programs = TerrainProgram.read(this.packPath, this.place, this.chosen,
-					this.profile, this.values, this.load, format, this.plan, this.chainTargets,
-					this.chainRuns, this.targets);
+			this.programs = TerrainProgram.build(this.loaded, this.values, this.load, format,
+					this.plan, this.chainTargets, this.chainRuns, this.targets);
 		}
 
 		TerrainProgram program = this.programs.get(pass);

--- a/common/src/main/java/dev/vitrail/render/TerrainProgram.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainProgram.java
@@ -109,38 +109,49 @@ public final class TerrainProgram implements DumpedProgram {
 	}
 
 	/**
-	 * Reads and translates the three programs the chunk renderer draws with, keyed by the pass each
-	 * one serves. A pass the pack ships nothing for is absent, and keeps the game's own shader.
+	 * Reads and translates the six programs the chunk renderer draws with, and says what mesh they
+	 * were written against. A pass the pack ships nothing for is absent, and keeps the game's own
+	 * shader.
 	 * <p>
-	 * A second reading of the pack, which costs one plan build for all three. The chain's own reading
+	 * A second reading of the pack, which costs one plan build for all six. The chain's own reading
 	 * translates what the chain runs, and a gbuffers program is not in it: folding this into that
 	 * walk would make every place pay for programs only this step uses.
+	 * <p>
+	 * <strong>Read where the pack is loaded and not where a chunk pass first asks.</strong> What the
+	 * mesh carries is the union of what these six read, and the mesh has to be settled before Sodium
+	 * builds the chunk renderer that meshes with it. The device is not touched here: the pipelines
+	 * are built by {@link #build}, at the first draw and against the format the renderer hands over.
+	 */
+	static PackProgram.Terrain read(Path packPath, String place, Map<String, OptionValue> chosen,
+			String profile, PackValues values) throws IOException {
+		// Which of the two colours the six vertex stages read, settled here because this is where
+		// the pack's own reading of separateAo is held. Two shapes for one word Sodium already
+		// writes, so it decides both which element a stage reads and whether the mesh carries the
+		// second one at all.
+		VertexInputs inputs = values.separateAo()
+				? VertexInputs.TERRAIN_SEPARATE_AO
+				: VertexInputs.TERRAIN;
+		PackProgram.Terrain read = PackProgram.loadTerrain(packPath, place, chosen, profile, inputs);
+		if (read.programs().isEmpty()) {
+			Vitrail.logger().warn("{} serves no terrain program with both stages in {}, so the "
+					+ "world keeps the game's own shader", packPath.getFileName(),
+					place.isEmpty() ? "its root" : place);
+		}
+
+		return read;
+	}
+
+	/**
+	 * Equips the programs already read with everything that needs a format and a plan, keyed by the
+	 * pass each one serves.
 	 *
 	 * @param format the chunk mesh format, handed in rather than looked up, because nothing in this
 	 *               module is allowed to name Sodium
 	 */
-	static Map<TerrainPass, TerrainProgram> read(Path packPath, String place,
-			Map<String, OptionValue> chosen, String profile, PackValues values, int load,
-			VertexFormat format, ChainPlan plan, TargetPlan chainTargets, boolean chainRuns,
-			ColorTargets targets) {
+	static Map<TerrainPass, TerrainProgram> build(Map<TerrainPass, PackProgram.Loaded> loaded,
+			PackValues values, int load, VertexFormat format, ChainPlan plan,
+			TargetPlan chainTargets, boolean chainRuns, ColorTargets targets) {
 		try {
-			// Which of the two colours the three vertex stages read, settled here because this is
-			// where the pack's own reading of separateAo is held. It is not a property of the mesh:
-			// every vertex carries both, so a pack that asks replacing one that does not costs a
-			// second reading of the programs and nothing else.
-			VertexInputs inputs = values.separateAo()
-					? VertexInputs.TERRAIN_SEPARATE_AO
-					: VertexInputs.TERRAIN;
-			Map<TerrainPass, PackProgram.Loaded> loaded =
-					PackProgram.loadTerrain(packPath, place, chosen, profile, inputs);
-			if (loaded.isEmpty()) {
-				Vitrail.logger().warn("{} serves no terrain program with both stages in {}, so the "
-						+ "world keeps the game's own shader", packPath.getFileName(),
-						place.isEmpty() ? "its root" : place);
-
-				return Map.of();
-			}
-
 			Map<TerrainPass, TerrainProgram> programs = new EnumMap<>(TerrainPass.class);
 			loaded.forEach((pass, one) -> {
 				// The samplers are bound again, against the chain's own plan and on the step of the
@@ -177,20 +188,28 @@ public final class TerrainProgram implements DumpedProgram {
 			});
 
 			return programs;
-		} catch (IOException | RuntimeException e) {
-			Vitrail.logger().error("Could not prepare the terrain programs of "
-					+ packPath.getFileName() + ", so the world keeps the game's own shader", e);
+		} catch (RuntimeException e) {
+			Vitrail.logger().error("Could not equip the terrain programs, so the world keeps the "
+					+ "game's own shader", e);
 
 			return Map.of();
 		}
 	}
 
-	/** Checks that the mesh is still the one the prologue decodes, and says so once when it is not. */
-	static boolean carries(VertexFormat format) {
+	/**
+	 * Checks that the mesh the renderer bound is the one these programs were written against, and
+	 * says so once when it is not.
+	 *
+	 * @param carried the elements the programs declare, which is what the pack was read for and what
+	 *                the format was built from. Compared rather than assumed because the two are
+	 *                settled at two moments, the reading of the pack and the rebuild of the chunk
+	 *                renderer, and nothing in between makes them agree by construction
+	 */
+	static boolean carries(VertexFormat format, List<String> carried) {
 		List<String> elements = format.getElements().stream()
 				.map(VertexFormatElement::name)
 				.toList();
-		if (elements.equals(SodiumVertex.ATTRIBUTES)) {
+		if (elements.equals(carried)) {
 			return true;
 		}
 
@@ -203,9 +222,9 @@ public final class TerrainProgram implements DumpedProgram {
 		// the world then came from the game while the sky came from the pack, which puts the sky in
 		// front of the trees and reads as a broken sky rather than as a terrain program that never
 		// ran. So the caller stops the whole pack.
-		Vitrail.logger().error("The chunk mesh carries {} and this engine decodes {}, so no terrain "
+		Vitrail.logger().error("The chunk mesh carries {} and these programs declare {}, so no terrain "
 				+ "program can be drawn and this pack is put away rather than drawn by halves",
-				elements, SodiumVertex.ATTRIBUTES);
+				elements, carried);
 
 		return false;
 	}

--- a/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
+++ b/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
@@ -16,6 +16,7 @@ import net.caffeinemc.mods.sodium.client.render.chunk.vertex.format.ChunkVertexT
 import org.lwjgl.system.MemoryUtil;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * The chunk mesh with the elements a pack reads and Sodium does not carry, appended after its own.
@@ -40,6 +41,12 @@ import java.util.Arrays;
  * three after the first land where this format does not want them and are moved up, backwards and
  * word by word so that a vertex is never written over a word still to be read.
  * <p>
+ * <strong>How many of the six are appended follows the pack.</strong> {@code TerrainDraw} translates
+ * the pack's six chunk programs far enough to know which names they read, and hands that list here;
+ * a vertex is then anything from twenty-four bytes to forty-four. The ones left out close the gap
+ * rather than leaving a hole, so an element's offset is where it lands in this pack's mesh and not
+ * where it lands in {@link Extra}.
+ * <p>
  * <strong>The new elements have to stay last, and after Sodium's four.</strong> An element the shader
  * does not declare shifts the location of every element AFTER it, in silence, because the pipeline
  * counts every element of the format and the shader module only counts the ones a stage declared.
@@ -50,13 +57,13 @@ import java.util.Arrays;
 public final class TerrainMesh implements ChunkVertexType {
 
 	/**
-	 * This format, built the first time one is wanted and kept because it holds no state of its own.
-	 * Null until then, and null for good once {@link #broken} is set.
+	 * The format in force, or null to leave Sodium's own alone. Held rather than rebuilt because it
+	 * holds no state of its own.
 	 * <p>
-	 * <strong>Which of the two answers is served is not settled for the run, and that is why a pack
-	 * picked in a running game draws the world.</strong> It moves only in {@link #settle()}, and
-	 * {@code TerrainDraw.wanted} is what asks for that to happen: it changes what the options say and
-	 * has the world rebuilt, and everything meshed at the old stride is thrown out on the way.
+	 * <strong>Which answer is served is not settled for the run, and that is why a pack picked in a
+	 * running game draws the world.</strong> It moves only in {@link #settle()}, and
+	 * {@code TerrainDraw} is what asks for that to happen: the elements it publishes change, it has
+	 * the world rebuilt, and everything meshed at the old stride is thrown out on the way.
 	 */
 	private static TerrainMesh built;
 
@@ -67,15 +74,14 @@ public final class TerrainMesh implements ChunkVertexType {
 	 */
 	private static boolean broken;
 
-	/** The answer in force, which only {@link #settle()} moves. */
-	private static boolean carrying;
-
 	/**
-	 * Whether the answer has ever been said out loud. Kept apart from {@link #carrying} because the
-	 * two share their initial value: without it, the first settle of a game nobody picked a pack in
-	 * would find nothing changed and stay silent, which is the case that most needs the line.
+	 * What the log last announced, and null until the first settle of a run.
+	 * <p>
+	 * Null and not the empty list, because the two would otherwise share their value: without the
+	 * difference, the first settle of a game nobody picked a pack in would find nothing changed and
+	 * stay silent, which is the case that most needs the line.
 	 */
-	private static boolean said;
+	private static List<String> said;
 
 	/**
 	 * What a texture coordinate is multiplied by before it is stored, which is Sodium's own
@@ -119,19 +125,36 @@ public final class TerrainMesh implements ChunkVertexType {
 	private final ChunkVertexEncoder innerEncoder = this.inner.getEncoder();
 	private final ChunkVertexEncoder encoder = this::encode;
 	private final int innerStride = this.inner.getVertexFormat().getVertexSize();
-	private final VertexFormat format = extend(this.inner.getVertexFormat());
-	private final int stride = this.format.getVertexSize();
 
-	private TerrainMesh() {
+	/** The whole format this was asked for, Sodium's own names first, kept to answer a second ask. */
+	private final List<String> carried;
+
+	/** The ones of {@link Extra} that list names, in the order they are laid out. */
+	private final List<Extra> extras;
+
+	/**
+	 * Where each element of {@link Extra} starts, counted from the end of Sodium's own bytes, and
+	 * {@link #ABSENT} for one this pack does not carry. Indexed by ordinal, which is how the layout
+	 * and the encoder read the same table rather than each counting for itself.
+	 */
+	private final int[] offsets;
+
+	private final VertexFormat format;
+	private final int stride;
+
+	/** What {@link #offsets} holds for an element the pack was not asked to carry. */
+	private static final int ABSENT = -1;
+
+	private TerrainMesh(List<String> carried) {
 		if (this.innerStride % Integer.BYTES != 0) {
 			throw new IllegalStateException("The chunk mesh is " + this.innerStride + " bytes, which "
 					+ "is not a whole number of words, and this engine moves it a word at a time");
 		}
 
-		// What holds the layout and the encoder together. Both take their offsets from
-		// Extra.offset(), which spends one word per element, and the encoder writes each of them
-		// with a single memPutInt. An element of any other width would put the two on different
-		// bytes without either of them saying so, and the pack would read the neighbour's.
+		// What holds the layout and the encoder together. Both take their offsets from the table
+		// below, which spends one word per element, and the encoder writes each of them with a
+		// single memPutInt. An element of any other width would put the two on different bytes
+		// without either of them saying so, and the pack would read the neighbour's.
 		for (Extra extra : Extra.values()) {
 			if (extra.format().blockSize() != Integer.BYTES) {
 				throw new IllegalStateException(extra.attribute() + " takes "
@@ -139,6 +162,19 @@ public final class TerrainMesh implements ChunkVertexType {
 						+ "one word for each of the elements it appends");
 			}
 		}
+
+		this.carried = List.copyOf(carried);
+		this.extras = Arrays.stream(Extra.values())
+				.filter(extra -> this.carried.contains(extra.attribute()))
+				.toList();
+		this.offsets = new int[Extra.values().length];
+		Arrays.fill(this.offsets, ABSENT);
+		for (int at = 0; at < this.extras.size(); at++) {
+			this.offsets[this.extras.get(at).ordinal()] = at * Integer.BYTES;
+		}
+
+		this.format = extend(this.inner.getVertexFormat(), this.extras);
+		this.stride = this.format.getVertexSize();
 	}
 
 	/**
@@ -156,11 +192,11 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * the wrong place and the world draws out of garbage.
 	 */
 	public static synchronized ChunkVertexType current() {
-		return carrying ? built : null;
+		return built;
 	}
 
 	/**
-	 * Takes the answer the options now ask for, at the one instant it is safe to change it.
+	 * Takes the format the loaded pack now asks for, at the one instant it is safe to change it.
 	 * <p>
 	 * That instant is the head of Sodium's {@code initRenderer}, the only place its section manager is
 	 * built, and {@code MixinSodiumWorldRendererInit} is what calls this from there. What makes it
@@ -168,29 +204,45 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * the format, so no two askers can end up disagreeing. Everything that will ask is built
 	 * afterwards, and every section is meshed again after that.
 	 * <p>
+	 * <strong>The elements are the pack's and not this class's</strong>, which is what makes a stride
+	 * that follows what the pack reads possible at all: {@code TerrainDraw} has already translated
+	 * the pack's chunk programs far enough to know, and has already asked for the world to be rebuilt
+	 * if the answer moved. Nothing is decided here beyond turning that list into a layout.
+	 * <p>
 	 * Built here rather than in a static field so that a mesh this cannot extend leaves the game
 	 * running on Sodium's own instead of failing to load a class in the middle of a world.
 	 */
 	public static synchronized void settle() {
-		boolean asked = TerrainDraw.asked() && !broken;
-		if (asked && built == null) {
+		List<String> carried = broken ? List.of() : TerrainDraw.carried();
+		// Sodium's own four and nothing of ours is the same layout Sodium already binds, so it is
+		// answered with Sodium's own rather than with a copy of it. No pack of the corpus is here,
+		// every one of them reading at least the block id, but a pack that read none of the six
+		// would be, and wrapping a format to change nothing about it is one more thing to be wrong.
+		if (carried.stream().noneMatch(TerrainMesh::ours)) {
+			carried = List.of();
+		}
+
+		if (!carried.isEmpty() && (built == null || !built.carried.equals(carried))) {
 			try {
-				built = new TerrainMesh();
+				built = new TerrainMesh(carried);
 			} catch (RuntimeException e) {
 				broken = true;
-				asked = false;
+				carried = List.of();
 				Vitrail.logger().error("This engine cannot extend the chunk mesh, so the terrain keeps "
 						+ "Sodium's own and no pack will draw it", e);
 			}
 		}
 
-		if (said && asked == carrying) {
+		if (carried.isEmpty()) {
+			built = null;
+		}
+
+		if (carried.equals(said)) {
 			return;
 		}
 
-		said = true;
-		carrying = asked;
-		if (!asked) {
+		said = carried;
+		if (carried.isEmpty()) {
 			// Said out loud, and it used to be the silent branch. Without naming a cause, because
 			// there are three and this cannot tell them apart: a terrain= line, no pack chosen yet,
 			// which is every first launch of a fresh instance, and a terrain program that threw.
@@ -202,9 +254,14 @@ public final class TerrainMesh implements ChunkVertexType {
 		}
 
 		Vitrail.logger().info("The chunk mesh carries {} bytes a vertex instead of {}, the difference "
-				+ "being what a pack reads and Sodium does not carry: {}",
+				+ "being what this pack reads and Sodium does not carry: {}",
 				built.stride, built.innerStride,
-				Arrays.stream(Extra.values()).map(Extra::attribute).toList());
+				built.extras.stream().map(Extra::attribute).toList());
+	}
+
+	/** Whether an element of the format is one this engine appends rather than one of Sodium's. */
+	private static boolean ours(String attribute) {
+		return Arrays.stream(Extra.values()).anyMatch(extra -> extra.attribute().equals(attribute));
 	}
 
 	@Override
@@ -224,11 +281,16 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * any padding Sodium leaves between two of them survives. The builder refuses a size that is not
 	 * a whole number of words, which is what makes the id four bytes wide where two would do.
 	 * <p>
-	 * Ours are placed at {@code Extra.offset()}, which is where the encoder writes them as well: the
-	 * two used to be a walk over the sizes here and six literal offsets there, and they agreed
-	 * because every element happens to be one word and for no other reason.
+	 * Ours are laid out one word after another in the order they are handed in, which is also where
+	 * the encoder writes them: both read {@code offsets}, and the two used to be a walk over the
+	 * sizes here and six literal offsets there, agreeing because every element happens to be one
+	 * word and for no other reason.
+	 *
+	 * @param extras the ones of {@link Extra} this pack asked for, in {@link Extra}'s own order.
+	 *               An element left out closes the gap rather than leaving a hole: the shader
+	 *               declares this list and no more, so there is nothing to keep a place for
 	 */
-	private static VertexFormat extend(VertexFormat base) {
+	private static VertexFormat extend(VertexFormat base, List<Extra> extras) {
 		VertexFormat.Builder builder = VertexFormat.builder(base.getStepRate());
 		for (VertexFormatElement element : base.getElements()) {
 			builder.addAttribute(element.name(), element.offset(), element.format().blockSize(),
@@ -236,24 +298,34 @@ public final class TerrainMesh implements ChunkVertexType {
 		}
 
 		int at = base.getVertexSize();
-		for (Extra extra : Extra.values()) {
-			builder.addAttribute(extra.attribute(), at + extra.offset(), extra.format().blockSize(),
-					extra.format(), 1);
+		for (Extra extra : extras) {
+			builder.addAttribute(extra.attribute(), at, extra.format().blockSize(), extra.format(), 1);
+			at += Integer.BYTES;
 		}
 
 		return builder.build();
 	}
 
 	/**
+	 * Where one of our elements starts, counted from the end of Sodium's own bytes, or
+	 * {@link #ABSENT} for one this pack does not carry.
+	 */
+	private int offset(Extra extra) {
+		return this.offsets[extra.ordinal()];
+	}
+
+	/**
 	 * The elements this engine adds after Sodium's own, in the order they are laid out.
 	 * <p>
 	 * Each is four bytes and each is named by {@link SodiumVertex}, which is the side that decodes
-	 * them. They are all appended rather than chosen per pack, where Iris keeps only the ones a pack's
-	 * compiled programs really reference, {@code FormatAnalyzer}. <strong>The reason this engine could
-	 * not do the same has gone</strong>: it was that the format was settled before any pack was
-	 * chosen, and the format follows the pack now. What is left is a plain difference in what a vertex
-	 * costs, and it is not closed here. What it would save is small either way: seven packs of the
-	 * corpus read {@code mc_midTexCoord} and eight read {@code at_tangent}.
+	 * them. <strong>Which of them a mesh really carries is the pack's answer</strong>, taken from
+	 * what its six chunk programs read, exactly as Iris takes it from what its transformed programs
+	 * reference, {@code FormatAnalyzer}. The ones left out close the gap rather than leaving a hole,
+	 * so this order decides which words move and not where any of them lands.
+	 * <p>
+	 * What is still not Iris's is the packing: it spends one word on the normal and the tangent
+	 * together and unpacks it in the patched text, where this spends two. The prologue is the place
+	 * that would unpack a combined word, and doing it there is a change of its own.
 	 */
 	private enum Extra {
 
@@ -304,9 +376,10 @@ public final class TerrainMesh implements ChunkVertexType {
 		 * shader draws this mesh too and reads the word. Iris has no such
 		 * window to cover, nothing of its own warming up over several frames.
 		 * <p>
-		 * Written for every pack, asked or not, like the five above it. The format is one answer for
-		 * all packs, and what a pack's directive decides is which of the two colours the translated
-		 * vertex stage reads, which costs no rebuild and is settled at translation.
+		 * <strong>The one element here whose presence is not a question about the pack's BODY.</strong>
+		 * The five above it are carried when a chunk program names them; this one is carried exactly
+		 * when the pack wrote {@code separateAo}, which is what makes every one of its vertex stages
+		 * read it. Two packs of the corpus write nothing, and their meshes carry one colour.
 		 */
 		TINT_AND_AO(SodiumVertex.TINT_AND_AO, GpuFormat.RGBA8_UNORM);
 
@@ -325,15 +398,6 @@ public final class TerrainMesh implements ChunkVertexType {
 		GpuFormat format() {
 			return this.format;
 		}
-
-		/**
-		 * Where this element starts, counted from the end of Sodium's own bytes. One word each,
-		 * which the constructor checks against the widths declared above, and the single list both
-		 * the layout and the encoder place these from.
-		 */
-		int offset() {
-			return ordinal() * Integer.BYTES;
-		}
 	}
 
 	/**
@@ -349,22 +413,35 @@ public final class TerrainMesh implements ChunkVertexType {
 		// and not a property of a corner, so the four vertices carry the same number. Iris does the
 		// same and packs it the same way, which is what lets a pack divide it by the number it
 		// already divides its own texture coordinate by.
-		int middle = midTexCoord(vertices);
+		//
+		// Guarded like the frame below it, and for a plainer reason than the frame's: an element the
+		// mesh does not carry has nowhere to be written, so working it out would be arithmetic on
+		// every quad of the world for a word that is then thrown away.
+		int middle = offset(Extra.MID_TEX_COORD) == ABSENT ? 0 : midTexCoord(vertices);
 
 		// Both are properties of the QUAD and not of a corner, like the middle above: the four
 		// vertices carry the same pair, and a pack that reads a normal per vertex on chunk geometry
 		// is reading what the face is, not what the corner is.
-		float[] frame = frame(vertices);
-		int normal = packAxis(frame[0], frame[1], frame[2], 0.0F);
-		int tangent = packAxis(frame[3], frame[4], frame[5], frame[6]);
+		//
+		// The two are found together and dropped together, Newell's sum being what the tangent is
+		// then squared up against: a pack reading one of them pays for both, and a pack reading
+		// neither pays for neither.
+		boolean framed = offset(Extra.NORMAL) != ABSENT || offset(Extra.TANGENT) != ABSENT;
+		float[] frame = framed ? frame(vertices) : null;
+		int normal = framed ? packAxis(frame[0], frame[1], frame[2], 0.0F) : 0;
+		int tangent = framed ? packAxis(frame[3], frame[4], frame[5], frame[6]) : 0;
+
+		// The one of the six that is a property of the CORNER, so it is asked for inside the loop
+		// and only the question is hoisted out of it.
+		boolean blockMiddle = offset(Extra.MID_BLOCK) != ABSENT;
 
 		// Backwards over the vertices, because a vertex moves up by the difference of the two strides
 		// times its own index, and one that has not been moved yet is the source of the move before
 		// it: at twenty-four bytes of difference the second vertex lands on [44, 64) and the third is
 		// still to be read from [40, 60). Word by word from the top of each vertex costs nothing and
-		// is what keeps the move right at any pair of strides, where at this pair a vertex's own two
-		// ranges are twenty-four bytes apart and never meet at all, the first being copied onto
-		// itself.
+		// is what keeps the move right at any pair of strides, which is what this now needs: the
+		// difference is four bytes for a pack that reads one of the six and twenty-four for one that
+		// reads them all, and at four the two ranges of one vertex DO overlap.
 		for (int at = vertices.length - 1; at >= 0; at--) {
 			long from = pointer + (long) at * this.innerStride;
 			long to = pointer + (long) at * this.stride;
@@ -373,20 +450,32 @@ public final class TerrainMesh implements ChunkVertexType {
 			}
 
 			long extra = to + this.innerStride;
-			MemoryUtil.memPutInt(extra + Extra.BLOCK_ID.offset(),
+			write(extra, Extra.BLOCK_ID,
 					((TerrainVertex) vertices[at]).vitrailBlockId() & BlockStateIds.PACKED_MASK);
-			MemoryUtil.memPutInt(extra + Extra.MID_TEX_COORD.offset(), middle);
-			MemoryUtil.memPutInt(extra + Extra.MID_BLOCK.offset(), midBlock(vertices[at]));
-			MemoryUtil.memPutInt(extra + Extra.NORMAL.offset(), normal);
-			MemoryUtil.memPutInt(extra + Extra.TANGENT.offset(), tangent);
+			write(extra, Extra.MID_TEX_COORD, middle);
+			write(extra, Extra.MID_BLOCK, blockMiddle ? midBlock(vertices[at]) : 0);
+			write(extra, Extra.NORMAL, normal);
+			write(extra, Extra.TANGENT, tangent);
 			// The two fields the encoder was handed, kept apart instead of multiplied together, out
 			// of Sodium's own published helper. Sodium's word beside it keeps the product, so this
 			// one is read by a pack that asked for it and by nothing else.
-			MemoryUtil.memPutInt(extra + Extra.TINT_AND_AO.offset(),
-					ColorABGR.withAlpha(vertices[at].color, vertices[at].ao));
+			write(extra, Extra.TINT_AND_AO, ColorABGR.withAlpha(vertices[at].color, vertices[at].ao));
 		}
 
 		return pointer + (long) vertices.length * this.stride;
+	}
+
+	/**
+	 * One of our words onto one vertex, or nothing at all where this pack does not carry it.
+	 * <p>
+	 * The one place the encoder asks whether an element is there, so that the writes above read as
+	 * the six they have always been and the question is answered once for each.
+	 */
+	private void write(long extra, Extra element, int value) {
+		int at = offset(element);
+		if (at != ABSENT) {
+			MemoryUtil.memPutInt(extra + at, value);
+		}
 	}
 
 	/**

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -45,8 +45,8 @@ pipeline in a map keyed by render pass, the map is static and the three passes a
 pipeline declares the vertex format of whichever renderer built it. Nothing ever empties it, so the
 entry made during one session's warm up goes on answering for every renderer built afterwards, at
 whatever stride it was born with. What it is handed to is the game's own chunk shader, which draws
-the terrain on every road where a pass is given back: a pipeline declaring 44 bytes a vertex over a
-mesh written at 20 reads every position out of the middle of some other vertex, and the terrain comes
+the terrain on every road where a pass is given back: a pipeline declaring a wider vertex than the
+mesh was written at reads every position out of the middle of some other vertex, and the terrain comes
 out as stretched coloured spikes while the sky, the entities and the interface stay right. So the
 engine compares that pipeline's own vertex binding against the format the renderer binds, and calls a
 disagreement a miss. An older Sodium asked the same question in the key itself, its memo being one
@@ -125,11 +125,25 @@ top of grass blocks. The engine hands that bias to the shader as a block member 
 for, alongside the depth-conversion constant.
 
 What the format does not carry is the interesting half: **no normal, no block id, no mid texture
-coordinate, no mid block, no tangent.** Packs declare all five as a matter of course, so none of them
-is an optional extra, and the engine appends an element for each. A sixth carries the separated
-colour described above, which answers no name of the pack's own but a second shape for one it already
-reads. The vertex therefore more than doubles: twenty bytes the renderer packs and twenty-four this
-engine adds after them.
+coordinate, no mid block, no tangent.** The engine appends an element for each, and a sixth carrying
+the separated colour described above, which answers no name of the pack's own but a second shape for
+one it already reads.
+
+**Which of the six a mesh really carries is the loaded pack's answer, not a constant.** The pack's
+six chunk programs are translated far enough to say which of those names each of them reads, and the
+union decides the format: a pack whose programs never mention the mid block gets no element for it,
+and one that never wrote `separateAo` gets one colour instead of two. So a vertex is anything from
+twenty-four bytes to forty-four, twenty of which are the renderer's own. The union and never one
+program's own answer, because of the pairing rule at the top of this page: every one of the six
+declares the whole format whether or not it reads all of it, and one that declared less would move
+the location of every element after the gap without a word.
+
+Two consequences follow from the format now depending on the pack rather than on a switch. **A pack
+swap rebuilds the world whenever that answer moves**, through the same door the terrain switch uses,
+because the sections standing at that instant carry their words at the other offsets. And **the pack
+is read where it is loaded rather than at the first chunk draw**: the format has to be settled before
+the chunk renderer that meshes with it is built, and that is earlier than any pass asking for a
+shader.
 
 One further difference to keep in mind when comparing images: the chunk renderer samples the
 lightmap at the vertex, while a pack handed a lightmap coordinate samples it at the fragment. That


### PR DESCRIPTION
## What changes

The chunk mesh appended six elements of its own to Sodium's twenty bytes for every pack that drew
the terrain, whichever of their names its programs actually mentioned, so a vertex was forty-four
bytes even where four of the six were never read. The pack's six chunk programs are now translated
once to say which of those names each of them reads, the union of the six builds the format, and the
second translation declares exactly that. Over the eight packs of the corpus a vertex is 32, 36, 40
or 44 bytes instead of 44 everywhere. The reading moves from the first chunk draw to the pack load,
because the format has to be settled before Sodium builds the chunk renderer that meshes with it,
and two packs whose answers differ rebuild the world between them through the door the terrain
switch already used.

## How it differs from the reference, and for what obstacle

Not on what the format ends up carrying: Iris builds its own from four booleans raised while its
chunk programs are transformed, `FormatAnalyzer.createFormat(blockId, normal, midUV, midBlock)` from
`pipeline/programs/SodiumPrograms.java:73`, and the union computed here is those four conditions plus
the `separateAo` colour, which is an element Iris has no equivalent for because it writes that pair
over Sodium's own colour word.

It differs on where the answer is read from. Iris raises its booleans with `getAttribLocation` on the
LINKED program, `SodiumPrograms.java:174-177`, so an attribute the compiler eliminated is one it
never carries; this engine compiles each stage to its own module and pairs by name, so it reads the
names the rewritten text mentions instead. A name mentioned only in code the compiler drops therefore
costs an element here that it would not cost there. It is four bytes and never a wrong picture, and
no pack of the corpus is in that position.

The other difference is the second half of #36, left owing below: `Extra.NORMAL` and `Extra.TANGENT`
are two elements where `IrisChunkMeshAttributes.NORMAL` is one packed word. That is why the maximum
here is forty-four where Iris's is thirty-six.

## What proves it

- `gradlew build` green, after the rebase onto `dev`.
- The out-of-game harness, `Terrain` with `--glslang`, over the eight packs of the corpus under both
  colour contracts: 192 stages of 192 compiled, seven invariants green, exit 0. Invariants 1 and 7
  now read against the format of that pack rather than against a fixed list of ten, and the seventh
  is the one that answers the declared-but-unread question, by reading each element back out of the
  disassembly at the location its place in the format gives it.
- The emitted text, before against after, over the same 192 files: only removed lines, 48
  `in vec4 a_TintAndAo;`, 36 `in ivec4 a_MidBlock;` and 12 `in uvec2 a_MidTexCoord;`. No line added,
  no line changed, and none of the 96 fragment stages differs at all.
- In the game, one clean launch on Body Camera. The Overworld settles at 32 bytes,
  `[a_BlockId, a_Normal, a_Tangent]`; walking into the End moves the answer to `[a_BlockId, a_Normal]`,
  says so, rebuilds the sections and settles at 28. The three chunk passes draw and nothing in the
  log is ours.

## What it leaves owing

The packing: the normal and the tangent in one word, unpacked in the vertex prologue, which is the
second half of #36 and lands on its own.

`a_BlockId`, `a_Normal` and `a_Tangent` are dropped by no pack of the corpus, so the paths that leave
them off are exercised by nothing here, the fallback constant for `of_Normal` included.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one: the javadoc of the
      four classes involved, `docs/internals/terrain.md`, and the line the engine prints when the
      format settles.
