### PR TITLE
feat(dh): give the far terrain of Distant Horizons its depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ what the next one holds.
 
 ### Added
 
+- **The far terrain of Distant Horizons is fogged at the distance it stands at, instead of being
+  treated as sky.** That mod draws its distant land into images of its own and paints only the
+  colour back onto the picture, so everything a pack works out from distance, fog, the point a depth
+  of field focuses on, what water knows is behind it, found nothing there and answered as though the
+  sky went all the way down. Its depth is now written into the world's own before the pack reads
+  any of it, converted on the way: the two are drawn through the same camera but not between the
+  same clip planes, and copied across untouched a hill a thousand blocks off would have landed a
+  few paces from the player's face. Packs are also told the far terrain is there, which is the
+  switch most of them put their own distant-land code behind.
+
+  Two limits worth knowing. What stands beyond the plane the game itself stops drawing at, which is
+  four times the render distance or the cloud distance, whichever is farther, still reads as sky:
+  there is no number left in the depth buffer past that point. And the far terrain is coloured by
+  Distant Horizons and not by the pack, so it is lit its own way and only its shape is the pack's to
+  work with.
+
+  This needs a build of Distant Horizons newer than 3.2.0-b. That one still ends the game on the
+  first frame for the reason `INSTALL.md` gives, and no version of Vitrail changes it.
+
 - **A mob and a piece of armour take the relief their resource pack draws for them.** A skin and an
   armour layer are textures of their own rather than sprites in an atlas, so the maps a material
   resource pack ships beside them were never read at all and both names came back flat: every mob

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,11 @@ what the next one holds.
   Distant Horizons and not by the pack, so it is lit its own way and only its shape is the pack's to
   work with.
 
-  This needs a build of Distant Horizons newer than 3.2.0-b. That one still ends the game on the
-  first frame for the reason `INSTALL.md` gives, and no version of Vitrail changes it.
+  What this waits on is Distant Horizons and not Vitrail. That mod has to draw on this backend at
+  all, which the version named in `INSTALL.md` does not, and it has to hand its depth back without
+  an OpenGL handle in it. The log says which of the two you are looking at, naming Distant Horizons
+  as found or as installed but not in a shape a depth can be read out of when the pack is read, and
+  naming the clip planes it folded between the first time it folds.
 
 - **A mob and a piece of armour take the relief their resource pack draws for them.** A skin and an
   armour layer are textures of their own rather than sprites in an atlas, so the maps a material

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,7 +90,11 @@ config shipped in the jar rather than anything summarised here.
 
 Any mod that unwraps a GPU texture into an OpenGL handle will crash on the Vulkan
 backend, with or without Vitrail. Distant Horizons 3.2.0-b does this and dies on
-the first frame. This is not something Vitrail can work around.
+the first frame. This is not something Vitrail can work around, and the fix is
+that mod's rather than this one's: its own sources no longer make the call on a
+backend that is not OpenGL. On a build that carries the fix, Vitrail folds its
+far terrain into the depth a pack reads and tells the pack the far terrain is
+there; the changelog says what that changes and what it does not reach.
 
 ## Building
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,11 +90,14 @@ config shipped in the jar rather than anything summarised here.
 
 Any mod that unwraps a GPU texture into an OpenGL handle will crash on the Vulkan
 backend, with or without Vitrail. Distant Horizons 3.2.0-b does this and dies on
-the first frame. This is not something Vitrail can work around, and the fix is
-that mod's rather than this one's: its own sources no longer make the call on a
-backend that is not OpenGL. On a build that carries the fix, Vitrail folds its
-far terrain into the depth a pack reads and tells the pack the far terrain is
-there; the changelog says what that changes and what it does not reach.
+the first frame. This is not something Vitrail can work around: the fix belongs
+to that mod and not to this one.
+
+Given a build of it that both draws on this backend and hands its depth back
+without an OpenGL handle in it, Vitrail folds its far terrain into the depth a
+pack reads and tells the pack the far terrain is there. The changelog says what
+that changes and what it does not reach, and the log names which of the two
+cases you are in when the pack is read.
 
 ## Building
 

--- a/common/src/main/java/dev/vitrail/dh/DhDepth.java
+++ b/common/src/main/java/dev/vitrail/dh/DhDepth.java
@@ -72,6 +72,14 @@ public final class DhDepth {
 	private static Field projectionScaleField;
 	private static Field projectionOffsetField;
 
+	private static Field configsField;
+	private static Method graphicsMethod;
+	private static Method renderDistanceMethod;
+	private static Method valueMethod;
+
+	/** Blocks across a chunk, which is what turns DH's own setting into what a pack reads. */
+	private static final int CHUNK = 16;
+
 	private static boolean resolved;
 	private static boolean usable;
 
@@ -167,6 +175,64 @@ public final class DhDepth {
 		}
 	}
 
