### PR TITLE
perf(sodium): pack the chunk normal and tangent in one word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,10 +72,20 @@ what the next one holds.
   normal, the tangent and a second copy of the colour, whichever of those the pack asked for: forty
   four bytes each, whether four of them were read or none. The pack's own chunk programs are now read
   first and the mesh is built from what they name, so a vertex costs between twenty four and forty
-  four bytes. Of the eight packs tested, one drops twelve bytes a vertex, one drops eight and one
-  drops four. It is video memory and the bandwidth of every chunk draw, so it is paid twice a frame
-  as soon as a shadow map is being filled. Switching between two packs that read different names
-  rebuilds the world, as switching the terrain off already did.
+  bytes. Of the eight packs tested, one drops sixteen bytes a vertex, one twelve, one eight and the
+  other five four. It is video memory and the bandwidth of every chunk draw, so it is paid twice a
+  frame as soon as a shadow map is being filled. Switching between two packs that read different
+  names rebuilds the world, as switching the terrain off already did.
+
+- **The normal and the tangent of a chunk vertex travel in one word instead of two.** The tangent is
+  at a right angle to the normal, so once the normal is known there is nothing left of it but an
+  angle and the direction the frame turns in, which is how the engine the packs are written against
+  has always stored the pair. That is the last four bytes of the paragraph above, on every pack that
+  lights the terrain by a normal, and it is where the upper bound of forty comes from. A pack reads
+  the same two directions as before: the normal comes back four times closer than it did, and the
+  tangent, which every normal map on the terrain is read through, is now exactly perpendicular to it
+  rather than a few thousandths off, at the price of being up to nine tenths of a degree round the
+  face from where it was.
 
 - **The settings screen is the one pack authors already know.** It is the screen of the engine packs
   are written against, ported rather than approximated: the same list of packs with the shaders

--- a/common/src/main/java/dev/vitrail/glsl/SodiumVertex.java
+++ b/common/src/main/java/dev/vitrail/glsl/SodiumVertex.java
@@ -21,7 +21,7 @@ import java.util.Set;
  * texture coordinate per axis and spends its top bit on which side of the sprite the corner lies.
  * {@code a_LightAndData}
  * holds the block light, the sky light, a byte of material bits and the index of the draw command,
- * one per byte. Everything past the twentieth is this engine's own, six elements of four bytes.
+ * one per byte. Everything past the twentieth is this engine's own, five elements of four bytes.
  * <p>
  * <strong>Sodium is under the PolyForm Shield licence, which this project cannot take code
  * from.</strong> So what is written below is this engine's own reading of that layout and not a
@@ -29,13 +29,13 @@ import java.util.Set;
  * ours. Nothing here is copied, and nothing here may be replaced by something copied.
  * <p>
  * <strong>Every name a pack reads of this geometry is now in the mesh.</strong> The block id, the
- * middle of the sprite, the offset to the middle of the block, the normal and the tangent are five
- * elements of this engine's own; {@link #TINT_AND_AO} is a sixth, and the one that answers no name
+ * middle of the sprite, the offset to the middle of the block and the tangent frame are four
+ * elements of this engine's own; {@link #TINT_AND_AO} is a fifth, and the one that answers no name
  * of the pack's but the shape of a name it already reads. The facing that used to stand in for a
  * normal, in the spare bits of the material byte, is gone with the last thing that read it.
  * <p>
