### PR TITLE
fix(pack): say when pack.txt names a pack the folder has lost

### DIFF
--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -128,6 +128,19 @@ public final class PackChain {
 	private static volatile boolean packOff;
 
 	/**
+	 * Whether {@code pack.txt} named a pack this folder does not hold, which is the one way of
+	 * drawing nothing that is not a way of asking for nothing.
+	 * <p>
+	 * <strong>Held apart from {@link #packOff} because the two ended in the same place and mean
+	 * opposite things.</strong> A file saying {@code none} asked for the game's own image and got it,
+	 * so nothing is wrong and nothing is said. A file naming a pack that was renamed, deleted or
+	 * mistyped asked for a picture and got the game's, and it used to raise {@link #packOff} as well:
+	 * the screen then read "No shader pack: the game draws its own image", which says the player got
+	 * what they asked for at the moment they did not.
+	 */
+	private static volatile boolean packMissing;
+
+	/**
 	 * What {@code pack.txt} asked for at the last load, which is not the same question as what is
 	 * drawn: the screen highlights the pack that was chosen even while shaders are switched off, and
 	 * it needs the name to do it.
@@ -461,11 +474,17 @@ public final class PackChain {
 		removed = List.of();
 		packsFirst = true;
 		packOff = false;
-		// Cleared here rather than left to choose(), which the empty folder path below returns ahead of:
-		// without this, a folder emptied between two loads would leave the screen highlighting a pack
-		// that is no longer there.
+		packMissing = false;
+		// Emptied before the read below rather than after it, so that a file that cannot be read at
+		// all leaves the screen naming nothing rather than whatever the load before it asked for.
 		askedFor = PackFile.EMPTY;
 		try {
+			// Read here and no longer inside choose(), which the empty folder road below returns ahead
+			// of. That road is the one a player takes who has just renamed or deleted their only pack,
+			// and without the name this far up it is the one road that cannot say which of the two
+			// happened: the folder is empty, which is true, and is not what they did.
+			askedFor = PackFile.read(packFile(gameDirectory));
+
 			// Both ways out of the next two blocks end with no pack drawing anything, and NEITHER mesh
 			// carries what a pack reads once none wants it: said here as well as on the road that
 			// loads a pack, or picking None after a pack would leave the extra bytes on every vertex
@@ -477,23 +496,41 @@ public final class PackChain {
 			// mesh goes on carrying for a family nothing serves.
 			List<Path> packs = PackLoader.candidates(gameDirectory);
 			if (packs.isEmpty()) {
-				lastError = "No shader pack in " + PackLoader.directory(gameDirectory);
 				TerrainDraw.wanted(false);
 				EntityDraw.wanted(false);
 				HandDraw.wanted(false);
+				// The empty folder is the smaller half of the truth whenever a pack was named: what a
+				// player who has just deleted or renamed their only one needs told is which name went
+				// unanswered, and the folder being empty is why.
+				if (namedAPack()) {
+					packIsMissing(gameDirectory);
+
+					return;
+				}
+
+				lastError = "No shader pack in " + PackLoader.directory(gameDirectory);
 				Vitrail.logger().info("No shader pack in {}, nothing to draw",
 						PackLoader.directory(gameDirectory));
 				return;
 			}
 
-			Path pack = choose(gameDirectory, packs).orElse(null);
-			// Nothing is left behind and nothing is reported as an error: this is the same path as
-			// an empty folder, taken because it was asked for rather than because nothing was found.
+			Path pack = choose(packs, askedFor).orElse(null);
 			if (pack == null) {
-				packOff = true;
+				// Both roads out of here draw nothing, so both take the meshes down, and only then are
+				// they told apart: what parts them is whether nothing was asked for or whether what was
+				// asked for is not there.
 				TerrainDraw.wanted(false);
 				EntityDraw.wanted(false);
 				HandDraw.wanted(false);
+				if (namedAPack()) {
+					packIsMissing(gameDirectory);
+
+					return;
+				}
+
+				// Nothing is left behind and nothing is reported as an error: this is the same path as
+				// an empty folder, taken because it was asked for rather than because nothing was found.
+				packOff = true;
 				Vitrail.logger().info("No pack asked for, so none of the {} in {} is read and the game "
 						+ "draws its own image. Pick one in the settings screen, or name it in {}",
 						packs.size(), PackLoader.directory(gameDirectory), packFile(gameDirectory));
@@ -654,6 +691,41 @@ public final class PackChain {
 		}
 	}
 
+	/**
+	 * Whether {@code pack.txt} named a pack at all, as opposed to asking for none of them.
+	 * <p>
+	 * The one test the two roads out of a load that draws nothing are told apart by, so that they
+	 * cannot answer differently: shaders switched off and the word {@code none} are both a player
+	 * asking for the game's own image, and anything else in that file is a player asking for a
+	 * picture. It repeats the two refusals {@link #choose} makes on the same grounds and has to: that
+	 * method is not reached at all when the folder holds nothing to search.
+	 */
+	private static boolean namedAPack() {
+		PackFile asked = askedFor;
+
+		return asked.wantsPack() && !asked.namesNone();
+	}
+
+	/**
+	 * Says, once and in one place, that the pack a player named is not there.
+	 * <p>
+	 * Two roads run into this and they are one fault to the player: the folder holds packs and none
+	 * of them answers the name, or the folder holds nothing at all. Written twice, the two would say
+	 * it in two ways and then drift, and the difference between them is not one a player can act on.
+	 * <p>
+	 * The reason is kept on {@link #lastError} rather than only logged, which is what carries it to
+	 * the chat line the reload key says and to the screen's bottom line, both of which read that
+	 * field and neither of which the log reaches.
+	 */
+	private static void packIsMissing(Path gameDirectory) {
+		packMissing = true;
+		lastError = "No pack named '" + askedFor.name() + "' in "
+				+ PackLoader.directory(gameDirectory) + ", so nothing is drawn";
+		Vitrail.logger().error("{} names '{}', and no pack of that name is in {}, so nothing is drawn."
+				+ " Check the name, or pick a pack in the settings screen", packFile(gameDirectory),
+				askedFor.name(), PackLoader.directory(gameDirectory));
+	}
+
 	/** The file naming the pack to draw, written by the settings screen and edited by hand. */
 	public static Path packFile(Path gameDirectory) {
 		return gameDirectory.resolve(Vitrail.MOD_ID).resolve("pack.txt");
@@ -663,6 +735,12 @@ public final class PackChain {
 	 * Which pack to draw: the one {@code vitrail/pack.txt} names, by whole or partial name, and none
 	 * at all when it names nothing this folder has, when it says {@link #NO_PACK}, or when it is not
 	 * there.
+	 * <p>
+	 * <strong>Those three empty answers are not one answer.</strong> Only the last two asked for the
+	 * game's own image; the first asked for a picture and cannot be given one. Which of the three it
+	 * was is not said here and is not returned either: {@link #namedAPack} tells them apart from the
+	 * file alone, which is what lets the road that never reaches this method, an empty folder, answer
+	 * the same way rather than nearly the same way.
 	 * <p>
 	 * <strong>Nothing is loaded until something is asked for</strong>, which is the rule every
 	 * shader loader follows and the only one that does not surprise: dropping this mod into an
@@ -680,15 +758,12 @@ public final class PackChain {
 	 * on a fragment the shorter one would answer for both: the settings screen writes the whole
 	 * name for that reason and would otherwise be unable to reach the longer one at all.
 	 *
+	 * @param asked what {@code pack.txt} says, read by the caller: the folder is searched here and
+	 *              the file is not, so that the one road out of a load that never searches a folder
+	 *              still knows what was asked of it
 	 * @return empty when no pack is to be drawn
 	 */
-	private static Optional<Path> choose(Path gameDirectory, List<Path> packs) throws IOException {
-		Path file = packFile(gameDirectory);
-		PackFile asked = PackFile.read(file);
-		// Held whichever way this goes, because the screen highlights the pack that was chosen even
-		// while shaders are switched off, and that is the whole point of the file carrying two facts.
-		askedFor = asked;
-
+	private static Optional<Path> choose(List<Path> packs, PackFile asked) {
 		if (!asked.wantsPack()) {
 			return Optional.empty();
 		}
@@ -709,9 +784,6 @@ public final class PackChain {
 				return Optional.of(pack);
 			}
 		}
-
-		Vitrail.logger().warn("No pack in the folder matches '{}' from {}, so none is drawn", wanted,
-				file);
 
 		return Optional.empty();
 	}
@@ -898,6 +970,18 @@ public final class PackChain {
 	 */
 	public static boolean noPackWanted() {
 		return packOff;
+	}
+
+	/**
+	 * Whether the pack {@code pack.txt} names is one the folder no longer holds, which is the third
+	 * answer to "why is nothing being drawn" and the only one of the three that is a fault.
+	 * <p>
+	 * The name that was asked for is {@link #askedFor}'s to give, which it does whether or not it was
+	 * found: a screen saying this has to be able to name it, or it says no more than the empty folder
+	 * it is not.
+	 */
+	public static boolean packMissing() {
+		return packMissing;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/screen/ScreenText.java
+++ b/common/src/main/java/dev/vitrail/screen/ScreenText.java
@@ -113,6 +113,13 @@ public final class ScreenText {
 	/** The other reason there is nothing to configure: the folder was left alone on purpose. */
 	public static final String PACK_OFF = "options.vitrail.pack_off";
 
+	/**
+	 * The third reason, and the only one that is a fault: a pack was named and the folder has no such
+	 * pack. One argument, the name that was asked for, without which this says no more than
+	 * {@link #NO_PACK} does.
+	 */
+	public static final String PACK_MISSING = "options.vitrail.pack_missing";
+
 	public static final String OPEN_SETTINGS = "key.vitrail.open_settings";
 
 	/**

--- a/common/src/main/java/dev/vitrail/screen/SettingsKey.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsKey.java
@@ -95,10 +95,13 @@ public final class SettingsKey {
 	 * that same question. Iris says both lines too, {@code Iris.java:184} and {@code Iris.java:191},
 	 * off a catch rather than off a question because throwing is what its own reload does.
 	 * <p>
-	 * <b>One reading that failed still answers as one that worked</b>, and it is the engine's answer
-	 * rather than this line's: a {@code pack.txt} naming a pack the folder no longer holds is warned
-	 * about and then treated as no pack having been asked for, so nothing is left to ask. The screen's
-	 * own bottom line says "no shader pack" in that same case, for the same reason.
+	 * <b>A reading that read nothing because the named pack is gone answers as a failure</b>, which it
+	 * did not always: a {@code pack.txt} naming a pack the folder no longer holds used to be warned
+	 * about and then treated as no pack having been asked for, so this line said "Shaders Reloaded!"
+	 * over a reading that had opened nothing, and the screen's own bottom line went further and said
+	 * the game was drawing its own image on purpose. Asking for no pack at all is still no failure and
+	 * still says the first line, which is the whole distinction: {@code PackChain.packMissing} holds
+	 * it.
 	 */
 	private static void reload() {
 		Path directory = PackChain.session()

--- a/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
@@ -538,7 +538,17 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 		button.setTooltip(button.active ? null : Tooltip.create(noPackReason()));
 	}
 
+	/**
+	 * Why there is nothing to configure, for the tooltip on the dead view switch, and the pack that
+	 * was named is named back rather than folded into either of the other two answers. It used to
+	 * fall into {@link ScreenText#PACK_OFF}, "the game draws its own image", which is what a file
+	 * saying {@code none} means and the opposite of what a mistyped or renamed pack did.
+	 */
 	private static Component noPackReason() {
+		if (PackChain.packMissing()) {
+			return Component.translatable(ScreenText.PACK_MISSING, PackChain.askedFor().name());
+		}
+
 		return Component.translatable(
 				PackChain.noPackWanted() ? ScreenText.PACK_OFF : ScreenText.NO_PACK);
 	}

--- a/common/src/main/resources/assets/vitrail/lang/de_de.json
+++ b/common/src/main/resources/assets/vitrail/lang/de_de.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "Es ist kein Shaderpaket geladen",
 	"options.vitrail.pack_off": "Kein Shaderpaket: Das Spiel zeichnet sein eigenes Bild",
+	"options.vitrail.pack_missing": "Das Shaderpaket \"%s\" ist nicht in deinem Shaderpaket-Ordner",
 	"key.vitrail.open_settings": "Shader-Einstellungen öffnen",
 	"key.vitrail.reload_pack": "Shader neu laden",
 	"options.vitrail.pack_reloaded": "Shader neu geladen!",

--- a/common/src/main/resources/assets/vitrail/lang/en_us.json
+++ b/common/src/main/resources/assets/vitrail/lang/en_us.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "No shader pack is loaded",
 	"options.vitrail.pack_off": "No shader pack: the game draws its own image",
+	"options.vitrail.pack_missing": "Shader pack \"%s\" is not in your Shader Packs folder",
 	"key.vitrail.open_settings": "Open shader pack settings",
 	"key.vitrail.reload_pack": "Reload Shaders",
 	"options.vitrail.pack_reloaded": "Shaders Reloaded!",

--- a/common/src/main/resources/assets/vitrail/lang/es_es.json
+++ b/common/src/main/resources/assets/vitrail/lang/es_es.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "No hay ningún Shader Pack cargado",
 	"options.vitrail.pack_off": "Sin Shader Pack: el juego dibuja su propia imagen",
+	"options.vitrail.pack_missing": "El Shader Pack \"%s\" no está en tu carpeta de Shader Packs",
 	"key.vitrail.open_settings": "Abrir la configuración del Shader Pack",
 	"key.vitrail.reload_pack": "Recargar Shaders",
 	"options.vitrail.pack_reloaded": "¡Shaders recargados!",

--- a/common/src/main/resources/assets/vitrail/lang/fr_fr.json
+++ b/common/src/main/resources/assets/vitrail/lang/fr_fr.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "Aucun pack de shaders n'est chargé",
 	"options.vitrail.pack_off": "Aucun pack de shaders : le jeu dessine sa propre image",
+	"options.vitrail.pack_missing": "Le pack de shaders \"%s\" n'est pas dans votre dossier de packs de shaders",
 	"key.vitrail.open_settings": "Ouvrir les options du pack de shaders",
 	"key.vitrail.reload_pack": "Recharger les shaders",
 	"options.vitrail.pack_reloaded": "Shaders rechargés !",

--- a/common/src/main/resources/assets/vitrail/lang/it_it.json
+++ b/common/src/main/resources/assets/vitrail/lang/it_it.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "Nessun pacchetto di shader caricato",
 	"options.vitrail.pack_off": "Nessun pacchetto di shader: il gioco disegna la propria immagine",
+	"options.vitrail.pack_missing": "Il pacchetto di shader \"%s\" non è nella cartella dei pacchetti di shader",
 	"key.vitrail.open_settings": "Apri le impostazioni del pacchetto di shader",
 	"key.vitrail.reload_pack": "Riavvia Shaders",
 	"options.vitrail.pack_reloaded": "Shaders Ricaricate!",

--- a/common/src/main/resources/assets/vitrail/lang/ja_jp.json
+++ b/common/src/main/resources/assets/vitrail/lang/ja_jp.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "シェーダーパックが読み込まれていません",
 	"options.vitrail.pack_off": "シェーダーパックなし：ゲームが自前の映像を描画します",
+	"options.vitrail.pack_missing": "シェーダーパック「%s」がシェーダーパックフォルダーにありません",
 	"key.vitrail.open_settings": "シェーダーパックの設定を開く",
 	"key.vitrail.reload_pack": "シェーダーを再読み込み",
 	"options.vitrail.pack_reloaded": "シェーダーを再読み込みしました！",

--- a/common/src/main/resources/assets/vitrail/lang/ko_kr.json
+++ b/common/src/main/resources/assets/vitrail/lang/ko_kr.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "불러온 셰이더 팩이 없습니다",
 	"options.vitrail.pack_off": "셰이더 팩 없음: 게임이 자체 화면을 그립니다",
+	"options.vitrail.pack_missing": "셰이더 팩 \"%s\"이(가) 셰이더 팩 폴더에 없습니다",
 	"key.vitrail.open_settings": "셰이더 팩 설정 열기",
 	"key.vitrail.reload_pack": "셰이더 새로고침",
 	"options.vitrail.pack_reloaded": "셰이더를 다시 불러왔습니다.",

--- a/common/src/main/resources/assets/vitrail/lang/nl_nl.json
+++ b/common/src/main/resources/assets/vitrail/lang/nl_nl.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "Er is geen shader pack geladen",
 	"options.vitrail.pack_off": "Geen shader pack: het spel tekent zijn eigen beeld",
+	"options.vitrail.pack_missing": "Shader pack \"%s\" staat niet in je shader pack-map",
 	"key.vitrail.open_settings": "Shader pack-instellingen openen",
 	"key.vitrail.reload_pack": "Herlaad Shaders",
 	"options.vitrail.pack_reloaded": "Shaders herladen!",

--- a/common/src/main/resources/assets/vitrail/lang/pl_pl.json
+++ b/common/src/main/resources/assets/vitrail/lang/pl_pl.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "Nie wczytano żadnego pakietu shaderów",
 	"options.vitrail.pack_off": "Brak pakietu shaderów: gra rysuje własny obraz",
+	"options.vitrail.pack_missing": "Pakietu shaderów \"%s\" nie ma w folderze pakietów shaderów",
 	"key.vitrail.open_settings": "Otwórz ustawienia pakietu shaderów",
 	"key.vitrail.reload_pack": "Przeładuj Shadery",
 	"options.vitrail.pack_reloaded": "Przeładowano Shadery!",

--- a/common/src/main/resources/assets/vitrail/lang/pt_br.json
+++ b/common/src/main/resources/assets/vitrail/lang/pt_br.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "Nenhum pacote de sombreadores carregado",
 	"options.vitrail.pack_off": "Sem pacote de sombreadores: o jogo desenha a própria imagem",
+	"options.vitrail.pack_missing": "O pacote de sombreadores \"%s\" não está na sua pasta de pacotes de sombreadores",
 	"key.vitrail.open_settings": "Abrir configurações do pacote de sombreadores",
 	"key.vitrail.reload_pack": "Recarregar sombreadores",
 	"options.vitrail.pack_reloaded": "Sombreadores recarregados!",

--- a/common/src/main/resources/assets/vitrail/lang/ru_ru.json
+++ b/common/src/main/resources/assets/vitrail/lang/ru_ru.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "Набор шейдеров не загружен",
 	"options.vitrail.pack_off": "Набора шейдеров нет: игра рисует собственное изображение",
+	"options.vitrail.pack_missing": "Набора шейдеров \"%s\" нет в вашей папке с наборами шейдеров",
 	"key.vitrail.open_settings": "Открыть настройки набора шейдеров",
 	"key.vitrail.reload_pack": "Перезагрузить шейдеры",
 	"options.vitrail.pack_reloaded": "Шейдеры перезагружены.",

--- a/common/src/main/resources/assets/vitrail/lang/tr_tr.json
+++ b/common/src/main/resources/assets/vitrail/lang/tr_tr.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "Yüklü bir shader paketi yok",
 	"options.vitrail.pack_off": "Shader paketi yok: oyun kendi görüntüsünü çiziyor",
+	"options.vitrail.pack_missing": "\"%s\" Shader Paketi senin Shader Paket klasöründe yok",
 	"key.vitrail.open_settings": "Shader paketi ayarlarını aç",
 	"key.vitrail.reload_pack": "Shaderları Yenile",
 	"options.vitrail.pack_reloaded": "Shaderlar Yeniden Yüklendi!",

--- a/common/src/main/resources/assets/vitrail/lang/uk_ua.json
+++ b/common/src/main/resources/assets/vitrail/lang/uk_ua.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "Пакет шейдерів не завантажено",
 	"options.vitrail.pack_off": "Пакета шейдерів немає: гра малює власне зображення",
+	"options.vitrail.pack_missing": "Пакета шейдерів \"%s\" немає у вашій папці пакетів шейдерів",
 	"key.vitrail.open_settings": "Відкрити налаштування пакета шейдерів",
 	"key.vitrail.reload_pack": "Перезавантажити шейдери",
 	"options.vitrail.pack_reloaded": "Шейдери перезавантажено!",

--- a/common/src/main/resources/assets/vitrail/lang/zh_cn.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_cn.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "未加载光影包",
 	"options.vitrail.pack_off": "无光影包：游戏绘制自己的画面",
+	"options.vitrail.pack_missing": "光影包\"%s\"不在光影包文件夹中",
 	"key.vitrail.open_settings": "打开光影包设置",
 	"key.vitrail.reload_pack": "重新加载光影包",
 	"options.vitrail.pack_reloaded": "已重新加载光影包！",

--- a/common/src/main/resources/assets/vitrail/lang/zh_tw.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_tw.json
@@ -37,6 +37,7 @@
 	"options.vitrail.error": "%s",
 	"options.vitrail.no_pack": "未載入光影包",
 	"options.vitrail.pack_off": "無光影包：遊戲繪製自己的畫面",
+	"options.vitrail.pack_missing": "「%s」光影包不在光影包資料夾中",
 	"key.vitrail.open_settings": "開啟光影包設定",
 	"key.vitrail.reload_pack": "重新載入光影",
 	"options.vitrail.pack_reloaded": "已重新載入光影！",


### PR DESCRIPTION
## What changes

`pack.txt` naming a pack the folder no longer holds, because it was renamed, deleted or mistyped, was warned about in the log and then answered exactly like a file saying `none`: it raised the same flag, so the reload key said "Shaders Reloaded!" over a reading that had opened nothing, and the settings screen's bottom line read "No shader pack: the game draws its own image", which is what a file saying `none` means and the opposite of what had happened. The same name in a folder that has just lost its last pack returned one road earlier still and said only that the folder was empty, which is why the name went unanswered rather than what went wrong. Both roads now run into one sentence naming the file, the name and the folder, at error level in the log and on `lastError`, which is the field the chat message and the screen's bottom line already read; `pack.txt` is read at the head of the load rather than inside `choose` so that the road which never searches a folder still knows what was asked of it. Asking for no pack at all is untouched and stays silent. The dead "Shader Pack Settings" button's tooltip gets a string of its own, `options.vitrail.pack_missing`, so it names the pack instead of repeating either empty answer; it is added to all fifteen language files.

## How it differs from the reference, and for what obstacle

It does not. Iris reports a pack it cannot find as a load failure and says so on both surfaces; this brings the missing-name case in line with that rather than away from it.

## What proves it

- `gradlew build` green, including a `--rerun-tasks` pass.
- Reading, for the four states: a named pack the folder cannot answer sets the error, with other packs present or with none at all; a file saying `none` still takes the `packOff` road untouched; shaders switched off with a name remembered takes it too, since `wantsPack()` is false; and a first boot with no `shaderpacks` folder still reports the empty folder, `PackLoader.candidates` returning empty and nothing having been named.
- Not confirmed in the game. Nobody has yet watched the chat line or the bottom line with a broken `pack.txt`, and that is still owed.

## What it leaves owing

The bottom line shows the engine's own English reason, like every other load failure on that line; only the tooltip is translated. The in-game confirmation above.
