### PR TITLE
feat(render): read the material maps of a texture that is no atlas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ what the next one holds.
 
 ### Added
 
+- **A mob and a piece of armour take the relief their resource pack draws for them.** A skin and an
+  armour layer are textures of their own rather than sprites in an atlas, so the maps a material
+  resource pack ships beside them were never read at all and both names came back flat: every mob
+  stayed matte while the terrain around it had relief. They are now read from whichever texture the
+  draw is really using, the same way the atlases already were, and the log names each texture that
+  answers as the skin first comes on screen. A skin downloaded from the skin server rather than
+  shipped by the resource pack has no maps beside it and is left alone.
+
 - **A normal map on a mob, on armour or on a chest is read the right way round.** The two values a
   pack works a bump out from, the middle of the sprite a face is mapped to and the direction the
   texture runs in over it, were the same constant for every face of every piece: a pack lighting a
@@ -24,7 +32,7 @@ what the next one holds.
   entities, on a held item and on the hand alike. Of the hundred and fifty entity programs the eight
   packs tested ship between them, seventy-five read the sprite middle and sixty-one read the
   direction. What it changes on screen depends on the resource pack as well: a mob with no normal
-  map beside its skin has nothing to tilt, which is a second thing and is not fixed here.
+  map beside its skin has nothing to tilt, and finding that map is the entry above.
 
 - **A mob flashes again when it is hurt, and a creeper whitens before it goes off.** The colour the
   game lays over a mob it has just damaged was reaching the pack as one number for the whole world,

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -4,6 +4,7 @@ import dev.vitrail.render.EntityDraw;
 import dev.vitrail.render.HandDraw;
 import dev.vitrail.render.PackChain;
 import dev.vitrail.render.PbrAtlases;
+import dev.vitrail.render.PbrTextures;
 import dev.vitrail.render.ShadowGeometry;
 import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.sodium.EntityMeshSerializer;
