### PR TITLE
refactor(pack): split directive values as Iris splits them

### DIFF
--- a/common/src/main/java/dev/vitrail/pack/program/AlphaTest.java
+++ b/common/src/main/java/dev/vitrail/pack/program/AlphaTest.java
@@ -84,7 +84,11 @@ public record AlphaTest(Function function, float reference) {
 
 		// A third token is ignored rather than refused, which is what Iris does with it: a trailing
 		// comment on the line would otherwise cost the pack its threshold.
-		String[] parts = value.split("\\s+", -1);
+		//
+		// One space and not a run of whitespace, because that is the separator Iris gives this
+		// directive: a value written with a tab or a double space parses into empty words there, and
+		// reading it here would accept a line the reference refuses.
+		String[] parts = value.split(" ", -1);
 		if (parts.length < 2) {
 			return Optional.empty();
 		}

--- a/common/src/main/java/dev/vitrail/pack/program/BlendMode.java
+++ b/common/src/main/java/dev/vitrail/pack/program/BlendMode.java
@@ -42,7 +42,10 @@ public record BlendMode(boolean off, String srcRgb, String dstRgb, String srcAlp
 			return Optional.of(OFF);
 		}
 
-		List<String> factors = List.of(trimmed.toUpperCase(Locale.ROOT).split("\\s+", -1));
+		// One space, the separator Iris gives the blend directives, and not a run of whitespace: a
+		// double space between two factors leaves an empty word between them there, so the value
+		// stops being four factors and the override is dropped.
+		List<String> factors = List.of(trimmed.toUpperCase(Locale.ROOT).split(" ", -1));
 		if (factors.size() == 4) {
 			return Optional.of(new BlendMode(false, factors.get(0), factors.get(1), factors.get(2),
 					factors.get(3)));

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -63,7 +63,7 @@ public final class ShaderProperties {
 	private static final Pattern ALPHA_TEST = Pattern.compile("^\\s*alphaTest\\.(\\S+)\\s*=\\s*(.*)$");
 	private static final Pattern SLIDERS = Pattern.compile("^\\s*sliders\\s*=\\s*(.*)$");
 	// Two lines that say what a pack cannot draw without, and what it would use if it were there.
-	// Whitespace separated lists, and the last line of each wins, which is how Iris reads them.
+	// Space separated lists, and the last line of each wins, which is how Iris reads them.
 	private static final Pattern IRIS_FEATURES =
 			Pattern.compile("^\\s*iris\\.features\\.(required|optional)\\s*=\\s*(.*)$");
 	private static final Pattern END_FLASH_SHADOWS = Pattern.compile("^\\s*endFlashShadows\\s*=\\s*(.*)$");
@@ -262,7 +262,11 @@ public final class ShaderProperties {
 			List<String> layout = builder.screens.computeIfAbsent(page, _ -> new ArrayList<>());
 			List<ScreenToken> slots = builder.screenLayout.computeIfAbsent(page, _ -> new ArrayList<>());
 
-			for (String token : screen.group(2).trim().split("\\s+", -1)) {
+			// A run of SPACES and not a run of whitespace. The list directives are the only ones Iris
+			// splits on more than one space, and even there a tab is not a separator; every other
+			// directive of this file is split on a single space, which is why the two forms sit side
+			// by side here rather than one being used throughout.
+			for (String token : screen.group(2).trim().split(" +", -1)) {
 				if (token.isEmpty()) {
 					continue;
 				}
@@ -306,7 +310,7 @@ public final class ShaderProperties {
 		Matcher features = IRIS_FEATURES.matcher(line);
 		if (features.matches()) {
 			List<String> named = new ArrayList<>();
-			for (String token : features.group(2).trim().split("\\s+", -1)) {
+			for (String token : features.group(2).trim().split(" +", -1)) {
 				if (!token.isEmpty()) {
 					named.add(token);
 				}
@@ -323,7 +327,7 @@ public final class ShaderProperties {
 
 		Matcher sliders = SLIDERS.matcher(line);
 		if (sliders.matches()) {
-			for (String token : sliders.group(1).trim().split("\\s+", -1)) {
+			for (String token : sliders.group(1).trim().split(" +", -1)) {
 				if (SCREEN_TOKEN.matcher(token).matches()) {
 					builder.sliders.add(token);
 				}
@@ -399,7 +403,7 @@ public final class ShaderProperties {
 		// really did take the splashes away. A line whose two words are both unreadable falls
 		// through, which is where a reader has to be able to find it.
 		Matcher weather = WEATHER.matcher(line);
-		if (weather.matches() && reads(weather.group(1).trim().split("\\s+", 0))) {
+		if (weather.matches() && reads(weather.group(1).trim().split(" ", 0))) {
 			return;
 		}
 
@@ -898,12 +902,12 @@ public final class ShaderProperties {
 		boolean particles = true;
 
 		for (Matcher line : live(WEATHER, defines)) {
-			// Split on whitespace, the first word being the rain and the second the splashes, and a
-			// second word left out leaves the splashes alone. Iris takes the words the same way and
+			// Split on one space, the first word being the rain and the second the splashes, and a
+			// second word left out leaves the splashes alone. Iris splits this value the same way and
 			// reads anything that is not "true" as false; this reads the four words the rest of the
 			// file takes and leaves the piece as it was on anything else, which is the rule every
 			// other boolean of this class already follows.
-			String[] words = line.group(1).trim().split("\\s+", 0);
+			String[] words = line.group(1).trim().split(" ", 0);
 			Boolean rain = truth(words[0]);
 			if (rain != null) {
 				drawn = rain;
@@ -1034,7 +1038,7 @@ public final class ShaderProperties {
 
 			Matcher image = IMAGE.matcher(line);
 			if (conditions.active() && image.matches()) {
-				String[] words = image.group(1).trim().split("\\s+", -1);
+				String[] words = image.group(1).trim().split(" ", -1);
 				if (!words[0].isEmpty() && !words[0].equalsIgnoreCase("none")) {
 					samplers.add(words[0]);
 				}
@@ -1068,7 +1072,8 @@ public final class ShaderProperties {
 			return;
 		}
 
-		for (String token : body.trim().split("\\s+", -1)) {
+		// A profile body is one of the lists, so it is split on a run of spaces like the others.
+		for (String token : body.trim().split(" +", -1)) {
 			if (token.isEmpty()) {
 				continue;
 			}

--- a/common/src/main/java/dev/vitrail/pack/target/TargetSize.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetSize.java
@@ -47,7 +47,9 @@ public record TargetSize(boolean relative, float width, float height) {
 	 *                {@code size.buffer.colortex1 = REFLECTION_RES REFLECTION_RES}
 	 */
 	public static Optional<TargetSize> parse(String value, Map<String, String> defines) {
-		String[] parts = value.trim().split("\\s+", -1);
+		// One space, as Iris splits size.buffer, and not a run of whitespace: two words separated by
+		// more than one space make three there, and the directive is refused instead of resized.
+		String[] parts = value.trim().split(" ", -1);
 		if (parts.length != 2) {
 			return Optional.empty();
 		}

--- a/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
@@ -201,7 +201,10 @@ public final class PackTextures {
 		// have a deferred read the scene as a lookup table, which is the picture nobody questions,
 		// where black is a question. The file itself is the one thing that can, and only by not
 		// being there at all; that case is at the bottom of this method.
-		String[] parts = value.trim().split("\\s+", -1);
+		// One space, the separator Iris gives the texture directives, and not a run of whitespace:
+		// the word count is what tells a PNG from a raw texture there, and an empty word between two
+		// real ones moves the value into a count the format gives no meaning to.
+		String[] parts = value.trim().split(" ", -1);
 		if (parts.length != PNG_TOKENS && (parts.length < RAW_1D_TOKENS || parts.length > RAW_3D_TOKENS)) {
 			refused.add(new Refused(key, value, "holds " + parts.length
 					+ " words, and the format gives a meaning to 1, 6, 7 and 8", stage, sampler));

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -103,6 +103,13 @@ buffer sizes, the sky toggles, the shadow caster directives, the noise and custo
 images and the per-program flip directives described further down. Patterns are anchored and tried
 in a fixed order, first match wins.
 
+**A value is cut on SPACES, and a tab never separates two words.** The lists, which are the screen
+and its pages, the two feature lines, the sliders and the profile bodies, take a run of spaces as
+one separator; every other directive takes a single space, so a double space there leaves an empty
+word in the middle of the value and changes how many words the directive holds. That is not a
+nicety of ours, it is where the reference draws the line, and a value written with a tab is read by
+neither.
+
 Two rules are worth calling out:
 
 **The per-program enable flag is read through the pack's own preprocessor conditionals**, using the


### PR DESCRIPTION
## What changes

Every value read out of shaders.properties was cut on a run of whitespace, which is a separator no
reference uses. Iris cuts each directive on a single space, and only the lists (the screen and its
pages, the two feature lines, the sliders and the profile bodies) on a run of spaces; a tab
separates nothing in either form. The eleven sites are now paired one by one with the directive
they read, so a value holding a tab or a double space holds the same number of words here as it
does there: an alphaTest that loses its threshold, a blend that stops being four factors, a
size.buffer refused, a customTexture that lands in a word count the format gives no meaning to.

## How it differs from the reference, and for what obstacle

It does not. Each site takes the separator its own directive takes in
`shaderpack/properties/ShaderProperties.java`, the single space at :242 to :515 and the ` +` of the
two list helpers at :712 and :720.

## What proves it

- `gradlew build` green.
- The out-of-game harness over the eight packs, run twice against one frozen copy of the tools,
  once on the branch point and once on the branch: Cibles, Chaine, Ordre, Echantillonneurs,
  Geometrie, Textures, Terrain, Entites, plus Harness, Cles, Verdicts and Expressions. Every TSV
  and every emitted stage is identical byte for byte; the summaries differ only in their elapsed
  times, the output path they echo and the row order Terrain prints. No pack of the corpus writes
  a tab or a double space at those places, so anything else would have been a mispairing rather
  than a gain.
- Not in the game: nothing here changes what is drawn for the packs of the corpus.

## What it leaves owing

The splits outside shaders.properties are untouched and keep their run-of-whitespace separator:
the block and entity id maps, the option comment that lists allowed values, the dimension
declarations and the preprocessor. They read other files, against other rules in the reference.
