### PR TITLE
Carry the sprite middle and the tangent on entity polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ what the next one holds.
 
 ### Added
 
+- **A normal map on a mob, on armour or on a chest is read the right way round.** The two values a
+  pack works a bump out from, the middle of the sprite a face is mapped to and the direction the
+  texture runs in over it, were the same constant for every face of every piece: a pack lighting a
+  mob through them tilted every bump on it the same way, whichever way the face was really turned.
+  Both are now worked out over each polygon and carried on its corners, on the mobs, on the block
+  entities, on a held item and on the hand alike. Of the hundred and fifty entity programs the eight
+  packs tested ship between them, seventy-five read the sprite middle and sixty-one read the
+  direction. What it changes on screen depends on the resource pack as well: a mob with no normal
+  map beside its skin has nothing to tilt, which is a second thing and is not fixed here.
+
 - **A mob flashes again when it is hurt, and a creeper whitens before it goes off.** The colour the
   game lays over a mob it has just damaged was reaching the pack as one number for the whole world,
   so a pack that paints the flash itself painted nothing: the red hit, the white of a creeper about

--- a/common/src/main/java/dev/vitrail/glsl/EntityVertex.java
+++ b/common/src/main/java/dev/vitrail/glsl/EntityVertex.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
  * then binds.
  * <p>
  * <strong>The three are Iris's own three and in its own order</strong>
