### PR TITLE
fix(sodium): drop RGSS from the filter list while a pack draws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ plus, because each of them files an upload per loader and has nowhere else to pu
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Fixed
+
+- The texture filtering selector in the video settings no longer offers RGSS while a pack draws the
+  world. That method is written into the terrain shader the game and Sodium ship, and neither of
+  those two draws once the pack's own terrain program does, so the setting read as live and moved
+  nothing at all. It comes back the moment no pack is drawing the terrain. Anisotropic filtering is
+  untouched and goes on working under a pack.
+
 ## 0.4.0-beta.1
 
 ### Added

--- a/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
+++ b/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
@@ -1,14 +1,19 @@
 package dev.vitrail.sodium;
 
 import dev.vitrail.Vitrail;
+import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.screen.ScreenText;
 import dev.vitrail.screen.SettingsScreen;
 
 import net.caffeinemc.mods.sodium.api.config.ConfigEntryPoint;
+import net.caffeinemc.mods.sodium.api.config.ConfigState;
 import net.caffeinemc.mods.sodium.api.config.structure.ConfigBuilder;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.TextureFilteringMethod;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
+
+import java.util.Set;
 
 /**
  * Puts the settings screen in the video settings, which Sodium owns.
@@ -22,7 +27,8 @@ import net.minecraft.resources.Identifier;
  * public API rather than by reaching into Sodium: one page under the mod's own name, which opens
  * this screen with the video settings as the screen to come back to. What the reference has and this
  * does not is a second page of its own video options, because everything this engine has to offer is
- * the pack's own and lives on the pack's pages.
+ * the pack's own and lives on the pack's pages. The one thing registered here that is not a page is
+ * an overlay over an option of Sodium's own, whose reason is written where it is registered.
  * <p>
  * Each loader's metadata names this class, and each reaches it its own way: on NeoForge Sodium is
  * handed the name and builds an instance by reflection, on Fabric the loader's own entry point
@@ -49,6 +55,15 @@ public final class ConfigEntry implements ConfigEntryPoint {
 	 */
 	private static final int THEME = 0xFF2E6FD9;
 
+	/** Sodium's own texture filtering selector, the one option here has anything to say about. */
+	private static final Identifier FILTERING = Identifier.parse("sodium:quality.filtering_mode");
+
+	/** What the selector offers while the pack draws the world, and what it offers otherwise. */
+	private static final Set<TextureFilteringMethod> WITHOUT_RGSS =
+			Set.of(TextureFilteringMethod.NONE, TextureFilteringMethod.ANISOTROPIC);
+	private static final Set<TextureFilteringMethod> EVERY_METHOD =
+			Set.of(TextureFilteringMethod.values());
+
 	@Override
 	public void registerConfigLate(ConfigBuilder builder) {
 		builder.registerOwnModOptions()
@@ -59,6 +74,30 @@ public final class ConfigEntry implements ConfigEntryPoint {
 				.addPage(builder.createExternalPage()
 						.setName(Component.translatable(ScreenText.PACKS_TITLE))
 						.setScreenConsumer(parent ->
-								Minecraft.getInstance().gui.setScreen(new SettingsScreen(parent))));
+								Minecraft.getInstance().gui.setScreen(new SettingsScreen(parent))))
+				// RGSS is shader code, written into the game's own terrain shader and into Sodium's,
+				// so it is worth nothing while the pack's terrain program is the one drawing: the
+				// player moves the selector and the image does not move. ANISOTROPIC keeps working,
+				// because it is a sampler and an atlas seam fix rather than a shader, and this engine
+				// takes both as it finds them. The reference registers this same overlay over the
+				// same two values, IrisConfig.java:78.
+				//
+				// What differs is the question asked, and only because this engine can answer a
+				// narrower one. The reference asks whether a pack is loaded, IrisConfig.java:87,
+				// which for it is the same thing: a loaded pack there always takes the terrain over.
+				// Here the pack's terrain program can be off on its own while the rest of the chain
+				// draws, either because the engine options refuse it or because reading it threw, and
+				// then Sodium's own shader draws the world and RGSS works again. So the question is
+				// whether that program draws, which is what TerrainDraw.asked answers.
+				//
+				// Asked through UPDATE_ON_REBUILD rather than read once, so the list follows a pack
+				// loaded or dropped while the game is up rather than the state the screen was first
+				// built under. A stored RGSS is not carried around the gap: Sodium falls back to the
+				// option's default for a value its own allowed set no longer holds.
+				.registerOptionOverlay(FILTERING,
+						builder.createEnumOption(FILTERING, TextureFilteringMethod.class)
+								.setAllowedValuesProvider(
+										state -> TerrainDraw.asked() ? WITHOUT_RGSS : EVERY_METHOD,
+										ConfigState.UPDATE_ON_REBUILD));
 	}
 }


### PR DESCRIPTION
## What changes

Sodium's texture filtering selector no longer offers RGSS while the pack's own terrain program is
the one drawing the world. RGSS is shader code, written into the terrain shader the game ships and
into Sodium's, and neither of those runs under a pack, so the control read as live and moved
nothing. The engine registers an overlay on `sodium:quality.filtering_mode` through the same public
options API it already uses for its own page, and hands it the two values that still do something,
NONE and ANISOTROPIC, the latter being a sampler and an atlas seam fix that this engine takes as it
finds them. The list is asked again on every rebuild of the screen rather than read once, so a pack
loaded or dropped while the game is up moves it; a stored RGSS falls back to the option's default
for as long as the list excludes it, which is Sodium's own handling of a value outside the allowed
set.

## How it differs from the reference, and for what obstacle

Same overlay, same two values, one narrower question. Iris asks whether a pack is loaded,
`common/src/main/java/net/irisshaders/iris/compat/sodium/config/IrisConfig.java:87`, which for it
is the same thing as the terrain being taken over. Here the pack's terrain program can be off on
its own while the rest of the chain draws, either because the engine options refuse it or because
reading it threw, `common/src/main/java/dev/vitrail/render/TerrainDraw.java:228`, and Sodium's own
shader then draws the world with RGSS working. So the test is `TerrainDraw.asked`, which is the
same rule stated against the state this engine has. It costs the image nothing.

Iris's second overlay on `sodium:quality.graphics` is not part of this branch.

## What proves it

- `gradlew build` green.
- Reading the 0.9.1 API off the jar in the Gradle cache: overlays merge field by field and keep the
  base option's name and tooltip, and `UPDATE_ON_REBUILD` is what re-evaluates a provider when the
  screen is built.

Not proven in the game: there is no harness for Sodium's screen, so the selector has not been
looked at with a pack loaded.

## What it leaves owing

The in-game check above.
