### PR TITLE
ci: fail when build/libs holds a jar no loader claims

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,11 @@ jobs:
       - name: Find the jars
         id: jars
         run: |
+          # The loaders a release is expected to carry, named once. Adding a third is this word
+          # plus a mirror step of its own further down, since a store files a loader per upload.
           shopt -s nullglob
+          expected=0
+
           for loader in neoforge fabric; do
             glob="build/libs/vitrail-$loader-*.jar"
             jars=($glob)
@@ -153,8 +157,21 @@ jobs:
               exit 1
             fi
 
+            expected=$((expected + 1))
             echo "$loader=${jars[0]}" >> "$GITHUB_OUTPUT"
           done
+
+          # The same silence read from the other end. The check above catches a jar that stopped
+          # being built; this one catches a jar that is built and answers to no loader on the list,
+          # which is what a module added to settings.gradle looks like on the day it lands. Without
+          # it that jar reaches neither store and nothing says so, the run ending as green as one
+          # where everything shipped. Counting is enough to find it: the patterns above share the
+          # vitrail- prefix and part at the loader, so no jar is claimed by two of them.
+          built=(build/libs/*.jar)
+          if [ ${#built[@]} -ne "$expected" ]; then
+            echo "::error::the list names $expected jars, and build/libs holds: $(ls build/libs)"
+            exit 1
+          fi
 
       - name: Publish on GitHub
         env:


### PR DESCRIPTION
## What changes

The release job's jar-finding step gains the other half of the check it already had. It refuses a
loader whose jar stopped being built; it now also refuses a jar that was built under a name no
loader on the list answers to. Such a jar reaches neither store and nothing says so, the run ending
as green as one where everything shipped, which is what a module added to `settings.gradle` looks
like on the day it lands. Counting is enough to catch it, the patterns sharing the `vitrail-` prefix
and parting at the loader, so no jar is claimed by two of them. Nothing else moves: the loaders are
still `neoforge fabric`, both jars still go to GitHub and to both stores, and each is still filed
under its own loader by a mirror step of its own.

Worth saying plainly, because the backlog entry this came from reads otherwise: the substance of it
landed on 14 August in "Send a jar per loader to GitHub and to both stores", and the entry was never
struck out. Both jars are real today, `gradlew build` puts `vitrail-neoforge-0.4.0-beta.1+mc26.2.jar`
and `vitrail-fabric-0.4.0-beta.1+mc26.2.jar` side by side in `build/libs`, so the Fabric module is
no longer the empty one some notes still describe. What was left open was only the silence in this
direction.

## How it differs from the reference, and for what obstacle

It does not. Nothing here touches the engine.

## What proves it

- `gradlew build` green, `checkText` included, which is what reads the workflow files.
- The workflow parses as YAML, and the step's `run` block was pulled out of it and run under the
  shell GitHub gives it, `bash -eo pipefail`, over five shapes of `build/libs`: both jars present
  (exit 0, both outputs set); the Fabric jar gone (exit 1); a third jar no loader claims (exit 1,
  on the new line); NeoForge built twice (exit 1); and the directory empty (exit 1).
- **Not proven, and it cannot be here: the real run.** A tag is the only thing that starts this
  workflow, so the first observation of it is the next release. What that leaves unverified is the
  step in its own runner rather than the logic, which is what the five cases above stand in for.

## What it leaves owing

A third loader is one word in the list plus a mirror step of its own, since a store files a loader
per upload and the action hangs one list of loaders on every file it is handed. That step cannot be
folded into a loop without giving up the per-upload loader, so it stays copied.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