- * <strong>Which of the six a mesh really carries follows the pack</strong>, and the format is
- * therefore anything from twenty bytes to forty-four. {@link #reads} says what one vertex stage
+ * <strong>Which of the five a mesh really carries follows the pack</strong>, and the format is
+ * therefore anything from twenty bytes to forty. {@link #reads} says what one vertex stage
  * needs, {@link #carried} turns the union over the pack's six chunk programs into the format, and
  * {@link #prologue} declares that list and nothing besides. The union and not each program's own
  * answer: an element the format carries that a stage does not declare shifts the location of every
@@ -86,23 +86,24 @@ public final class SodiumVertex {
 	public static final String MID_BLOCK = "a_MidBlock";
 
 	/**
-	 * The quad's own normal, taken from its corners rather than from the axis its facing names.
+	 * The quad's own normal, the direction the texture's U axis runs in over it, and the handedness
+	 * of the frame the two build, all in one word.
 	 * <p>
-	 * The facing this engine read before is one of six axes plus a value meaning none, so anything
-	 * that is not a box face got one of six wrong answers: a plant drawn as a cross, a sloped fluid
+	 * The normal is taken from the quad's corners rather than from the axis its facing names. The
+	 * facing this engine read before is one of six axes plus a value meaning none, so anything that
+	 * is not a box face got one of six wrong answers: a plant drawn as a cross, a sloped fluid
 	 * surface, every custom model. And the facing never reached a translucent quad or a fluid at all,
-	 * so glass and water were lit as if they faced up.
-	 */
-	public static final String NORMAL = "a_Normal";
-
-	/**
-	 * The direction the texture's own U axis runs in over this quad, with the handedness of the frame
-	 * in the fourth component.
+	 * so glass and water were lit as if they faced up. Every normal map on the terrain is read
+	 * through the tangent, and this engine handed back a constant for it, which tilts all of them the
+	 * same wrong way. Eight packs of the corpus read {@code at_tangent}.
 	 * <p>
-	 * Every normal map on the terrain is read through it, and this engine handed back a constant,
-	 * which tilts all of them the same wrong way. Eight packs of the corpus read {@code at_tangent}.
+	 * <strong>One word and not two, which is Iris's own bargain</strong>, {@code encodeNormalTangent}
+	 * ({@code NormalHelper.java:512-520}): the tangent is at a right angle to the normal, so what is
+	 * left of it once the normal is known is one angle in the normal's own plane and the sign that
+	 * says which way the third axis turns. {@link #prologue} is the patched text that undoes it, and
+	 * {@code TerrainMesh.Extra} says how the bits are shared out and what that costs.
 	 */
-	public static final String TANGENT = "a_Tangent";
+	public static final String TANGENT_FRAME = "a_TangentFrame";
 
 	/**
 	 * The block's tint undivided, with the ambient occlusion in the fourth component rather than
@@ -137,7 +138,7 @@ public final class SodiumVertex {
 	 */
 	public static final List<String> ATTRIBUTES =
 			List.of("a_Position", "a_Color", "a_TexCoord", "a_LightAndData", BLOCK_ID, MID_TEX_COORD,
-					MID_BLOCK, NORMAL, TANGENT, TINT_AND_AO);
+					MID_BLOCK, TANGENT_FRAME, TINT_AND_AO);
 
 	/**
 	 * The ones of {@link #ATTRIBUTES} this engine appends, which are also the only ones a pack may
@@ -145,7 +146,7 @@ public final class SodiumVertex {
 	 * engine is doing, and its own chunk shader reads all four.
 	 */
 	private static final Set<String> OURS =
-			Set.of(BLOCK_ID, MID_TEX_COORD, MID_BLOCK, NORMAL, TANGENT, TINT_AND_AO);
+			Set.of(BLOCK_ID, MID_TEX_COORD, MID_BLOCK, TANGENT_FRAME, TINT_AND_AO);
 
 	/**
 	 * What the translation has turned {@code gl_Normal} into by the time a head is written. The one
@@ -218,9 +219,11 @@ public final class SodiumVertex {
 		}
 
 		// Not one of the four, because it answers no name the pack writes: a body reads gl_Normal,
-		// and the translation has already turned that into of_Normal by the time this is asked.
+		// and the translation has already turned that into of_Normal by the time this is asked. It
+		// is the same element at_tangent comes out of, so a pack that reads one of the two pays for
+		// both and a pack that reads neither pays for neither.
 		if (used.contains(OWN_NORMAL)) {
-			reads.add(NORMAL);
+			reads.add(TANGENT_FRAME);
 		}
 
 		// Nor is this, for the other reason: it is a second shape for a word the mesh already
@@ -313,6 +316,12 @@ public final class SodiumVertex {
 				+ " float((index >> 2u) & 7u)) * 16.0;");
 		lines.add("}");
 
+		// Both functions read the element by name, so they are written only where the format carries
+		// it: emitted over a mesh without it, they would name an input the stage never declared.
+		if (carried.contains(TANGENT_FRAME)) {
+			lines.addAll(TangentFrame.decode(globals.containsKey("at_tangent")));
+		}
+
 		lines.add("void " + PROLOGUE + "() {");
 		lines.add("\tvec3 ofLocal = vec3(ofAxis(0u), ofAxis(10u), ofAxis(20u));");
 		lines.add("\tof_Vertex = vec4(ofLocal + of_RegionOffset"
@@ -340,8 +349,8 @@ public final class SodiumVertex {
 		// no spelling of the pack's. A pack no chunk program of which reads gl_Normal leaves the
 		// element off the mesh, and what stands here is then the constant every other family hands
 		// back for a mesh with no normal in it.
-		lines.add("\tof_Normal = " + (carried.contains(NORMAL)
-				? NORMAL + ".xyz"
+		lines.add("\tof_Normal = " + (carried.contains(TANGENT_FRAME)
+				? TangentFrame.NORMAL_OF + "(" + TANGENT_FRAME + ")"
 				: VertexPrologue.value(OWN_NORMAL, "vec3")) + ";");
 		globals.forEach((name, type) -> {
 			if (answered(carried, name)) {
@@ -403,11 +412,13 @@ public final class SodiumVertex {
 	 * and gets the direction alone, which is what asking for three means.
 	 */
 	private static String tangent(String type) {
+		String frame = TangentFrame.TANGENT_OF + "(" + OWN_NORMAL + ", " + TANGENT_FRAME + ")";
+
 		return switch (type) {
-			case "float" -> "float(" + TANGENT + ".x)";
-			case "vec2" -> "vec2(" + TANGENT + ".xy)";
-			case "vec3" -> "vec3(" + TANGENT + ".xyz)";
-			case "vec4" -> TANGENT;
+			case "float" -> frame + ".x";
+			case "vec2" -> frame + ".xy";
+			case "vec3" -> frame + ".xyz";
+			case "vec4" -> frame;
 			// A tangent is an axis and not a zero: a pack normalises what it reads here, and
 			// normalize(vec3(0)) puts a NaN in the colour. That rule is carried by the vec3 and vec4
 			// arms above, which hand back a whole direction, and by the at_tangent entry of
@@ -483,9 +494,9 @@ public final class SodiumVertex {
 		return switch (attribute) {
 			case "a_Position", "a_TexCoord", MID_TEX_COORD -> "uvec2";
 			case MID_BLOCK -> "ivec4";
-			case NORMAL, TANGENT, TINT_AND_AO -> "vec4";
+			case TINT_AND_AO -> "vec4";
 			case "a_LightAndData" -> "uvec4";
-			case BLOCK_ID -> "uint";
+			case BLOCK_ID, TANGENT_FRAME -> "uint";
 			default -> "vec4";
 		};
 	}
@@ -495,7 +506,7 @@ public final class SodiumVertex {
 		names.put("mc_Entity", BLOCK_ID);
 		names.put("mc_midTexCoord", MID_TEX_COORD);
 		names.put("at_midBlock", MID_BLOCK);
-		names.put("at_tangent", TANGENT);
+		names.put("at_tangent", TANGENT_FRAME);
 
 		return Collections.unmodifiableMap(names);
 	}

--- a/common/src/main/java/dev/vitrail/glsl/TangentFrame.java
+++ b/common/src/main/java/dev/vitrail/glsl/TangentFrame.java
@@ -1,0 +1,268 @@
+package dev.vitrail.glsl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The quad's normal, the tangent of its texture mapping and the handedness of the frame the two
+ * build, in one word of the chunk mesh, and the text that undoes it.
+ * <p>
+ * <strong>Both halves of the bargain live here on purpose.</strong> The word is written by
+ * {@code TerrainMesh} and read by the vertex prologue, which is generated GLSL, so the two sides
+ * never meet in a compiler and nothing would say a word if they drifted apart. They are one subject
+ * and they are kept in one file, where a change to either has the other under its eyes.
+ * <p>
+ * <strong>The bargain is Iris's</strong>, {@code NormalHelper.encodeNormalTangent}
+ * ({@code NormalHelper.java:512-520}): the tangent is left at a right angle to the normal by the
+ * encoder, so once the normal is known what is left of the tangent is one angle in the normal's own
+ * plane and one sign. Iris spends twenty-four bits on the normal, octahedral and twelve bits an
+ * axis, and its top byte on that angle.
+ * <p>
+ * <strong>Where the sign lives is this engine's own, and it is forced.</strong> Iris reads it out of
+ * a material bit, {@code (a_LightAndData.z & 1u) != 0u} at {@code SodiumTransformer.java:231},
+ * which leaves its own word entirely to the two directions. Nothing of this engine can ride the
+ * material: a translucent quad reaches the encoder from the sorter under a material Sodium chose
+ * itself, so the bit would be gone by then for every translucent quad and every fluid, and nothing
+ * would say so. The sign therefore takes a bit of this word, and it is taken off the NORMAL rather
+ * than off the angle, because the normal has bits to spare where the angle has none. Eleven bits on
+ * the octahedral y instead of twelve still leaves the normal four times closer than the three signed
+ * bytes this replaces, 0.09 degrees at worst against 0.39 and 0.03 on average against 0.17, where
+ * taking the bit off the angle would have doubled the tangent's own error instead.
+ * <p>
+ * So: twelve bits of octahedral x, eleven of octahedral y, the sign, then the angle.
+ * <p>
+ * <strong>What the tangent pays for it, said plainly</strong>: it lands about twice as far out as
+ * the three bytes it replaces, 0.90 degrees at worst against 0.39, which is the eight bit angle's
+ * own quantum and therefore exactly what the reference spends. What it gains is that it comes back
+ * at a right angle to the normal to seven decimal places, where three rounded bytes were a few
+ * thousandths off it, and it is the tangent and not the bitangent that carries that lean into every
+ * normal map on the terrain. All of these are measured by the off-game harness, which is the only
+ * witness this arithmetic has.
+ */
+public final class TangentFrame {
+
+	/** What the prologue calls the function that reads the normal back out of the word. */
+	public static final String NORMAL_OF = "ofFrameNormal";
+
+	/** And the one that reads the tangent back out of the word and that normal together. */
+	public static final String TANGENT_OF = "ofFrameTangent";
+
+	/**
+	 * What the octahedral x is scaled by, which is what twelve bits hold once the sign is taken out
+	 * of them. Iris's own, {@code NormalHelper.snorm12}.
+	 */
+	private static final int X_MAX = 2047;
+
+	/** The same for the y, which has eleven bits here where Iris gives it twelve. */
+	private static final int Y_MAX = 1023;
+
+	/**
+	 * The sum of absolute components under which a tangent is taken to lie flat against the whole
+	 * plane and to have no angle to give, which is Iris's own {@code NormalHelper.EPS}. The encoder
+	 * squares the tangent up against the normal before anything reaches here, so a unit vector in
+	 * that plane never falls this low; it is the reference's own guard and it is kept as one.
+	 */
+	private static final float FLAT = 1.0E-20F;
+
+	private TangentFrame() {
+	}
+
+	/**
+	 * The seven floats of a frame into the word: the normal in the first three, the tangent in the
+	 * next three, and the handedness in the last.
+	 * <p>
+	 * <strong>The angle is measured against the DECODED normal and not against the one the quad
+	 * had.</strong> The basis the angle is read in is built from the normal, so the two sides have to
+	 * build it from the same vector or the tangent comes back somewhere else entirely; the prologue
+	 * has only the decoded one, so this reads the word back before going on.
+	 * <p>
+	 * <strong>That is a divergence, and this is what it works around.</strong> Iris hands
+	 * {@code packDiamondByte} the un-quantised normal, {@code NormalHelper.java:512-520}, while its
+	 * own patched text builds the basis out of the decoded one,
+	 * {@code SodiumTransformer.java:230-231}. Frisvad's basis turns over on the sign of the normal's
+	 * z, so where the two sides disagree about that sign the tangent comes back nearly reversed: the
+	 * harness pairs them the reference's way over four hundred thousand frames and the worst tangent
+	 * lands 179.9 degrees out. Following the reference here would be following it into that, so this
+	 * pairs the two sides instead and the worst is 0.90.
+	 */
+	public static int pack(float[] frame) {
+		int normal = packNormal(frame[0], frame[1], frame[2]);
+		float[] decoded = normal(normal);
+
+		return normal | (frame[6] >= 0.0F ? 1 << 23 : 0)
+				| (packTangent(decoded, frame[3], frame[4], frame[5]) << 24);
+	}
+
+	/**
+	 * The normal back out of the word, by the same arithmetic {@link #decode} emits. The two have to
+	 * agree to the last bit, because {@link #pack} measures its angle in a basis built from what
+	 * comes out of here and the prologue reads it in a basis built from its own copy.
+	 */
+	public static float[] normal(int word) {
+		float x = (word << 20 >> 20) / (float) X_MAX;
+		float y = (word << 9 >> 21) / (float) Y_MAX;
+		float z = 1.0F - Math.abs(x) - Math.abs(y);
+		float[] normal = z >= 0.0F
+				? new float[] {x, y, z}
+				: new float[] {(1.0F - Math.abs(y)) * sideOf(x),
+						(1.0F - Math.abs(x)) * sideOf(y), z};
+		normalise(normal);
+
+		return normal;
+	}
+
+	/**
+	 * The tangent and its handedness back out of the word and the normal, as four floats. Not
+	 * reached by the engine, which leaves this to the prologue on the device; it is here so that the
+	 * arithmetic the prologue is written from can be measured off the game.
+	 */
+	public static float[] tangent(float[] normal, int word) {
+		float side = sideOf(normal[2]);
+		float scale = -1.0F / (side + normal[2]);
+		float across = normal[0] * normal[1] * scale;
+		float[] first = {1.0F + side * normal[0] * normal[0] * scale, side * across,
+				-side * normal[0]};
+		float[] second = {across, side + normal[1] * normal[1] * scale, -normal[1]};
+
+		float turn = (word >>> 24) * (1.0F / 256.0F);
+		float along = 1.0F - 4.0F * Math.abs(turn - 0.5F);
+		float away = (turn >= 0.5F ? 1.0F : -1.0F) * (1.0F - Math.abs(along));
+
+		float[] tangent = {along * first[0] + away * second[0], along * first[1] + away * second[1],
+				along * first[2] + away * second[2], (word >> 23 & 1) != 0 ? 1.0F : -1.0F};
+		normalise(tangent);
+
+		return tangent;
+	}
+
+	/**
+	 * The two functions the vertex prologue is given to undo all this: the normal out of the word,
+	 * and the tangent out of the word and that normal together.
+	 * <p>
+	 * <strong>Every line of it is the shape Iris patches into its own chunk stages</strong>,
+	 * {@code SodiumTransformer.java:162-198}: the octahedral decode, Frisvad's basis for the normal,
+	 * and the diamond angle read back in that basis. What differs is where the two numbers sit in
+	 * the word.
+	 *
+	 * @param tangent whether the pack reads {@code at_tangent}. A pack that reads the normal alone
+	 *                gets the first function and not the second, the word being one element either
+	 *                way
+	 */
+	public static List<String> decode(boolean tangent) {
+		List<String> lines = new ArrayList<>();
+
+		// Twelve bits of octahedral x and eleven of y, each read back as a signed integer and
+		// divided by what its own width can hold.
+		lines.add("vec3 " + NORMAL_OF + "(uint word) {");
+		lines.add("\tvec2 folded = vec2(bitfieldExtract(int(word), 0, 12),"
+				+ " bitfieldExtract(int(word), 12, 11)) * vec2(1.0 / " + X_MAX + ".0, 1.0 / "
+				+ Y_MAX + ".0);");
+		lines.add("\tfloat up = 1.0 - abs(folded.x) - abs(folded.y);");
+		lines.add("\tvec2 sides = vec2(folded.x >= 0.0 ? 1.0 : -1.0, folded.y >= 0.0 ? 1.0 : -1.0);");
+		// The lower half of the octahedron is reflected over the diagonals, so it is unreflected
+		// here. Leaving it out answers the mirror image of every downward normal.
+		lines.add("\treturn normalize(vec3(up >= 0.0 ? folded"
+				+ " : (1.0 - abs(folded.yx)) * sides, up));");
+		lines.add("}");
+
+		if (!tangent) {
+			return List.copyOf(lines);
+		}
+
+		lines.add("vec4 " + TANGENT_OF + "(vec3 normal, uint word) {");
+		// Frisvad: an orthonormal pair for the normal that has no branch on which axis it is nearest
+		// and no singularity at either pole, which is what makes the angle below mean one direction.
+		lines.add("\tfloat side = normal.z >= 0.0 ? 1.0 : -1.0;");
+		lines.add("\tfloat scale = -1.0 / (side + normal.z);");
+		lines.add("\tfloat across = normal.x * normal.y * scale;");
+		lines.add("\tvec3 first = vec3(1.0 + side * normal.x * normal.x * scale,"
+				+ " side * across, -side * normal.x);");
+		lines.add("\tvec3 second = vec3(across, side + normal.y * normal.y * scale, -normal.y);");
+		// The diamond: an angle round the unit square rather than round the circle, so that the
+		// eight bits are spent evenly on a direction without a trigonometric function either side.
+		lines.add("\tfloat turn = float(word >> 24u) * (1.0 / 256.0);");
+		lines.add("\tfloat along = 1.0 - 4.0 * abs(turn - 0.5);");
+		lines.add("\tfloat away = (turn >= 0.5 ? 1.0 : -1.0) * (1.0 - abs(along));");
+		lines.add("\treturn vec4(normalize(along * first + away * second),"
+				+ " ((word >> 23u) & 1u) != 0u ? 1.0 : -1.0);");
+		lines.add("}");
+
+		return List.copyOf(lines);
+	}
+
+	/**
+	 * A unit vector as an octahedral pair, twelve bits of x in the low bits and eleven of y above
+	 * them.
+	 * <p>
+	 * The sphere is projected onto the octahedron and then onto the plane, and the lower half is
+	 * reflected over the diagonals so that the whole sphere fills the square. Iris does the same and
+	 * with the same fold, {@code NormalHelper.encodeNormal} lines 438 to 464.
+	 */
+	private static int packNormal(float x, float y, float z) {
+		float onto = 1.0F / (Math.abs(x) + Math.abs(y) + Math.abs(z));
+		float px = x * onto;
+		float py = y * onto;
+		float ox = z > 0.0F ? px : (1.0F - Math.abs(py)) * sideOf(px);
+		float oy = z > 0.0F ? py : (1.0F - Math.abs(px)) * sideOf(py);
+
+		return (snorm(ox, X_MAX) & 0xFFF) | ((snorm(oy, Y_MAX) & 0x7FF) << 12);
+	}
+
+	/**
+	 * The tangent as an angle round the unit square in the normal's own plane, eight bits of it.
+	 * <p>
+	 * The basis is Frisvad's, as the encoder already builds it for a tangent it had to substitute
+	 * and as {@link #decode} builds it again, and the diamond is Iris's,
+	 * {@code NormalHelper.packDiamondByte} lines 489 to 510: an angle round a square rather than
+	 * round a circle, so that the eight bits are spent evenly on a direction with no trigonometric
+	 * function on either side.
+	 * <p>
+	 * A tangent flat against the whole plane has no angle to give and takes the middle of the range,
+	 * which is Iris's own answer for it.
+	 */
+	private static int packTangent(float[] normal, float x, float y, float z) {
+		float side = sideOf(normal[2]);
+		float scale = -1.0F / (side + normal[2]);
+		float across = normal[0] * normal[1] * scale;
+		float along = x * (1.0F + side * normal[0] * normal[0] * scale) + y * side * across
+				+ z * -side * normal[0];
+		float away = x * across + y * (side + normal[1] * normal[1] * scale) + z * -normal[1];
+
+		float span = Math.abs(along) + Math.abs(away);
+		if (span <= FLAT) {
+			return 128;
+		}
+
+		float turn = away >= 0.0F
+				? 0.25F * (1.0F - along / span) + 0.5F
+				: 0.25F * (along / span) + 0.25F;
+
+		return Math.round(turn * 256.0F) & 0xFF;
+	}
+
+	/** One component of an octahedral pair as a signed integer of that many bits, less the sign. */
+	private static int snorm(float value, int max) {
+		return Math.round(Math.clamp(value, -1.0F, 1.0F) * max);
+	}
+
+	/**
+	 * Plus one for a number that is nought or above and minus one below it, which is what the
+	 * octahedral fold multiplies by and which way round Frisvad's basis turns. Nought is on the
+	 * positive side on both sides of the fold, here and in the prologue, so a component that lands
+	 * exactly on it folds the same way twice.
+	 */
+	private static float sideOf(float value) {
+		return value >= 0.0F ? 1.0F : -1.0F;
+	}
+
+	/** The first three components to unit length, the fourth left alone where there is one. */
+	private static void normalise(float[] vector) {
+		float length = (float) Math.sqrt(
+				vector[0] * vector[0] + vector[1] * vector[1] + vector[2] * vector[2]);
+		if (length > 0.0F) {
+			vector[0] /= length;
+			vector[1] /= length;
+			vector[2] /= length;
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
+++ b/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
@@ -1,6 +1,7 @@
 package dev.vitrail.sodium;
 
 import dev.vitrail.glsl.SodiumVertex;
+import dev.vitrail.glsl.TangentFrame;
 import dev.vitrail.render.BlockStateIds;
 import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.Vitrail;
@@ -41,9 +42,9 @@ import java.util.List;
  * three after the first land where this format does not want them and are moved up, backwards and
  * word by word so that a vertex is never written over a word still to be read.
  * <p>
- * <strong>How many of the six are appended follows the pack.</strong> {@code TerrainDraw} translates
+ * <strong>How many of the five are appended follows the pack.</strong> {@code TerrainDraw} translates
  * the pack's six chunk programs far enough to know which names they read, and hands that list here;
- * a vertex is then anything from twenty-four bytes to forty-four. The ones left out close the gap
+ * a vertex is then anything from twenty-four bytes to forty. The ones left out close the gap
  * rather than leaving a hole, so an element's offset is where it lands in this pack's mesh and not
  * where it lands in {@link Extra}.
  * <p>
@@ -216,7 +217,7 @@ public final class TerrainMesh implements ChunkVertexType {
 		List<String> carried = broken ? List.of() : TerrainDraw.carried();
 		// Sodium's own four and nothing of ours is the same layout Sodium already binds, so it is
 		// answered with Sodium's own rather than with a copy of it. No pack of the corpus is here,
-		// every one of them reading at least the block id, but a pack that read none of the six
+		// every one of them reading at least the block id, but a pack that read none of the five
 		// would be, and wrapping a format to change nothing about it is one more thing to be wrong.
 		if (carried.stream().noneMatch(TerrainMesh::ours)) {
 			carried = List.of();
@@ -283,8 +284,8 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * <p>
 	 * Ours are laid out one word after another in the order they are handed in, which is also where
 	 * the encoder writes them: both read {@code offsets}, and the two used to be a walk over the
-	 * sizes here and six literal offsets there, agreeing because every element happens to be one
-	 * word and for no other reason.
+	 * sizes here and a literal offset for each there, agreeing because every element happens to
+	 * be one word and for no other reason.
 	 *
 	 * @param extras the ones of {@link Extra} this pack asked for, in {@link Extra}'s own order.
 	 *               An element left out closes the gap rather than leaving a hole: the shader
@@ -322,10 +323,6 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * what its six chunk programs read, exactly as Iris takes it from what its transformed programs
 	 * reference, {@code FormatAnalyzer}. The ones left out close the gap rather than leaving a hole,
 	 * so this order decides which words move and not where any of them lands.
-	 * <p>
-	 * What is still not Iris's is the packing: it spends one word on the normal and the tangent
-	 * together and unpacks it in the patched text, where this spends two. The prologue is the place
-	 * that would unpack a combined word, and doing it there is a change of its own.
 	 */
 	private enum Extra {
 
@@ -349,17 +346,21 @@ public final class TerrainMesh implements ChunkVertexType {
 		MID_BLOCK(SodiumVertex.MID_BLOCK, GpuFormat.RGBA8_SINT),
 
 		/**
-		 * The quad's own normal, and the tangent of its texture mapping with the sign that says which
-		 * way the third axis of that frame points.
+		 * The quad's own normal, the tangent of its texture mapping and the sign that says which way
+		 * the third axis of that frame points, in one word.
 		 * <p>
-		 * Signed and normalised, so the shader reads them as a {@code vec4} in minus one to one with
-		 * nothing to undo. Iris packs the pair into one word of its own and unpacks it in the patched
-		 * text; two elements cost four bytes more and no arithmetic, and this engine has no patched
-		 * text to unpack them in.
+		 * <strong>One word and not two, which is Iris's own bargain</strong>: what
+		 * {@link #orthogonalise} leaves is at a right angle to the normal, so once the normal is known
+		 * the tangent is one angle in the normal's plane and one sign. {@link TangentFrame} is where
+		 * the bits are shared out and where that is argued against the reference; the prologue reads
+		 * the word back with text the same class writes.
+		 * <p>
+		 * What it costs against the two words of signed bytes it replaces is measured by the off-game
+		 * harness rather than argued, and {@link TangentFrame} carries the figures. The short of it: the
+		 * normal comes back four times closer, the tangent about twice as far but exactly
+		 * perpendicular, and the handedness never turns over.
 		 */
-		NORMAL(SodiumVertex.NORMAL, GpuFormat.RGBA8_SNORM),
-
-		TANGENT(SodiumVertex.TANGENT, GpuFormat.RGBA8_SNORM),
+		TANGENT_FRAME(SodiumVertex.TANGENT_FRAME, GpuFormat.R32_UINT),
 
 		/**
 		 * The block's tint undivided, with the ambient occlusion in the alpha rather than multiplied
@@ -419,28 +420,22 @@ public final class TerrainMesh implements ChunkVertexType {
 		// every quad of the world for a word that is then thrown away.
 		int middle = offset(Extra.MID_TEX_COORD) == ABSENT ? 0 : midTexCoord(vertices);
 
-		// Both are properties of the QUAD and not of a corner, like the middle above: the four
-		// vertices carry the same pair, and a pack that reads a normal per vertex on chunk geometry
-		// is reading what the face is, not what the corner is.
-		//
-		// The two are found together and dropped together, Newell's sum being what the tangent is
-		// then squared up against: a pack reading one of them pays for both, and a pack reading
-		// neither pays for neither.
-		boolean framed = offset(Extra.NORMAL) != ABSENT || offset(Extra.TANGENT) != ABSENT;
-		float[] frame = framed ? frame(vertices) : null;
-		int normal = framed ? packAxis(frame[0], frame[1], frame[2], 0.0F) : 0;
-		int tangent = framed ? packAxis(frame[3], frame[4], frame[5], frame[6]) : 0;
+		// A property of the QUAD and not of a corner, like the middle above: the four vertices carry
+		// the same word, and a pack that reads a normal per vertex on chunk geometry is reading what
+		// the face is, not what the corner is. The normal and the tangent share it, so a pack reading
+		// one of the two pays for both and a pack reading neither pays for neither.
+		int frame = offset(Extra.TANGENT_FRAME) == ABSENT ? 0 : TangentFrame.pack(frame(vertices));
 
-		// The one of the six that is a property of the CORNER, so it is asked for inside the loop
+		// The one of the five that is a property of the CORNER, so it is asked for inside the loop
 		// and only the question is hoisted out of it.
 		boolean blockMiddle = offset(Extra.MID_BLOCK) != ABSENT;
 
 		// Backwards over the vertices, because a vertex moves up by the difference of the two strides
 		// times its own index, and one that has not been moved yet is the source of the move before
-		// it: at twenty-four bytes of difference the second vertex lands on [44, 64) and the third is
+		// it: at twenty bytes of difference the second vertex lands on [40, 60) and the third is
 		// still to be read from [40, 60). Word by word from the top of each vertex costs nothing and
 		// is what keeps the move right at any pair of strides, which is what this now needs: the
-		// difference is four bytes for a pack that reads one of the six and twenty-four for one that
+		// difference is four bytes for a pack that reads one of the five and twenty for one that
 		// reads them all, and at four the two ranges of one vertex DO overlap.
 		for (int at = vertices.length - 1; at >= 0; at--) {
 			long from = pointer + (long) at * this.innerStride;
@@ -454,8 +449,7 @@ public final class TerrainMesh implements ChunkVertexType {
 					((TerrainVertex) vertices[at]).vitrailBlockId() & BlockStateIds.PACKED_MASK);
 			write(extra, Extra.MID_TEX_COORD, middle);
 			write(extra, Extra.MID_BLOCK, blockMiddle ? midBlock(vertices[at]) : 0);
-			write(extra, Extra.NORMAL, normal);
-			write(extra, Extra.TANGENT, tangent);
+			write(extra, Extra.TANGENT_FRAME, frame);
 			// The two fields the encoder was handed, kept apart instead of multiplied together, out
 			// of Sodium's own published helper. Sodium's word beside it keeps the product, so this
 			// one is read by a pack that asked for it and by nothing else.
@@ -469,7 +463,7 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * One of our words onto one vertex, or nothing at all where this pack does not carry it.
 	 * <p>
 	 * The one place the encoder asks whether an element is there, so that the writes above read as
-	 * the six they have always been and the question is answered once for each.
+	 * the five they are and the question is answered once for each.
 	 */
 	private void write(long extra, Extra element, int value) {
 		int at = offset(element);
@@ -565,12 +559,12 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * normalising here does is give that cross product a length of one as well, and the handedness
 	 * bit goes on meaning what {@link #handedness} says it means.
 	 * <p>
-	 * <strong>What is left of the difference is the quantisation.</strong> Iris spends one byte on an
-	 * angle in a plane, so its tangent is perpendicular to the last bit; this spends three on the
-	 * vector itself and rounds each of them, so the dot product with the normal comes back at a few
-	 * thousandths rather than at nought. Three bytes for three components is what
-	 * {@link Extra#TANGENT} declares and this engine has no patched vertex text to unpack an angle
-	 * in.
+	 * <strong>Nothing of that difference is left in the quantisation any more.</strong> This used to
+	 * store the vector itself as three rounded bytes, so the dot product with the normal came back at
+	 * a few thousandths rather than at nought and the work below was undone by the rounding.
+	 * {@link Extra#TANGENT_FRAME} now stores the angle in the plane, which is what Iris stores, so
+	 * what a pack reads is perpendicular to the last bit on both engines and this projection is what
+	 * decides the angle rather than a step on the way to it.
 	 */
 	private static void orthogonalise(float[] frame) {
 		float along = frame[0] * frame[3] + frame[1] * frame[4] + frame[2] * frame[5];
@@ -735,22 +729,6 @@ public final class TerrainMesh implements ChunkVertexType {
 		frame[4] = upright ? 0.0F : frame[2];
 		frame[5] = upright ? frame[0] : -frame[1];
 		normalise(frame, 3);
-	}
-
-	/** Three components and a fourth into one word of signed bytes, as the format declares them. */
-	private static int packAxis(float x, float y, float z, float w) {
-		return (byteOf(x) & 0xFF) | ((byteOf(y) & 0xFF) << 8) | ((byteOf(z) & 0xFF) << 16)
-				| ((byteOf(w) & 0xFF) << 24);
-	}
-
-	/**
-	 * One component of a unit vector as a signed byte.
-	 * <p>
-	 * Scaled by 127 and not by 128, so that one comes back as one: the backend divides a signed byte
-	 * by 127, and a value stored at 128 would have wrapped to the other end of the range anyway.
-	 */
-	private static int byteOf(float value) {
-		return Math.round(Math.clamp(value, -1.0F, 1.0F) * 127.0F);
 	}
 
 	/**

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -125,15 +125,16 @@ top of grass blocks. The engine hands that bias to the shader as a block member 
 for, alongside the depth-conversion constant.
 
 What the format does not carry is the interesting half: **no normal, no block id, no mid texture
-coordinate, no mid block, no tangent.** The engine appends an element for each, and a sixth carrying
-the separated colour described above, which answers no name of the pack's own but a second shape for
-one it already reads.
+coordinate, no mid block, no tangent.** The engine appends an element for the block id, one for the
+mid texture coordinate, one for the mid block and one that carries the normal and the tangent
+together, and a fifth carrying the separated colour described above, which answers no name of the
+pack's own but a second shape for one it already reads.
 
-**Which of the six a mesh really carries is the loaded pack's answer, not a constant.** The pack's
+**Which of the five a mesh really carries is the loaded pack's answer, not a constant.** The pack's
 six chunk programs are translated far enough to say which of those names each of them reads, and the
 union decides the format: a pack whose programs never mention the mid block gets no element for it,
 and one that never wrote `separateAo` gets one colour instead of two. So a vertex is anything from
-twenty-four bytes to forty-four, twenty of which are the renderer's own. The union and never one
+twenty-four bytes to forty, twenty of which are the renderer's own. The union and never one
 program's own answer, because of the pairing rule at the top of this page: every one of the six
 declares the whole format whether or not it reads all of it, and one that declared less would move
 the location of every element after the gap without a word.
@@ -171,7 +172,7 @@ reaches the encoder whichever road the quad took. The block id, the block's own 
 light emission all travel that way, and the encoder turns the last two into the offset from a vertex
 to the middle of its block.
 
-**Three of the five are properties of the quad rather than of a corner**, and are computed in the
+**Three of the four are properties of the quad rather than of a corner**, and are computed in the
 encoder from the corners it already has. The middle of the sprite is their mean. The normal is
 Newell's sum over the loop, which is what makes it right for a plant drawn as a cross, a sloped
 fluid surface and any model that is not a box: a face direction offers six axes and a seventh value
@@ -221,12 +222,30 @@ element the stage does not declare shifts every element after it, and there is n
 last one. That single placement decision is what lets the renderer keep drawing through a format it
 was never told about.
 
-**They are all appended, never chosen per pack**, where the reference builds its format out of the
-names a pack's compiled programs really reference. The reason this engine could not do the same was
-that its format was settled before any pack was chosen, and that is no longer so: the format now
-follows the pack. What is left is a plain difference in what the vertex costs, and it has not been
-closed. Seven packs of the test corpus read the sprite middle and eight read the tangent, so what a
-conditional would save is small either way.
+**The normal and the tangent share one of those words.** The tangent is squared up against the
+normal before anything is stored, so what is left of it once the normal is known is one angle in the
+normal's own plane and one bit saying which way the third axis of the frame turns. The reference
+makes the same bargain and the engine follows it: twelve bits of octahedral x, then the octahedral
+y, then that bit, then the eight bits of angle. Where the two part is the bit: the reference keeps
+its whole word for the two directions and reads the handedness out of a spare material bit instead,
+which nothing here can do, since a translucent quad reaches the encoder from the sorter under a
+material the renderer chose itself and anything written in that byte is gone by then. The bit is
+therefore taken off the normal rather than off the angle, eleven bits of octahedral y where the
+reference spends twelve, because at that end it costs three hundredths of a degree and at the other
+end it would cost nine tenths.
+
+Against the two words of signed bytes this replaces, a pack reads a normal four times closer to the
+true one and a tangent up to nine tenths of a degree round the face from where it was, and that
+tangent is now exactly perpendicular to the normal where three rounded bytes left it a few
+thousandths off. The out-of-game harness measures all of it over four hundred thousand frames, which
+is the only witness there is: nothing off the game runs the text that undoes the word.
+
+One thing the reference does here is not followed, and reproducing it would be reproducing a defect.
+It measures the angle against the normal the quad had, while its own patched shader reads that angle
+back in a basis built from the normal the word holds. That basis turns over on the sign of the
+normal's z, so a quad whose two normals straddle it gets a tangent back nearly reversed; measured
+the same way, the worst such tangent is a hundred and eighty degrees out. The engine measures the
+angle against the decoded normal instead, so both sides build the same basis.
 
 The encoding itself matches the reference implementation term for term: the id plus one, shifted up
 by one bit, with the low bit flagging a fluid, and a default of minus one so that an unmapped block


### PR DESCRIPTION
## What changes

The second half of #36, the first having landed in #43. The commit carries the closing line, as
`CONTRIBUTING.md` asks: a keyword written here would fire against `main` and leave the issue open.

The chunk mesh spent one element on the normal and another on the tangent, three signed bytes and a
sign in each. The tangent is squared up against the normal before anything is stored, so once the
normal is known what is left of it is one angle in the normal's own plane and one bit of handedness,
and the two elements are now one word that the vertex prologue takes apart. Over the eight packs of
the corpus the maximum falls from forty-four bytes a vertex to forty, and every pack that lights the
terrain by a normal drops four; nothing else about the format moves. Both halves of the packing live
in one class, since they never meet in a compiler: it writes the word and it writes the text that
undoes it.

## How it differs from the reference, and for what obstacle

Two divergences, and each is a workaround.

**Where the handedness lives.** Iris spends its whole word on the two directions, twelve bits of
octahedral x, twelve of y and a top byte of angle, and reads the sign out of a material bit instead,
`(a_LightAndData.z & 1u) != 0u` at `SodiumTransformer.java:231`. Nothing here can ride the material:
a translucent quad reaches `TerrainMesh.encode` from Sodium's sorter under a material Sodium chose
itself, so the bit is gone by then for every translucent quad and every fluid and nothing says so.
The sign therefore takes a bit of the word, off the normal rather than off the angle, because at
that end it costs the normal 0.03 degrees and at the other end it would cost the tangent 0.9. The
angle keeps the eight bits Iris gives it.

**Which normal the angle is measured against.** Iris hands `packDiamondByte` the un-quantised normal,
`NormalHelper.java:512-520`, while its own patched text builds the basis from the decoded one,
`SodiumTransformer.java:230-231`. Frisvad's basis turns over on the sign of the normal's z, so a quad
whose two normals straddle it gets a tangent back nearly reversed: pairing the two sides the way the
reference pairs them, the worst tangent over four hundred thousand frames is 179.9 degrees out. This
measures the angle against the decoded normal, so both sides build the same basis.

## What proves it

- `gradlew build` green, on a branch that is `dev` plus this one commit.
- The out-of-game harness, `Terrain` with `--glslang`, over the eight packs under both colour
  contracts: 192 stages of 192 compiled, seven invariants green, every element of the format still
  in the SPIR-V at the location its place gives it, exit 0. The printed strides are 28, 32, 36 and
  40 where they were 32, 36, 40 and 44.
- The emitted text, before against after, over the same 192 files: each of the 96 vertex stages
  swaps `in vec4 a_Normal` and `in vec4 a_Tangent` for `in uint a_TangentFrame`, gains the decode,
  and changes the two lines that fill `of_Normal` and `at_tangent`. The 46 stages that read
  `at_tangent` gain the second function. None of the 96 fragment stages differs at all.
- A new harness tool for the round trip, four hundred thousand frames: the handedness never turns
  over, nothing comes back as a NaN or off unit length, the normal lands 0.091 degrees out at worst
  against 0.388 for the bytes it replaces, the tangent 0.896 against 0.386, and the tangent is
  perpendicular to the normal to 3e-07 where three rounded bytes were a few thousandths off. One
  frame in forty gets a normal slightly further out than the old bytes happened to land, which is
  two quantisations disagreeing and not a regression; the bound is what does not move.
- Not in the game. Nothing here is visible without an A/B on the same camera, and the numbers above
  are what a screenshot could not settle.

## What it leaves owing

The Java that the harness measures the decode through is a transliteration of the GLSL the same
class emits, not that GLSL executed: nothing off the game runs a shader. They are kept in step by
sitting in one file, and that is the whole of what keeps them there.

`a_TangentFrame` is dropped by no pack of the corpus, so the road where the prologue falls back on a
constant normal is exercised by nothing here.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one: the javadoc of the
      three classes involved and `docs/internals/terrain.md`, whose paragraph on the packing was
      left behind by the branch before this one and is now right.