- * ({@code vertices/IrisVertexFormats.java:61-70}: {@code iris_Entity}, then {@code mc_midTexCoord},
+ * ({@code vertices/IrisVertexFormats.java:49-60}: {@code iris_Entity}, then {@code mc_midTexCoord},
  * then {@code at_tangent}). The last two are what a pack asks of a POLYGON rather than of a corner,
  * the four corners of a quad carrying one pair and one tangent between them;
  * {@code render/EntityFrame} works both out, and the two roads that write them in are
@@ -48,6 +48,14 @@ import java.util.stream.Stream;
  * gives: a global initialised from a vertex input is not a constant expression and the language
  * refuses it, and the chunk mesh only escapes that by having a prologue it needs anyway. Here
  * there is nothing to compute, so there is no prologue to hang it on.
+ * <p>
+ * <strong>A macro is not shadowable where a global is</strong>, and that is the one thing it costs.
+ * A pack that spells one of these names for something of its own meets a substitution rather than a
+ * name, and what comes out does not parse. The attribute a pack declares is answered by the
+ * translation, which takes that declaration out of the body before the head is written; a LOCAL of
+ * the same name inside a function is answered by nothing, and would have compiled under a global.
+ * Both are measured rather than argued: the off-game harness translates and compiles every entity
+ * stage of the corpus, so either would have failed there, and none does.
  */
 public final class EntityVertex {
 

--- a/common/src/main/java/dev/vitrail/glsl/EntityVertex.java
+++ b/common/src/main/java/dev/vitrail/glsl/EntityVertex.java
@@ -4,20 +4,30 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * What the entity mesh carries, and how the names a pack reads are made out of it.
  * <p>
  * {@code DefaultVertexFormat.ENTITY} holds six elements in thirty-six bytes: {@code Position} as
  * three floats, {@code Color} as four normalised bytes, {@code UV0} as two floats, {@code UV1} and
- * {@code UV2} as two signed shorts each, {@code Normal} as four signed bytes. This engine appends a
- * seventh, {@link #IDENTIFIERS}, on a format of its OWN built out of those six: Sodium writes every
- * cuboid of a mob at the game's own stride and copies the run over raw whenever the two formats are
- * the same object, so lengthening the game's would copy forty-four bytes a vertex out of thirty-six
- * and leave no mob on screen. {@code EntityMesh} is where that is built, and it carries what a draw
- * a loaded pack does not serve then binds.
+ * {@code UV2} as two signed shorts each, {@code Normal} as four signed bytes. This engine appends
+ * three more, {@link #IDENTIFIERS}, {@link #MID_TEX_COORD} and {@link #TANGENT}, on a format of its
+ * OWN built out of those six: Sodium writes every cuboid of a mob at the game's own stride and
+ * copies the run over raw whenever the two formats are the same object, so lengthening the game's
+ * would copy fifty-six bytes a vertex out of thirty-six and leave no mob on screen.
+ * {@code EntityMesh} is where that is built, and it carries what a draw a loaded pack does not serve
+ * then binds.
  * <p>
- * <strong>All seven are declared, and no fewer.</strong> The pairing is by name and asymmetric in
+ * <strong>The three are Iris's own three and in its own order</strong>
+ * ({@code vertices/IrisVertexFormats.java:61-70}: {@code iris_Entity}, then {@code mc_midTexCoord},
+ * then {@code at_tangent}). The last two are what a pack asks of a POLYGON rather than of a corner,
+ * the four corners of a quad carrying one pair and one tangent between them;
+ * {@code render/EntityFrame} works both out, and the two roads that write them in are
+ * {@code sodium/EntityMeshSerializer} for a mob and {@code mixin/BufferBuilderMixin} for everything
+ * else this format draws.
+ * <p>
+ * <strong>All nine are declared, and no fewer.</strong> The pairing is by name and asymmetric in
  * both directions. A name the stage declares that the format has not got is refused outright,
  * {@code IntermediaryShaderModule.rebind:205-207}. An element the stage does not declare is simply
  * stepped over, and since {@code VulkanRenderPipeline} counts every element while {@code rebind}
@@ -28,10 +38,10 @@ import java.util.Set;
  * the hit flash and the damage tint, and what reads it is not a name of the prologue: the wrapper
  * around {@code main} fetches the texel it points at and hands the colour on as
  * {@code entityColor}, which is where Iris takes it from as well
- * ({@code EntityPatcher.patchOverlayColor}). See {@code GlslTranslator.overlayPrologue}. All seven
+ * ({@code EntityPatcher.patchOverlayColor}). See {@code GlslTranslator.overlayPrologue}. All nine
  * elements are declared whether or not a pack asks for any of them, which is safe for the one reason
  * that matters and is measured rather than assumed: the off-game harness reads the SPIR-V of every
- * entity stage of the corpus back and checks that all seven variables are still in it, because a
+ * entity stage of the corpus back and checks that all nine variables are still in it, because a
  * variable the compiler dropped is one {@code rebind} cannot find.
  * <p>
  * Written as macros rather than as globals for the reason {@link LegacyGlsl#FULLSCREEN_ATTRIBUTES}
@@ -59,11 +69,55 @@ public final class EntityVertex {
 	public static final String IDENTIFIERS = "EntityIds";
 
 	/**
-	 * The elements of the entity mesh, in the format's own order, the six the game lays out and the
-	 * one this engine appends after them. {@code EntityMesh} is what appends it.
+	 * The middle of the sprite a polygon is mapped to, as the pair of floats {@code UV0} already
+	 * spells a corner in, so that the two are compared without a scale between them.
+	 * <p>
+	 * It is a property of the POLYGON and not of a corner: the four corners of a quad carry the same
+	 * pair. That is what a pack tests a corner against to know which side of its sprite the corner
+	 * lies on, and on an entity it is what tells a cape's lower edge from its upper one, or picks the
+	 * middle texel of a sprite to read a colour from without an edge in it.
 	 */
-	public static final List<String> ATTRIBUTES =
-			List.of("Position", "Color", "UV0", "UV1", "UV2", "Normal", IDENTIFIERS);
+	public static final String MID_TEX_COORD = "MidTexCoord";
+
+	/**
+	 * The direction the texture's U axis runs in over a polygon, and the handedness of the frame it
+	 * builds with the normal, in four normalised bytes as the game spells {@code Normal} beside it.
+	 * <p>
+	 * A property of the polygon like {@link #MID_TEX_COORD}, and the one every normal map on an
+	 * entity is read through: a pack builds its tangent frame out of this and {@code gl_Normal}, so
+	 * an engine answering it with a constant tilts every bump on every mob the same wrong way.
+	 * <p>
+	 * <strong>The fourth component is not padding</strong>: it is plus or minus one and says which
+	 * way the third axis of the frame turns, which is what a pack multiplies its bitangent by. A skin
+	 * whose sprite is mirrored lights its bumps as dents without it. {@code EntityFrame.tangent} is
+	 * where it is worked out.
+	 */
+	public static final String TANGENT = "Tangent";
+
+	/**
+	 * The three this engine appends, in the order {@code EntityMesh} appends them and the order they
+	 * have to keep: an element sits at the location its place in the format gives it.
+	 */
+	public static final List<String> APPENDED = List.of(IDENTIFIERS, MID_TEX_COORD, TANGENT);
+
+	/**
+	 * The elements of the entity mesh, in the format's own order, the six the game lays out and the
+	 * three this engine appends after them. {@code EntityMesh} is what appends them.
+	 */
+	public static final List<String> ATTRIBUTES = Stream.concat(
+			Stream.of("Position", "Color", "UV0", "UV1", "UV2", "Normal"), APPENDED.stream())
+			.toList();
+
+	/**
+	 * The ones of {@link VertexPrologue#SYNTHESIZED} this mesh answers for real rather than with a
+	 * constant. What is left of that set is what the log has to call a constant, and
+	 * {@code EntityProgram} is what hands this on to it.
+	 * <p>
+	 * {@code mc_Entity} is not in here and is the one worth naming: the chunk mesh serves it out of
+	 * the block id it carries, and an entity is not a block state and has no id to travel on. Iris
+	 * does not serve it on this mesh either.
+	 */
+	public static final Set<String> ANSWERED = Set.of("mc_midTexCoord", "at_tangent");
 
 	/**
 	 * What the light map names read on a piece the game draws at full light, which is the value a
@@ -83,8 +137,8 @@ public final class EntityVertex {
 	}
 
 	/**
-	 * The head of an entity vertex stage: the seven elements, the names a pack reads made out of
-	 * five of them, and whatever the pack asks for that the mesh has not got.
+	 * The head of an entity vertex stage: the nine elements, the names a pack reads made out of
+	 * seven of them, and whatever the pack asks for that the mesh has not got.
 	 *
 	 * @param used        every name the rewritten body mentions, so that nothing is declared for a
 	 *                    pack that never asks
@@ -121,11 +175,57 @@ public final class EntityVertex {
 
 		lines.add("#define of_Normal Normal.xyz");
 
-		// The chunk mesh answers mc_Entity out of the block id it carries and this one cannot: an
-		// entity mesh has no room for one. So every name here is a constant, including that one,
-		// and what the picture is then wrong about is what the caller has to name in the log.
-		lines.addAll(VertexPrologue.tail(used, synthesized));
+		// The two the mesh really carries are macros over their element, like every name above them
+		// and for the same reason: a global initialised from a vertex input is not a constant
+		// expression. The rest stay constants, mc_Entity among them, and what the picture is then
+		// wrong about is what the caller has to name in the log.
+		VertexPrologue.globals(used, synthesized, Map.of()).forEach((name, type) -> lines.add(
+				ANSWERED.contains(name)
+						? "#define " + name + " " + answer(name, type)
+						: VertexPrologue.declaration(name, type)));
 
 		return List.copyOf(lines);
+	}
+
+	/** One of the two names the mesh answers, in the shape the pack declared it under. */
+	private static String answer(String name, String type) {
+		return name.equals("at_tangent") ? tangent(type) : midTexCoord(type);
+	}
+
+	/**
+	 * {@code mc_midTexCoord} out of the element, in the shape the pack declared it under.
+	 * <p>
+	 * The shapes are what a driver would have handed a stage declaring that many components against
+	 * an element carrying two, which is exactly what a pack meets under Iris: its element is the
+	 * pair and the pack's own declaration is the input. So three components get a nought and four
+	 * get a nought and a one, and the two engines answer alike whatever the pack wrote. A type this
+	 * does not know keeps its zero, which is a pack declaring this name as something the corpus has
+	 * never used.
+	 */
+	private static String midTexCoord(String type) {
+		return switch (type) {
+			case "float" -> MID_TEX_COORD + ".x";
+			case "vec2" -> MID_TEX_COORD;
+			case "vec3" -> "vec3(" + MID_TEX_COORD + ", 0.0)";
+			case "vec4" -> "vec4(" + MID_TEX_COORD + ", 0.0, 1.0)";
+			default -> VertexPrologue.zero(type);
+		};
+	}
+
+	/**
+	 * {@code at_tangent} out of the element, in the shape the pack declared it under.
+	 * <p>
+	 * Four components is what every pack of the corpus declares, and the fourth is the handedness
+	 * rather than a spare lane. A pack declaring three loses it and gets the direction alone, which
+	 * is what asking for three means.
+	 */
+	private static String tangent(String type) {
+		return switch (type) {
+			case "float" -> TANGENT + ".x";
+			case "vec2" -> TANGENT + ".xy";
+			case "vec3" -> TANGENT + ".xyz";
+			case "vec4" -> TANGENT;
+			default -> VertexPrologue.zero(type);
+		};
 	}
 }

--- a/common/src/main/java/dev/vitrail/glsl/VertexPrologue.java
+++ b/common/src/main/java/dev/vitrail/glsl/VertexPrologue.java
@@ -137,14 +137,15 @@ public final class VertexPrologue {
 	 * {@code UV2} as pairs of signed shorts wherever they appear, and a family reading one of them
 	 * as a float would read a different number from the same bytes.
 	 * <p>
-	 * {@link EntityVertex#IDENTIFIERS} is in here rather than beside its own head for that same
-	 * reason and no other: it is an element of a format like the six around it, and the one format
-	 * that carries it is the one this engine appends it to.
+	 * The three {@link EntityVertex} appends are in here rather than beside their own head for that
+	 * same reason and no other: they are elements of a format like the six around them, and the one
+	 * format that carries them is the one this engine appends them to. {@link EntityVertex#TANGENT}
+	 * takes the default, being four normalised bytes exactly as {@code Normal} is.
 	 */
 	public static String elementType(String element) {
 		return switch (element) {
 			case "Position" -> "vec3";
-			case "UV0" -> "vec2";
+			case "UV0", EntityVertex.MID_TEX_COORD -> "vec2";
 			case "UV1", "UV2" -> "ivec2";
 			case EntityVertex.IDENTIFIERS -> "uvec4";
 			default -> "vec4";

--- a/common/src/main/java/dev/vitrail/mixin/BufferBuilderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/BufferBuilderMixin.java
@@ -1,13 +1,16 @@
 package dev.vitrail.mixin;
 
 import dev.vitrail.glsl.EntityVertex;
+import dev.vitrail.render.EntityFrame;
 import dev.vitrail.render.EntityIdentifiers;
 
 import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+import com.mojang.blaze3d.vertex.MeshData;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
 import com.mojang.blaze3d.PrimitiveTopology;
+import org.jspecify.annotations.Nullable;
 import org.lwjgl.system.MemoryUtil;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -19,9 +22,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
- * Writes the three identifiers onto every vertex of the entity mesh, since nothing in the game will.
+ * Writes the three elements this engine appends onto every vertex of the entity mesh that does not
+ * come from Sodium, since nothing in the game will.
  * <p>
- * <strong>The builder knows seven elements and ours is not one of them.</strong>
+ * <strong>The builder knows seven elements and none of ours is one of them.</strong>
  * {@code BufferBuilder} holds its elements in an array indexed by a semantic id, seven names long
  * ({@code BufferBuilder:39}), and {@code beginElement} takes that id rather than an element; an
  * eighth is filled by nobody and, for the same reason, missed by nobody either, its
@@ -35,11 +39,30 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * everything else through the eleven setters. Both begin the vertex here, and this is also where the
  * pointer to write at is handed out.
  * <p>
- * Four shorts and not one long: {@code MemoryUtil} writes in the machine's own order, so a short at
- * a time lands each lane where the format put it whichever way round the machine is, where a long
- * would swap them on a big endian one. The fourth lane is written too, at nought: it is a lane of
- * the element like the other three and leaving it would hand a stage that reads the whole element
- * whatever the arena held.
+ * <strong>Two of the three belong to the POLYGON, and a polygon is only finished one vertex
+ * late.</strong> The middle of the sprite is the mean of the corners' texture coordinates and the
+ * tangent comes off three corners at once, so neither can be written where its own vertex begins:
+ * the corners after it do not exist yet, and the corner in hand is nothing but a reserved stretch of
+ * arena. So each vertex leaves its offset behind, and the polygon is filled in at the first moment
+ * its last corner is known to be whole, which is the next {@code beginVertex} or {@code build}.
+ * <p>
+ * <strong>Those two callers and not {@code endLastVertex}, which is where Iris does the same
+ * work</strong> ({@code mixin/vertices/MixinBufferBuilder.iris$beforeNext}) and which both of them
+ * call. Sodium's {@code push} writes a whole run without ever beginning a vertex and leaves
+ * {@code vertexPointer} on the last of them, so a hook there counts a corner belonging to no polygon
+ * of this builder's; Iris carries a {@code skipEndVertexOnce} flag for exactly that, and taking the
+ * callers instead leaves nothing to skip. A run pushed between two polygons is then simply invisible
+ * here, which is right: {@link dev.vitrail.sodium.EntityMeshSerializer} has already filled it.
+ * <p>
+ * <strong>Offsets and not pointers.</strong> {@code ByteBufferBuilder.reserve} grows the arena with
+ * a {@code realloc} when the next vertex would not fit, and every pointer handed out before that
+ * moves with it. {@link ByteBufferBuilderAccessor} is where the base is asked for again.
+ * <p>
+ * Four shorts and not one long for the identifiers: {@code MemoryUtil} writes in the machine's own
+ * order, so a short at a time lands each lane where the format put it whichever way round the
+ * machine is, where a long would swap them on a big endian one. The fourth lane is written too, at
+ * nought: it is a lane of the element like the other three and leaving it would hand a stage that
+ * reads the whole element whatever the arena held.
  */
 @Mixin(BufferBuilder.class)
 public abstract class BufferBuilderMixin {
@@ -48,30 +71,249 @@ public abstract class BufferBuilderMixin {
 	@Final
 	private VertexFormat format;
 
+	@Shadow
+	@Final
+	private ByteBufferBuilder buffer;
+
 	/**
-	 * Where the element starts inside a vertex of this builder, or minus one when this builder is not
-	 * building the entity mesh. Taken once in the constructor, the format of a builder being final.
+	 * Where the identifiers start inside a vertex of this builder, or minus one when this builder is
+	 * not building the entity mesh. Taken once in the constructor, the format of a builder being
+	 * final, and it is the gate for all of this: the five offsets below are elements of the same
+	 * format and stand or fall with it.
 	 */
 	@Unique
-	private int vitrail$offset;
+	private int vitrail$identifiers;
+
+	@Unique
+	private int vitrail$midTexCoord;
+
+	@Unique
+	private int vitrail$tangent;
+
+	@Unique
+	private int vitrail$position;
+
+	@Unique
+	private int vitrail$texCoord;
+
+	@Unique
+	private int vitrail$normal;
+
+	/**
+	 * How many corners a polygon of this builder has, or nought where its topology draws none that
+	 * can be walked: a strip and a fan share corners with their neighbours, so there is no place a
+	 * polygon begins. Those keep the stand-in every vertex is written with. Iris reads the same two
+	 * topologies and no others.
+	 */
+	@Unique
+	private int vitrail$corners;
+
+	/** Where the corners of the polygon in hand begin, from the arena's own base. */
+	@Unique
+	private long @Nullable [] vitrail$corner;
+
+	/** How many of those are written and whole. */
+	@Unique
+	private int vitrail$written;
+
+	/** Those corners read back, five floats each: the position, then the texture coordinate. */
+	@Unique
+	private float @Nullable [] vitrail$read;
+
+	/** The normal a quad's tangent is measured against, which is worked out rather than read. */
+	@Unique
+	private float @Nullable [] vitrail$face;
 
 	@Inject(method = "<init>", at = @At("RETURN"), require = 1)
-	private void vitrail$findElement(ByteBufferBuilder buffer, PrimitiveTopology topology,
+	private void vitrail$findElements(ByteBufferBuilder buffer, PrimitiveTopology topology,
 			VertexFormat format, CallbackInfo callback) {
 		VertexFormatElement element = this.format.getElement(EntityVertex.IDENTIFIERS);
-		this.vitrail$offset = element == null ? -1 : element.offset();
-	}
-
-	@Inject(method = "beginVertex", at = @At("RETURN"), require = 1)
-	private void vitrail$writeIdentifiers(CallbackInfoReturnable<Long> callback) {
-		if (this.vitrail$offset < 0) {
+		this.vitrail$identifiers = element == null ? -1 : element.offset();
+		if (element == null) {
 			return;
 		}
 
-		long pointer = callback.getReturnValueJ() + this.vitrail$offset;
-		MemoryUtil.memPutShort(pointer, (short) EntityIdentifiers.entity());
-		MemoryUtil.memPutShort(pointer + 2L, (short) EntityIdentifiers.blockEntity());
-		MemoryUtil.memPutShort(pointer + 4L, (short) EntityIdentifiers.item());
-		MemoryUtil.memPutShort(pointer + 6L, (short) 0);
+		this.vitrail$midTexCoord = vitrail$offsetOf(EntityVertex.MID_TEX_COORD);
+		this.vitrail$tangent = vitrail$offsetOf(EntityVertex.TANGENT);
+		this.vitrail$position = vitrail$offsetOf("Position");
+		this.vitrail$texCoord = vitrail$offsetOf("UV0");
+		this.vitrail$normal = vitrail$offsetOf("Normal");
+		this.vitrail$corners = switch (topology) {
+			case QUADS -> 4;
+			case TRIANGLES -> 3;
+			default -> 0;
+		};
+		this.vitrail$corner = new long[4];
+		this.vitrail$read = new float[20];
+		this.vitrail$face = new float[3];
+	}
+
+	/**
+	 * The identifiers, and the stand-in for the two the polygon owes.
+	 * <p>
+	 * The stand-in is written on every vertex and not only where a polygon will never come: what
+	 * fills the two in runs one vertex late, so a buffer whose last polygon is a corner short would
+	 * hand the pack whatever the arena held there. Nought for the middle of the sprite and an axis
+	 * for the tangent, which are the two values {@code VertexPrologue} hands a mesh carrying neither,
+	 * and the axis is not a nicety: a tangent of nought normalises to a NaN that reaches the colour.
+	 */
+	@Inject(method = "beginVertex", at = @At("RETURN"), require = 1)
+	private void vitrail$writeVertex(CallbackInfoReturnable<Long> callback) {
+		if (this.vitrail$identifiers < 0) {
+			return;
+		}
+
+		// Before anything of this vertex is recorded, and it has to be here: the vertex that just
+		// ended is the last corner of the polygon in hand, so this is the first moment all of it is
+		// written.
+		vitrail$fill();
+
+		long pointer = callback.getReturnValueJ();
+		long identifiers = pointer + this.vitrail$identifiers;
+		MemoryUtil.memPutShort(identifiers, (short) EntityIdentifiers.entity());
+		MemoryUtil.memPutShort(identifiers + 2L, (short) EntityIdentifiers.blockEntity());
+		MemoryUtil.memPutShort(identifiers + 4L, (short) EntityIdentifiers.item());
+		MemoryUtil.memPutShort(identifiers + 6L, (short) 0);
+		MemoryUtil.memPutFloat(pointer + this.vitrail$midTexCoord, 0.0F);
+		MemoryUtil.memPutFloat(pointer + this.vitrail$midTexCoord + 4L, 0.0F);
+		MemoryUtil.memPutInt(pointer + this.vitrail$tangent, EntityFrame.FLAT);
+
+		long[] corner = this.vitrail$corner;
+		if (corner != null && this.vitrail$corners > 0) {
+			corner[this.vitrail$written++] =
+					pointer - ((ByteBufferBuilderAccessor) this.buffer).vitrail$pointer();
+		}
+	}
+
+	/**
+	 * The last polygon of the buffer, which no {@code beginVertex} follows.
+	 * <p>
+	 * At the head, ahead of {@code endLastVertex} and of the mesh being taken: a caller has written
+	 * its last vertex whole by the time it asks for the mesh, and everything past this point only
+	 * reads.
+	 */
+	@Inject(method = "build", at = @At("HEAD"), require = 1)
+	private void vitrail$finishPolygon(CallbackInfoReturnable<MeshData> callback) {
+		if (this.vitrail$identifiers >= 0) {
+			vitrail$fill();
+		}
+	}
+
+	/**
+	 * The middle of the sprite and the tangent onto every corner of the polygon in hand, once all of
+	 * its corners are written. Silent where there is no whole polygon to fill, which is every vertex
+	 * but the one that follows a polygon's last.
+	 */
+	@Unique
+	private void vitrail$fill() {
+		long[] corner = this.vitrail$corner;
+		float[] read = this.vitrail$read;
+		float[] face = this.vitrail$face;
+		int corners = this.vitrail$corners;
+		if (corner == null || read == null || face == null || corners == 0
+				|| this.vitrail$written < corners) {
+			return;
+		}
+
+		this.vitrail$written = 0;
+		long base = ((ByteBufferBuilderAccessor) this.buffer).vitrail$pointer();
+		float midU = 0.0F;
+		float midV = 0.0F;
+		for (int at = 0; at < corners; at++) {
+			long vertex = base + corner[at];
+			int into = at * 5;
+			read[into] = MemoryUtil.memGetFloat(vertex + this.vitrail$position);
+			read[into + 1] = MemoryUtil.memGetFloat(vertex + this.vitrail$position + 4L);
+			read[into + 2] = MemoryUtil.memGetFloat(vertex + this.vitrail$position + 8L);
+			read[into + 3] = MemoryUtil.memGetFloat(vertex + this.vitrail$texCoord);
+			read[into + 4] = MemoryUtil.memGetFloat(vertex + this.vitrail$texCoord + 4L);
+			midU += read[into + 3];
+			midV += read[into + 4];
+		}
+
+		midU /= corners;
+		midV /= corners;
+
+		// A quad is lit flat and a triangle is not, which is Iris's own split and is a fact about
+		// what the two carry rather than a preference (MixinBufferBuilder.fillExtendedData): the
+		// game writes one normal over a quad's four corners, so a quad has a normal of its own and
+		// its four tangents are one tangent; a triangle may be smooth shaded, so each corner keeps
+		// the normal it was given and takes the tangent that normal's own plane gives it.
+		if (corners == 4) {
+			vitrail$fillQuad(base, corner, read, face, midU, midV);
+
+			return;
+		}
+
+		for (int at = 0; at < corners; at++) {
+			long vertex = base + corner[at];
+			int normal = MemoryUtil.memGetInt(vertex + this.vitrail$normal);
+			vitrail$write(vertex, midU, midV, EntityFrame.tangent(EntityFrame.unpack(normal, 0),
+					EntityFrame.unpack(normal, 1), EntityFrame.unpack(normal, 2), true,
+					read[0], read[1], read[2], read[3], read[4],
+					read[5], read[6], read[7], read[8], read[9],
+					read[10], read[11], read[12], read[13], read[14]));
+		}
+	}
+
+	/**
+	 * The same for a quad, whose normal is taken from its own corners rather than read off one of
+	 * them, and <strong>written back over the one the game left there</strong>.
+	 * <p>
+	 * That write-back is Iris's answer ({@code MixinBufferBuilder.fillExtendedData}, its
+	 * {@code recalculateNormal} branch) and costs nothing on the geometry this road really carries: a
+	 * cuboid's four corners are handed the same normal already, so the two agree to the quantum.
+	 * Where they do not agree, the corners were given a normal that is not the face's, and a tangent
+	 * measured against one normal beside a light computed from another is a frame that does not
+	 * close.
+	 * <p>
+	 * A quad of no area is the one case that keeps what the game wrote: corners lying on a line have
+	 * no normal to give, and normalising nought is a NaN that reaches the colour.
+	 * {@code EntityFrame.faceNormal} is what refuses, and Iris has no such branch.
+	 */
+	@Unique
+	private void vitrail$fillQuad(long base, long[] corner, float[] read, float[] face, float midU,
+			float midV) {
+		boolean own = EntityFrame.faceNormal(face, read[0], read[1], read[2], read[5], read[6],
+				read[7], read[10], read[11], read[12], read[15], read[16], read[17]);
+		if (!own) {
+			int given = MemoryUtil.memGetInt(base + corner[0] + this.vitrail$normal);
+			face[0] = EntityFrame.unpack(given, 0);
+			face[1] = EntityFrame.unpack(given, 1);
+			face[2] = EntityFrame.unpack(given, 2);
+		}
+
+		int tangent = EntityFrame.tangent(face[0], face[1], face[2], false,
+				read[0], read[1], read[2], read[3], read[4],
+				read[5], read[6], read[7], read[8], read[9],
+				read[10], read[11], read[12], read[13], read[14]);
+		int normal = EntityFrame.pack(face[0], face[1], face[2], 0.0F);
+		for (int at = 0; at < 4; at++) {
+			long vertex = base + corner[at];
+			if (own) {
+				MemoryUtil.memPutInt(vertex + this.vitrail$normal, normal);
+			}
+
+			vitrail$write(vertex, midU, midV, tangent);
+		}
+	}
+
+	/** One corner's share of what the polygon worked out. */
+	@Unique
+	private void vitrail$write(long vertex, float midU, float midV, int tangent) {
+		MemoryUtil.memPutFloat(vertex + this.vitrail$midTexCoord, midU);
+		MemoryUtil.memPutFloat(vertex + this.vitrail$midTexCoord + 4L, midV);
+		MemoryUtil.memPutInt(vertex + this.vitrail$tangent, tangent);
+	}
+
+	/** One element of this builder's format, which is known to carry it by the time this is asked. */
+	@Unique
+	private int vitrail$offsetOf(String element) {
+		VertexFormatElement found = this.format.getElement(element);
+		if (found == null) {
+			throw new IllegalStateException("The entity mesh was built without " + element);
+		}
+
+		return found.offset();
 	}
 }

--- a/common/src/main/java/dev/vitrail/mixin/BufferBuilderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/BufferBuilderMixin.java
@@ -127,17 +127,29 @@ public abstract class BufferBuilderMixin {
 	@Inject(method = "<init>", at = @At("RETURN"), require = 1)
 	private void vitrail$findElements(ByteBufferBuilder buffer, PrimitiveTopology topology,
 			VertexFormat format, CallbackInfo callback) {
-		VertexFormatElement element = this.format.getElement(EntityVertex.IDENTIFIERS);
-		this.vitrail$identifiers = element == null ? -1 : element.offset();
-		if (element == null) {
+		int identifiers = vitrail$offsetOf(EntityVertex.IDENTIFIERS);
+		int midTexCoord = vitrail$offsetOf(EntityVertex.MID_TEX_COORD);
+		int tangent = vitrail$offsetOf(EntityVertex.TANGENT);
+		int position = vitrail$offsetOf("Position");
+		int texCoord = vitrail$offsetOf("UV0");
+		int normal = vitrail$offsetOf("Normal");
+		// Six or none, and never some of them: what this builder is is one question, and a format
+		// carrying the first without the rest is not a state this engine can build. Answering it the
+		// way a builder of any other format is answered is what keeps a constructor the game runs
+		// thousands of times a frame from being a place anything can be thrown out of.
+		if (identifiers < 0 || midTexCoord < 0 || tangent < 0 || position < 0 || texCoord < 0
+				|| normal < 0) {
+			this.vitrail$identifiers = -1;
+
 			return;
 		}
 
-		this.vitrail$midTexCoord = vitrail$offsetOf(EntityVertex.MID_TEX_COORD);
-		this.vitrail$tangent = vitrail$offsetOf(EntityVertex.TANGENT);
-		this.vitrail$position = vitrail$offsetOf("Position");
-		this.vitrail$texCoord = vitrail$offsetOf("UV0");
-		this.vitrail$normal = vitrail$offsetOf("Normal");
+		this.vitrail$identifiers = identifiers;
+		this.vitrail$midTexCoord = midTexCoord;
+		this.vitrail$tangent = tangent;
+		this.vitrail$position = position;
+		this.vitrail$texCoord = texCoord;
+		this.vitrail$normal = normal;
 		this.vitrail$corners = switch (topology) {
 			case QUADS -> 4;
 			case TRIANGLES -> 3;
@@ -234,11 +246,12 @@ public abstract class BufferBuilderMixin {
 		midU /= corners;
 		midV /= corners;
 
-		// A quad is lit flat and a triangle is not, which is Iris's own split and is a fact about
-		// what the two carry rather than a preference (MixinBufferBuilder.fillExtendedData): the
-		// game writes one normal over a quad's four corners, so a quad has a normal of its own and
-		// its four tangents are one tangent; a triangle may be smooth shaded, so each corner keeps
-		// the normal it was given and takes the tangent that normal's own plane gives it.
+		// A quad is read flat and a triangle is not, which is Iris's own split
+		// (MixinBufferBuilder.fillExtendedData) and its own reason: it took the face normal off the
+		// triangle branch deliberately, its note at NormalHelper's call site saying that was "to
+		// enable smooth shaded triangles". So a quad gets one tangent for its four corners, measured
+		// against the normal its own corners give it; a triangle keeps the normal each corner was
+		// given and takes the tangent that normal's own plane gives it.
 		if (corners == 4) {
 			vitrail$fillQuad(base, corner, read, face, midU, midV);
 
@@ -257,26 +270,43 @@ public abstract class BufferBuilderMixin {
 	}
 
 	/**
-	 * The same for a quad, whose normal is taken from its own corners rather than read off one of
-	 * them, and <strong>written back over the one the game left there</strong>.
+	 * The same for a quad, whose tangent is measured against a normal taken from its own corners
+	 * rather than read off one of them, exactly as Iris measures it
+	 * ({@code MixinBufferBuilder.fillExtendedData}, {@code NormalHelper.computeFaceNormal} then
+	 * {@code computeTangent} on what it gives).
 	 * <p>
-	 * That write-back is Iris's answer ({@code MixinBufferBuilder.fillExtendedData}, its
-	 * {@code recalculateNormal} branch) and costs nothing on the geometry this road really carries: a
-	 * cuboid's four corners are handed the same normal already, so the two agree to the quantum.
-	 * Where they do not agree, the corners were given a normal that is not the face's, and a tangent
-	 * measured against one normal beside a light computed from another is a frame that does not
-	 * close.
+	 * <strong>The normal itself is left as the game wrote it, and Iris writes its own back.</strong>
+	 * A divergence, and what it works around is that this engine has no moment to hang the write-back
+	 * on. Iris does it only inside the level render ({@code MixinBufferBuilder.java:244},
+	 * {@code recalculateNormal = ImmediateState.isRenderingLevel}, under a comment at {@code :243}
+	 * naming an item batching mod), and outside it the question never arises because it does not
+	 * extend the format there at all ({@code MixinBufferBuilder.java:98} and
+	 * {@code MixinRenderPipeline.java:26}, both on the same flag). This engine settles its format
+	 * once and binds it wherever the game declares the entity one,
+	 * {@link dev.vitrail.render.EntityMesh#settle()} saying why it cannot be read live and
+	 * {@link dev.vitrail.mixin.RenderPipelineMixin} doing the binding, so a write-back here would
+	 * reach geometry Iris never touches, an item drawn into an inventory screen among it.
 	 * <p>
-	 * A quad of no area is the one case that keeps what the game wrote: corners lying on a line have
-	 * no normal to give, and normalising nought is a NaN that reaches the colour.
-	 * {@code EntityFrame.faceNormal} is what refuses, and Iris has no such branch.
+	 * <strong>What it costs is the handedness and not the direction.</strong> The corners are not
+	 * flattened onto this normal's plane here, so it reaches {@code EntityFrame.tangent} for one
+	 * thing only, the sign in the fourth component. A quad whose corners were given a normal that is
+	 * not the face's therefore keeps a tangent pointing the right way and may get that sign turned
+	 * over, which is a bump lighting as a dent. No entity geometry of the game reaches this road in
+	 * that state: a {@code ModelPart} cuboid does not come this way at all, Sodium's
+	 * {@code CubeMixin} taking it, and a baked quad carries one normal over its four corners.
+	 * <p>
+	 * A quad of no area falls back on the normal of its first corner: corners lying on a line have no
+	 * normal to give, and normalising nought is a NaN that would travel into the colour through the
+	 * whole tangent frame. {@code EntityFrame.faceNormal} is what refuses, and Iris has no such
+	 * branch: {@code NormalHelper.computeFaceNormalManual:85-91} normalises whatever the cross
+	 * product gave. It costs a degenerate quad a tangent measured against a corner normal rather than
+	 * a NaN, and the game draws no such quad here.
 	 */
 	@Unique
 	private void vitrail$fillQuad(long base, long[] corner, float[] read, float[] face, float midU,
 			float midV) {
-		boolean own = EntityFrame.faceNormal(face, read[0], read[1], read[2], read[5], read[6],
-				read[7], read[10], read[11], read[12], read[15], read[16], read[17]);
-		if (!own) {
+		if (!EntityFrame.faceNormal(face, read[0], read[1], read[2], read[5], read[6], read[7],
+				read[10], read[11], read[12], read[15], read[16], read[17])) {
 			int given = MemoryUtil.memGetInt(base + corner[0] + this.vitrail$normal);
 			face[0] = EntityFrame.unpack(given, 0);
 			face[1] = EntityFrame.unpack(given, 1);
@@ -287,14 +317,8 @@ public abstract class BufferBuilderMixin {
 				read[0], read[1], read[2], read[3], read[4],
 				read[5], read[6], read[7], read[8], read[9],
 				read[10], read[11], read[12], read[13], read[14]);
-		int normal = EntityFrame.pack(face[0], face[1], face[2], 0.0F);
 		for (int at = 0; at < 4; at++) {
-			long vertex = base + corner[at];
-			if (own) {
-				MemoryUtil.memPutInt(vertex + this.vitrail$normal, normal);
-			}
-
-			vitrail$write(vertex, midU, midV, tangent);
+			vitrail$write(base + corner[at], midU, midV, tangent);
 		}
 	}
 
@@ -306,14 +330,11 @@ public abstract class BufferBuilderMixin {
 		MemoryUtil.memPutInt(vertex + this.vitrail$tangent, tangent);
 	}
 
-	/** One element of this builder's format, which is known to carry it by the time this is asked. */
+	/** Where one element starts inside a vertex of this builder, or minus one where it has none. */
 	@Unique
 	private int vitrail$offsetOf(String element) {
 		VertexFormatElement found = this.format.getElement(element);
-		if (found == null) {
-			throw new IllegalStateException("The entity mesh was built without " + element);
-		}
 
-		return found.offset();
+		return found == null ? -1 : found.offset();
 	}
 }

--- a/common/src/main/java/dev/vitrail/mixin/ByteBufferBuilderAccessor.java
+++ b/common/src/main/java/dev/vitrail/mixin/ByteBufferBuilderAccessor.java
@@ -1,0 +1,24 @@
+package dev.vitrail.mixin;
+
+import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * Where the arena a {@code BufferBuilder} writes into currently begins.
+ * <p>
+ * <strong>It moves, and that is the whole reason this exists.</strong> {@code reserve} grows the
+ * arena with a {@code realloc} whenever the next vertex would not fit, and every pointer handed out
+ * before that moves with it. {@code BufferBuilderMixin} has to look back at the corners of a polygon
+ * once its last one is written, so it keeps them as offsets from this and asks for it again at the
+ * moment it reads them. Iris keeps the same base for the same reason, through an accessor of its own
+ * ({@code vertices/MojangBufferAccessor}).
+ * <p>
+ * The field is private with no getter beside it, so an accessor is the only road to it.
+ */
+@Mixin(ByteBufferBuilder.class)
+public interface ByteBufferBuilderAccessor {
+
+	@Accessor("pointer")
+	long vitrail$pointer();
+}

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -317,8 +317,9 @@ public final class EntityDraw {
 		 * takes the one that answers the light map names with a constant.
 		 * <p>
 		 * <strong>Two contracts and not two formats</strong>, which is why {@link #format} does not
-		 * split with it and must not: the mesh is the same thirty-six bytes and {@code UV2} is bound
-		 * and declared either way. What changes is one line of the vertex head and the texture behind
+		 * split with it and must not: the mesh is the same elements at the same stride and
+		 * {@code UV2} is bound and declared either way. What changes is one line of the vertex head
+		 * and the texture behind
 		 * one sampler. It reaches the translation because this constant is part of the key a program
 		 * is translated under, so the two contracts are two modules and neither is handed the other's
 		 * text.
@@ -1407,9 +1408,9 @@ public final class EntityDraw {
 		// ten draws in a hand pass.
 		boolean inMoment = (element != null && element.hand()) ? HandDraw.wanted()
 				: wanted && element != null && inWindow(element);
-		// And the mesh has to be carrying the identifiers, whatever the moment says. Every row but the
-		// glint's is read against EntityMesh.format, so a draw served before the mesh settled would
-		// bind forty-four bytes of layout over a vertex of thirty-six. It lasts from the load that
+		// And the mesh has to be carrying, whatever the moment says. Every row but the glint's is read
+		// against EntityMesh.format, so a draw served before the mesh settled would bind fifty-six
+		// bytes of layout over a vertex of thirty-six. It lasts from the load that
 		// asked until the extract that rebuilds the world, which is one frame in the ordinary case.
 		//
 		// What it costs is NOT the same thing on the two roads, and saying it once would be wrong on

--- a/common/src/main/java/dev/vitrail/render/EntityFrame.java
+++ b/common/src/main/java/dev/vitrail/render/EntityFrame.java
@@ -32,9 +32,20 @@ public final class EntityFrame {
 	 * What a polygon that has no tangent to give is written with, which is the axis
 	 * {@code VertexPrologue} hands a mesh carrying no tangent at all.
 	 * <p>
-	 * A tangent of nought is not harmless: every pack normalises the one it reads, and
+	 * <strong>A divergence, and Iris has no one value to follow here.</strong> Its two roads answer
+	 * differently: the mob one gives up and returns {@code -1} as a whole word,
+	 * {@code vertices/NormalHelper.java:375-377} read at
+	 * {@code vertices/sodium/ModelToEntityVertexSerializer.java:61}, which is every component at
+	 * minus one; the buffer builder one has no test at all and packs whatever came out, which for a
+	 * tangent of no length is nought, {@code NormalHelper.java:294-300}. What makes neither usable
+	 * here is what a pack does with what it reads: every one of them normalises it, and
 	 * {@code normalize(vec3(0))} is a division by nought whose NaN travels into the colour through
-	 * the whole tangent frame.
+	 * the whole tangent frame, while a tangent of minus one on all three axes is a direction pointing
+	 * nowhere the texture runs. So both roads of this engine answer with the axis instead,
+	 * {@link #tangent} and {@link dev.vitrail.sodium.EntityMeshSerializer#serialize} writing it and
+	 * {@code VertexPrologue.BETTER_DEFAULTS} already holding it for a mesh with no tangent at all. It
+	 * costs a polygon that has no texture gradient a tangent along X rather than a NaN or a corner of
+	 * a cube.
 	 */
 	public static final int FLAT = pack(1.0F, 0.0F, 0.0F, 1.0F);
 
@@ -44,6 +55,19 @@ public final class EntityFrame {
 	/**
 	 * The squared length below which a vector is taken to be nought rather than normalised. On the
 	 * square so that no root is taken of a degenerate case on the way to finding out.
+	 * <p>
+	 * <strong>A threshold where Iris tests for exact nought</strong>, {@code NormalHelper.rsqrt}
+	 * ({@code NormalHelper.java:417-424}) special-casing {@code 0.0f} and
+	 * {@code computeFaceNormalManual} ({@code :85-91}) testing nothing whatever. What it works around
+	 * is that a float that is merely near nought normalises to a direction made entirely of rounding
+	 * error, and {@link #tangent} and {@link #faceNormal} both hand that direction on to the tangent
+	 * frame, which carries it into every normal map on the piece.
+	 * <p>
+	 * <strong>What it reaches is not the same size on the two.</strong> {@link #faceNormal} squares
+	 * the CROSS PRODUCT of the diagonals, whose length is twice the quad's area, so the refusal
+	 * covers a quad of about seven ten-thousandths of a block a side and smaller. {@link #tangent}
+	 * squares a length, so there it is a millionth. The game draws neither, an entity model being
+	 * built in sixteenths of a block.
 	 */
 	private static final float TINY = 1.0E-12F;
 
@@ -58,10 +82,12 @@ public final class EntityFrame {
 	 * rather than one corner's: a quad whose four corners are not quite coplanar has two edge
 	 * normals and one diagonal normal.
 	 * <p>
-	 * <strong>The refusal is this engine's own and Iris has no such branch.</strong> A quad of no
-	 * area gives a cross product of nought, and normalising that is a NaN that reaches the colour
-	 * through the tangent frame; the caller keeps the normal the game wrote instead. Nothing of the
-	 * game's own entity geometry is known to draw one, so this is a guard rather than a case.
+	 * <strong>The refusal is this engine's own and Iris has no such branch</strong>,
+	 * {@code NormalHelper.computeFaceNormalManual:85-91} normalising whatever the cross product gave.
+	 * A quad of no area gives nought there, and normalising that is a NaN that reaches the colour
+	 * through the tangent frame; the caller keeps the normal the game wrote instead. It costs such a
+	 * quad a tangent measured against a corner's normal rather than a NaN, and nothing of the game's
+	 * own entity geometry is known to draw one, so this is a guard rather than a case.
 	 */
 	public static boolean faceNormal(float[] into, float x0, float y0, float z0, float x1, float y1,
 			float z1, float x2, float y2, float z2, float x3, float y3, float z3) {
@@ -177,11 +203,10 @@ public final class EntityFrame {
 	 * Four normalised components into one word, low byte first, which is how the element is laid out
 	 * and how the game writes the normal beside it.
 	 * <p>
-	 * <strong>Rounded where Iris and the game both truncate</strong> ({@code NormI8.pack},
-	 * {@code BufferBuilder.normalIntValue}), which is what {@code TangentFrame.snorm} already does
-	 * for the chunk mesh: truncation pulls every component toward nought by up to a whole step where
-	 * rounding pulls it by half of one. It is a quantisation and not a convention, so both engines
-	 * read the same direction either way, to within four tenths of a degree.
+	 * Truncated toward nought rather than rounded, which is what both engines already do to a
+	 * normalised byte ({@code NormI8.pack}, {@code BufferBuilder.normalIntValue}) and is therefore
+	 * the same word out of the same tangent. Rounding would land closer to the direction, by up to
+	 * half a step, and be a different word for no reason a pack could name.
 	 */
 	public static int pack(float x, float y, float z, float w) {
 		return (snorm(x) & 0xFF) | ((snorm(y) & 0xFF) << 8) | ((snorm(z) & 0xFF) << 16)
@@ -195,6 +220,6 @@ public final class EntityFrame {
 
 	/** One component as the signed byte the element holds it in. */
 	private static int snorm(float value) {
-		return Math.round(Math.clamp(value, -1.0F, 1.0F) * RANGE);
+		return (int) (Math.clamp(value, -1.0F, 1.0F) * RANGE);
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/EntityFrame.java
+++ b/common/src/main/java/dev/vitrail/render/EntityFrame.java
@@ -1,0 +1,200 @@
+package dev.vitrail.render;
+
+/**
+ * The direction the texture's U axis runs in over an entity POLYGON, and the normal that direction
+ * is squared against, neither of which any one vertex knows.
+ * <p>
+ * <strong>Both roads into the entity mesh come through here, and that is the point.</strong> A mob
+ * is written by Sodium at the game's own stride and converted by
+ * {@link dev.vitrail.sodium.EntityMeshSerializer}; a block entity, a held item and the hand are
+ * written vertex by vertex through {@code BufferBuilder} and filled by
+ * {@link dev.vitrail.mixin.BufferBuilderMixin}. The two see completely different memory and would
+ * have written this arithmetic twice, which for a tangent is not a tidiness argument: the handedness
+ * in the fourth component decides whether a bump lights as a bump or as a dent, so two copies that
+ * drifted apart would light one half of the picture inside out and nothing would say a word.
+ * <p>
+ * The other name the polygon answers, {@code mc_midTexCoord}, is not here and does not need to be:
+ * it is the mean of the corners' texture coordinates, which each road works out as it walks them
+ * and which has nothing in it to get wrong.
+ * <p>
+ * <strong>Nothing here names an API of the game</strong>, which is what lets the off-game harness
+ * compile it and measure the numbers. That harness is the only witness this arithmetic has: the
+ * values reach the shader as bytes read straight off the element, so no generated text stands
+ * between the two sides and there is nothing in the game to read back and compare.
+ * <p>
+ * The arithmetic is Iris's, {@code vertices/NormalHelper.computeTangent} and
+ * {@code computeTangentSmooth}, and it is the standard tangent of a triangle: the two texture
+ * gradients inverted onto the two edges. What differs is spelled out where it differs.
+ */
+public final class EntityFrame {
+
+	/**
+	 * What a polygon that has no tangent to give is written with, which is the axis
+	 * {@code VertexPrologue} hands a mesh carrying no tangent at all.
+	 * <p>
+	 * A tangent of nought is not harmless: every pack normalises the one it reads, and
+	 * {@code normalize(vec3(0))} is a division by nought whose NaN travels into the colour through
+	 * the whole tangent frame.
+	 */
+	public static final int FLAT = pack(1.0F, 0.0F, 0.0F, 1.0F);
+
+	/** What one signed byte of a normalised component holds, which is the element's own scale. */
+	private static final float RANGE = 127.0F;
+
+	/**
+	 * The squared length below which a vector is taken to be nought rather than normalised. On the
+	 * square so that no root is taken of a degenerate case on the way to finding out.
+	 */
+	private static final float TINY = 1.0E-12F;
+
+	private EntityFrame() {
+	}
+
+	/**
+	 * The quad's own normal into {@code into}, or {@code false} where its corners give none.
+	 * <p>
+	 * Taken across the two DIAGONALS rather than off two edges, which is Iris's own
+	 * ({@code NormalHelper.computeFaceNormalManual}) and is what makes it the whole quad's answer
+	 * rather than one corner's: a quad whose four corners are not quite coplanar has two edge
+	 * normals and one diagonal normal.
+	 * <p>
+	 * <strong>The refusal is this engine's own and Iris has no such branch.</strong> A quad of no
+	 * area gives a cross product of nought, and normalising that is a NaN that reaches the colour
+	 * through the tangent frame; the caller keeps the normal the game wrote instead. Nothing of the
+	 * game's own entity geometry is known to draw one, so this is a guard rather than a case.
+	 */
+	public static boolean faceNormal(float[] into, float x0, float y0, float z0, float x1, float y1,
+			float z1, float x2, float y2, float z2, float x3, float y3, float z3) {
+		float ax = x2 - x0;
+		float ay = y2 - y0;
+		float az = z2 - z0;
+		float bx = x3 - x1;
+		float by = y3 - y1;
+		float bz = z3 - z1;
+
+		float nx = ay * bz - az * by;
+		float ny = az * bx - ax * bz;
+		float nz = ax * by - ay * bx;
+		float square = nx * nx + ny * ny + nz * nz;
+		if (square <= TINY) {
+			return false;
+		}
+
+		float scale = (float) (1.0 / Math.sqrt(square));
+		into[0] = nx * scale;
+		into[1] = ny * scale;
+		into[2] = nz * scale;
+
+		return true;
+	}
+
+	/**
+	 * The tangent of a polygon, from its normal and the first three of its corners, packed as the
+	 * element carries it.
+	 * <p>
+	 * The first three and no more, whether the polygon has three corners or four: three corners
+	 * already give both texture gradients, and this is Iris's own reading as well.
+	 *
+	 * @param flatten whether the corners are first flattened onto the plane the normal stands on,
+	 *                which is what Iris does for a polygon lit from a normal per corner
+	 *                ({@code NormalHelper.computeTangentSmooth}) and not for one lit flat. Left out
+	 *                where it is owed, a smooth shaded corner's tangent leans by however far its own
+	 *                normal leans from the polygon's
+	 */
+	public static int tangent(float normalX, float normalY, float normalZ, boolean flatten,
+			float x0, float y0, float z0, float u0, float v0,
+			float x1, float y1, float z1, float u1, float v1,
+			float x2, float y2, float z2, float u2, float v2) {
+		float px0 = x0;
+		float py0 = y0;
+		float pz0 = z0;
+		float px1 = x1;
+		float py1 = y1;
+		float pz1 = z1;
+		float px2 = x2;
+		float py2 = y2;
+		float pz2 = z2;
+		if (flatten) {
+			float onto0 = x0 * normalX + y0 * normalY + z0 * normalZ;
+			float onto1 = x1 * normalX + y1 * normalY + z1 * normalZ;
+			float onto2 = x2 * normalX + y2 * normalY + z2 * normalZ;
+			px0 -= onto0 * normalX;
+			py0 -= onto0 * normalY;
+			pz0 -= onto0 * normalZ;
+			px1 -= onto1 * normalX;
+			py1 -= onto1 * normalY;
+			pz1 -= onto1 * normalZ;
+			px2 -= onto2 * normalX;
+			py2 -= onto2 * normalY;
+			pz2 -= onto2 * normalZ;
+		}
+
+		float edge1x = px1 - px0;
+		float edge1y = py1 - py0;
+		float edge1z = pz1 - pz0;
+		float edge2x = px2 - px0;
+		float edge2y = py2 - py0;
+		float edge2z = pz2 - pz0;
+
+		float du1 = u1 - u0;
+		float dv1 = v1 - v0;
+		float du2 = u2 - u0;
+		float dv2 = v2 - v0;
+
+		// Three corners sharing a texture coordinate leave no gradient to invert. Iris carries the
+		// same guard and the same value for it, and what comes out of it is an edge rather than
+		// anything meaningful: the point is to keep the branch out of the division.
+		float span = du1 * dv2 - du2 * dv1;
+		float scale = span == 0.0F ? 1.0F : 1.0F / span;
+
+		float tx = scale * (dv2 * edge1x - dv1 * edge2x);
+		float ty = scale * (dv2 * edge1y - dv1 * edge2y);
+		float tz = scale * (dv2 * edge1z - dv1 * edge2z);
+		float square = tx * tx + ty * ty + tz * tz;
+		if (square <= TINY) {
+			return FLAT;
+		}
+
+		float unit = (float) (1.0 / Math.sqrt(square));
+		tx *= unit;
+		ty *= unit;
+		tz *= unit;
+
+		// The bitangent the texture really runs along, against the one this frame would predict from
+		// the tangent and the normal. Where the two point apart the third axis turns the other way,
+		// and that is the whole of what the fourth component says: a mirrored piece of a skin lights
+		// its bumps as dents without it.
+		float bx = scale * (-du2 * edge1x + du1 * edge2x);
+		float by = scale * (-du2 * edge1y + du1 * edge2y);
+		float bz = scale * (-du2 * edge1z + du1 * edge2z);
+		float side = bx * (ty * normalZ - tz * normalY) + by * (tz * normalX - tx * normalZ)
+				+ bz * (tx * normalY - ty * normalX);
+
+		return pack(tx, ty, tz, side < 0.0F ? -1.0F : 1.0F);
+	}
+
+	/**
+	 * Four normalised components into one word, low byte first, which is how the element is laid out
+	 * and how the game writes the normal beside it.
+	 * <p>
+	 * <strong>Rounded where Iris and the game both truncate</strong> ({@code NormI8.pack},
+	 * {@code BufferBuilder.normalIntValue}), which is what {@code TangentFrame.snorm} already does
+	 * for the chunk mesh: truncation pulls every component toward nought by up to a whole step where
+	 * rounding pulls it by half of one. It is a quantisation and not a convention, so both engines
+	 * read the same direction either way, to within four tenths of a degree.
+	 */
+	public static int pack(float x, float y, float z, float w) {
+		return (snorm(x) & 0xFF) | ((snorm(y) & 0xFF) << 8) | ((snorm(z) & 0xFF) << 16)
+				| ((snorm(w) & 0xFF) << 24);
+	}
+
+	/** One normalised component back out of a word, by its place in it. */
+	public static float unpack(int word, int component) {
+		return (byte) (word >> (component * 8)) * (1.0F / RANGE);
+	}
+
+	/** One component as the signed byte the element holds it in. */
+	private static int snorm(float value) {
+		return Math.round(Math.clamp(value, -1.0F, 1.0F) * RANGE);
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/EntityMesh.java
+++ b/common/src/main/java/dev/vitrail/render/EntityMesh.java
@@ -202,7 +202,7 @@ public final class EntityMesh {
 
 		Vitrail.logger().info("The pack draws the entities or the hand {} now, and the entity mesh "
 				+ "carries {} only while it does, so the world is built again",
-				asked ? "and did not" : "and did", EntityVertex.IDENTIFIERS);
+				asked ? "and did not" : "and did", EntityVertex.APPENDED);
 		minecraft.levelExtractor.allChanged();
 		rebuildAsked = true;
 	}
@@ -241,30 +241,33 @@ public final class EntityMesh {
 
 		if (!asked) {
 			Vitrail.logger().info("Neither the entities nor the hand are drawn by the pack, so the "
-					+ "entity mesh keeps the game's own format and carries no {}",
-					EntityVertex.IDENTIFIERS);
+					+ "entity mesh keeps the game's own format and carries none of {}",
+					EntityVertex.APPENDED);
 
 			return;
 		}
 
 		Vitrail.logger().info("The entity mesh carries {} bytes a vertex instead of {}, the "
-				+ "difference being {}, which is the three identifiers a pack tells one entity, block "
-				+ "entity or held item apart by",
+				+ "difference being {}, which are the three identifiers a pack tells one entity, "
+				+ "block entity or held item apart by, then the middle of the sprite a polygon is "
+				+ "mapped to and the tangent of that mapping",
 				FORMAT.getVertexSize(), DefaultVertexFormat.ENTITY.getVertexSize(),
-				EntityVertex.IDENTIFIERS);
+				EntityVertex.APPENDED);
 	}
 
 	/**
-	 * The game's entity format with one element appended after its six.
+	 * The game's entity format with three elements appended after its six.
 	 * <p>
 	 * Rebuilt element by element from the game's own rather than written out again, so that the six
 	 * keep the names, the formats and the offsets the game gave them whatever the game does to them
-	 * next. Every element of that format is laid out end to end, so appending one after the last
-	 * leaves the six exactly where they were.
+	 * next. Every element of that format is laid out end to end, so appending after the last leaves
+	 * the six exactly where they were.
 	 * <p>
-	 * Four lanes of which three are read, and unsigned: {@code EntityVertex.IDENTIFIERS} says why
-	 * both, and four is in any case the only width that fits, a vertex having to be a whole number of
-	 * words wide.
+	 * The order and the widths are Iris's, {@code vertices/IrisVertexFormats.java:61-70}. The
+	 * identifiers are four unsigned shorts of which three are read; the middle of the sprite is the
+	 * pair of floats {@code UV0} already spells a corner in; the tangent is four normalised bytes,
+	 * which is what the game spells {@code Normal} as and what the fourth component being a
+	 * handedness needs. Each is a whole number of words wide, which a vertex has to stay.
 	 */
 	private static VertexFormat extend() {
 		VertexFormat.Builder builder = VertexFormat.builder(DefaultVertexFormat.ENTITY.getStepRate());
@@ -272,6 +275,9 @@ public final class EntityMesh {
 			builder.addAttribute(element.name(), element.format());
 		}
 
-		return builder.addAttribute(EntityVertex.IDENTIFIERS, GpuFormat.RGBA16_UINT).build();
+		return builder.addAttribute(EntityVertex.IDENTIFIERS, GpuFormat.RGBA16_UINT)
+				.addAttribute(EntityVertex.MID_TEX_COORD, GpuFormat.RG32_FLOAT)
+				.addAttribute(EntityVertex.TANGENT, GpuFormat.RGBA8_SNORM)
+				.build();
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/EntityMesh.java
+++ b/common/src/main/java/dev/vitrail/render/EntityMesh.java
@@ -14,7 +14,7 @@ import net.minecraft.client.Minecraft;
 import org.jspecify.annotations.Nullable;
 
 /**
- * The game's entity mesh with the three identifiers appended to it, as a format of this engine's
+ * The game's entity mesh with three elements of this engine's appended to it, as a format of its
  * own, and the one instant at which it comes into force.
  * <p>
  * <strong>A format APART, which is Iris's own shape</strong>
@@ -30,7 +30,7 @@ import org.jspecify.annotations.Nullable;
  * {@code mixin/core/render/immediate/consumer/BufferBuilderMixin.push} reserves
  * {@code count * this.vertexSize} and copies the source over it RAW whenever
  * {@code srcFormat == this.format}. Lengthening the game's field leaves that identity test passing
- * and copies forty-four bytes a vertex out of a buffer carrying thirty-six. It was measured rather
+ * and copies fifty-six bytes a vertex out of a buffer carrying thirty-six. It was measured rather
  * than deduced: under the lengthened field, on one bench and with only the jar changing, the spider,
  * the enderman, the warden, the charged creeper and the player's own arm were all gone, and only the
  * enderman's particles were left hanging where its body should have been. All three readings are off
@@ -39,7 +39,7 @@ import org.jspecify.annotations.Nullable;
  * A separate object fails that identity test, so the same {@code push} takes {@code copySlow}, which
  * asks {@code VertexSerializerRegistry} for a serializer from one format to the other.
  * {@link dev.vitrail.sodium.EntityMeshSerializer} is what answers, and it has to: left to itself the
- * registry generates one that copies the elements the two formats share and leaves the eight bytes
+ * registry generates one that copies the elements the two formats share and leaves the twenty bytes
  * after them at whatever the arena last held.
  * <p>
  * <strong>It buys a second thing for nothing, and Iris pays a mixin for it.</strong>
@@ -58,11 +58,12 @@ import org.jspecify.annotations.Nullable;
  * the mesh and the binding move together and cannot disagree. {@link dev.vitrail.mixin.RenderPipelineMixin}
  * is that method here.
  * <p>
- * What makes it safe is that the element goes LAST. The game's entity vertex stage declares the six
- * names the game's format spells and knows nothing of a seventh; {@code IntermediaryShaderModule.rebind}
- * walks the format's names and only counts the ones it finds in the SPIR-V, while
- * {@code VulkanRenderPipeline} counts every element of the format, so an element the stage skips
- * shifts the location of everything AFTER it and there has to be nothing after it. That is already
+ * What makes it safe is that the three go LAST. The game's entity vertex stage declares the six
+ * names the game's format spells and knows nothing of the three after them;
+ * {@code IntermediaryShaderModule.rebind} walks the format's names and only counts the ones it finds
+ * in the SPIR-V, while {@code VulkanRenderPipeline} counts every element of the format, so an
+ * element the stage skips shifts the location of everything AFTER it and there has to be nothing
+ * after them. That is already
  * this engine's answer for the chunk mesh, and {@code sodium/TerrainMesh} says it there for Sodium's
  * own shader.
  *
@@ -201,7 +202,7 @@ public final class EntityMesh {
 		}
 
 		Vitrail.logger().info("The pack draws the entities or the hand {} now, and the entity mesh "
-				+ "carries {} only while it does, so the world is built again",
+				+ "only carries these while it does, so the world is built again: {}",
 				asked ? "and did not" : "and did", EntityVertex.APPENDED);
 		minecraft.levelExtractor.allChanged();
 		rebuildAsked = true;
@@ -248,9 +249,9 @@ public final class EntityMesh {
 		}
 
 		Vitrail.logger().info("The entity mesh carries {} bytes a vertex instead of {}, the "
-				+ "difference being {}, which are the three identifiers a pack tells one entity, "
-				+ "block entity or held item apart by, then the middle of the sprite a polygon is "
-				+ "mapped to and the tangent of that mapping",
+				+ "difference being the three identifiers a pack tells one entity, block entity or "
+				+ "held item apart by, then the middle of the sprite a polygon is mapped to and the "
+				+ "tangent of that mapping: {}",
 				FORMAT.getVertexSize(), DefaultVertexFormat.ENTITY.getVertexSize(),
 				EntityVertex.APPENDED);
 	}
@@ -263,7 +264,7 @@ public final class EntityMesh {
 	 * next. Every element of that format is laid out end to end, so appending after the last leaves
 	 * the six exactly where they were.
 	 * <p>
-	 * The order and the widths are Iris's, {@code vertices/IrisVertexFormats.java:61-70}. The
+	 * The order and the widths are Iris's, {@code vertices/IrisVertexFormats.java:49-60}. The
 	 * identifiers are four unsigned shorts of which three are read; the middle of the sprite is the
 	 * pair of floats {@code UV0} already spells a corner in; the tangent is four normalised bytes,
 	 * which is what the game spells {@code Normal} as and what the fourth component being a

--- a/common/src/main/java/dev/vitrail/render/EntityProgram.java
+++ b/common/src/main/java/dev/vitrail/render/EntityProgram.java
@@ -1,5 +1,6 @@
 package dev.vitrail.render;
 
+import dev.vitrail.glsl.EntityVertex;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.program.ProgramFallbacks;
 import dev.vitrail.pack.program.RenderStage;
@@ -96,18 +97,21 @@ final class EntityProgram implements DumpedProgram {
 	private static final String NAMESPACE = Vitrail.MOD_ID;
 
 	/**
-	 * The names the mesh really carries under the spelling a pack writes, which is none of them.
+	 * The names the mesh this piece is drawn from really carries under the spelling a pack writes.
 	 * <p>
-	 * Empty and not an oversight: {@code EntityVertex} answers every fixed function name out of the
-	 * six elements of the format, and there is no room in those six for anything a pack declares for
-	 * itself. {@code mc_Entity} is the one worth naming, since the chunk mesh does carry it: an
-	 * entity is not a block state and has no id to travel on, so a pack branching on it here is
-	 * branching on a constant, and the log says so at every load.
+	 * <strong>Asked of the piece rather than fixed for the family</strong>, because the glint comes
+	 * in by this same door with a mesh of its own: {@code POSITION_TEX}, two elements, out of which
+	 * {@code GlintVertex} makes every other name with a constant. A set fixed here would have the log
+	 * tell a reader that the glint's mesh carries a tangent, and telling a reader which names are
+	 * real is the whole of what that line is for.
 	 * <p>
-	 * The glint's mesh answers the same, and with room to spare: it carries two elements, and
-	 * {@code GlintVertex} makes every other name out of a constant.
+	 * {@code mc_Entity} is in neither answer and is the one worth naming, since the chunk mesh does
+	 * carry it: an entity is not a block state and has no id to travel on, so a pack branching on it
+	 * here is branching on a constant.
 	 */
-	private static final Set<String> ANSWERED = Set.of();
+	private static Set<String> answered(EntityDraw.Element element) {
+		return element.glint() ? Set.of() : EntityVertex.ANSWERED;
+	}
 
 	private final GeometryProgram body;
 
@@ -159,7 +163,7 @@ final class EntityProgram implements DumpedProgram {
 		RenderPipeline game = element.pipeline();
 
 		return new EntityProgram(new GeometryProgram(new GeometryProgram.Pass(FAMILY,
-				element.element(), NAMESPACE, ANSWERED, shadow,
+				element.element(), NAMESPACE, answered(element), shadow,
 				// Nothing blends into the shadow map, whatever the pipeline the row was made from
 				// says. Every shadow program of Iris is declared with BlendModeOverride.OFF
 				// (shaderpack/loading/ProgramId.java:13-19), and the reason is what a map is for:

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -1491,7 +1491,8 @@ final class GeometryProgram {
 		}
 
 		// Split by what the mesh really answers. Only names the mesh has no element for are a gap;
-		// the chunk mesh now answers four of them and the entity mesh answers none.
+		// the chunk mesh now answers four of them and the entity mesh two, while the glint's answers
+		// none, which is why this comes off the PASS rather than off the family.
 		List<String> constants = this.loaded.program().synthesized().keySet().stream()
 				.filter(name -> !this.pass.answered().contains(name))
 				.toList();

--- a/common/src/main/java/dev/vitrail/sodium/EntityMeshSerializer.java
+++ b/common/src/main/java/dev/vitrail/sodium/EntityMeshSerializer.java
@@ -1,6 +1,7 @@
 package dev.vitrail.sodium;
 
 import dev.vitrail.glsl.EntityVertex;
+import dev.vitrail.render.EntityFrame;
 import dev.vitrail.render.EntityIdentifiers;
 import dev.vitrail.render.EntityMesh;
 
@@ -25,20 +26,21 @@ import java.util.Objects;
  * asks {@code VertexSerializerRegistry} for the pair. A format apart is what makes that test fail;
  * this is what answers the question it then asks.
  * <p>
- * <strong>And it has to write the identifiers itself, which is not a detail of this class but the
- * second half of why the mesh cannot simply be widened.</strong> Sodium never calls
+ * <strong>And it has to write the three appended elements itself, which is not a detail of this
+ * class but the second half of why the mesh cannot simply be widened.</strong> Sodium never calls
  * {@code beginVertex} on that road, so {@code BufferBuilderMixin} never runs for a cuboid: without
- * this, no mob would carry the three whatever the stride agreed on. Iris carries the same three in
- * the same place ({@code vertices/sodium/ModelToEntityVertexSerializer.java:76-78}).
+ * this, no mob would carry an identifier, a sprite middle or a tangent whatever the stride agreed
+ * on. Iris carries the same three in the same place
+ * ({@code vertices/sodium/ModelToEntityVertexSerializer.java:66-83}).
  * <p>
  * <strong>Registering is not optional either.</strong> Left with no pair, the registry GENERATES a
  * serializer that copies the elements the two formats share
- * ({@code VertexSerializerRegistryImpl.createSerializer}), which is the six of them: the eight bytes
+ * ({@code VertexSerializerRegistryImpl.createSerializer}), which is the six of them: the twenty bytes
  * after those would keep whatever the arena last held, and a pack would read one mob's identifier off
- * another's leavings.
+ * another's leavings and light it through a tangent that was never written.
  * <p>
- * The three come from {@link EntityIdentifiers}, taken once for the whole run rather than per vertex.
- * That is right for the same reason Iris takes them once per run: a push is one submission's
+ * The identifiers come from {@link EntityIdentifiers}, taken once for the whole run rather than per
+ * vertex. That is right for the same reason Iris takes them once per run: a push is one submission's
  * geometry, so all of it was built while one entity was in hand.
  */
 public final class EntityMeshSerializer implements VertexSerializer {
@@ -49,12 +51,39 @@ public final class EntityMeshSerializer implements VertexSerializer {
 	/** What this engine binds, which is that plus the element. */
 	private static final int CARRIED = EntityMesh.format().getVertexSize();
 
-	/** Where the element starts inside one of those, taken off the format rather than counted. */
-	private static final int OFFSET = Objects.requireNonNull(
-			EntityMesh.format().getElement(EntityVertex.IDENTIFIERS),
-			"The entity mesh was built without " + EntityVertex.IDENTIFIERS).offset();
+	/** Where the identifiers start inside one of those, taken off the format rather than counted. */
+	private static final int IDENTIFIERS = carried(EntityVertex.IDENTIFIERS);
+
+	/** And the middle of the sprite, and the tangent, which are the other two this engine appends. */
+	private static final int MID_TEX_COORD = carried(EntityVertex.MID_TEX_COORD);
+
+	private static final int TANGENT = carried(EntityVertex.TANGENT);
+
+	/**
+	 * Where the three the polygon is worked out from sit inside what Sodium wrote. Off the game's own
+	 * format for the same reason as above: Sodium writes at the game's stride, and reading a position
+	 * or a texture coordinate a fixed number of bytes in would be a literal to keep in step with a
+	 * layout this engine does not own.
+	 */
+	private static final int POSITION = written("Position");
+
+	private static final int TEX_COORD = written("UV0");
+
+	private static final int NORMAL = written("Normal");
 
 	private EntityMeshSerializer() {
+	}
+
+	/** Where one element of the mesh this engine binds starts inside a vertex of it. */
+	private static int carried(String element) {
+		return Objects.requireNonNull(EntityMesh.format().getElement(element),
+				"The entity mesh was built without " + element).offset();
+	}
+
+	/** The same for the game's own format, which is what Sodium hands over. */
+	private static int written(String element) {
+		return Objects.requireNonNull(DefaultVertexFormat.ENTITY.getElement(element),
+				"The game's entity format has no " + element).offset();
 	}
 
 	/**
@@ -72,10 +101,22 @@ public final class EntityMeshSerializer implements VertexSerializer {
 	}
 
 	/**
-	 * Four shorts and not one long, for the reason {@code BufferBuilderMixin} writes four:
-	 * {@code MemoryUtil} writes in the machine's own order, so a short at a time lands each lane
-	 * where the format put it whichever way round the machine is. The fourth lane is a lane of the
-	 * element like the other three and is written at nought rather than left.
+	 * A run of Sodium's vertices into a run of this engine's, quad by quad.
+	 * <p>
+	 * <strong>Quad by quad because two of the three elements belong to the polygon</strong>, and this
+	 * is the road where the four corners are simply four strides apart: Sodium wrote them into one
+	 * arena and handed the whole run over at once. Iris walks it the same way,
+	 * {@code vertices/sodium/ModelToEntityVertexSerializer.serialize}.
+	 * <p>
+	 * <strong>The normal is left exactly as Sodium wrote it</strong>, which is also Iris's answer on
+	 * this road and not on the other: {@code EntityRenderer.renderCuboid} writes a face's own normal
+	 * onto all four of its corners already, so there is nothing a quad could be asked that its
+	 * corners do not agree on. The {@code BufferBuilder} road has no such promise and works one out.
+	 * <p>
+	 * A run that is not a whole number of quads keeps the flat stand-in on whatever is left over,
+	 * rather than being dropped: Iris's loop copies {@code vertexCount >> 2} quads and never touches
+	 * the remainder at all, which would leave those vertices at whatever the arena last held. Nothing
+	 * of the game writes a partial quad down this road, so it is a guard and not a case.
 	 */
 	@Override
 	public void serialize(long written, long carried, int vertices) {
@@ -83,16 +124,75 @@ public final class EntityMeshSerializer implements VertexSerializer {
 		short blockEntity = (short) EntityIdentifiers.blockEntity();
 		short item = (short) EntityIdentifiers.item();
 
+		int quads = vertices >> 2;
 		long from = written;
 		long into = carried;
-		for (int vertex = 0; vertex < vertices; vertex++) {
-			MemoryUtil.memCopy(from, into, WRITTEN);
-			MemoryUtil.memPutShort(into + OFFSET, entity);
-			MemoryUtil.memPutShort(into + OFFSET + 2L, blockEntity);
-			MemoryUtil.memPutShort(into + OFFSET + 4L, item);
-			MemoryUtil.memPutShort(into + OFFSET + 6L, (short) 0);
+		for (int quad = 0; quad < quads; quad++) {
+			long second = from + WRITTEN;
+			long third = second + WRITTEN;
+			long fourth = third + WRITTEN;
+
+			int normal = MemoryUtil.memGetInt(from + NORMAL);
+			float midU = (MemoryUtil.memGetFloat(from + TEX_COORD)
+					+ MemoryUtil.memGetFloat(second + TEX_COORD)
+					+ MemoryUtil.memGetFloat(third + TEX_COORD)
+					+ MemoryUtil.memGetFloat(fourth + TEX_COORD)) * 0.25F;
+			float midV = (MemoryUtil.memGetFloat(from + TEX_COORD + 4L)
+					+ MemoryUtil.memGetFloat(second + TEX_COORD + 4L)
+					+ MemoryUtil.memGetFloat(third + TEX_COORD + 4L)
+					+ MemoryUtil.memGetFloat(fourth + TEX_COORD + 4L)) * 0.25F;
+			int tangent = EntityFrame.tangent(EntityFrame.unpack(normal, 0),
+					EntityFrame.unpack(normal, 1), EntityFrame.unpack(normal, 2), false,
+					MemoryUtil.memGetFloat(from + POSITION),
+					MemoryUtil.memGetFloat(from + POSITION + 4L),
+					MemoryUtil.memGetFloat(from + POSITION + 8L),
+					MemoryUtil.memGetFloat(from + TEX_COORD),
+					MemoryUtil.memGetFloat(from + TEX_COORD + 4L),
+					MemoryUtil.memGetFloat(second + POSITION),
+					MemoryUtil.memGetFloat(second + POSITION + 4L),
+					MemoryUtil.memGetFloat(second + POSITION + 8L),
+					MemoryUtil.memGetFloat(second + TEX_COORD),
+					MemoryUtil.memGetFloat(second + TEX_COORD + 4L),
+					MemoryUtil.memGetFloat(third + POSITION),
+					MemoryUtil.memGetFloat(third + POSITION + 4L),
+					MemoryUtil.memGetFloat(third + POSITION + 8L),
+					MemoryUtil.memGetFloat(third + TEX_COORD),
+					MemoryUtil.memGetFloat(third + TEX_COORD + 4L));
+
+			for (int corner = 0; corner < 4; corner++) {
+				copy(from, into, entity, blockEntity, item);
+				MemoryUtil.memPutFloat(into + MID_TEX_COORD, midU);
+				MemoryUtil.memPutFloat(into + MID_TEX_COORD + 4L, midV);
+				MemoryUtil.memPutInt(into + TANGENT, tangent);
+				from += WRITTEN;
+				into += CARRIED;
+			}
+		}
+
+		for (int vertex = quads << 2; vertex < vertices; vertex++) {
+			copy(from, into, entity, blockEntity, item);
+			MemoryUtil.memPutFloat(into + MID_TEX_COORD, MemoryUtil.memGetFloat(from + TEX_COORD));
+			MemoryUtil.memPutFloat(into + MID_TEX_COORD + 4L,
+					MemoryUtil.memGetFloat(from + TEX_COORD + 4L));
+			MemoryUtil.memPutInt(into + TANGENT, EntityFrame.FLAT);
 			from += WRITTEN;
 			into += CARRIED;
 		}
+	}
+
+	/**
+	 * One vertex of Sodium's over one of this engine's, with the identifiers written after it.
+	 * <p>
+	 * Four shorts and not one long, for the reason {@code BufferBuilderMixin} writes four:
+	 * {@code MemoryUtil} writes in the machine's own order, so a short at a time lands each lane
+	 * where the format put it whichever way round the machine is. The fourth lane is a lane of the
+	 * element like the other three and is written at nought rather than left.
+	 */
+	private static void copy(long from, long into, short entity, short blockEntity, short item) {
+		MemoryUtil.memCopy(from, into, WRITTEN);
+		MemoryUtil.memPutShort(into + IDENTIFIERS, entity);
+		MemoryUtil.memPutShort(into + IDENTIFIERS + 2L, blockEntity);
+		MemoryUtil.memPutShort(into + IDENTIFIERS + 4L, item);
+		MemoryUtil.memPutShort(into + IDENTIFIERS + 6L, (short) 0);
 	}
 }

--- a/common/src/main/java/dev/vitrail/sodium/EntityMeshSerializer.java
+++ b/common/src/main/java/dev/vitrail/sodium/EntityMeshSerializer.java
@@ -113,10 +113,13 @@ public final class EntityMeshSerializer implements VertexSerializer {
 	 * onto all four of its corners already, so there is nothing a quad could be asked that its
 	 * corners do not agree on. The {@code BufferBuilder} road has no such promise and works one out.
 	 * <p>
-	 * A run that is not a whole number of quads keeps the flat stand-in on whatever is left over,
-	 * rather than being dropped: Iris's loop copies {@code vertexCount >> 2} quads and never touches
-	 * the remainder at all, which would leave those vertices at whatever the arena last held. Nothing
-	 * of the game writes a partial quad down this road, so it is a guard and not a case.
+	 * A run that is not a whole number of quads keeps the stand-in on whatever is left over, rather
+	 * than being dropped: Iris's loop copies {@code vertexCount >> 2} quads and never touches the
+	 * remainder at all, which would leave those vertices at whatever the arena last held. It is the
+	 * same stand-in {@code BufferBuilderMixin} writes for the same reason, nought for the sprite
+	 * middle and {@code EntityFrame.FLAT} for the tangent, which are the two values
+	 * {@code VertexPrologue} hands a mesh carrying neither. Nothing of the game writes a partial quad
+	 * down this road, so it is a guard and not a case.
 	 */
 	@Override
 	public void serialize(long written, long carried, int vertices) {
@@ -171,9 +174,8 @@ public final class EntityMeshSerializer implements VertexSerializer {
 
 		for (int vertex = quads << 2; vertex < vertices; vertex++) {
 			copy(from, into, entity, blockEntity, item);
-			MemoryUtil.memPutFloat(into + MID_TEX_COORD, MemoryUtil.memGetFloat(from + TEX_COORD));
-			MemoryUtil.memPutFloat(into + MID_TEX_COORD + 4L,
-					MemoryUtil.memGetFloat(from + TEX_COORD + 4L));
+			MemoryUtil.memPutFloat(into + MID_TEX_COORD, 0.0F);
+			MemoryUtil.memPutFloat(into + MID_TEX_COORD + 4L, 0.0F);
 			MemoryUtil.memPutInt(into + TANGENT, EntityFrame.FLAT);
 			from += WRITTEN;
 			into += CARRIED;

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -11,6 +11,7 @@
 		"BlockEntityRenderStateAccessor",
 		"BlockRendererMixin",
 		"BufferBuilderMixin",
+		"ByteBufferBuilderAccessor",
 		"ChunkMeshFormatsMixin",
 		"ChunkVertexMixin",
 		"ClientLevelMixin",

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -223,13 +223,14 @@ unaffected.
 Two consequences follow from how that geometry reaches the pack, and both are worth recognising
 rather than reporting as separate bugs:
 
-- **One value a pack reads off it is a constant rather than this piece's own**, the material id, and
-  there the reference does the same: an entity mesh carries none. Everything else a pack reads of
-  this geometry is now its own. The middle of the sprite a face is mapped to and the tangent of that
-  mapping are worked out over each polygon and handed over on its corners, which is what a normal
-  map on a mob or on a piece of armour is read through; so are the three a pack compares against a
-  kind of mob, the block a block entity stands in and the item being drawn. The held hand shows
-  whatever the mobs show, arriving by the same door and in the same vertex format.
+- **The values a pack reads off a polygon are this piece's own, and the ones that describe a BLOCK
+  are constants.** The middle of the sprite a face is mapped to and the tangent of that mapping are
+  worked out over each polygon and handed over on its corners, which is what a normal map on a mob
+  or on a piece of armour is read through; so are the three a pack compares against a kind of mob,
+  the block a block entity stands in and the item being drawn. What stays constant is the material
+  id and the offset to the middle of a block, and there the reference does the same: an entity is
+  not a block and has neither. The held hand shows whatever the mobs show, arriving by the same door
+  and in the same vertex format.
 - A pack can allocate a colour target for a family that is not drawn through it. BSL allocates one
   for glowing entities alone, and its deferred pass samples that target, so the chain reads a clear
   across a whole target.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -223,16 +223,13 @@ unaffected.
 Two consequences follow from how that geometry reaches the pack, and both are worth recognising
 rather than reporting as separate bugs:
 
-- **Two of the values a pack reads off it are constants rather than this piece's own**: the middle
-  of the sprite a face is mapped to, and the tangent of that mapping. Neither is a property of one
-  vertex, both having to be worked out over a whole polygon, and that is the work this engine does
-  not do yet: the reference does it and hands the answer over on the vertex, where a pack reads the
-  same constant here for every draw. What that looks like is entirely the pack's business. The
-  material id is a constant too, and
-  there the reference does the same, an entity mesh carrying none. The three a pack compares against
-  a kind of mob, the block a block entity stands in and the item being drawn are this piece's own
-  and no longer constants. The held hand shows whatever the mobs show, arriving by the same door and
-  in the same vertex format.
+- **One value a pack reads off it is a constant rather than this piece's own**, the material id, and
+  there the reference does the same: an entity mesh carries none. Everything else a pack reads of
+  this geometry is now its own. The middle of the sprite a face is mapped to and the tangent of that
+  mapping are worked out over each polygon and handed over on its corners, which is what a normal
+  map on a mob or on a piece of armour is read through; so are the three a pack compares against a
+  kind of mob, the block a block entity stands in and the item being drawn. The held hand shows
+  whatever the mobs show, arriving by the same door and in the same vertex format.
 - A pack can allocate a colour target for a family that is not drawn through it. BSL allocates one
   for glowing entities alone, and its deferred pass samples that target, so the chain reads a clear
   across a whole target.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -225,21 +225,27 @@ attribute read from the wrong offset - a picture, and a wrong one, with nothing 
 refused and named in the log instead. The glint is the one exception and it is a narrow one: it is
 drawn from a two-element quad the door decodes as well.
 
-That layout is the game's own with **one element appended**, holding the three numbers a pack tells
-one kind of mob, block entity or held item apart by. It is a format of the engine's rather than the
-game's own object lengthened, and the difference is not cosmetic: Sodium writes every cuboid of a mob
-at the game's stride and copies the run over untouched whenever the two are the same object, so
-widening the game's own leaves that copy reading eight bytes a vertex past what was written and no
-mob is drawn at all. The engine registers the conversion between the two formats with Sodium instead,
-which is where those cuboids get their three numbers.
+That layout is the game's own with **three elements appended**: the numbers a pack tells one kind of
+mob, block entity or held item apart by, then the middle of the sprite a face is mapped to and the
+direction the texture runs in over that face. The last two belong to a POLYGON rather than to a
+corner, so the four corners of a quad carry one pair and one direction between them, and they are
+what a normal map on a mob is read through. It is a format of the engine's rather than the game's
+own object lengthened, and the difference is not cosmetic: Sodium writes every cuboid of a mob at
+the game's stride and copies the run over untouched whenever the two are the same object, so
+widening the game's own leaves that copy reading twenty bytes a vertex past what was written and no
+mob is drawn at all. The engine registers the conversion between the two formats with Sodium
+instead, which is where those cuboids get their three. What the game writes vertex by vertex rather
+than as a cuboid, a held item and a chest among them, is filled on a road of its own, one polygon at
+a time as its last corner is written.
 
-The element goes **last**, and that is what lets the game go on drawing through the same mesh. On
-every road where a draw is handed back - a program that would not compile, a family a switch turned
-off, the warm up that follows every load - the game's own entity shader draws it, and that shader
-declares the six names it knows and nothing of the seventh. An element a stage skips shifts the
-location of every element after it in silence, so there has to be nothing after it. The mesh only
-carries the element while the pack is drawing the entities or the hand; turning either switch asks
-the game to rebuild the world, the same door F3+A uses, and it does not ask for a restart.
+The three go **last**, and that is what lets the game go on drawing through the same mesh. On every
+road where a draw is handed back, whether by a program that would not compile, by a family a switch
+turned off or by the warm up that follows every load, the game's own entity shader draws it, and
+that shader declares the six names it knows and nothing of the three after them. An element a stage
+skips shifts the location of every element after it in silence, so there has to be nothing after
+them. The mesh only carries them while the pack is drawing the entities or the hand; turning either
+switch asks the game to rebuild the world, the same door F3+A uses, and it does not ask for a
+restart.
 
 That is the whole reason the beacon beam, the lightning bolt and the text of a sign or a name plate
 still come from the game's own shader: they bind the block, position-colour and glyph layouts. They


### PR DESCRIPTION
## What changes

The entity mesh gains the two elements a pack reads of a polygon rather than of a corner,
`mc_midTexCoord` and `at_tangent`, appended after the identifiers in Iris's own order and widths.
Both roads that write that mesh fill them: `EntityMeshSerializer`, which converts the cuboids Sodium
writes for every mob, and `BufferBuilderMixin`, which every block entity, held item and hand vertex
goes through. Serving one road alone was the thing to avoid: the log would have stopped naming the
pair for the whole family while half of it went on reading a constant. `EntityFrame` holds the
arithmetic the two roads share, which is the tangent and the quad's own normal; the sprite middle is
a mean each road takes as it walks its corners.

## How it differs from the reference, and for what obstacle

Three, all narrower than Iris rather than wider, and each written up where it lives.

- **The normal a quad's corners were given is left alone**, where Iris writes the recomputed face
  normal back over it inside the level render (`MixinBufferBuilder.java:243`,
  `recalculateNormal = ImmediateState.isRenderingLevel`). This engine has no such moment to hang it
  on: it settles its format once and binds it wherever the game declares the entity one, so the
  write would reach geometry Iris never touches, since Iris does not extend the format outside the
  level at all (`MixinBufferBuilder.java:98`). Cost: a quad whose corners carry a normal that is not
  its face's has its tangent measured against the face and its light computed from the corner. No
  entity geometry of the game reaches this road in that state, a `ModelPart` cuboid going by
  Sodium's `CubeMixin` and a baked quad carrying one normal over its four corners.
- **A quad of no area and a tangent of no length are refused** rather than normalised into a NaN,
  where `NormalHelper.computeFaceNormalManual:85-91` has no branch and `rsqrt:417-424` tests exact
  nought. Cost: a polygon a millionth of a block across gets an axis. `EntityFrame` carries the
  whole of it, Iris's two roads answering that case with two different values of their own.
- **A run that is not a whole number of quads keeps the stand-in** instead of being skipped. Iris's
  serializer walks `vertexCount >> 2` quads and never touches the remainder
  (`ModelToEntityVertexSerializer.java`), which would leave those vertices at whatever the arena
  last held.

The polygon is filled in from `beginVertex` and `build` rather than from `endLastVertex`, where Iris
does it (`MixinBufferBuilder.iris$beforeNext`). Those two are the only callers of `endLastVertex`, so
the moment is the same; what it buys is that Sodium's `push` writes a whole run without beginning a
vertex and leaves `vertexPointer` on the last of them, which Iris has to skip with a flag and which
is simply invisible here. No behaviour differs.

## What proves it

- `gradlew build` green.
- `Entites --glslang` over the eight packs: 150 programs, 300 stages compiled out of 300, the nine
  elements present in every vertex stage, text invariants green. 75 programs read `mc_midTexCoord`
  and 61 read `at_tangent`, and all of them are now answered off their element rather than out of a
  constant, which is a new invariant of that tool. `Terrain --glslang` and `Particules` unchanged.
- `Relief`, a new harness tool, over 200 000 generated quads with an analytic reference: the tangent
  lands 0.626 degrees out at worst, which is what three components truncated into signed bytes give
  and is what Iris stores in the same element, it never points against the texture's U axis, and the
  handedness is right on all of them with half the sample mirrored on purpose. Six binary invariants,
  non-zero exit on the first that falls.
- In the game, Bliss on a bench of mobs, twice: a clean launch, no program refused, no error of this
  engine's, the line that names what the mesh carries none of down to `mc_Entity` alone on all nine
  entity programs, and the mobs, their eyes and the arm all drawn.

## What it leaves owing

- The material maps themselves, which are the other half of relief on a mob and are issue #28: a skin
  and an armour layer are plain textures rather than sprites in an atlas, so nothing is built for them
  and both names still read the flat value. A tangent is what a normal map is read THROUGH, so this
  is the half that had to come first, but neither half alone puts relief on a mob.
- No regression check stands behind the two writers themselves. Both name classes of the game, so the
  off-game harness cannot compile them; what it covers is the arithmetic they share and the head that
  reads the elements.

Closes #49