+	/**
+	 * DH's own near and far clip planes this frame, in blocks, out of the row it drew with. False
+	 * while there is none to be had.
+	 * <p>
+	 * Taken from the matrix and not from {@code getNearClipPlaneDistanceInBlocks}, which answers the
+	 * unclamped near the class comment carries. Iris publishes the unclamped one and is right to:
+	 * under Iris the LODs are drawn by Iris's own programs with a projection Iris builds from it, so
+	 * there it IS the plane the far terrain was rasterised against. Here DH draws them itself, so
+	 * the plane a pack has to be told is DH's own.
+	 *
+	 * @param dest filled with the near plane and then the far one, and left alone on false
+	 */
+	public static boolean planes(Vector2f dest) {
+		if (!zRow(dest)) {
+			return false;
+		}
+
+		float scale = dest.x;
+		float offset = dest.y;
+		if (scale <= 0.0F) {
+			return false;
+		}
+
+		dest.set(offset / (1.0F + scale), offset / scale);
+
+		return true;
+	}
+
+	/**
+	 * How far DH draws, in blocks, or -1 when it cannot be asked. Blocks and not chunks, because
+	 * blocks is what a pack does arithmetic with and what Iris publishes under the same name.
+	 */
+	public static int renderDistanceBlocks() {
+		if (!resolved) {
+			resolve();
+		}
+
+		if (!usable) {
+			return -1;
+		}
+
+		try {
+			Object configs = configsField.get(null);
+			if (configs == null) {
+				return -1;
+			}
+
+			Object value = renderDistanceMethod.invoke(graphicsMethod.invoke(configs));
+
+			return (valueMethod.invoke(value) instanceof Integer chunks) ? chunks * CHUNK : -1;
+		} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
+			usable = false;
+			Vitrail.logger().warn("Distant Horizons' render distance cannot be read, so its far "
+					+ "terrain will stay flat for the rest of this session", e);
+			return -1;
+		}
+	}
+
 	/** Whether anything at all can be expected from DH, without touching the frame's state. */
 	public static boolean present() {
 		if (!resolved) {
@@ -195,6 +261,11 @@ public final class DhDepth {
 			textureViewMethod = wrapperType.getMethod("getTextureView");
 
 			resolveProjection();
+
+			configsField = delayed.getField("configs");
+			graphicsMethod = configsField.getType().getMethod("graphics");
+			renderDistanceMethod = graphicsMethod.getReturnType().getMethod("chunkRenderDistance");
+			valueMethod = renderDistanceMethod.getReturnType().getMethod("getValue");
 
 			usable = true;
 			Vitrail.logger().info("Distant Horizons found, its far terrain will be given a depth");

--- a/common/src/main/java/dev/vitrail/dh/DhDepth.java
+++ b/common/src/main/java/dev/vitrail/dh/DhDepth.java
@@ -3,12 +3,13 @@ package dev.vitrail.dh;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.textures.GpuTextureView;
+import org.joml.Vector2f;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 /**
- * Distant Horizons' own depth image, when there is one to be had.
+ * Distant Horizons' own depth image, and the projection it was drawn with.
  * <p>
  * <strong>Why this exists at all.</strong> DH draws its far terrain into its own colour and depth
  * images and then composites the colour onto the game's texture with depth writing and depth
@@ -18,6 +19,15 @@ import java.lang.reflect.Method;
  * distance at infinity, water that does not know what is behind it. Folding this image into the
  * game's depth before {@code PackDepth} takes its copies is what makes those effects right, and it
  * is the whole of what this package is for.
+ * <p>
+ * <strong>The image is not in the game's volume, and that is why a projection is handed back
+ * beside it.</strong> The two windows agree, both being a reversed Z over zero to one cleared to
+ * zero, and the agreement stops there: {@code RenderUtil.setDhProjectionMatrix} takes the game's
+ * matrix and overwrites its z row with clip planes of DH's own, a near plane pulled in to seven and
+ * a half blocks and a far plane out past the last LOD. A hill a thousand blocks off then carries a
+ * value the game's own volume reads as eight blocks off, which is the player's face. Folded raw the
+ * far terrain would not be flat, it would be in the way. So the fold is a conversion, and
+ * {@link #zRow} is the half of it only DH can answer.
  * <p>
  * <strong>Why reflection.</strong> The accessors that hand back a rendering-API neutral object,
  * {@code getDhDepthTextureBlazeWrapper} and its colour twin, were added to DH's API on
@@ -29,20 +39,38 @@ import java.lang.reflect.Method;
  * carrying those methods ships, this class can become an ordinary typed dependency and the shape of
  * it will not change.
  * <p>
+ * <strong>The projection is reached by an uglier road, and the published ones are wrong.</strong>
+ * {@code IDhApiRenderProxy.getNearClipPlaneDistanceInBlocks} and the {@code nearClipPlane} field of
+ * the event parameter both answer {@code RenderUtil.getNearClipPlaneInBlocks()}, which is the value
+ * BEFORE the clamp to seven and a half the matrix itself is built with: at any ordinary render
+ * distance the two are more than a factor of ten apart. The matrix DH really rasterised with is
+ * held in one place, the private render parameter of its client entry point, so that is what is
+ * read. Iris never needs it, its own programs drawing the LODs with a projection Iris supplies.
+ * <p>
  * Nothing here throws into a frame. Every failure resolves once, says so once, and answers
  * {@code null} forever after, because a far terrain that is merely flat is a picture and a far
- * terrain that raises inside the render is not.
+ * terrain that rises inside the render is not. The image and the projection stand or fall together:
+ * half a conversion is worse than none.
  */
 public final class DhDepth {
 
 	/** DH's entry point holds its proxies in static fields that stay null until the mod is up. */
 	private static final String DELAYED = "com.seibel.distanthorizons.api.DhApi$Delayed";
 
+	/** Where DH keeps the one frame of render parameters it hands its own renderer. */
+	private static final String CLIENT_API =
+			"com.seibel.distanthorizons.core.api.internal.ClientApi";
+
 	/** Resolved once, on the first frame that asks. Null means "asked and cannot be served". */
 	private static Method depthWrapperMethod;
 	private static Method textureViewMethod;
 	private static Field payloadField;
 	private static Field renderProxyField;
+
+	private static Field renderParamsField;
+	private static Field dhProjectionField;
+	private static Field projectionScaleField;
+	private static Field projectionOffsetField;
 
 	private static boolean resolved;
 	private static boolean usable;
@@ -54,9 +82,10 @@ public final class DhDepth {
 	 * DH's depth image as it stands this frame, or null when DH is absent, not yet up, still on its
 	 * OpenGL renderer, or a build too old to answer.
 	 * <p>
-	 * The image is reversed Z over zero to one, cleared to zero, which is the same window the game
-	 * rasterises in, so a merge is a comparison and not a conversion. The conversion a pack reads
-	 * belongs to {@code PackDepth} and stays there.
+	 * The image is reversed Z over zero to one, cleared to zero. That is the window the game
+	 * rasterises in as well, but not the volume: {@link #zRow} carries what has to be undone before
+	 * a value from here means anything beside a value of the game's. The conversion a pack reads is
+	 * a third one again, and belongs to {@code PackDepth}.
 	 */
 	public static GpuTextureView view() {
 		if (!resolved) {
@@ -91,6 +120,53 @@ public final class DhDepth {
 		}
 	}
 
+	/**
+	 * The z row of the matrix DH drew this frame with, as its scale and its offset: the two terms
+	 * that turn an eye distance into the value its image holds. False while there is none to be had.
+	 * <p>
+	 * Two terms and not the two clip planes, because two terms are what the arithmetic wants and the
+	 * planes would have to be turned into them anyway. Read every frame rather than kept: DH moves
+	 * both of its planes with its own render distance, with the player's height above the world and
+	 * with the vanilla render distance its overdraw is worked out from.
+	 *
+	 * @param dest filled with the pair, and left alone when this answers false
+	 */
+	public static boolean zRow(Vector2f dest) {
+		if (!resolved) {
+			resolve();
+		}
+
+		if (!usable) {
+			return false;
+		}
+
+		try {
+			Object params = renderParamsField.get(null);
+			Object matrix = params == null ? null : dhProjectionField.get(params);
+			if (matrix == null) {
+				return false;
+			}
+
+			float offset = projectionOffsetField.getFloat(matrix);
+			if (offset == 0.0F) {
+				// Still the identity it was made as: DH has not rendered a frame of this world yet.
+				return false;
+			}
+
+			dest.set(projectionScaleField.getFloat(matrix), offset);
+
+			return true;
+			// The error is caught with the rest and on purpose: the first read of that field is what
+			// loads DH's client entry point, and a class of DH's that will not load is a far terrain
+			// this engine goes without rather than a frame this engine drops.
+		} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
+			usable = false;
+			Vitrail.logger().warn("Distant Horizons' projection cannot be read, so its depth cannot be "
+					+ "converted and its far terrain will stay flat for the rest of this session", e);
+			return false;
+		}
+	}
+
 	/** Whether anything at all can be expected from DH, without touching the frame's state. */
 	public static boolean present() {
 		if (!resolved) {
@@ -118,6 +194,8 @@ public final class DhDepth {
 					"com.seibel.distanthorizons.api.interfaces.render.IDhApiBlazeTextureWrapper");
 			textureViewMethod = wrapperType.getMethod("getTextureView");
 
+			resolveProjection();
+
 			usable = true;
 			Vitrail.logger().info("Distant Horizons found, its far terrain will be given a depth");
 		} catch (ClassNotFoundException e) {
@@ -125,8 +203,32 @@ public final class DhDepth {
 			usable = false;
 		} catch (ReflectiveOperationException | RuntimeException e) {
 			usable = false;
-			Vitrail.logger().info("Distant Horizons is installed but too old to hand back a "
-					+ "backend neutral depth image, its far terrain will stay flat");
+			Vitrail.logger().info("Distant Horizons is installed but not in a shape a depth can be "
+					+ "read out of, so its far terrain will stay flat: {}", e.toString());
 		}
+	}
+
+	/**
+	 * Opens the road to the matrix. The field it starts at is private, which is the whole reason
+	 * this is a road rather than a call, and the two it ends at are public members of the published
+	 * event parameter DH's own render parameter extends.
+	 */
+	private static void resolveProjection() throws ReflectiveOperationException {
+		// Without initialising it, which matters: the symbols are wanted before the first pack is
+		// read and that class builds its render parameter out of DH's own injector as it loads. The
+		// first read of the field below is what runs it, and that read is a frame being drawn, by
+		// which time DH is up.
+		Class<?> clientApi = Class.forName(CLIENT_API, false, DhDepth.class.getClassLoader());
+		renderParamsField = clientApi.getDeclaredField("RENDER_PARAMS");
+		renderParamsField.setAccessible(true);
+
+		dhProjectionField = renderParamsField.getType().getField("dhProjectionMatrix");
+
+		// Named for what they do and not for what they are called, because the two conventions
+		// disagree: this is m22 and m23 of DH's own matrix class, which numbers the row first where
+		// JOML numbers the column first and calls the same pair m22 and m32.
+		Class<?> matrixType = dhProjectionField.getType();
+		projectionScaleField = matrixType.getField("m22");
+		projectionOffsetField = matrixType.getField("m23");
 	}
 }

--- a/common/src/main/java/dev/vitrail/dh/DhDepth.java
+++ b/common/src/main/java/dev/vitrail/dh/DhDepth.java
@@ -1,0 +1,132 @@
+package dev.vitrail.dh;
+
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.textures.GpuTextureView;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Distant Horizons' own depth image, when there is one to be had.
+ * <p>
+ * <strong>Why this exists at all.</strong> DH draws its far terrain into its own colour and depth
+ * images and then composites the colour onto the game's texture with depth writing and depth
+ * testing both switched off. So its colour reaches the pack the way any family that does not draw
+ * through the pack reaches it, through the seed, and its depth reaches nothing. Every effect a pack
+ * indexes on depth therefore reads sky where the far terrain stands: fog at the far plane, a focal
+ * distance at infinity, water that does not know what is behind it. Folding this image into the
+ * game's depth before {@code PackDepth} takes its copies is what makes those effects right, and it
+ * is the whole of what this package is for.
+ * <p>
+ * <strong>Why reflection.</strong> The accessors that hand back a rendering-API neutral object,
+ * {@code getDhDepthTextureBlazeWrapper} and its colour twin, were added to DH's API on
+ * 11 July 2026, four days after the version number moved past 3.2.0-b. No released build of DH
+ * carries them, so there is no coordinate to compile against; the older accessors that are released
+ * hand back an OpenGL name, which is exactly the thing that cannot exist on this backend. Compiling
+ * against a locally built jar would tie this repository to a path on one machine, so the call is
+ * made by name instead and simply stays quiet on any DH that cannot answer it. When a build
+ * carrying those methods ships, this class can become an ordinary typed dependency and the shape of
+ * it will not change.
+ * <p>
+ * Nothing here throws into a frame. Every failure resolves once, says so once, and answers
+ * {@code null} forever after, because a far terrain that is merely flat is a picture and a far
+ * terrain that raises inside the render is not.
+ */
+public final class DhDepth {
+
+	/** DH's entry point holds its proxies in static fields that stay null until the mod is up. */
+	private static final String DELAYED = "com.seibel.distanthorizons.api.DhApi$Delayed";
+
+	/** Resolved once, on the first frame that asks. Null means "asked and cannot be served". */
+	private static Method depthWrapperMethod;
+	private static Method textureViewMethod;
+	private static Field payloadField;
+	private static Field renderProxyField;
+
+	private static boolean resolved;
+	private static boolean usable;
+
+	private DhDepth() {
+	}
+
+	/**
+	 * DH's depth image as it stands this frame, or null when DH is absent, not yet up, still on its
+	 * OpenGL renderer, or a build too old to answer.
+	 * <p>
+	 * The image is reversed Z over zero to one, cleared to zero, which is the same window the game
+	 * rasterises in, so a merge is a comparison and not a conversion. The conversion a pack reads
+	 * belongs to {@code PackDepth} and stays there.
+	 */
+	public static GpuTextureView view() {
+		if (!resolved) {
+			resolve();
+		}
+
+		if (!usable) {
+			return null;
+		}
+
+		try {
+			Object proxy = renderProxyField.get(null);
+			if (proxy == null) {
+				// DH is present but has not finished starting, which is ordinary on the first frames.
+				return null;
+			}
+
+			Object result = depthWrapperMethod.invoke(proxy);
+			Object wrapper = payloadField.get(result);
+			if (wrapper == null) {
+				// DH answers a failed result until its own texture has been created and bound.
+				return null;
+			}
+
+			Object textureView = textureViewMethod.invoke(wrapper);
+			return (textureView instanceof GpuTextureView view) ? view : null;
+		} catch (ReflectiveOperationException | RuntimeException e) {
+			usable = false;
+			Vitrail.logger().warn("Distant Horizons' depth image cannot be read, its far terrain "
+					+ "will stay flat for the rest of this session", e);
+			return null;
+		}
+	}
+
+	/** Whether anything at all can be expected from DH, without touching the frame's state. */
+	public static boolean present() {
+		if (!resolved) {
+			resolve();
+		}
+
+		return usable;
+	}
+
+	private static void resolve() {
+		resolved = true;
+
+		try {
+			Class<?> delayed = Class.forName(DELAYED);
+			renderProxyField = delayed.getField("renderProxy");
+
+			Class<?> proxyType = renderProxyField.getType();
+			depthWrapperMethod = proxyType.getMethod("getDhDepthTextureBlazeWrapper");
+
+			payloadField = depthWrapperMethod.getReturnType().getField("payload");
+
+			// The wrapper hands its objects back as Object on purpose, so that a Vulkan texture
+			// travels through an API whose older half speaks OpenGL names.
+			Class<?> wrapperType = Class.forName(
+					"com.seibel.distanthorizons.api.interfaces.render.IDhApiBlazeTextureWrapper");
+			textureViewMethod = wrapperType.getMethod("getTextureView");
+
+			usable = true;
+			Vitrail.logger().info("Distant Horizons found, its far terrain will be given a depth");
+		} catch (ClassNotFoundException e) {
+			// The ordinary case: DH is simply not installed. Not worth a line above debug.
+			usable = false;
+		} catch (ReflectiveOperationException | RuntimeException e) {
+			usable = false;
+			Vitrail.logger().info("Distant Horizons is installed but too old to hand back a "
+					+ "backend neutral depth image, its far terrain will stay flat");
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/dh/DhDepth.java
+++ b/common/src/main/java/dev/vitrail/dh/DhDepth.java
@@ -30,14 +30,13 @@ import java.lang.reflect.Method;
  * {@link #zRow} is the half of it only DH can answer.
  * <p>
  * <strong>Why reflection.</strong> The accessors that hand back a rendering-API neutral object,
- * {@code getDhDepthTextureBlazeWrapper} and its colour twin, were added to DH's API on
- * 11 July 2026, four days after the version number moved past 3.2.0-b. No released build of DH
- * carries them, so there is no coordinate to compile against; the older accessors that are released
- * hand back an OpenGL name, which is exactly the thing that cannot exist on this backend. Compiling
- * against a locally built jar would tie this repository to a path on one machine, so the call is
- * made by name instead and simply stays quiet on any DH that cannot answer it. When a build
- * carrying those methods ships, this class can become an ordinary typed dependency and the shape of
- * it will not change.
+ * {@code getDhDepthTextureBlazeWrapper} and its colour twin, belong to a newer API than the one
+ * this can be built against: the accessors old enough to compile against hand back an OpenGL name,
+ * which is exactly the thing that cannot exist on this backend. Compiling against a locally built
+ * jar would tie this repository to a path on one machine, so the call is made by name instead and
+ * simply stays quiet on any DH that cannot answer it. The day a build carrying those methods is a
+ * dependency this can resolve, this class becomes an ordinary typed one and the shape of it does
+ * not change.
  * <p>
  * <strong>The projection is reached by an uglier road, and the published ones are wrong.</strong>
  * {@code IDhApiRenderProxy.getNearClipPlaneDistanceInBlocks} and the {@code nearClipPlane} field of
@@ -45,7 +44,9 @@ import java.lang.reflect.Method;
  * BEFORE the clamp to seven and a half the matrix itself is built with: at any ordinary render
  * distance the two are more than a factor of ten apart. The matrix DH really rasterised with is
  * held in one place, the private render parameter of its client entry point, so that is what is
- * read. Iris never needs it, its own programs drawing the LODs with a projection Iris supplies.
+ * read. Iris reaches that same matrix off the public event parameter and sets it on its generic
+ * object program, {@code compat/dh/IrisGenericRenderProgram.java:240}; its terrain, water and
+ * shadow programs are handed a projection Iris builds instead, {@code compat/dh/DHCompat.java:54}.
  * <p>
  * Nothing here throws into a frame. Every failure resolves once, says so once, and answers
  * {@code null} forever after, because a far terrain that is merely flat is a picture and a far
@@ -75,6 +76,7 @@ public final class DhDepth {
 	private static Field configsField;
 	private static Method graphicsMethod;
 	private static Method renderDistanceMethod;
+	private static Method renderingEnabledMethod;
 	private static Method valueMethod;
 
 	/** Blocks across a chunk, which is what turns DH's own setting into what a pack reads. */
@@ -82,6 +84,15 @@ public final class DhDepth {
 
 	private static boolean resolved;
 	private static boolean usable;
+
+	/**
+	 * Latched off on its own, and the line is drawn by what the answer is for rather than by which
+	 * accessor gave it. How far DH draws is a number handed to a pack, so losing it must not stop
+	 * the folding of an image that still reads; whether DH is drawing at all is the question of
+	 * there being anything to fold, so losing that one latches the whole of it, which is why
+	 * {@link #renderingEnabled} sets the flag beside this one.
+	 */
+	private static boolean distanceUsable = true;
 
 	private DhDepth() {
 	}
@@ -120,7 +131,9 @@ public final class DhDepth {
 
 			Object textureView = textureViewMethod.invoke(wrapper);
 			return (textureView instanceof GpuTextureView view) ? view : null;
-		} catch (ReflectiveOperationException | RuntimeException e) {
+			// The error is caught here for the reason it is caught in the two below: a class of DH's
+			// that will not link is a far terrain this engine goes without, not a frame it drops.
+		} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
 			usable = false;
 			Vitrail.logger().warn("Distant Horizons' depth image cannot be read, its far terrain "
 					+ "will stay flat for the rest of this session", e);
@@ -180,10 +193,23 @@ public final class DhDepth {
 	 * while there is none to be had.
 	 * <p>
 	 * Taken from the matrix and not from {@code getNearClipPlaneDistanceInBlocks}, which answers the
-	 * unclamped near the class comment carries. Iris publishes the unclamped one and is right to:
-	 * under Iris the LODs are drawn by Iris's own programs with a projection Iris builds from it, so
-	 * there it IS the plane the far terrain was rasterised against. Here DH draws them itself, so
-	 * the plane a pack has to be told is DH's own.
+	 * unclamped near the class comment carries.
+	 * <p>
+	 * <strong>Both planes therefore carry a number Iris does not publish, and that is a divergence
+	 * rather than a preference.</strong> Iris answers the near with
+	 * {@code renderProxy.getNearClipPlaneDistanceInBlocks} at
+	 * {@code compat/dh/DHCompatInternal.java:133}, published through
+	 * {@code uniforms/CommonUniforms.java:185}, and the far with a formula of its own,
+	 * {@code (chunkRenderDistance * 16 + 512) * sqrt(2)} at
+	 * {@code compat/dh/DHCompatInternal.java:124}. Both are right there and neither is right here,
+	 * because under Iris the LODs are drawn by Iris's own programs against exactly those two planes,
+	 * and DH itself switches to Iris's far formula when it sees Iris,
+	 * {@code core/util/RenderUtil.java:289}. Here DH draws the LODs itself, between the planes its
+	 * own matrix carries. What both engines publish is the same fact, the pair the far terrain was
+	 * rasterised against; the numbers differ only because the terrain was. Serving Iris's numbers
+	 * here would cost a pack every distance it works out from them: the near it publishes is the
+	 * unclamped one the class comment carries, and since the clamp only ever pulls that plane in, it
+	 * is always the further out of the two. Its far is out by the ratio of the two formulas.
 	 *
 	 * @param dest filled with the near plane and then the far one, and left alone on false
 	 */
@@ -212,7 +238,7 @@ public final class DhDepth {
 			resolve();
 		}
 
-		if (!usable) {
+		if (!usable || !distanceUsable) {
 			return -1;
 		}
 
@@ -226,20 +252,58 @@ public final class DhDepth {
 
 			return (valueMethod.invoke(value) instanceof Integer chunks) ? chunks * CHUNK : -1;
 		} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
-			usable = false;
-			Vitrail.logger().warn("Distant Horizons' render distance cannot be read, so its far "
-					+ "terrain will stay flat for the rest of this session", e);
+			distanceUsable = false;
+			Vitrail.logger().warn("Distant Horizons' render distance cannot be read, so the far "
+					+ "terrain keeps its depth and a pack is given the game's own distance and clip "
+					+ "planes instead of that mod's, for the rest of this session", e);
 			return -1;
 		}
 	}
 
-	/** Whether anything at all can be expected from DH, without touching the frame's state. */
+	/**
+	 * Whether the far terrain is there to be had: DH answering, and DH's own rendering switched on.
+	 * <p>
+	 * <strong>The second half is Iris's condition and not a caution of ours.</strong> Iris poses
+	 * {@code DISTANT_HORIZONS} on the mod being loaded AND {@code DHCompat.hasRenderingEnabled()},
+	 * {@code gl/shader/StandardMacros.java:64}, which is a live read of
+	 * {@code configs.graphics().renderingEnabled()}, {@code compat/dh/DHCompatInternal.java:143}.
+	 * Without it a player who switches DH's rendering off keeps a pack that has been told the far
+	 * terrain is there, and the pack then takes its distant road over every pixel of sky.
+	 * <p>
+	 * Read live rather than kept, because that switch is reachable without leaving the world:
+	 * {@link dev.vitrail.render.PackDefines} watches this answer the way it watches the world's own
+	 * symbols, so a flip reads the pack again. Iris does the same with a reload of its own,
+	 * {@code compat/dh/DHCompatInternal.java:148}.
+	 */
 	public static boolean present() {
 		if (!resolved) {
 			resolve();
 		}
 
-		return usable;
+		return usable && renderingEnabled();
+	}
+
+	/**
+	 * DH's own rendering switch. False while DH is still starting up, which is not a failure and
+	 * latches nothing off: the switch is read again on the next frame that asks.
+	 */
+	private static boolean renderingEnabled() {
+		try {
+			Object configs = configsField.get(null);
+			if (configs == null) {
+				return false;
+			}
+
+			Object value = renderingEnabledMethod.invoke(graphicsMethod.invoke(configs));
+
+			return valueMethod.invoke(value) instanceof Boolean on && on;
+		} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
+			usable = false;
+			Vitrail.logger().warn("Distant Horizons' rendering switch cannot be read, so its far "
+					+ "terrain will stay flat for the rest of this session", e);
+
+			return false;
+		}
 	}
 
 	private static void resolve() {
@@ -265,6 +329,7 @@ public final class DhDepth {
 			configsField = delayed.getField("configs");
 			graphicsMethod = configsField.getType().getMethod("graphics");
 			renderDistanceMethod = graphicsMethod.getReturnType().getMethod("chunkRenderDistance");
+			renderingEnabledMethod = graphicsMethod.getReturnType().getMethod("renderingEnabled");
 			valueMethod = renderDistanceMethod.getReturnType().getMethod("getValue");
 
 			usable = true;

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -135,11 +135,11 @@ public final class EngineDefines {
 		}
 
 		// What a pack branches its far terrain on. Posed only where the terrain really reaches the
-		// pack, which is what the name means to the packs that read it: the eleven blend lines and
-		// four buffer sizes of the corpus that sit under it are written for a picture with a far
-		// terrain in its depth, and posing it over a depth that has none applies them to a screen
-		// they were never meant for. Iris poses it on the same terms, the mod being loaded AND its
-		// rendering answering for the frame.
+		// pack, which is what the name means to the packs that read it: what sits under it in the
+		// corpus is written for a picture with a far terrain in its depth, its own blend states and
+		// its own programs, and posing it over a depth that has none applies them to a screen they
+		// were never meant for. Iris poses it on the mod being loaded AND its rendering answering,
+		// gl/shader/StandardMacros.java:64; render/PackDefines asks the same two questions here.
 		if (environment.distantHorizons()) {
 			defines.put("DISTANT_HORIZONS", "");
 		}

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -73,6 +73,9 @@ public final class EngineDefines {
 	 *
 	 * @param vendorName      the device's vendor as the driver reports it, classified here
 	 * @param rendererName    the driver's own description, classified here
+	 * @param distantHorizons whether the far terrain of Distant Horizons is both there and reaching
+	 *                        the pack, which is a promise and not an installed mod list; see the
+	 *                        symbol below
 	 * @param biomes          registered biome path to id, in the order the ids were handed out. It
 	 *                        is the id a pack's biome comparison is written against, so the two
 	 *                        have to come from the same place
@@ -80,10 +83,11 @@ public final class EngineDefines {
 	 *                        {@code CAT_DESERT} the number the biome value carries
 	 */
 	public record Environment(int mcVersion, Os os, String vendorName, String rendererName,
-			int mipmapLevel, Map<String, Integer> biomes, List<String> biomeCategories) {
+			int mipmapLevel, boolean distantHorizons, Map<String, Integer> biomes,
+			List<String> biomeCategories) {
 
 		public static Environment of(int mcVersion) {
-			return new Environment(mcVersion, Os.WINDOWS, "", "", DEFAULT_MIPMAP_LEVEL,
+			return new Environment(mcVersion, Os.WINDOWS, "", "", DEFAULT_MIPMAP_LEVEL, false,
 					Map.of(), List.of());
 		}
 	}
@@ -128,6 +132,16 @@ public final class EngineDefines {
 		// number the block carries cannot part company. The value IS the ordinal.
 		for (RenderStage stage : RenderStage.values()) {
 			defines.put(stage.symbol(), Integer.toString(stage.ordinal()));
+		}
+
+		// What a pack branches its far terrain on. Posed only where the terrain really reaches the
+		// pack, which is what the name means to the packs that read it: the eleven blend lines and
+		// four buffer sizes of the corpus that sit under it are written for a picture with a far
+		// terrain in its depth, and posing it over a depth that has none applies them to a screen
+		// they were never meant for. Iris poses it on the same terms, the mod being loaded AND its
+		// rendering answering for the frame.
+		if (environment.distantHorizons()) {
+			defines.put("DISTANT_HORIZONS", "");
 		}
 
 		// Distant Horizons block kinds. No pack declares them and several read them, so leaving

--- a/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
@@ -38,10 +38,25 @@ public final class SamplerPlan {
 	 * The depth Distant Horizons keeps apart from the game's, which this engine does not keep apart:
 	 * {@code render/DhFold} writes the far terrain into the game's own depth before anything copies
 	 * it, so a pack reads the far terrain through {@code depthtex0} and the rest like any other
-	 * surface. These names therefore answer the far plane, which is what every pack of the corpus
-	 * tests for before it takes its Distant Horizons road: BSL reaches its at
-	 * {@code composite.glsl:281} with {@code else if (dhZ0 < 1.0)}, and it must not be taken, or the
-	 * sky would be rebuilt as a surface a hand's width from the camera.
+	 * surface.
+	 * <p>
+	 * <strong>Iris binds DH's real image under these names and this engine does not, which is a
+	 * divergence.</strong> Iris hands {@code dhDepthTex} and {@code dhDepthTex0} DH's own depth and
+	 * {@code dhDepthTex1} a copy of it without translucents,
+	 * {@code samplers/IrisSamplers.java:109} and {@code :110}. It has to: under Iris the far terrain
+	 * is nowhere else,
+	 * its LODs being drawn into targets of the pack's through a projection of DH's. Here it is in
+	 * the game's own depth already, so binding it a second time would offer a pack the same surface
+	 * twice in two different volumes, only one of which is the volume the matrix under these names
+	 * unprojects. What it costs is that the road a pack keeps for its distant land is never taken,
+	 * so a pack that lights the far terrain differently from the near one lights all of it the near
+	 * way.
+	 * <p>
+	 * These names therefore answer the far plane, which in the window a pack reads a depth in is
+	 * WHITE, the engine's own reversed window being the other way round. That is what every pack of
+	 * the corpus tests for before it takes its Distant Horizons road: BSL v10.1.3 reaches its at
+	 * {@code shaders/program/composite.glsl:282} with {@code else if (dhZ0 < 1.0)}, and it must not
+	 * be taken, or the sky would be rebuilt as a surface a hand's width from the camera.
 	 */
 	private static final Set<String> DISTANT_DEPTH =
 			Set.of("dhDepthTex", "dhDepthTex0", "dhDepthTex1");

--- a/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
@@ -33,6 +33,18 @@ public final class SamplerPlan {
 	private static final Set<String> DEPTH = Set.of("depthtex0", "depthtex1", "depthtex2", "gdepthtex");
 	private static final Set<String> SHADOW_DEPTH =
 			Set.of("shadowtex0", "shadowtex1", "shadow", "watershadow");
+
+	/**
+	 * The depth Distant Horizons keeps apart from the game's, which this engine does not keep apart:
+	 * {@code render/DhFold} writes the far terrain into the game's own depth before anything copies
+	 * it, so a pack reads the far terrain through {@code depthtex0} and the rest like any other
+	 * surface. These names therefore answer the far plane, which is what every pack of the corpus
+	 * tests for before it takes its Distant Horizons road: BSL reaches its at
+	 * {@code composite.glsl:281} with {@code else if (dhZ0 < 1.0)}, and it must not be taken, or the
+	 * sky would be rebuilt as a surface a hand's width from the camera.
+	 */
+	private static final Set<String> DISTANT_DEPTH =
+			Set.of("dhDepthTex", "dhDepthTex0", "dhDepthTex1");
 	private static final String SHADOW_COLOUR_PREFIX = "shadowcolor";
 	private static final String NOISE = "noisetex";
 	private static final String WATER_SHADOW = "watershadow";
@@ -82,8 +94,8 @@ public final class SamplerPlan {
 	 * over a name that already meant something else.
 	 */
 	public enum Kind {
-		COLORTEX, DEPTH, SHADOW_DEPTH, SHADOW_COLOUR, NOISE, PACK_TEXTURE, CENTER_DEPTH, UNSERVED,
-		UNBINDABLE
+		COLORTEX, DEPTH, SHADOW_DEPTH, SHADOW_COLOUR, NOISE, PACK_TEXTURE, CENTER_DEPTH,
+		DISTANT_DEPTH, UNSERVED, UNBINDABLE
 	}
 
 	/**
@@ -208,6 +220,10 @@ public final class SamplerPlan {
 
 		if (SHADOW_DEPTH.contains(name)) {
 			return Kind.SHADOW_DEPTH;
+		}
+
+		if (DISTANT_DEPTH.contains(name)) {
+			return Kind.DISTANT_DEPTH;
 		}
 
 		if (isShadowColour(name)) {

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -122,6 +122,12 @@ public final class EngineStages {
 		// world's translucents or, once the level returns, the screen.
 		EntityDraw.opaqueFeatures(false);
 
+		// Then Distant Horizons' far terrain into the game's depth, ahead of every line below and
+		// not only ahead of the deferred stage: each of the next three reads that depth, and a fold
+		// placed between two of them would give the pack a far terrain in one depth and not the
+		// other. PackChain.foldDistantDepth says why here is the only place it fits.
+		PackChain.foldDistantDepth();
+
 		// Then the depth the pack reads past the hand with, which has to be taken while the hand is
 		// still not in it, and the hand's solid half. The order of these three lines is the whole of
 		// where the hand belongs in the frame: after the game's own opaque features, which the window

--- a/common/src/main/java/dev/vitrail/render/DhFold.java
+++ b/common/src/main/java/dev/vitrail/render/DhFold.java
@@ -1,0 +1,331 @@
+package dev.vitrail.render;
+
+import dev.vitrail.dh.DhDepth;
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.PrimitiveTopology;
+import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.buffers.Std140Builder;
+import com.mojang.blaze3d.pipeline.BindGroupLayout;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.DepthStencilState;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.platform.CompareOp;
+import com.mojang.blaze3d.shaders.ShaderSource;
+import com.mojang.blaze3d.shaders.ShaderType;
+import com.mojang.blaze3d.shaders.UniformType;
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.RenderPass;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import net.minecraft.client.renderer.BindGroupLayouts;
+import net.minecraft.client.renderer.MappableRingBuffer;
+import net.minecraft.resources.Identifier;
+import org.joml.Vector2f;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+/**
+ * Folds Distant Horizons' far terrain into the game's depth, so that everything downstream of the
+ * game's depth knows the far terrain is there.
+ * <p>
+ * It is one pass and not three because of where it runs. Fold the game's own image once, before the
+ * depth the pack reads past the hand with is taken, and the three copies {@link PackDepth} makes,
+ * the cut the scene seed is drawn against, and the depth every family the game still draws itself
+ * tests against all carry the far terrain without any of them knowing this class exists. Folding
+ * into the copies instead would be three conversions, would leave the seed and the game's own
+ * translucents reading a world with a hole in it, and would have to be kept in step by hand.
+ * <p>
+ * <strong>The conversion, and why it is exactly two numbers.</strong> DH rasterises with the game's
+ * matrix and its own z row, {@code RenderUtil.setDhProjectionMatrix} overwriting that row and
+ * nothing else. Two projections that differ only in their z row share a w row, so the eye distance
+ * behind a texel falls out of one and back into the other with no matrix and no unprojection at
+ * all: with a row written {@code (scale, offset)}, a texel holds {@code offset / d - scale}, so
+ * {@code d = offset / (z + scale)} on the way out and the composition of the two is
+ * {@code z' = a * z + b} with {@code a = offsetGame / offsetFar} and
+ * {@code b = a * scaleFar - scaleGame}. One multiply and one add, per texel, and it is exact rather
+ * than fitted.
+ * <p>
+ * <strong>One test does the work of three.</strong> A folded value at or below nought is thrown
+ * away, and that covers every case at once: DH clears its image to nought, which is its own far
+ * plane and also every texel it drew nothing into, and both land below the game's far plane once
+ * converted. So does anything genuinely past the game's far plane, which is the honest limit of
+ * this pass and is written out below.
+ * <p>
+ * <strong>What cannot be folded.</strong> The game clips at {@code max(renderDistance * 4,
+ * cloudRange * 16)} blocks, two thousand and forty-eight of them with both sliders at their default,
+ * and a reversed Z has no value left for anything beyond that: the far plane IS nought. DH's own
+ * terrain reaches the same two thousand at its default, so the band that matters is inside, and it
+ * grows with the render distance rather than against it. What sits past the game's far plane keeps
+ * reading as sky, exactly as the whole of the far terrain did before this pass existed.
+ * <p>
+ * The colour attachment is written by nothing and is there because the encoder demands one: a pass
+ * with a depth attachment alone is legal, but the first colour attachment may not be absent, and a
+ * pipeline built without a colour target state is given one. So the game's own colour rides along
+ * with its write mask shut.
+ */
+final class DhFold {
+
+	private static final Identifier VERTEX_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/distant_depth_vertex");
+	private static final Identifier FRAGMENT_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/distant_depth_fragment");
+
+	/** DH's own depth image, as it stands after DH has drawn and composited its colour. */
+	private static final String SAMPLER = "InSampler";
+
+	private static final String UNIFORM_BLOCK = "OfDistantFold";
+
+	/** One vec2, rounded up to what a uniform buffer binding is allowed to start on. */
+	private static final int BLOCK_BYTES = 16;
+
+	/** Two triangles, the quad every full screen pass of this engine draws. */
+	private static final int VERTICES = 6;
+
+	/**
+	 * The game's own near plane, which {@code Camera.update} passes and never varies. The far plane
+	 * is the frame's and is handed in, {@code Camera.depthFar} moving with two sliders.
+	 */
+	private static final float NEAR = 0.05F;
+
+	private static final String LABEL = "Vitrail distant depth";
+
+	private static final String VERTEX = """
+			#version 460 core
+
+			in vec3 Position;
+			in vec2 UV0;
+
+			out vec2 ofTexCoord;
+
+			void main() {
+				ofTexCoord = UV0;
+				gl_Position = vec4(Position.xy * 2.0 - 1.0, 0.0, 1.0);
+			}
+			""";
+
+	/**
+	 * The test is written as a negation so that a NaN goes the same way an empty texel does. A DH
+	 * image is cleared rather than left, so nothing should decode to one, but a fragment that wrote
+	 * a NaN into the game's depth would take every later test of the frame with it.
+	 */
+	private static final String FRAGMENT = """
+			#version 460 core
+
+			uniform sampler2D InSampler;
+
+			layout(std140) uniform OfDistantFold {
+				vec2 of_DistantFold;
+			};
+
+			in vec2 ofTexCoord;
+
+			layout(location = 0) out vec4 ofFragData0;
+
+			void main() {
+				float folded = of_DistantFold.x * texture(InSampler, ofTexCoord).r + of_DistantFold.y;
+				if (!(folded > 0.0)) {
+					discard;
+				}
+
+				ofFragData0 = vec4(0.0);
+				gl_FragDepth = folded;
+			}
+			""";
+
+	private static final ShaderSource SOURCE = (id, type) -> {
+		if (type == ShaderType.FRAGMENT) {
+			return FRAGMENT_ID.equals(id) ? FRAGMENT : null;
+		}
+
+		return VERTEX_ID.equals(id) ? VERTEX : null;
+	};
+
+	/** Read every frame and never held: DH moves both its planes with the world around the player. */
+	private final Vector2f far = new Vector2f();
+
+	private RenderPipeline pipeline;
+
+	/**
+	 * Which colour format the kept pipeline was built for. A pipeline carries a state per colour
+	 * target and the pass refuses one whose format is not the attachment's, so the format the game's
+	 * own target happens to be is read rather than assumed.
+	 */
+	private GpuFormat built;
+
+	private MappableRingBuffer terms;
+
+	/** Said once and not per frame, so that a driver that will not have this shader is readable. */
+	private boolean refused;
+
+	/** Said once, because what a player wants to know is that it happened at all. */
+	private boolean said;
+
+	/**
+	 * Folds DH's far terrain into the game's depth. Must run on the render thread and outside any
+	 * render pass, which opens one of its own.
+	 * <p>
+	 * Answers false whenever there is nothing to fold, and the ordinary reasons are the quiet ones:
+	 * DH is not installed, has not started, or has not drawn a frame of this world yet. The screen
+	 * then looks exactly as it did before this class existed.
+	 *
+	 * @param colour   the game's own colour target, written by nothing here
+	 * @param depth    the game's depth as it stands, with its opaque world in it
+	 * @param depthFar the plane the game clips at this frame, which is {@code Camera.depthFar}
+	 */
+	boolean fold(CommandEncoder encoder, GpuDevice device, GpuBuffer quad, GpuTextureView colour,
+			GpuTextureView depth, float depthFar) {
+		if (this.refused || quad == null || colour == null || depth == null || depthFar <= NEAR) {
+			return false;
+		}
+
+		GpuTextureView distant = DhDepth.view();
+		if (distant == null || !DhDepth.zRow(this.far)) {
+			return false;
+		}
+
+		// The two images are made against the same window and resized with it, so a disagreement is
+		// one frame of a resize where one of them has moved and the other has not. Stretching DH's
+		// image over the screen for that frame would put its terrain somewhere it is not.
+		if (distant.getWidth(0) != depth.getWidth(0)
+				|| distant.getHeight(0) != depth.getHeight(0)) {
+			return false;
+		}
+
+		RenderPipeline compiled = pipeline(device, colour.texture().getFormat());
+		if (compiled == null || !ensure()) {
+			return false;
+		}
+
+		float scaleGame = NEAR / (depthFar - NEAR);
+		float offsetGame = NEAR * depthFar / (depthFar - NEAR);
+		float scale = offsetGame / this.far.y;
+		float offset = scale * this.far.x - scaleGame;
+
+		// Written through the game's own builder rather than into the buffer by hand, which is what
+		// every other block of this engine does: two floats are a layout too, and the two would
+		// drift.
+		this.terms.rotate();
+		try (GpuBufferSlice.MappedView view = this.terms.currentBuffer().map(false, true)) {
+			Std140Builder.intoBuffer(view.data()).putVec2(scale, offset);
+		}
+
+		// Loaded on both attachments: the world's own depth is exactly what this pass tests against,
+		// and a clear of either would be the end of the frame rather than a fold into it.
+		try (RenderPass pass = encoder.createRenderPass(() -> LABEL, colour, Optional.empty(), depth,
+				OptionalDouble.empty())) {
+			pass.setPipeline(compiled);
+			RenderSystem.bindDefaultUniforms(pass);
+			pass.setUniform(UNIFORM_BLOCK, this.terms.currentBuffer());
+			pass.setVertexBuffer(0, quad.slice());
+			// NEAREST, and it is the same reason the depth window binds NEAREST: one destination
+			// texel covers one source texel, and a filtered depth is an average of two surfaces that
+			// stands in front of neither.
+			pass.bindTexture(SAMPLER, distant,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+			pass.draw(VERTICES, 1, 0, 0);
+		}
+
+		if (!this.said) {
+			this.said = true;
+			// The planes rather than the terms, because the planes are what a player can compare
+			// against two sliders, and it is the first thing to look at when the band is in the
+			// wrong place. They come straight back out of the row: the far one is the ratio of the
+			// two terms and the near one is the offset over one plus the scale.
+			Vitrail.logger().info("Distant Horizons' far terrain is folded into the game's depth, "
+					+ "from its own {} to {} blocks into the game's {} to {}, so what a pack reads "
+					+ "as a depth carries it out to the nearer of the two far planes",
+					this.far.y / (1.0F + this.far.x), this.far.y / this.far.x, NEAR, depthFar);
+		}
+
+		return true;
+	}
+
+	/** Frees the buffer behind the terms. The pipeline is the device's and cannot be handed back. */
+	void release() {
+		if (this.terms != null) {
+			this.terms.close();
+			this.terms = null;
+		}
+	}
+
+	/**
+	 * Makes the buffer the two terms are written into exist. Nothing here depends on the size of the
+	 * screen, so it is allocated once and kept across a resize.
+	 */
+	private boolean ensure() {
+		if (this.terms != null) {
+			return true;
+		}
+
+		try {
+			// Three buffers and a fence per turn, so a frame never writes over what the previous one
+			// is still being read for.
+			this.terms = new MappableRingBuffer(() -> LABEL,
+					GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, BLOCK_BYTES);
+		} catch (RuntimeException e) {
+			this.refused = true;
+			Vitrail.logger().error("Vitrail could not allocate the buffer the distant depth "
+					+ "conversion is driven from, so the far terrain of Distant Horizons stays flat "
+					+ "for the rest of this session", e);
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * The pipeline, compiled the first time it is asked for and kept until the colour format under
+	 * it moves.
+	 * <p>
+	 * The compiled form lives in the device cache, which the game empties at every resource reload,
+	 * so this asks the device every time rather than trusting a flag of its own: that call is a
+	 * {@code computeIfAbsent} on the device side and costs nothing once it has been made.
+	 */
+	private RenderPipeline pipeline(GpuDevice device, GpuFormat format) {
+		if (this.pipeline == null || this.built != format) {
+			this.pipeline = build(format);
+			this.built = format;
+		}
+
+		if (device.precompilePipeline(this.pipeline, SOURCE).isValid()) {
+			return this.pipeline;
+		}
+
+		this.refused = true;
+		this.pipeline = null;
+		Vitrail.logger().error("The distant depth conversion did not compile, so the far terrain of "
+				+ "Distant Horizons stays at the far plane for every depth this pack reads");
+
+		return null;
+	}
+
+	private static RenderPipeline build(GpuFormat format) {
+		return RenderPipeline.builder()
+				.withLocation(Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pipeline/distant_depth"))
+				.withVertexShader(VERTEX_ID)
+				.withFragmentShader(FRAGMENT_ID)
+				.withBindGroupLayout(BindGroupLayouts.GLOBALS)
+				.withBindGroupLayout(BindGroupLayout.builder()
+						.withUniform(UNIFORM_BLOCK, UniformType.UNIFORM_BUFFER)
+						.withSampler(SAMPLER)
+						.build())
+				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
+				.withColorTargetState(new ColorTargetState(Optional.empty(), format,
+						ColorTargetState.WRITE_NONE))
+				// Greater and not greater or equal, in a reversed Z where greater is nearer: what
+				// the game has already drawn stands, and a far terrain that ties with it changes
+				// nothing worth a write.
+				.withDepthStencilState(new DepthStencilState(CompareOp.GREATER_THAN, true))
+				.withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
+				.withCull(false)
+				.build();
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/DhFold.java
+++ b/common/src/main/java/dev/vitrail/render/DhFold.java
@@ -23,6 +23,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import net.minecraft.client.Camera;
 import net.minecraft.client.renderer.BindGroupLayouts;
 import net.minecraft.client.renderer.MappableRingBuffer;
 import net.minecraft.resources.Identifier;
@@ -53,17 +54,36 @@ import java.util.OptionalDouble;
  * than fitted.
  * <p>
  * <strong>One test does the work of three.</strong> A folded value at or below nought is thrown
- * away, and that covers every case at once: DH clears its image to nought, which is its own far
- * plane and also every texel it drew nothing into, and both land below the game's far plane once
- * converted. So does anything genuinely past the game's far plane, which is the honest limit of
- * this pass and is written out below.
+ * away, and that covers every case at once: DH clears its image to nought, which on a reversed Z is
+ * its own far plane and is also every texel it drew nothing into,
+ * {@code common/render/blaze/BlazeDhMetaRenderer.java:48} taking that value from
+ * {@code core/render/EDhRenderDepth.java:18} and clearing with it at {@code :114}. Both land at or
+ * below nought once converted, and the
+ * conversion is monotonic, so anything genuinely past the game's far plane goes with them. That the
+ * cleared value lands there and not in front of the player is not luck: it holds exactly while the
+ * game's far plane is no further out than DH's, which the paragraph below shows is every setting
+ * the game allows.
  * <p>
  * <strong>What cannot be folded.</strong> The game clips at {@code max(renderDistance * 4,
- * cloudRange * 16)} blocks, two thousand and forty-eight of them with both sliders at their default,
- * and a reversed Z has no value left for anything beyond that: the far plane IS nought. DH's own
- * terrain reaches the same two thousand at its default, so the band that matters is inside, and it
- * grows with the render distance rather than against it. What sits past the game's far plane keeps
- * reading as sky, exactly as the whole of the far terrain did before this pass existed.
+ * cloudRange * 16)} blocks with the render distance already in blocks, {@code Camera.update}, and
+ * both of those cap at two thousand and forty-eight: thirty-two chunks is the most the render
+ * distance slider gives and a hundred and twenty-eight the most the cloud one does. A reversed Z
+ * has no value left beyond that plane, the far plane IS nought, so what stands past it keeps
+ * reading as sky exactly as the whole of the far terrain did before this pass existed. DH's own far
+ * clip is {@code (chunkRenderDistance * 16 + 512) * 2} and its render distance will not go below
+ * thirty-two chunks, so the nearest plane DH can rasterise against is that same two thousand and
+ * forty-eight, and at its default of two hundred and fifty-six chunks it is nine thousand two
+ * hundred and sixteen. The game's plane is therefore never the further of the two, and the band
+ * this pass wins is everything between them.
+ * <p>
+ * <strong>What is folded is the shape and not the light.</strong> The far terrain keeps the colour
+ * DH gave it: this engine puts DH's depth into the game's and nothing more. Iris does not stop
+ * there, drawing the LODs itself with the pack's own {@code dh_terrain}, {@code dh_water} and
+ * {@code dh_generic} programs into the pack's own targets,
+ * {@code compat/dh/DHCompatInternal.java:67}. Those three families are not served here at all, and
+ * a family served by the wrong program would be worse than one left alone. What it costs is that
+ * the far terrain is lit DH's way while everything nearer is lit the pack's, so the two meet at a
+ * seam a pack cannot close from here; what it buys is every effect a pack indexes on depth.
  * <p>
  * The colour attachment is written by nothing and is there because the encoder demands one: a pass
  * with a depth attachment alone is legal, but the first colour attachment may not be absent, and a
@@ -89,10 +109,14 @@ final class DhFold {
 	private static final int VERTICES = 6;
 
 	/**
-	 * The game's own near plane, which {@code Camera.update} passes and never varies. The far plane
-	 * is the frame's and is handed in, {@code Camera.depthFar} moving with two sliders.
+	 * The game's own near plane, under the game's own name for it. {@code Camera.update} passes the
+	 * same number as a literal rather than through this constant, and javac inlines a constant
+	 * anyway, so what the name buys is not a wire: it is that a reader sees which plane is meant,
+	 * and that a rebuild against a game which moved that plane moves this with it. It never varies
+	 * within a run. The far plane does, is the frame's, and is handed in, {@code Camera.depthFar}
+	 * moving with two sliders.
 	 */
-	private static final float NEAR = 0.05F;
+	private static final float NEAR = Camera.PROJECTION_Z_NEAR;
 
 	private static final String LABEL = "Vitrail distant depth";
 
@@ -185,8 +209,19 @@ final class DhFold {
 			return false;
 		}
 
+		// Asked every frame rather than once, because DH's rendering switch is reachable from its
+		// own screen without leaving the world and its images keep whatever was last drawn into
+		// them. Folding those after DH has stopped would stand the last far terrain it drew in
+		// front of a world that has moved on.
+		if (!DhDepth.present()) {
+			return false;
+		}
+
 		GpuTextureView distant = DhDepth.view();
-		if (distant == null || !DhDepth.zRow(this.far)) {
+		// The row is refused rather than divided by. Both of its terms are positive on any matrix
+		// built the way DH builds this one, and neither the conversion below nor the line it logs
+		// would say anything true if one of them were not.
+		if (distant == null || !DhDepth.zRow(this.far) || this.far.x <= 0.0F || this.far.y <= 0.0F) {
 			return false;
 		}
 

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -437,13 +437,20 @@ public final class FrameState implements WorldState {
 				split ? cameraState.projectionMatrix : rendered, renderDistance * 16.0F,
 				renderDistance);
 
-		// And what Distant Horizons drew this frame with, which is nothing at all on the sessions
-		// that have no far terrain. Read here rather than where the depth is folded, because these
-		// three are written into the block once a frame and the fold happens after that: taken
-		// there, a pack would read the frame before's planes.
-		if (DhDepth.planes(this.distantPlanes)) {
-			this.view.advanceDistant(this.distantPlanes.x, this.distantPlanes.y,
-					DhDepth.renderDistanceBlocks());
+		// And what Distant Horizons drew with, which is nothing at all on the sessions that have no
+		// far terrain. The three are taken together or not at all, the distance first: advanceDistant
+		// says what a frame that served two of them from DH and the third from the game costs.
+		//
+		// What they carry is the projection DH drew the PREVIOUS frame with, and that is worth
+		// saying rather than hiding. DH fills its render parameter from the opaque chunk pass, while
+		// the pack's frame opens ahead of it at the first sky draw. Reading them where the depth is
+		// folded would not mend it: the block is written once, here, so a value taken after it would
+		// reach a pack one frame later still. What it costs is nothing measurable, both planes moving
+		// with DH's own settings and with the player's height above the world rather than with the
+		// camera. The fold does not read the block at all: it takes the row itself as it converts.
+		int distance = DhDepth.renderDistanceBlocks();
+		if (distance >= 0 && DhDepth.planes(this.distantPlanes)) {
+			this.view.advanceDistant(this.distantPlanes.x, this.distantPlanes.y, distance);
 		} else {
 			this.view.advanceDistant(ViewMatrices.FALLBACK_PLANE, ViewMatrices.FALLBACK_PLANE, -1);
 		}

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -1,5 +1,6 @@
 package dev.vitrail.render;
 
+import dev.vitrail.dh.DhDepth;
 import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.target.PackDirectives;
 import dev.vitrail.uniform.ClipSpace;
@@ -42,6 +43,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4fc;
+import org.joml.Vector2f;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.joml.Vector3f;
@@ -88,6 +90,9 @@ public final class FrameState implements WorldState {
 	private static final int FOG_SHAPE_OFF = -1;
 
 	private final ViewMatrices view = new ViewMatrices();
+
+	/** Refilled every frame by the reading of Distant Horizons, and never read outside it. */
+	private final Vector2f distantPlanes = new Vector2f();
 	private final BiomeClassifier biomes = new BiomeClassifier();
 	private final CameraShift shift = new CameraShift();
 
@@ -431,6 +436,17 @@ public final class FrameState implements WorldState {
 		this.view.advance(cameraState.viewRotationMatrix, CameraBob.taken(),
 				split ? cameraState.projectionMatrix : rendered, renderDistance * 16.0F,
 				renderDistance);
+
+		// And what Distant Horizons drew this frame with, which is nothing at all on the sessions
+		// that have no far terrain. Read here rather than where the depth is folded, because these
+		// three are written into the block once a frame and the fold happens after that: taken
+		// there, a pack would read the frame before's planes.
+		if (DhDepth.planes(this.distantPlanes)) {
+			this.view.advanceDistant(this.distantPlanes.x, this.distantPlanes.y,
+					DhDepth.renderDistanceBlocks());
+		} else {
+			this.view.advanceDistant(ViewMatrices.FALLBACK_PLANE, ViewMatrices.FALLBACK_PLANE, -1);
+		}
 
 		this.view.advanceShadow(sunAngle(isDay()) / 360.0F, this.directives.sunPathRotation(),
 				this.directives.shadowIntervalSize(), this.shift.unshifted(),
@@ -1738,8 +1754,8 @@ public final class FrameState implements WorldState {
 	}
 
 	@Override
-	public int dhRenderDistanceChunks() {
-		return this.view.dhRenderDistanceChunks();
+	public int dhRenderDistance() {
+		return this.view.dhRenderDistance();
 	}
 
 	@Override

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -1231,9 +1231,10 @@ final class GeometryProgram {
 			// which is the one thing a texture.STAGE.NAME override needs to know. Mellow moves
 			// noisetex there and nowhere else, so this is not a case the chain also covers.
 			case PACK_TEXTURE -> packTexture(sampler);
-			// The far plane, because this engine folds the far terrain into the game's own depth
-			// rather than keeping a second one: the name has nothing left to say that depthtex0
-			// has not already said. SamplerPlan carries what black would do instead.
+			// The far plane, which is white in the window a pack reads a depth in, because this
+			// engine folds the far terrain into the game's own depth rather than keeping a second
+			// one: the name has nothing left to say that depthtex0 has not already said. SamplerPlan
+			// carries what black would do instead.
 			case DISTANT_DEPTH -> this.white.getColorTextureView();
 			default -> this.black.getColorTextureView();
 		};

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -1231,6 +1231,10 @@ final class GeometryProgram {
 			// which is the one thing a texture.STAGE.NAME override needs to know. Mellow moves
 			// noisetex there and nowhere else, so this is not a case the chain also covers.
 			case PACK_TEXTURE -> packTexture(sampler);
+			// The far plane, because this engine folds the far terrain into the game's own depth
+			// rather than keeping a second one: the name has nothing left to say that depthtex0
+			// has not already said. SamplerPlan carries what black would do instead.
+			case DISTANT_DEPTH -> this.white.getColorTextureView();
 			default -> this.black.getColorTextureView();
 		};
 	}

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -1443,6 +1443,11 @@ final class GeometryProgram {
 						&& this.shadow.colour(binding.index()) != null);
 	}
 
+	/** A name answered with the far plane on purpose, which is not the same as one nothing fills. */
+	private boolean readsTheDistantDepth(String sampler) {
+		return this.loaded.samplers().binding(sampler).kind() == SamplerPlan.Kind.DISTANT_DEPTH;
+	}
+
 	private FilterMode filter(String sampler) {
 		if (LIGHTMAP.equals(sampler)) {
 			return FilterMode.LINEAR;
@@ -1523,8 +1528,19 @@ final class GeometryProgram {
 				.filter(this::readsATexture)
 				.map(this::describe)
 				.toList();
-		List<String> flat = this.samplers.stream().filter(name -> !readsATexture(name)).toList();
+		// Kept out of the line below rather than counted in it, because that line is about a gap and
+		// this is not one: nothing will ever fill these, they answer the far plane on purpose, and
+		// PackChain says once for the whole chain what that means.
+		List<String> distant = this.samplers.stream().filter(this::readsTheDistantDepth).toList();
+		List<String> flat = this.samplers.stream()
+				.filter(name -> !readsATexture(name) && !readsTheDistantDepth(name))
+				.toList();
 		Vitrail.logger().info("{} samplers of this program read a real texture: {}", real.size(), real);
+		if (!distant.isEmpty()) {
+			Vitrail.logger().info("{} read the far plane, the far terrain of Distant Horizons being "
+					+ "in the world's own depth rather than beside it: {}", distant.size(), distant);
+		}
+
 		if (!flat.isEmpty()) {
 			// What is left is what nothing fills for this pass: the shadow map, the depth on the
 			// passes that draw before the copy of this frame is taken, and the two material maps

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -940,6 +940,10 @@ public final class PackChain {
 			Vitrail.logger().info("Left {} for {}: a dimension replaces the root rather than layering "
 					+ "over it, so the whole pack is read, translated and its colour targets allocated "
 					+ "again, which is the hitch at the portal", PackPlace.settled(), PackPlace.world());
+		} else if (PackDefines.distantHorizonsMoved()) {
+			Vitrail.logger().info("Distant Horizons is drawing a far terrain now, or has stopped, so "
+					+ "the pack is read again against DISTANT_HORIZONS: the symbol is what a pack "
+					+ "branches its distant land on, and it cannot be right for both");
 		} else {
 			Vitrail.logger().info("The world's own symbols are known now, reloading the pack against "
 					+ "them");
@@ -1410,7 +1414,8 @@ public final class PackChain {
 	 * has finished its opaque features.
 	 * <p>
 	 * <strong>The place is the whole design and it is one line wide.</strong> DH draws its LODs from
-	 * {@code renderSectionLayer}, long before this, and composes only its colour; so by here its
+	 * inside the game's own opaque chunk pass, {@code ChunkSectionsToRender.renderGroup}, long
+	 * before this, and composes only its colour; so by here its
 	 * image is this frame's and the game's depth is everything the game itself drew. Every reader of
 	 * the game's depth is still downstream: {@link #markPreHandDepth} takes {@code depthtex2} on the
 	 * next line, {@link #drawEarly} takes {@code depthtex1} two lines later, the scene seed is cut

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -220,6 +220,13 @@ public final class PackChain {
 	private final WeatherDraw weather;
 	private final ParticleDraw particles;
 
+	/**
+	 * The far terrain's road into the game's depth. Held by the chain and not by the targets,
+	 * because it writes nothing of the pack's: it lives here for the same reason {@link #quad} does,
+	 * which is that it is asked for from an entry point of its own.
+	 */
+	private final DhFold distant = new DhFold();
+
 	private List<PackPass> programs;
 	private PackPass last;
 
@@ -1399,6 +1406,51 @@ public final class PackChain {
 	}
 
 	/**
+	 * Folds Distant Horizons' far terrain into the game's depth, at the head of the moment the game
+	 * has finished its opaque features.
+	 * <p>
+	 * <strong>The place is the whole design and it is one line wide.</strong> DH draws its LODs from
+	 * {@code renderSectionLayer}, long before this, and composes only its colour; so by here its
+	 * image is this frame's and the game's depth is everything the game itself drew. Every reader of
+	 * the game's depth is still downstream: {@link #markPreHandDepth} takes {@code depthtex2} on the
+	 * next line, {@link #drawEarly} takes {@code depthtex1} two lines later, the scene seed is cut
+	 * against the same image, and the world's translucents have not been drawn. Folded one line
+	 * later the pack would read a far terrain in two of its three depths and not the third; folded
+	 * after the chain it would read it in none.
+	 * <p>
+	 * Only when a pack is being drawn. Nothing of the game's own picture wants this: DH already
+	 * composes its colour, and a depth the game would only ever test against is a change to the
+	 * game's own image for no reader. {@link DhFold} carries what the fold costs and what it cannot
+	 * reach.
+	 */
+	public static void foldDistantDepth() {
+		PackChain chain = active;
+		GpuDevice device = RenderSystem.tryGetDevice();
+		Minecraft minecraft = Minecraft.getInstance();
+		if (disabled || chain == null || device == null || minecraft == null || !chainWanted) {
+			return;
+		}
+
+		RenderTarget main = minecraft.gameRenderer.mainRenderTarget();
+		if (main == null || !main.useDepth) {
+			return;
+		}
+
+		// Caught like every other point the game calls this engine back at: an exception here reaches
+		// the game through an event handler and comes back on the very next frame.
+		try {
+			chain.distant.fold(device.createCommandEncoder(), device, chain.quad(device),
+					main.getColorTextureView(), main.getDepthTextureView(),
+					minecraft.gameRenderer.gameRenderState().levelRenderState.cameraRenderState
+							.depthFar);
+		} catch (RuntimeException e) {
+			disabled = true;
+			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
+			chain.release();
+		}
+	}
+
+	/**
 	 * Keeps the world's depth as it stands before the player's own hand is drawn, which is what the
 	 * pack reads as {@code depthtex2}. Called from the event the hand's solid half is drawn at and
 	 * one line ahead of it.
@@ -2172,6 +2224,8 @@ public final class PackChain {
 		if (this.features != null) {
 			this.features.release();
 		}
+
+		this.distant.release();
 
 		this.terrain.release();
 		this.sky.release();

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2184,6 +2184,9 @@ public final class PackChain {
 		named(byKind, SamplerPlan.Kind.CENTER_DEPTH,
 				"read the smoothed depth at the centre of the screen, which is what a depth of field "
 						+ "focuses on");
+		named(byKind, SamplerPlan.Kind.DISTANT_DEPTH,
+				"read the far plane, the far terrain of Distant Horizons being folded into the "
+						+ "world's own depth rather than kept beside it");
 		named(byKind, SamplerPlan.Kind.UNBINDABLE,
 				"are declared under a type this backend cannot bind, and should have gone with "
 						+ "their pass");

--- a/common/src/main/java/dev/vitrail/render/PackDefines.java
+++ b/common/src/main/java/dev/vitrail/render/PackDefines.java
@@ -34,6 +34,11 @@ import java.util.Map;
  * world costs the same half second reload as editing a setting does and the symbols are right
  * afterwards.
  * <p>
+ * Distant Horizons rides the same road for the same reason. Whether its far terrain reaches the
+ * pack is a thing the player changes from that mod's own screen, without leaving the world, so
+ * {@link #stale()} watches it beside the registry rather than trusting what was true when the pack
+ * was read.
+ * <p>
  * Two biomes of different namespaces can carry the same path, and only the first of them gets the
  * symbol. Iris has the same limit, and a pack naming a modded biome is naming its path anyway.
  */
@@ -41,6 +46,9 @@ public final class PackDefines {
 
 	/** Which registry the installed table was built from, so that a change of one is noticed. */
 	private static volatile long installed;
+
+	/** And whether the far terrain was there, which the player can change without leaving. */
+	private static volatile boolean distant;
 
 	private PackDefines() {
 	}
@@ -61,6 +69,7 @@ public final class PackDefines {
 	 */
 	public static void settle() {
 		installed = stamp();
+		distant = DhDepth.present();
 	}
 
 	/**
@@ -69,7 +78,24 @@ public final class PackDefines {
 	 * being a reload every second.
 	 */
 	public static boolean stale() {
-		return stamp() != installed;
+		return stamp() != installed || distantHorizonsMoved();
+	}
+
+	/**
+	 * Whether it is the far terrain that moved rather than the world, which is the other half of
+	 * what Iris does with {@code DISTANT_HORIZONS}: it reads DH's rendering switch every frame and
+	 * reloads on the flip, {@code compat/dh/DHCompatInternal.java:143} and {@code :148}. Without
+	 * this the symbol would be whatever it was when the pack was read, and a player who switches
+	 * that mod's rendering off would keep a pack lighting a far terrain that is no longer drawn.
+	 * <p>
+	 * What {@link #settle()} records is the live answer and not the one {@link #gather} compiled
+	 * with, so a flip inside the half second a pack takes to read is not noticed until the next
+	 * flip. Recording what the read compiled with instead would mean recording nothing when the
+	 * read could not happen at all, and that is the case this whole pair exists to keep out of a
+	 * reload every frame.
+	 */
+	public static boolean distantHorizonsMoved() {
+		return DhDepth.present() != distant;
 	}
 
 	private static long stamp() {
@@ -93,10 +119,10 @@ public final class PackDefines {
 
 		int mipmap = minecraft == null ? 4 : minecraft.options.mipmapLevels().get();
 
-		// Asked of the one class that knows whether the far terrain can be read at all, and not of
-		// the loader's mod list. An installed Distant Horizons this engine cannot get a depth image
-		// or a projection out of leaves the far terrain flat, and a pack told otherwise would light
-		// a picture that has none.
+		// Asked of the one class that knows whether the far terrain reaches the pack at all, and not
+		// of the loader's mod list. An installed Distant Horizons this engine cannot get a depth
+		// image or a projection out, or whose own rendering is switched off, leaves the far terrain
+		// flat, and a pack told otherwise would light a picture that has none.
 		return new EngineDefines.Environment(EngineDefines.DEFAULT_MC_VERSION, os(), vendor,
 				renderer, mipmap, DhDepth.present(), biomeIds(minecraft, biomes), categories());
 	}

--- a/common/src/main/java/dev/vitrail/render/PackDefines.java
+++ b/common/src/main/java/dev/vitrail/render/PackDefines.java
@@ -1,5 +1,6 @@
 package dev.vitrail.render;
 
+import dev.vitrail.dh.DhDepth;
 import dev.vitrail.pack.option.EngineDefines;
 import dev.vitrail.uniform.BiomeCategory;
 
@@ -92,8 +93,12 @@ public final class PackDefines {
 
 		int mipmap = minecraft == null ? 4 : minecraft.options.mipmapLevels().get();
 
+		// Asked of the one class that knows whether the far terrain can be read at all, and not of
+		// the loader's mod list. An installed Distant Horizons this engine cannot get a depth image
+		// or a projection out of leaves the far terrain flat, and a pack told otherwise would light
+		// a picture that has none.
 		return new EngineDefines.Environment(EngineDefines.DEFAULT_MC_VERSION, os(), vendor,
-				renderer, mipmap, biomeIds(minecraft, biomes), categories());
+				renderer, mipmap, DhDepth.present(), biomeIds(minecraft, biomes), categories());
 	}
 
 	private static Map<String, Integer> biomeIds(Minecraft minecraft, BiomeClassifier biomes) {

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -509,10 +509,11 @@ final class PackPass {
 				// own window and so a focus point at the horizon. Black would be a focus point at the
 				// camera, which is the defect this whole path exists to close.
 				case CENTER_DEPTH -> or(targets.centerDepth().view(), targets.white());
-				// White here as well, and here it is not a fallback but the answer: this engine keeps
-				// no depth of the far terrain apart from the game's, so the name says there is
-				// nothing at this texel that depthtex0 has not already got. SamplerPlan carries what
-				// black would do to the sky.
+				// White here as well, and here it is not a fallback but the answer: white is the far
+				// plane in the window a pack reads a depth in, and this engine keeps no depth of the
+				// far terrain apart from the game's, so the name says there is nothing at this texel
+				// that depthtex0 has not already got. SamplerPlan carries what black would do to the
+				// sky.
 				case DISTANT_DEPTH -> targets.white();
 				// A name this backend cannot bind should have taken its program out of the chain
 				// before a frame was drawn. It is still answered rather than left out, because the

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -509,6 +509,11 @@ final class PackPass {
 				// own window and so a focus point at the horizon. Black would be a focus point at the
 				// camera, which is the defect this whole path exists to close.
 				case CENTER_DEPTH -> or(targets.centerDepth().view(), targets.white());
+				// White here as well, and here it is not a fallback but the answer: this engine keeps
+				// no depth of the far terrain apart from the game's, so the name says there is
+				// nothing at this texel that depthtex0 has not already got. SamplerPlan carries what
+				// black would do to the sky.
+				case DISTANT_DEPTH -> targets.white();
 				// A name this backend cannot bind should have taken its program out of the chain
 				// before a frame was drawn. It is still answered rather than left out, because the
 				// layout carries it either way and the draw throws on the first name it misses.

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -216,12 +216,16 @@ public final class ViewMatrices implements ViewSource {
 	 * Takes what Distant Horizons drew this frame with, or puts the three values back where they
 	 * stand when it drew nothing.
 	 * <p>
-	 * The three move together on purpose. A pack that has been told the far terrain is there works
-	 * its fog out of the render distance and rebuilds a position out of the planes, so a frame that
-	 * served two of the three from DH and the third from the game would fog the far terrain against
-	 * a distance a fifteenth of the one it stands at. The far plane is the one to watch: BSL takes
-	 * {@code fogFar = max(fogFar, float(dhRenderDistance))} at {@code lib/atmospherics/fog.glsl:137}
-	 * and Complementary the same at {@code lib/common.glsl:708}.
+	 * The three move together on purpose, and {@code render/FrameState} takes them that way. A pack
+	 * that has been told the far terrain is there works its fog out of the render distance and
+	 * rebuilds a position out of the planes, so a frame that served two of the three from DH and the
+	 * third from the game would fog the far terrain against a distance a fifteenth of the one it
+	 * stands at. The render distance is the one to watch, and the two packs read most closely here
+	 * do different things with it: BSL v10.1.3 widens the fog it already had,
+	 * {@code fogFar = max(fogFar, float(dhRenderDistance))} at
+	 * {@code shaders/lib/atmospherics/fog.glsl:137}, while Complementary Unbound r5.8.1 replaces the
+	 * distance outright, {@code float renderDistance = float(dhRenderDistance);} at
+	 * {@code shaders/lib/common.glsl:708}, which is what the whole of its fog is measured against.
 	 *
 	 * @param near     DH's own near plane in blocks, or {@link #FALLBACK_PLANE} for none
 	 * @param far      DH's own far plane in blocks, or {@link #FALLBACK_PLANE} for none
@@ -524,11 +528,17 @@ public final class ViewMatrices implements ViewSource {
 	 * and falls back the same way, which is why a pack that reads {@code dhProjection} outside the
 	 * mod still compiles there and did not here.
 	 * <p>
-	 * The three matrices stay the game's own on both roads, and that is not a gap left open. What a
-	 * pack unprojects with them is a {@code dhDepthTex} lookup, and this engine answers those with
-	 * the far plane: the far terrain is in the game's own depth by then, so the road that would use
-	 * a matrix of DH's is a road no pack takes. The planes and the render distance are read outside
-	 * that road, which is why those three are DH's own the moment DH has drawn.
+	 * <strong>The three matrices stay the game's own even while DH is drawing, and that is a
+	 * divergence.</strong> Iris builds a perspective of DH's out of the game's field of view and
+	 * aspect with DH's own two planes, {@code compat/dh/DHCompat.java:54}, and registers that under
+	 * these three names. It is right there and would be wrong here. What a pack unprojects with them
+	 * is a {@code dhDepthTex} lookup, and {@code pack/target/SamplerPlan} answers those names with
+	 * the far plane, the far terrain being in the game's own depth by then: the road that needs a
+	 * matrix of DH's is a road no pack reaches. Handing one over anyway would cost the packs that
+	 * read {@code dhProjection} outside that road, which are the ones the paragraph above is about;
+	 * they would unproject the game's own depth through a volume it was never drawn in. The planes
+	 * and the render distance are read outside that road, which is why those three are DH's own the
+	 * moment DH has drawn.
 	 */
 	@Override
 	public Matrix4fc dhProjection() {

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -37,6 +37,12 @@ public final class ViewMatrices implements ViewSource {
 	 */
 	private static final float RENDER_DISTANCE_SENTINEL = -1.0F;
 
+	/**
+	 * What the two Distant Horizons planes answer while there is no far terrain. Iris's own number,
+	 * and it is deliberately one no pack can mistake for a real distance.
+	 */
+	static final float FALLBACK_PLANE = 0.01F;
+
 	private final Matrix4f modelView = new Matrix4f();
 	private final Matrix4f modelViewInverse = new Matrix4f();
 	private final Matrix4f projection = new Matrix4f();
@@ -133,6 +139,14 @@ public final class ViewMatrices implements ViewSource {
 	private boolean shadowSeeded;
 
 	/**
+	 * What Distant Horizons drew this frame with, or nothing when it drew nothing. See
+	 * {@link #advanceDistant} for why the three move together.
+	 */
+	private float dhNear = FALLBACK_PLANE;
+	private float dhFar = FALLBACK_PLANE;
+	private int dhRenderDistanceBlocks = -1;
+
+	/**
 	 * Takes this frame's view and projection, publishes them, and shifts the previous frame's
 	 * copies down. It is also the boundary a pass's own matrix and colour are dropped at, for the
 	 * reason written on the two lines that drop them.
@@ -196,6 +210,30 @@ public final class ViewMatrices implements ViewSource {
 
 		this.far = far;
 		this.renderDistanceChunks = renderDistanceChunks;
+	}
+
+	/**
+	 * Takes what Distant Horizons drew this frame with, or puts the three values back where they
+	 * stand when it drew nothing.
+	 * <p>
+	 * The three move together on purpose. A pack that has been told the far terrain is there works
+	 * its fog out of the render distance and rebuilds a position out of the planes, so a frame that
+	 * served two of the three from DH and the third from the game would fog the far terrain against
+	 * a distance a fifteenth of the one it stands at. The far plane is the one to watch: BSL takes
+	 * {@code fogFar = max(fogFar, float(dhRenderDistance))} at {@code lib/atmospherics/fog.glsl:137}
+	 * and Complementary the same at {@code lib/common.glsl:708}.
+	 *
+	 * @param near     DH's own near plane in blocks, or {@link #FALLBACK_PLANE} for none
+	 * @param far      DH's own far plane in blocks, or {@link #FALLBACK_PLANE} for none
+	 * @param distance how far DH draws in blocks, or -1 for none, in which case the game's own
+	 *                 render distance in CHUNKS is published instead. The change of unit is Iris's
+	 *                 own and it is what packs are written against: without the mod the name
+	 *                 answers {@code getEffectiveRenderDistance}, and with it, chunks times sixteen
+	 */
+	void advanceDistant(float near, float far, int distance) {
+		this.dhNear = near;
+		this.dhFar = far;
+		this.dhRenderDistanceBlocks = distance;
 	}
 
 	/**
@@ -482,9 +520,15 @@ public final class ViewMatrices implements ViewSource {
 	}
 
 	/**
-	 * Distant Horizons is not loaded, and these are answered anyway. Iris registers them without a
-	 * condition and falls back the same way, which is why a pack that reads {@code dhProjection}
-	 * outside the mod still compiles there and did not here.
+	 * Answered whether or not Distant Horizons is loaded. Iris registers them without a condition
+	 * and falls back the same way, which is why a pack that reads {@code dhProjection} outside the
+	 * mod still compiles there and did not here.
+	 * <p>
+	 * The three matrices stay the game's own on both roads, and that is not a gap left open. What a
+	 * pack unprojects with them is a {@code dhDepthTex} lookup, and this engine answers those with
+	 * the far plane: the far terrain is in the game's own depth by then, so the road that would use
+	 * a matrix of DH's is a road no pack takes. The planes and the render distance are read outside
+	 * that road, which is why those three are DH's own the moment DH has drawn.
 	 */
 	@Override
 	public Matrix4fc dhProjection() {
@@ -503,17 +547,18 @@ public final class ViewMatrices implements ViewSource {
 
 	@Override
 	public float dhNearPlane() {
-		return 0.01F;
+		return this.dhNear;
 	}
 
 	@Override
 	public float dhFarPlane() {
-		return 0.01F;
+		return this.dhFar;
 	}
 
 	@Override
-	public int dhRenderDistanceChunks() {
-		return this.renderDistanceChunks;
+	public int dhRenderDistance() {
+		return this.dhRenderDistanceBlocks < 0 ? this.renderDistanceChunks
+				: this.dhRenderDistanceBlocks;
 	}
 
 	@Override

--- a/common/src/main/java/dev/vitrail/uniform/ViewSource.java
+++ b/common/src/main/java/dev/vitrail/uniform/ViewSource.java
@@ -148,7 +148,13 @@ public interface ViewSource {
 
 	float dhFarPlane();
 
-	int dhRenderDistanceChunks();
+	/**
+	 * How far the far terrain reaches, in BLOCKS while Distant Horizons is drawing one and in
+	 * CHUNKS while it is not. The change of unit is Iris's own and packs are written against it:
+	 * without the mod the name answers {@code getEffectiveRenderDistance} and with it, that mod's
+	 * own chunk setting times sixteen.
+	 */
+	int dhRenderDistance();
 
 	float near();
 

--- a/common/src/main/java/dev/vitrail/uniform/values/DhValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/DhValues.java
@@ -4,16 +4,19 @@ import dev.vitrail.uniform.UniformCatalog;
 import dev.vitrail.uniform.UniformShape;
 
 /**
- * The Distant Horizons values, supplied unconditionally with a fallback.
+ * The Distant Horizons values, supplied unconditionally.
  * <p>
- * {@code DISTANT_HORIZONS} itself is not defined, which is the parity: a pack must not be told the
- * mod is there. But the names are read outside that guard by packs that only meant to be careful,
- * and a name nothing declares is a wall of undeclared identifiers rather than a missing feature, so
- * they are answered from our own view either way. This is what closes the twenty four
- * {@code dhProjection} failures the translation stage measured.
+ * Unconditionally, because the names are read outside the {@code DISTANT_HORIZONS} guard by packs
+ * that only meant to be careful, and a name nothing declares is a wall of undeclared identifiers
+ * rather than a missing feature. This is what closes the twenty four {@code dhProjection} failures
+ * the translation stage measured, and it is what Iris does as well: it registers all six without a
+ * condition.
  * <p>
- * The two planes answer 0.01, which is Iris's own fallback and is deliberately a number no pack
- * can mistake for a real distance.
+ * What each of them answers is {@code render/ViewMatrices}'s and moves with the frame. The two
+ * planes and the render distance are DH's own the moment DH has drawn one, and fall back to
+ * Iris's 0.01 otherwise, which is deliberately a number no pack can mistake for a real distance.
+ * The three matrices stay the game's own on both roads, and ViewMatrices says why that is an
+ * answer rather than a gap.
  */
 public final class DhValues {
 
@@ -30,6 +33,6 @@ public final class DhValues {
 		builder.add("dhNearPlane", UniformShape.FLOAT, (world, out) -> out.set(world.dhNearPlane()));
 		builder.add("dhFarPlane", UniformShape.FLOAT, (world, out) -> out.set(world.dhFarPlane()));
 		builder.add("dhRenderDistance", UniformShape.INT,
-				(world, out) -> out.set(world.dhRenderDistanceChunks()));
+				(world, out) -> out.set(world.dhRenderDistance()));
 	}
 }

--- a/common/src/main/java/dev/vitrail/uniform/values/DhValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/DhValues.java
@@ -13,10 +13,13 @@ import dev.vitrail.uniform.UniformShape;
  * condition.
  * <p>
  * What each of them answers is {@code render/ViewMatrices}'s and moves with the frame. The two
- * planes and the render distance are DH's own the moment DH has drawn one, and fall back to
- * Iris's 0.01 otherwise, which is deliberately a number no pack can mistake for a real distance.
- * The three matrices stay the game's own on both roads, and ViewMatrices says why that is an
- * answer rather than a gap.
+ * planes and the render distance are DH's own the moment DH has drawn one. Without one the planes
+ * fall back to Iris's 0.01, {@code compat/dh/DHCompat.java:94} and {@code :104}, deliberately a
+ * number no pack can mistake for a real distance; the render distance falls back to the game's own
+ * in chunks, which is Iris's fallback as well, {@code compat/dh/DHCompat.java:114}, and the change
+ * of unit that comes with it is on {@code uniform/ViewSource}. The three matrices stay the game's
+ * own on both roads, and ViewMatrices says why that is a divergence with a reason under it rather
+ * than a gap.
  */
 public final class DhValues {
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -36,6 +36,7 @@ rather than guess.
 | The sky turns into a flat grey sheet at sunrise | [The sky goes flat](#the-sky-goes-flat) |
 | Blocks wave, glow or cast wrong shadows after switching packs | [You just changed packs](#you-just-changed-packs) |
 | The terrain is uniformly too dark | [Terrain that is too dark](#terrain-that-is-too-dark) |
+| Distant land is there but reads as sky: no fog, wrong focus | [The far terrain is flat](#the-far-terrain-is-flat) |
 
 **Before anything else, read the log.** The engine announces what it refused, what it could not
 serve, and which program it chose for each pass. Most of what follows is already printed there in
@@ -293,6 +294,30 @@ So terrain that is still uniformly too dark is worth reporting rather than attri
 is diagnosed by comparing two builds at the same camera and the same world time on a corner where
 occlusion is strong, not by toggling settings: switching shadows off makes it worse rather than
 better.
+
+## The far terrain is flat
+
+**Distant Horizons is drawing its distant land, you can see it, and the pack treats it as though it
+were sky.** No fog on it, a depth of field focused past it, water that does not know it is behind
+it. It looks like a pack fault and it is not one.
+
+That mod draws its far terrain into images of its own and paints only the colour back onto the
+picture. Its depth never reaches the game's, so everything a pack works out from distance finds
+nothing there and answers with the far plane. Vitrail converts that depth and writes it into the
+world's own before the pack reads any of it, which is what makes those effects right, and it tells
+the pack the far terrain is there so that the pack's own distant-land code runs.
+
+**The log says whether that happened**, and there are three things it can say. Distant Horizons
+found, when the pack is read, and then the two clip planes it was folded between the first time it
+is folded. Distant Horizons installed but not in a shape a depth can be read out of, which is that
+mod's version and not a setting of yours. Or nothing at all, which is the mod not being installed.
+
+Two limits stay whatever the log says. What stands beyond the plane the game itself stops drawing
+at keeps reading as sky, because a reversed depth buffer has no number left past its far plane, and
+that plane is the further of four times the render distance and the cloud distance. And the far
+terrain is coloured by Distant Horizons rather than by the pack, so it is lit its own way and only
+its shape is the pack's to work with; a pack that lights its distant land differently from its near
+land will light all of it the near way.
 
 ## What packs ask for that is unusual
 


### PR DESCRIPTION
## What changes

Distant Horizons draws its far terrain into images of its own and composites only the colour back,
so its depth reached nothing and every effect a pack works out from distance took that land for sky:
no fog on it, a focus point at infinity, water that did not know what stood behind it. Its depth is
now folded into the game's own, at the head of the moment the game has finished its opaque features,
which is ahead of the three copies `PackDepth` takes, of the cut the scene seed is drawn against and
of the world's translucents. The values cannot be copied across: the two are drawn through one
camera but between different clip planes, so a hill a thousand blocks off would land eight blocks
from the player's face. Two projections that differ only in their z row share a w row, so the
conversion is one multiply and one add per texel and is exact rather than fitted. Packs are then
told the far terrain is there, and the six `dh` names answer what that mod really drew with instead
of a stand-in.

## How it differs from the reference, and for what obstacle

Four, each written out with all three parts in the file that carries it.

- The three `dhDepthTex` names answer the far plane where Iris binds that mod's real depth image,
  `IrisSamplers.java:109`. It is nowhere else under Iris; here it is in the game's own depth
  already. `pack/target/SamplerPlan.java`.
- `dhProjection` and its two relatives stay the game's own where Iris builds a perspective of that
  mod's, `DHCompat.java:54`. The road that needs one is the one above. `render/ViewMatrices.java`.
- Both clip planes come out of that mod's matrix where Iris publishes an unclamped near and a far of
  its own formula, `DHCompatInternal.java:133` and `:124`. Iris draws the LODs against exactly those
  two; here that mod draws them itself. `dh/DhDepth.java`.
- The far terrain keeps that mod's colour where Iris draws the LODs with the pack's own `dh_terrain`,
  `dh_water` and `dh_generic`, `DHCompatInternal.java:67`. Those three families are not served here
  at all, and a family served by the wrong program is worse than one left alone. `render/DhFold.java`.

`DISTANT_HORIZONS` is posed on Iris's own two conditions, `StandardMacros.java:64`: that mod
answering, and its rendering switched on. A flip of that switch reads the pack again, as Iris
reloads on it.

## What proves it

- `gradlew build` green after the rebase onto `dev`.
- In the game on BSL v10.1.3 and Complementary Unbound r5.8.1, at one point with the time frozen at
  noon: across the horizon band the mean falls from 194.7 to 113.8 and the deviation rises from 42.4
  to 63.2, which is that band ceasing to be sky and becoming terrain.
- Not in the game: the switch this branch now follows, and the refusal to serve half the numbers.
  Both landed after that measurement and neither touches the conversion.

## What it leaves owing

What stands past the plane the game itself stops drawing at still reads as sky, and closing it would
mean moving the game's own far plane. The three `dh_` families are untouched. Nothing in the
out-of-game harness covers the conversion, the unit of `dhRenderDistance` or the white the three
`dhDepthTex` names answer with; and a `shadowNearPlane` of -1 still resolves against the game's
render distance where Iris resolves it against that mod's.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