@@ -66,8 +67,19 @@ public final class EngineStages {
 	 * <p>
 	 * The frame graph no longer carries a pass of ours, only this reading: the shadow map is drawn
 	 * at the end of the frame, for the next one, and this is what the stage needs from here.
+	 * <p>
+	 * It is also the top of the level frame, which is a second thing entirely and is why the first
+	 * line below has nothing to do with the two arguments.
 	 */
 	public static void frameGraphSetup(Matrix4fc modelView, Vec3 cameraPosition) {
+		// First, and before the shadow question below can send this line home: the graph is being
+		// BUILT here and not executed, so it is the first point of a level frame where no render pass
+		// is open. That is what the material maps of a plain texture need, and it is the reason they
+		// cannot be read where they are wanted - inside the bind of a draw already being recorded.
+		// Nothing to do on a frame that met no new image, which is every frame but the few where a
+		// mob first comes on screen.
+		PbrTextures.load();
+
 		if (!TerrainDraw.shadows()) {
 			return;
 		}
@@ -188,7 +200,9 @@ public final class EngineStages {
 		ShadowGeometry.close();
 
 		// And the material maps, which belong to the resource pack rather than to any shader pack:
-		// nothing in a pack's lifetime touches them, so nothing but the end of the session does.
+		// nothing in a pack's lifetime touches them, so nothing but the end of the session does. Both
+		// doors, the atlases and the plain textures, and neither of them is the other's business.
 		PbrAtlases.close();
+		PbrTextures.close();
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -1151,7 +1151,16 @@ final class GeometryProgram {
 			// atlas and every entity texture answer for themselves without this step knowing which of
 			// them it is drawing. Iris resolves it from the bound albedo for the same reason
 			// (pipeline/IrisRenderingPipeline.java:849-871).
+			//
+			// Two doors and not one, because the two shapes of image are read differently: a stitched
+			// atlas has its maps stitched to match it, and a texture of its own has them beside it
+			// under its own name. Iris keeps the same pair and picks between them by the class of the
+			// bound texture (pbr/loader/PBRTextureLoaderRegistry.java:15-16); here the atlas door
+			// answers only for an image it was built against, so asking it first picks the same one.
 			GpuTextureView served = PbrAtlases.view(this.atlas, material);
+			if (served == null) {
+				served = PbrTextures.view(this.atlas, material);
+			}
 
 			return served == null ? this.flatMaps.get(material).getColorTextureView() : served;
 		}

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -759,9 +759,13 @@ final class GeometryProgram {
 
 		PbrMap material = material(name);
 		if (material != null) {
-			// The atlas's own sampler, because these images ARE the atlas: the same size, the same
-			// chain, and the same sprite under the same texture coordinate, so anything read
-			// differently would be read at a different place than the albedo beside it.
+			// The albedo's own sampler, because a map is read at the albedo's own texture coordinate
+			// whichever door served it, so anything read differently would be read at a different
+			// place than the albedo beside it. What that means is not the same on the two doors: an
+			// atlas's maps ARE the atlas, the same size and the same chain with every sprite in the
+			// same slot, where a plain texture's cover the same whole range at a resolution of their
+			// own and carry no chain at all. A mipmapped sampler on the second is harmless rather
+			// than overlooked: the view carries one level, so the read is bounded by the image.
 			//
 			// Except the specular map under labPBR, where a filter that blends two texels of it
 			// produces a material that is in neither of them. Iris asks the same question here

--- a/common/src/main/java/dev/vitrail/render/PbrAtlases.java
+++ b/common/src/main/java/dev/vitrail/render/PbrAtlases.java
@@ -27,15 +27,16 @@ import java.util.Properties;
  * atlas, the item atlas and the particle atlas each answer for themselves without anything having
  * to know which is which.
  * <p>
- * <strong>A texture that is not an atlas gets nothing, and that is a divergence.</strong> Iris
- * registers a second loader for a plain texture
+ * <strong>A texture that is not an atlas is not this file's business, and it is not lost either.</strong>
+ * Iris registers a second loader for a plain texture
  * ({@code pbr/loader/PBRTextureLoaderRegistry.java:15} onto
  * {@code pbr/loader/SimplePBRLoader.java:19-31}), resolved per bound albedo at
- * {@code pbr/texture/PBRTextureManager.java:126-138}, so an entity skin and an armour layer read
- * their own {@code _n} and {@code _s} there. Here nothing but a stitched atlas is a door, so those
- * read the flat value: a mob stays matte while the terrain around it has relief. Nothing in 26.2
- * forbids the second door - the game hands out plain textures by name like any other - so this is
- * work not done rather than a wall, and it is the honest name for it.
+ * {@code pbr/texture/PBRTextureManager.java:126-141}, so an entity skin and an armour layer read
+ * their own {@code _n} and {@code _s} there. {@link PbrTextures} is that second door, and
+ * {@link GeometryProgram} asks this one first and it second. What decides between them here is not
+ * the class of the texture but the answer: these maps are built against one image and follow it
+ * alone, so an atlas the pack ships nothing for and a texture that is no atlas at all both fall
+ * through to the same place.
  * <p>
  * Only the geometry programs are served, which is Iris's shape: {@code normals} and
  * {@code specular} are added by {@code IrisSamplers.addLevelSamplers} and by nothing else

--- a/common/src/main/java/dev/vitrail/render/PbrTextures.java
+++ b/common/src/main/java/dev/vitrail/render/PbrTextures.java
@@ -67,6 +67,15 @@ public final class PbrTextures {
 	 * rather than the image, this is what lets a reload be met without a hook of its own - the new
 	 * image misses below, its name is found here, and what the old one held is handed back before the
 	 * new is built.
+	 * <p>
+	 * <strong>What that does not cover is a name that is never drawn again, and it is a divergence
+	 * worth its two lines.</strong> Iris hands a pair back the moment the albedo it followed is
+	 * deleted ({@code pbr/texture/PBRTextureManager.java:147-152}). Here nothing is watching the
+	 * deletion, so after a resource reload the two images built for a skin the player never meets
+	 * again stay resident until the session ends. It is bounded rather than open - one pair per
+	 * distinct name ever served, and the next reload of that name frees it - so this is work not
+	 * done rather than a wall: what it would take is a hook on the game closing a texture, which is
+	 * a mixin nothing else here needs yet.
 	 */
 	private static final Map<Identifier, Maps> BY_NAME = new HashMap<>();
 
@@ -200,9 +209,16 @@ public final class PbrTextures {
 	/**
 	 * The name the game loaded an image under, or null where no texture of its own carries it.
 	 * <p>
-	 * Only a {@link SimpleTexture} is answered for, which is Iris's own line: its registry holds this
-	 * class and the atlas one and nothing else, so an image the game builds rather than reads - the
-	 * light map, the overlay, a skin that came down over HTTP - has no map beside it on either side.
+	 * Only a {@link SimpleTexture} is answered for, which is where Iris draws the same line: its
+	 * registry holds this class and the atlas one and nothing else, so an image the game builds
+	 * rather than reads - the light map, the overlay, a skin that came down over HTTP - has no map
+	 * beside it on either side. The test is not written the same way and the difference is worth the
+	 * sentence: Iris looks the loader up by the EXACT class ({@code texture.getClass()} into a map
+	 * at {@code pbr/texture/PBRTextureManager.java:129} and
+	 * {@code pbr/loader/PBRTextureLoaderRegistry.java:27-28}), where this takes subclasses too. On
+	 * 26.2 the two answer the same for everything the game ships, {@code SimpleTexture} having no
+	 * subclass in it, so what the difference decides today is nothing.
+	 * <p>
 	 * The name is the texture's own resource identifier rather than the key it is registered under,
 	 * which is the one Iris reads too ({@code pbr/loader/SimplePBRLoader.java:20}): the two differ
 	 * wherever the game loads one file into a slot named after something else.

--- a/common/src/main/java/dev/vitrail/render/PbrTextures.java
+++ b/common/src/main/java/dev/vitrail/render/PbrTextures.java
@@ -1,0 +1,317 @@
+package dev.vitrail.render;
+
+import dev.vitrail.mixin.TextureManagerAccessor;
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.platform.NativeImage;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.GpuTexture;
+import com.mojang.blaze3d.textures.GpuTextureView;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.AbstractTexture;
+import net.minecraft.client.renderer.texture.SimpleTexture;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.server.packs.resources.ResourceManager;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * The other door onto the same two names: what a resource pack ships beside a texture that is a
+ * texture and not an atlas, which is what an entity skin and an armour layer are.
+ * <p>
+ * {@link PbrAtlases} answers for a stitched atlas, where every sprite lives inside one image and the
+ * maps have to be stitched to match it. Nothing of that applies here. The draw binds one whole image
+ * and reads it over its whole range, so {@code creeper_n.png} beside {@code creeper.png} is uploaded
+ * as it is drawn: no slot to land in, no border to replicate, and no mip chain, the albedo beside it
+ * having none either ({@code ReloadableTexture.doLoad} creates its texture with one level).
+ * <p>
+ * That pair of doors is Iris's shape and not a division invented here: it registers one loader per
+ * texture class ({@code pbr/loader/PBRTextureLoaderRegistry.java:15-16}), the atlas one against
+ * {@code TextureAtlas} and {@code pbr/loader/SimplePBRLoader.java:19-31} against
+ * {@code SimpleTexture}, and resolves between them from the albedo the draw has bound
+ * ({@code pbr/texture/PBRTextureManager.java:126-141}). The resolution on this side is the same
+ * question asked of the same thing, and it lands in the same place: {@link GeometryProgram} tries
+ * the atlas door first and this one behind it.
+ * <p>
+ * <strong>A map cannot be read at the moment it is wanted, and that decides the whole shape of this
+ * file.</strong> The want is discovered inside {@code GeometryProgram.bind}, which runs inside the
+ * render pass the draw is being recorded into, where creating a texture and writing to it is not
+ * allowed. So a texture met for the first time is remembered, answered with the flat value for that
+ * frame, and read at the top of the next one. Iris does the same, at the same place and by the same
+ * means: {@code pipeline/IrisRenderingPipeline.java:856} asks for the maps while it binds its
+ * samplers, and {@code pbr/texture/PBRTextureManager.java:116-123} answers with the flat pair and
+ * queues the read into its own {@code onNewFrame}. What a player sees either way is one frame of a
+ * mob without relief, at the moment it first comes on screen.
+ */
+public final class PbrTextures {
+
+	/** Written once and sampled. Nothing is ever cleared into one of these, so no attachment. */
+	private static final int USAGE = GpuTexture.USAGE_COPY_DST | GpuTexture.USAGE_TEXTURE_BINDING;
+
+	/**
+	 * By the name the texture was loaded from, because the texture is what a resource reload
+	 * replaces: the game closes the old one and builds another under the same name. Keyed on the name
+	 * rather than the image, this is what lets a reload be met without a hook of its own - the new
+	 * image misses below, its name is found here, and what the old one held is handed back before the
+	 * new is built.
+	 */
+	private static final Map<Identifier, Maps> BY_NAME = new HashMap<>();
+
+	/**
+	 * By the image a draw really binds, which is the question {@link #view} is asked and the only one
+	 * it can answer without walking the game's whole register. It holds the empty answer too, or a
+	 * texture the pack ships nothing for would be looked up again at every draw of it.
+	 * <p>
+	 * Weakly, and that is what keeps a session of reloads from growing: the keys are the game's own
+	 * images, an entry lives exactly as long as the image a draw could still bind, and {@link Maps}
+	 * deliberately holds no reference back to the image it was built from. Identity comes with the
+	 * map for free, {@code GpuTexture} defining neither {@code equals} nor {@code hashCode}.
+	 */
+	private static final Map<GpuTexture, Maps> BY_TEXTURE = new WeakHashMap<>();
+
+	/** The images met since the last frame began, read at the top of the next one. */
+	private static final Set<GpuTexture> WANTED = Collections.newSetFromMap(new IdentityHashMap<>());
+
+	/** What a texture the resource pack ships neither map for is remembered as. */
+	private static final Maps NOTHING = new Maps();
+
+	private PbrTextures() {
+	}
+
+	/**
+	 * The map behind one of the two names for the image a pass is drawing with, or null where the
+	 * resource pack ships none for it, where the image is not one the game loaded from a resource, or
+	 * where it is met for the first time and has not been read yet.
+	 *
+	 * @param bound the image the pass draws with, which is null for every family that has none
+	 * @param map   which of the two names is being answered
+	 */
+	static GpuTextureView view(GpuTextureView bound, PbrMap map) {
+		if (bound == null) {
+			return null;
+		}
+
+		Maps built = BY_TEXTURE.get(bound.texture());
+		if (built == null) {
+			WANTED.add(bound.texture());
+
+			return null;
+		}
+
+		return built.views.get(map);
+	}
+
+	/**
+	 * Reads what the images met during the last frame have beside them, at a point of the frame where
+	 * no render pass is open.
+	 */
+	public static void load() {
+		if (WANTED.isEmpty()) {
+			return;
+		}
+
+		Minecraft minecraft = Minecraft.getInstance();
+		if (minecraft == null) {
+			WANTED.clear();
+
+			return;
+		}
+
+		Map<Identifier, AbstractTexture> loaded =
+				((TextureManagerAccessor) minecraft.getTextureManager()).vitrail$byPath();
+		ResourceManager resources = minecraft.getResourceManager();
+
+		for (GpuTexture wanted : WANTED) {
+			BY_TEXTURE.put(wanted, read(wanted, loaded, resources));
+		}
+
+		WANTED.clear();
+	}
+
+	/**
+	 * Hands back every image built for every texture. Called where the device is still alive, which
+	 * is the whole reason it is a call and not a finaliser.
+	 */
+	public static void close() {
+		BY_NAME.values().forEach(Maps::close);
+		BY_NAME.clear();
+		BY_TEXTURE.clear();
+		WANTED.clear();
+	}
+
+	/**
+	 * What one image of the game has beside it, or {@link #NOTHING} where it has neither map, where
+	 * the game did not load it from a resource, or where reading it failed.
+	 */
+	private static Maps read(GpuTexture wanted, Map<Identifier, AbstractTexture> loaded,
+			ResourceManager resources) {
+		Identifier name = named(wanted, loaded);
+		if (name == null) {
+			return NOTHING;
+		}
+
+		// Whatever this name held before, which is what a resource reload leaves behind: the image
+		// under it has been replaced, so the maps built against the old one are reached by nothing
+		// and go back here rather than at the end of the session.
+		Maps replaced = BY_NAME.remove(name);
+		if (replaced != null) {
+			replaced.close();
+		}
+
+		Maps built = new Maps();
+		try {
+			for (PbrMap map : PbrMap.values()) {
+				read(built, map, beside(name, map), resources);
+			}
+		} catch (RuntimeException e) {
+			// Named and swallowed, the same answer PbrAtlases gives for the same reason: an image
+			// beside a texture is an improvement on a flat texel and none of them is owed, so a
+			// resource pack's file does not take the world down with it.
+			built.close();
+			Vitrail.logger().error("The material maps of {} could not be built, so it keeps the flat "
+					+ "values", name, e);
+
+			return NOTHING;
+		}
+
+		if (built.views.isEmpty()) {
+			return NOTHING;
+		}
+
+		BY_NAME.put(name, built);
+		Vitrail.logger().info("The resource pack answers {} for {}", built.answered(), name);
+
+		return built;
+	}
+
+	/**
+	 * The name the game loaded an image under, or null where no texture of its own carries it.
+	 * <p>
+	 * Only a {@link SimpleTexture} is answered for, which is Iris's own line: its registry holds this
+	 * class and the atlas one and nothing else, so an image the game builds rather than reads - the
+	 * light map, the overlay, a skin that came down over HTTP - has no map beside it on either side.
+	 * The name is the texture's own resource identifier rather than the key it is registered under,
+	 * which is the one Iris reads too ({@code pbr/loader/SimplePBRLoader.java:20}): the two differ
+	 * wherever the game loads one file into a slot named after something else.
+	 */
+	private static Identifier named(GpuTexture wanted, Map<Identifier, AbstractTexture> loaded) {
+		for (AbstractTexture texture : loaded.values()) {
+			if (texture instanceof SimpleTexture simple && holds(simple, wanted)) {
+				return simple.resourceId();
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether a texture of the game's is the image wanted. Identity and never contents, and caught
+	 * rather than tested: a texture registered for the next reload holds no image until that reload
+	 * applies one, and the getter answers that with a throw.
+	 */
+	@SuppressWarnings("ReferenceEquality")
+	private static boolean holds(AbstractTexture texture, GpuTexture wanted) {
+		try {
+			return texture.getTexture() == wanted;
+		} catch (IllegalStateException absent) {
+			return false;
+		}
+	}
+
+	/**
+	 * Where a map lives beside a plain texture, the suffix going before the extension rather than
+	 * after it: {@code creeper.png} is answered by {@code creeper_n.png} and never by
+	 * {@code creeper.png_n}. Iris builds the same name at {@code pbr/texture/PBRType.java:57-64}, and
+	 * falls back the same way on a path that carries no extension at all.
+	 */
+	private static Identifier beside(Identifier texture, PbrMap map) {
+		String path = texture.getPath();
+		int dot = path.lastIndexOf('.');
+		String suffixed = dot > path.lastIndexOf('/')
+				? path.substring(0, dot) + map.suffix() + path.substring(dot)
+				: path + map.suffix();
+
+		return Identifier.fromNamespaceAndPath(texture.getNamespace(), suffixed);
+	}
+
+	/**
+	 * One map, read and uploaded whole, or nothing added at all where the pack ships none under that
+	 * name or ships one that cannot be decoded.
+	 * <p>
+	 * No scaling and no mip chain, where {@link PbrAtlas} does both: a map is read over its own whole
+	 * range by a texture coordinate that runs from nought to one, so a pack drawing its maps at
+	 * another resolution than its skins is met by the sampler rather than by a resample. That is
+	 * Iris's answer as well, its simple loader handing the file straight to a texture of the game's.
+	 */
+	private static void read(Maps into, PbrMap map, Identifier location, ResourceManager resources) {
+		Optional<Resource> resource = resources.getResource(location);
+		if (resource.isEmpty()) {
+			return;
+		}
+
+		NativeImage image;
+		try (InputStream stream = resource.get().open()) {
+			image = NativeImage.read(stream);
+		} catch (IOException | RuntimeException e) {
+			Vitrail.logger().warn("{} could not be read, so its texture keeps the flat {} value",
+					location, map.sampler(), e);
+
+			return;
+		}
+
+		try {
+			GpuDevice device = RenderSystem.getDevice();
+			GpuTexture texture = device.createTexture(location::toString, USAGE,
+					GpuFormat.RGBA8_UNORM, image.getWidth(), image.getHeight(), 1, 1);
+			// Held before the view is made and not after: a throw between the two would otherwise
+			// leave an image nothing can ever close.
+			into.textures.put(map, texture);
+			into.views.put(map, device.createTextureView(texture));
+			device.createCommandEncoder().writeToTexture(texture, image);
+		} finally {
+			image.close();
+		}
+	}
+
+	/**
+	 * The two images that follow one texture of the game, each of them absent wherever the resource
+	 * pack ships nothing under that name.
+	 * <p>
+	 * <strong>It holds no reference to the texture it was built from, and that is not an
+	 * omission</strong>: {@link #BY_TEXTURE} keys on that texture weakly, and a value pointing back
+	 * at its own key is what would keep every image of every reload alive for the session.
+	 */
+	private static final class Maps {
+
+		private final Map<PbrMap, GpuTexture> textures = new EnumMap<>(PbrMap.class);
+		private final Map<PbrMap, GpuTextureView> views = new EnumMap<>(PbrMap.class);
+
+		/** Which of the two names answered, in the order the names are declared. */
+		String answered() {
+			return this.views.keySet().stream().map(PbrMap::sampler)
+					.collect(Collectors.joining(" and "));
+		}
+
+		void close() {
+			// The views first: closing a texture does not close the views onto it, and nothing on the
+			// Vulkan backend checks that a bound view is still alive.
+			this.views.values().forEach(GpuTextureView::close);
+			this.views.clear();
+			this.textures.values().forEach(GpuTexture::close);
+			this.textures.clear();
+		}
+	}
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -111,10 +111,15 @@ near the top of the log rather than around world load. No line means either that
 the stack ships a map, or that building them failed, and the failure says so on its own line just
 above.
 
-Two more places relief goes missing even with a material pack installed: **mobs and armour have
-none**, and **an animated block's map does not animate**. Both are named work not done, with what
-they cost, in [Material maps](internals/material-maps.md#what-is-not-done), which is also where the
-rest of the mechanism lives.
+**A mob and a piece of armour are named one at a time, and later.** Their maps are not stitched into
+an atlas, so they are read the first time the skin is drawn rather than at the resource load: expect
+those lines around the moment a mob first comes on screen, one per texture, naming the texture
+itself. The mob that line names wears its relief from the next frame on.
+
+One place relief still goes missing even with a material pack installed: **an animated block's map
+does not animate**. It is named work not done, with what it costs, in
+[Material maps](internals/material-maps.md#what-is-not-done), which is also where the rest of the
+mechanism lives.
 
 ## The water
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -114,7 +114,8 @@ above.
 **A mob and a piece of armour are named one at a time, and later.** Their maps are not stitched into
 an atlas, so they are read the first time the skin is drawn rather than at the resource load: expect
 those lines around the moment a mob first comes on screen, one per texture, naming the texture
-itself. The mob that line names wears its relief from the next frame on.
+itself. A line is printed at the top of a frame and the mob wears its relief in that same frame, so
+what a player sees is one flat frame: the one the mob first appeared in.
 
 One place relief still goes missing even with a material pack installed: **an animated block's map
 does not animate**. It is named work not done, with what it costs, in

--- a/docs/internals/material-maps.md
+++ b/docs/internals/material-maps.md
@@ -78,20 +78,37 @@ constant and is exposed nowhere, so it is recovered from the sprite's own first 
 resolution from its blocks. The map is resampled to the sprite's size first, by point sampling when
 the target is a whole multiple of the source and by a weighted average otherwise.
 
+## The second door: a texture that is no atlas
+
+An entity skin and an armour layer are textures of their own rather than sprites in an atlas, so
+none of the mechanism above applies to them: there is no slot to land in, no border to replicate and
+no companion to stitch. `creeper_n.png` beside `creeper.png` is read whole and uploaded whole, at
+its own resolution, with no mip chain, because the albedo beside it has none either.
+
+Iris keeps exactly this pair of doors, one loader per texture class, and picks between them from the
+albedo the draw has bound. Here the pick is made by the answer rather than by the class: the atlas
+maps are built against one image and follow it alone, so an image no atlas answers for falls through
+to this second door on its own.
+
+**A map is read one frame after it is first wanted.** The want is discovered while a draw is being
+recorded, inside a render pass, where a texture cannot be created; so a skin met for the first time
+is remembered, answered with the flat value for that frame, and read at the top of the next one.
+Iris defers the same read at the same place and for the same reason. What either engine shows is one
+frame of a mob without relief, at the moment it first comes on screen.
+
+**What has no map on either side** is an image the game builds rather than reads: the light map, the
+overlay, and a player skin that came down over HTTP rather than out of the resource pack. The engine
+names each texture that does answer, one line each, as it is read.
+
+A held item is **not** in this second group, and it is worth saying because it looks like it should
+be: item textures are sprites in an atlas of their own, so they are served like any other sprite.
+
 ## What is not done
 
-Both of these are work not done rather than a limit of the backend, and both are things Iris does.
+This is work not done rather than a limit of the backend, and it is a thing Iris does.
 
 **The maps do not animate.** A sprite whose albedo has frames gets the first frame of its map, held
 still, so flowing water keeps a moving surface and a fixed normal. Iris gives its companion sprites
 their own animation states and ticks them with the atlas. Nothing in the game's API forbids the same
 here: those animation states are public and the game drives its own atlases through them.
 
-**Textures that are not atlases have no maps.** An entity skin and an armour layer are textures of
-their own rather than sprites in an atlas, so nothing is built for them and the two names read the
-flat value: a mob stays matte while the terrain around it has relief. Iris has a second loader for
-exactly this case, resolved from whichever texture the draw has bound. Nothing here forbids the same
-door; it is not built yet.
-
-A held item is **not** in this second group, and it is worth saying because it looks like it should
-be: item textures are sprites in an atlas of their own, so they are served like any other sprite.

--- a/docs/internals/material-maps.md
+++ b/docs/internals/material-maps.md
@@ -93,8 +93,9 @@ to this second door on its own.
 **A map is read one frame after it is first wanted.** The want is discovered while a draw is being
 recorded, inside a render pass, where a texture cannot be created; so a skin met for the first time
 is remembered, answered with the flat value for that frame, and read at the top of the next one.
-Iris defers the same read at the same place and for the same reason. What either engine shows is one
-frame of a mob without relief, at the moment it first comes on screen.
+Iris defers the same read at the same place and by the same means, and says nothing about what for:
+that reason is this engine's own. What either engine shows is one frame of a mob without relief, the
+one it first comes on screen in.
 
 **What has no map on either side** is an image the game builds rather than reads: the light map, the
 overlay, and a player skin that came down over HTTP rather than out of the resource pack. The engine


### PR DESCRIPTION
## What changes

The two material map names had one door: a stitched atlas. An entity skin and an armour layer are
textures of their own, so nothing was ever built for them and both names came back flat, which left
every mob matte while the terrain around it had relief. This adds the second door. The maps are
resolved from the albedo the draw has bound, exactly as the atlas ones already were, so the pick
between the two costs nothing and nothing has to be told which family it is drawing. A plain
texture's map is read whole and uploaded whole: no slot to land in, no border to replicate and no
mip chain, the albedo beside it having none either.

## How it differs from the reference, and for what obstacle

It does not. Iris keeps the same pair of loaders, one per texture class
(`pbr/loader/PBRTextureLoaderRegistry.java:15-16`), resolves between them from the bound albedo
(`pbr/texture/PBRTextureManager.java:126-141`), reads the suffix in before the extension
(`pbr/texture/PBRType.java:57-64`), and answers for a `SimpleTexture` and nothing else, so an image
the game builds rather than reads has no map on either side.

The one thing worth naming because it looks like a divergence and is not: the read is deferred by a
frame. The want is discovered inside `GeometryProgram.bind`, which runs inside the render pass the
draw is being recorded into, where a texture cannot be created. Iris defers the same read at the
same place, `pipeline/IrisRenderingPipeline.java:856` asking and
`pbr/texture/PBRTextureManager.java:116-123` answering with the flat pair and queueing. What either
engine shows is one frame of a mob without relief, the moment it first comes on screen.

## What proves it

- `gradlew build` green.
- In the game, BSL v10.1.3 with `ADVANCED_MATERIALS` forced on, which is off by default and is what
  gates the pack's whole material path on its entity programs. A hand-made labPBR resource pack
  carries a normal map beside the mob skins. A clean launch names ten of them one at a time as the
  mobs come on screen, each by its own texture, in a sentence the atlas door cannot print.
- No harness: `render/` is covered by none.

## What it leaves owing

The companion maps of an atlas still do not animate, which is unchanged and is written up where it
lives. A skin downloaded from the skin server is not a resource and has no maps, which is Iris's
line too rather than a gap.
