### PR TITLE
Raise the version to 0.4.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ plus, because each of them files an upload per loader and has nowhere else to pu
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.4.0-beta.1
 
 ### Added
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.3.0-alpha.1
+mod_version=0.4.0-beta.1
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

Raises `mod_version` to 0.4.0-beta.1 and names the changelog section: the far terrain of Distant
Horizons drawn by the pack's own programs, and the material maps read on mobs and armour, are what
this version carries over 0.3.0-alpha.1. First beta.

## How it differs from the reference, and for what obstacle

It does not: two lines of housekeeping.

## What proves it

- `gradlew build` green with the new number, both jars named for it.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.