### PR TITLE
Settle the entity mesh only when it really moves

### DIFF
--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -1410,10 +1410,14 @@ public final class EntityDraw {
 		// And the mesh has to be carrying the identifiers, whatever the moment says. Every row but the
 		// glint's is read against EntityMesh.format, so a draw served before the mesh settled would
 		// bind forty-four bytes of layout over a vertex of thirty-six. It lasts from the load that
-		// asked until the extract that rebuilds the world, which is one frame in the ordinary case,
-		// and what it costs is the frame's mobs drawn by the game rather than by the pack. The glint
-		// is held out with them rather than let through: it comes in by this door, and a run of draws
-		// is one pass with one program.
+		// asked until the extract that rebuilds the world, which is one frame in the ordinary case.
+		//
+		// What it costs is NOT the same thing on the two roads, and saying it once would be wrong on
+		// the second. In the picture's windows a no hands the draw back, so the frame's mobs are drawn
+		// by the game rather than by the pack. Inside the light's walk there is no handing back: draw
+		// turns every no into a drop, so those casters are drawn by nobody and the map has holes for
+		// that frame. The glint is held out with them rather than let through: it comes in by this
+		// door, and a run of draws is one pass with one program.
 		if (!inMoment || !EntityMesh.carrying() || device == null || element == null) {
 			draw.end();
 

--- a/common/src/main/java/dev/vitrail/render/EntityMesh.java
+++ b/common/src/main/java/dev/vitrail/render/EntityMesh.java
@@ -17,9 +17,12 @@ import org.jspecify.annotations.Nullable;
  * The game's entity mesh with the three identifiers appended to it, as a format of this engine's
  * own, and the one instant at which it comes into force.
  * <p>
- * <strong>A format APART, and lengthening {@code DefaultVertexFormat.ENTITY} itself is what this
- * replaces.</strong> That is Iris's shape ({@code mixin/vertices/MixinBufferBuilder.iris$extendFormat}),
- * and here it is an obstacle rather than a preference. Sodium's
+ * <strong>A format APART, which is Iris's own shape</strong>
+ * ({@code mixin/vertices/MixinBufferBuilder.iris$extendFormat:107-111} hands back
+ * {@code IrisVertexFormats.ENTITY}, an object of its own built at
+ * {@code vertices/IrisVertexFormats.java:49-60}). <strong>What this replaces is lengthening
+ * {@code DefaultVertexFormat.ENTITY} itself</strong>, which was this engine's first answer and is
+ * nobody else's: it drew no mob at all. Sodium's
  * {@code api/vertex/format/common/EntityVertex} declares {@code FORMAT = DefaultVertexFormat.ENTITY},
  * the same object, beside a {@code STRIDE = 36} its compiler folds into every caller;
  * {@code mixin/features/render/entity/CubeMixin} cancels the game's own {@code compile} for every
@@ -68,7 +71,8 @@ import org.jspecify.annotations.Nullable;
  * Iris reads its gate live, at every buffer and at every call for a format, and can afford to: it
  * runs against a backend that rebuilds the vertex array from the pipeline's bindings at the draw.
  * Here {@code VulkanRenderPipeline.compile} bakes the stride into the compiled pipeline
- * ({@code VulkanRenderPipeline:82-96}), and {@code VulkanDevice.pipelineCache} is an identity map
+ * ({@code VulkanRenderPipeline:99}, {@code .stride(bindings.getVertexSize())} over the bindings it
+ * reads at {@code :82}), and {@code VulkanDevice.pipelineCache} is an identity map
  * that nothing empties but {@code ShaderManager.apply}. A live answer would therefore leave a mesh
  * built under one answer bound by a pipeline compiled under the other, which is the same wrong stride
  * by another road.
@@ -103,6 +107,17 @@ public final class EntityMesh {
 	 * would find nothing changed and stay silent, which is the case that most needs the line.
 	 */
 	private static boolean said;
+
+	/**
+	 * Whether a rebuild has already been asked for since the last settle, so that one load asks for
+	 * one.
+	 * <p>
+	 * The two switches are set one after the other and nothing settles between them, so
+	 * {@link #ask()} would find the same disagreement twice and print the same line twice for one
+	 * load. Comparing against {@link #carrying} cannot see that: the answer in force is exactly what
+	 * has not moved yet.
+	 */
+	private static boolean rebuildAsked;
 
 	private EntityMesh() {
 	}
@@ -163,15 +178,26 @@ public final class EntityMesh {
 	 * a settings file saved with neither switch touched owes no rebuild.
 	 */
 	static void ask() {
+		boolean asked = asked();
+		if (asked == carrying) {
+			// Back in agreement, so whatever was asked for is owed no longer and the next real
+			// disagreement gets its own line. This is the road a load takes when it turns one switch
+			// off and the other leaves the answer where it was.
+			rebuildAsked = false;
+
+			return;
+		}
+
 		Minecraft minecraft = Minecraft.getInstance();
-		if (asked() == carrying || minecraft == null || minecraft.level == null) {
+		if (rebuildAsked || minecraft == null || minecraft.level == null) {
 			return;
 		}
 
 		Vitrail.logger().info("The pack draws the entities or the hand {} now, and the entity mesh "
 				+ "carries {} only while it does, so the world is built again",
-				asked() ? "and did not" : "and did", EntityVertex.IDENTIFIERS);
+				asked ? "and did not" : "and did", EntityVertex.IDENTIFIERS);
 		minecraft.levelExtractor.allChanged();
+		rebuildAsked = true;
 	}
 
 	/**
@@ -179,19 +205,27 @@ public final class EntityMesh {
 	 */
 	public static void settle() {
 		boolean asked = asked();
-		if (said && asked == carrying) {
+		boolean moved = asked != carrying;
+		if (said && !moved) {
 			return;
 		}
 
 		said = true;
 		carrying = asked;
+		rebuildAsked = false;
 
-		// The game precompiles every static pipeline at every resource load and caches it by
-		// identity (ShaderManager.apply, VulkanDevice.pipelineCache), so the entity ones standing at
-		// this instant were compiled under the answer that has just moved. Emptying the cache is what
-		// ShaderManager itself does before it recompiles, and what is dropped here comes back on
-		// demand through the same shader source the device was built with.
-		GpuDevice device = RenderSystem.tryGetDevice();
+		// ONLY where the answer really moved, and the two conditions are not one. The first settle of
+		// a session has never said anything and must print, but a session nobody picked a pack in
+		// settles false onto false and has nothing to drop: dropping anyway is a full recompile of
+		// every static pipeline at the first world join, for a stride that did not change.
+		//
+		// Where it did move, the drop is owed. The game precompiles every static pipeline at every
+		// resource load and caches it by identity (ShaderManager.apply, VulkanDevice.pipelineCache),
+		// so the entity ones standing here were compiled under the other answer, and this backend
+		// bakes the stride into them. Emptying the cache is what ShaderManager itself does before it
+		// recompiles, and what is dropped comes back on demand through the same shader source the
+		// device was built with.
+		GpuDevice device = moved ? RenderSystem.tryGetDevice() : null;
 		if (device != null) {
 			device.clearPipelineCache();
 		}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -224,9 +224,11 @@ Two consequences follow from how that geometry reaches the pack, and both are wo
 rather than reporting as separate bugs:
 
 - **Two of the values a pack reads off it are constants rather than this piece's own**: the middle
-  of the sprite a face is mapped to, and the tangent of that mapping. Both are worked out per
-  polygon rather than per vertex, and a pack that branches on either takes the same branch for every
-  draw; what that looks like is entirely the pack's business. The material id is a constant too, and
+  of the sprite a face is mapped to, and the tangent of that mapping. Neither is a property of one
+  vertex, both having to be worked out over a whole polygon, and that is the work this engine does
+  not do yet: the reference does it and hands the answer over on the vertex, where a pack reads the
+  same constant here for every draw. What that looks like is entirely the pack's business. The
+  material id is a constant too, and
   there the reference does the same, an entity mesh carrying none. The three a pack compares against
   a kind of mob, the block a block entity stands in and the item being drawn are this piece's own
   and no longer constants. The held hand shows whatever the mobs show, arriving by the same door and


### PR DESCRIPTION
## What changes

Two defects an adversarial review found on the entity identifier batch, already in `dev`, plus four
sentences it caught. The one that costs anything at runtime is `EntityMesh.settle`: it emptied the
game's compiled pipeline cache on its first call whatever it decided, because the guard that lets the
first call through is the one that makes it print the line. A session nobody picked a pack in settled
false onto false and dropped every static pipeline `ShaderManager.apply` had just precompiled, which
is a full recompile on demand at the first world join for a stride that did not move. The second is
`EntityMesh.ask` asking twice for one load, `PackChain` setting the entity switch and the hand switch
one after the other with nothing settling between them.

## How it differs from the reference, and for what obstacle

It does not. Both defects are in the machinery this engine owes to its own backend and Iris has no
counterpart to either: it reads its gate live and never drops a pipeline cache.

## What proves it

- `gradlew build` green.
- The reasoning of each fix is checked against the source it cites: `VulkanDevice.clearPipelineCache`
  and `ShaderManager.apply:152-155` for the first, `PackChain.load` for the second.
- Not in the game. Neither fix changes a pixel: the first removes work nobody asked for and the
  second removes a duplicate log line and a second request for a rebuild the first already asked for.

## What it leaves owing

Nothing of its own. What the identifier batch still owed is unchanged: `mc_midTexCoord` and
`at_tangent`, `heldItemId` and its neighbours, and `Entites` not sweeping the `shadow` family.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
