### PR TITLE
feat(render): give the shadow distance a slider of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ what the next one holds.
 
 ## Unreleased
 
+### Added
+
+- **A Max Shadow Distance slider in the video settings, under Vitrail.** Pulling it in is the
+  cheapest frame rate a shader pack has to offer: the world is walked a second time for the light
+  every frame, and this decides how much of it. It goes from 32 chunks down to none at all. At none
+  the shadow pass does not run: the shadow depth every pack reads is emptied to its far plane, so
+  nothing casts a shadow, and the only thing left standing is a `shadowcolor` buffer the pack asked
+  to keep between frames, which holds the last one drawn until the setting moves again.
+
+- **A pack that fixes its own shadow render distance now gets it.** `shadowDistanceRenderMul` was
+  read by no part of this engine, so the light gathered the whole world it could see whatever a pack
+  asked. Seven of the eight packs tested declare that line, and the shadow walk now stops where they
+  meant it to: Mellow and Body Camera at 96 blocks, Complementary and Reverie at 192, BSL at 256.
+  How many of them that changes anything for depends on your render distance, since a shadow walk
+  asking for more than the world you have loaded is left alone: at 12 chunks it bites on the shorter
+  three and not on the rest. Those packs decide the distance, so the slider greys out and says so;
+  it is the packs that stay silent, Sildur's among them, where it is the player's to move.
+
 ### Fixed
 
 - The texture filtering selector in the video settings no longer offers RGSS while a pack draws the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -145,6 +145,8 @@ pack.txt       pack=  which pack of the folder to load, by whole or partial
                       name, or none to load nothing at all
                enabled=  false to switch shaders off without forgetting which
                       pack was picked
+               shadowdistance=  how far the shadow map reaches, in chunks, 0 to
+                      32; the Max Shadow Distance slider writes this line
 options.txt    engine switches, one NAME=value per line; wins over the settings
 ```
 

--- a/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
+++ b/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
@@ -50,6 +50,8 @@ public final class PackDirectives {
 	private final int noiseTextureResolution;
 	private final int shadowMapResolution;
 	private final float shadowDistance;
+	private final float shadowDistanceRenderMul;
+	private final boolean forcesShadowRenderDistance;
 	private final float entityShadowDistanceMul;
 	private final float shadowNearPlane;
 	private final float shadowFarPlane;
@@ -85,6 +87,8 @@ public final class PackDirectives {
 		this.noiseTextureResolution = builder.noiseTextureResolution;
 		this.shadowMapResolution = builder.shadowMapResolution;
 		this.shadowDistance = builder.shadowDistance;
+		this.shadowDistanceRenderMul = builder.shadowDistanceRenderMul;
+		this.forcesShadowRenderDistance = builder.forcesShadowRenderDistance;
 		this.entityShadowDistanceMul = builder.entityShadowDistanceMul;
 		this.shadowNearPlane = builder.shadowNearPlane;
 		this.shadowFarPlane = builder.shadowFarPlane;
@@ -195,6 +199,34 @@ public final class PackDirectives {
 	}
 
 	/**
+	 * What the pack multiplies {@link #shadowDistance()} by to get how far the light still gathers
+	 * geometry, which is a different question from how far its projection reaches: the projection is
+	 * the half plane above, and this bounds the WALK that fills it.
+	 * <p>
+	 * Minus one unless the pack declares it, and a negative value is not a distance at all: it is the
+	 * pack saying it has no opinion, and the player's own setting decides instead
+	 * ({@code shadows/ShadowRenderer.java:336-339}, the {@code renderMultiplier < 0} branch). Read
+	 * beside {@link #forcesShadowRenderDistance()}, which is what tells a declared minus one from a
+	 * pack that never wrote the line.
+	 */
+	public float shadowDistanceRenderMul() {
+		return this.shadowDistanceRenderMul;
+	}
+
+	/**
+	 * Whether the pack really declared {@code shadowDistanceRenderMul} with a value it means, which
+	 * is what takes the choice away from the player.
+	 * <p>
+	 * Both halves are needed, exactly as Iris asks them
+	 * ({@code pipeline/IrisRenderingPipeline.java:285-295}): the line has to have been written AND
+	 * to carry a value that is not negative. A pack that writes a negative one has declared that it
+	 * wants the player's setting, so it forces nothing.
+	 */
+	public boolean forcesShadowRenderDistance() {
+		return this.forcesShadowRenderDistance && this.shadowDistanceRenderMul >= 0.0F;
+	}
+
+	/**
 	 * How much shorter the light reaches for the casters that MOVE than for the world, one unless the
 	 * pack says otherwise.
 	 * <p>
@@ -294,6 +326,8 @@ public final class PackDirectives {
 		private int noiseTextureResolution = 256;
 		private int shadowMapResolution = 1024;
 		private float shadowDistance = 160.0F;
+		private float shadowDistanceRenderMul = -1.0F;
+		private boolean forcesShadowRenderDistance;
 		private float entityShadowDistanceMul = 1.0F;
 		private float shadowNearPlane = -100.05F;
 		private float shadowFarPlane = 156.0F;
@@ -332,6 +366,13 @@ public final class PackDirectives {
 						value -> this.noiseTextureResolution = Math.clamp(value, 1, MAX_NOISE_RESOLUTION));
 				case "shadowMapResolution" -> asInt(directive, value -> this.shadowMapResolution = value);
 				case "shadowDistance" -> asFloat(directive, value -> this.shadowDistance = value);
+				// The flag is raised inside the setter and not beside it, so that it follows the
+				// value: a line whose type or number does not parse is dropped without a word here
+				// as it is in Iris, and dropped means the pack never said anything at all.
+				case "shadowDistanceRenderMul" -> asFloat(directive, value -> {
+					this.shadowDistanceRenderMul = value;
+					this.forcesShadowRenderDistance = true;
+				});
 				case "entityShadowDistanceMul" -> asFloat(directive,
 						value -> this.entityShadowDistanceMul = value);
 				case "shadowNearPlane" -> asFloat(directive, value -> this.shadowNearPlane = value);

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -148,6 +148,18 @@ public final class PackChain {
 	private static volatile PackFile askedFor = PackFile.EMPTY;
 
 	/**
+	 * How far the player asked the light to reach, in chunks, the one line of {@code pack.txt} that
+	 * is not about which pack to draw.
+	 * <p>
+	 * Held apart from {@link #askedFor} rather than read off it, because the slider moves it with no
+	 * load behind it: that one is what the last load was asked for, and writing a screen's number
+	 * into it would have it answer for a pack choice nobody made. This one is written wherever the
+	 * number comes from, the file at load and the slider afterwards, and the shadow walk reads it
+	 * either way.
+	 */
+	private static volatile int shadowDistance = PackFile.DEFAULT_SHADOW_DISTANCE;
+
+	/**
 	 * Whether this frame's values have been moved on yet.
 	 * <p>
 	 * The frame used to begin where the chain draws, which is after the world. A terrain program runs
@@ -484,6 +496,10 @@ public final class PackChain {
 			// and without the name this far up it is the one road that cannot say which of the two
 			// happened: the folder is empty, which is true, and is not what they did.
 			askedFor = PackFile.read(packFile(gameDirectory));
+			// Off that same read rather than a second one, and before anything can refuse the load:
+			// this line belongs to the player and not to the pack, and every return below is reached
+			// with no pack drawn and the shadow distance still theirs.
+			shadowDistance = askedFor.shadowDistance();
 
 			// Both ways out of the next two blocks end with no pack drawing anything, and NEITHER mesh
 			// carries what a pack reads once none wants it: said here as well as on the road that
@@ -993,6 +1009,37 @@ public final class PackChain {
 	 */
 	public static PackFile askedFor() {
 		return askedFor;
+	}
+
+	/**
+	 * How far the player asked the light to reach, in CHUNKS. Read every frame the shadow map is
+	 * walked, so it answers from memory rather than from the file.
+	 */
+	public static int shadowDistance() {
+		return shadowDistance;
+	}
+
+	/**
+	 * Takes a new one and puts it away, and takes effect on the next shadow walk rather than on a
+	 * reload: nothing about a pack changes, only how far the walk that is already happening goes.
+	 * <p>
+	 * The file is READ BEFORE IT IS WRITTEN, and it is not tidiness: the settings screen writes the
+	 * two pack lines of this same file, so building a record out of what this side holds would hand
+	 * back whatever pack was chosen when this class last looked. Reading first also means a file
+	 * edited by hand between two moves of the slider keeps its edit.
+	 */
+	public static void shadowDistance(Path gameDirectory, int chunks) {
+		// Taken on first and put away second, so that a folder that cannot be written still moves
+		// the image the player just asked to move. What they lose then is the next session, not
+		// this one, and the line below is what says so.
+		shadowDistance = PackFile.EMPTY.withShadowDistance(chunks).shadowDistance();
+
+		Path file = packFile(gameDirectory);
+		try {
+			PackFile.write(file, PackFile.read(file).withShadowDistance(chunks));
+		} catch (IOException | RuntimeException e) {
+			Vitrail.logger().error("Vitrail could not write the shadow distance to {}", file, e);
+		}
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -51,6 +52,9 @@ import java.util.stream.IntStream;
  * anything per frame.
  */
 public final class PackValues {
+
+	/** How many blocks a chunk is wide, which is the whole of the conversion between the two units. */
+	private static final int CHUNK_BLOCKS = 16;
 
 	private final FrameState state = new FrameState();
 
@@ -277,14 +281,124 @@ public final class PackValues {
 	}
 
 	/**
-	 * How far from the camera a caster that moves may still be and reach the map, or a value that is
-	 * not positive where the pack sets no bound of its own beyond the light's.
+	 * How far from the camera the light still gathers the world, IN BLOCKS, or minus one where
+	 * nothing bounds it beyond the light's own frustum.
+	 * <p>
+	 * <strong>Zero is a distance and not the absence of one</strong>, which is why the two are told
+	 * apart by a sentinel rather than by a sign: a player who drags the setting to the bottom is
+	 * asking for a shadow map with nothing in it, and Iris gathers nothing there too, its box culler
+	 * being built at zero like any other value ({@code shadows/ShadowRenderer.java:354}).
+	 * <p>
+	 * <strong>This is where the two units meet, and they are not the same unit.</strong> The pack
+	 * declares a half plane in BLOCKS, {@code shadowDistance}, and multiplies it by
+	 * {@code shadowDistanceRenderMul} to say how far the walk goes. The player's setting is in
+	 * CHUNKS, because that is the unit the game's own render distance is offered in and the unit
+	 * Iris offers this one in ({@code gui/option/IrisVideoSettings.java:50}, a range of 0 to 32).
+	 * The conversion is one multiplication and it is done here and nowhere else:
+	 * <strong>blocks = chunks x 16</strong>, which is Iris's own
+	 * {@code IrisVideoSettings.shadowDistance * 16} at {@code shadows/ShadowRenderer.java:337}.
+	 * <p>
+	 * Who wins is decided exactly as Iris decides it:
+	 * <ul>
+	 * <li>the pack, where it declared a multiplier it means
+	 *     ({@link PackDirectives#forcesShadowRenderDistance()}). The distance is then its own half
+	 *     plane times its own multiplier, and the player's setting is not consulted at all;</li>
+	 * <li>the player otherwise, which covers both the pack that never wrote the line and the pack
+	 *     that wrote a negative one. Iris takes the same branch for both, on the sign of the
+	 *     multiplier alone ({@code shadows/ShadowRenderer.java:336});</li>
+	 * <li>nobody, where whoever won asks for at least as far as the world is loaded. Iris drops the
+	 *     bound entirely there ({@code shadows/ShadowRenderer.java:341-345}), and so does this: a
+	 *     box that cannot cut anything is a test paid for on every section for nothing. The setting
+	 *     starts at 32 chunks, the largest render distance the game offers, so a player who never
+	 *     touches it lands here and the light is walked against its own frustum alone.</li>
+	 * </ul>
+	 * <p>
+	 * <strong>A default slider is NOT the same thing as no bound, and most of the corpus proves
+	 * it.</strong> Seven of the eight packs tested declare {@code shadowDistanceRenderMul}, six of
+	 * them at one, so they take the first branch and are bounded at their own half plane whatever
+	 * the slider says. That is the pack getting the distance it asked for and was tuned against; it
+	 * is parity, and it is a walk that stops earlier than this engine used to stop it.
+	 *
+	 * @param userChunks           what the player asked for, in chunks
+	 * @param renderDistanceChunks the game's effective render distance, in chunks, which is as far
+	 *                             as there is a world to gather
 	 */
-	public float entityShadowDistance() {
-		float multiplier = this.state.directives().entityShadowDistanceMul();
+	public float shadowRenderDistance(int userChunks, int renderDistanceChunks) {
+		return distanceFor(this.state.directives().shadowDistanceRenderMul(), userChunks,
+				renderDistanceChunks);
+	}
 
-		return multiplier == 1.0F || multiplier < 0.0F ? -1.0F
+	/**
+	 * One multiplier turned into a distance in blocks, which is the whole of Iris's
+	 * {@code createShadowFrustum} ({@code shadows/ShadowRenderer.java:333-345}) and is asked twice:
+	 * once for the world and once, under a different multiplier, for the casters that move.
+	 * <p>
+	 * <strong>The sign is the switch and the value is only read when it is not negative.</strong>
+	 * Iris branches on nothing else ({@code :336}), which is what makes a pack that never declared
+	 * the directive and a pack that declared a negative one the same case: the default is minus one.
+	 */
+	private float distanceFor(float multiplier, int userChunks, int renderDistanceChunks) {
+		float blocks = multiplier < 0.0F
+				? userChunks * (float) CHUNK_BLOCKS
 				: this.state.directives().shadowDistance() * multiplier;
+
+		return blocks >= renderDistanceChunks * (float) CHUNK_BLOCKS ? -1.0F : blocks;
+	}
+
+	/**
+	 * How far the pack itself insists the light gathers, in CHUNKS and rounded up, or empty where it
+	 * leaves the distance to the player. What a settings screen greys its slider out on.
+	 * <p>
+	 * Rounded up rather than truncated, and by Iris's own arithmetic
+	 * ({@code pipeline/IrisRenderingPipeline.java:287-289}): a pack asking for 161 blocks is asking
+	 * for more than ten chunks, and a slider that reads ten would be reading a lie.
+	 * <p>
+	 * <strong>One thing is answered differently from Iris and it is the screen alone.</strong> Iris
+	 * fills this whenever the line was WRITTEN, including with a negative value, and hands out minus
+	 * one in that case ({@code pipeline/IrisRenderingPipeline.java:292}); its slider then greys out
+	 * while {@code ShadowRenderer} goes on reading the player's number, so the screen says the pack
+	 * decides and the image says otherwise. Here the answer is empty in that case, which is what the
+	 * image does. Nothing the pack can read changes either way.
+	 */
+	public OptionalInt forcedShadowRenderDistanceChunks() {
+		PackDirectives directives = this.state.directives();
+		if (!directives.forcesShadowRenderDistance()) {
+			return OptionalInt.empty();
+		}
+
+		int blocks = (int) (directives.shadowDistance() * directives.shadowDistanceRenderMul());
+
+		return OptionalInt.of((blocks + CHUNK_BLOCKS - 1) / CHUNK_BLOCKS);
+	}
+
+	/**
+	 * How far from the camera a caster that MOVES may still be and reach the map, in blocks, or
+	 * minus one where nothing bounds it beyond the light's own frustum.
+	 * <p>
+	 * <strong>The two multipliers are multiplied together, they are not the smaller of the two.</strong>
+	 * Iris builds this frustum by handing {@code createShadowFrustum} the product
+	 * {@code renderDistanceMultiplier * entityShadowDistanceMultiplier}
+	 * ({@code shadows/ShadowRenderer.java:540}), so a pack asking for half the world and half again
+	 * for its mobs gets a quarter, not a half.
+	 * <p>
+	 * <strong>And the product carries the sign, which is what makes the pack's entity multiplier
+	 * DISAPPEAR whenever the player governs.</strong> The world multiplier is minus one then, so the
+	 * product is negative whatever the entity one says, and the branch taken is the player's own
+	 * distance: the casters that move are bounded exactly as the world is. That is not a rounding of
+	 * Iris, it is Iris, and it falls out of the same line.
+	 * <p>
+	 * One multiplier and one only is short-circuited before any of that: one, and anything negative,
+	 * mean the pack asks nothing extra of its moving casters, and the answer is then the world's own
+	 * bound rather than a second computation ({@code shadows/ShadowRenderer.java:536-537}).
+	 */
+	public float entityShadowDistance(int userChunks, int renderDistanceChunks) {
+		float multiplier = this.state.directives().entityShadowDistanceMul();
+		if (multiplier == 1.0F || multiplier < 0.0F) {
+			return shadowRenderDistance(userChunks, renderDistanceChunks);
+		}
+
+		return distanceFor(this.state.directives().shadowDistanceRenderMul() * multiplier,
+				userChunks, renderDistanceChunks);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
@@ -99,8 +99,13 @@ public final class ShadowGeometry {
 	private static boolean emittersOnly;
 
 	/**
-	 * How far a caster that moves may stand from the camera and still reach the map, or a value that
-	 * is not positive where the pack asks for no bound beyond the light's own.
+	 * How far a caster that moves may stand from the camera and still reach the map, or a NEGATIVE
+	 * value where nothing bounds it beyond the light's own frustum.
+	 * <p>
+	 * Negative and not "not positive", because zero is a bound like any other: a pack that writes
+	 * {@code entityShadowDistanceMul 0}, or a player who drags the shadow distance to the bottom, is
+	 * asking for no moving caster in the map at all, and Iris hands both of them a box culler built
+	 * at zero rather than no culler ({@code shadows/ShadowRenderer.java:333-354}).
 	 */
 	private static float reach = -1.0F;
 
@@ -167,6 +172,11 @@ public final class ShadowGeometry {
 		// against a SECOND, shorter frustum where the pack asked for one, built at the shadow
 		// distance times entityShadowDistanceMul (shadows/ShadowRenderer.java:536-541); here the
 		// shape stays the light's and only the reach is cut, which is what the multiplier means.
+		//
+		// It is one bound and not two: the shadow distance the player set is folded into this same
+		// number rather than applied beside it, because Iris builds the entity frustum out of the
+		// PRODUCT of the two multipliers (:540) and the world's own is negative whenever the player
+		// governs. PackValues.entityShadowDistance carries that arithmetic and its sign.
 		reach = TerrainDraw.entityShadowDistance();
 
 		// The light's own camera, built the way Iris builds it and NOT the frame's borrowed: a state
@@ -491,7 +501,7 @@ public final class ShadowGeometry {
 			return false;
 		}
 
-		if (reach > 0.0F && (Math.abs(entity.getX() - at.x) > reach
+		if (reach >= 0.0F && (Math.abs(entity.getX() - at.x) > reach
 				|| Math.abs(entity.getY() - at.y) > reach
 				|| Math.abs(entity.getZ() - at.z) > reach)) {
 			return false;

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 /**
  * The door the chunk renderer comes in by, and the one place a pack's terrain program is read.
@@ -352,7 +353,55 @@ public final class TerrainDraw {
 	public static float entityShadowDistance() {
 		TerrainDraw self = PackChain.terrain();
 
-		return self == null ? -1.0F : self.values.entityShadowDistance();
+		return self == null ? -1.0F
+				: self.values.entityShadowDistance(PackChain.shadowDistance(), renderDistanceChunks());
+	}
+
+	/**
+	 * How far from the camera the light still gathers the world, in BLOCKS, or minus one where
+	 * nothing bounds it beyond the light's own frustum.
+	 * <p>
+	 * The arithmetic and the two units are {@link PackValues#shadowRenderDistance}'s and are said
+	 * there; what happens here is that the two numbers it needs are fetched from the two places
+	 * that hold them, the player's setting from {@code pack.txt} and the render distance from the
+	 * game's own options.
+	 */
+	public static float shadowRenderDistance() {
+		TerrainDraw self = PackChain.terrain();
+
+		return self == null ? -1.0F
+				: self.values.shadowRenderDistance(PackChain.shadowDistance(), renderDistanceChunks());
+	}
+
+	/**
+	 * How far the light reaches once the pack has had its say, in CHUNKS: the pack's own number
+	 * where it forces one, and the player's otherwise. Iris's
+	 * {@code IrisVideoSettings.getOverriddenShadowDistance} ({@code gui/option/IrisVideoSettings.java:61-65}),
+	 * and read for the two things that number decides rather than a distance: what the slider shows,
+	 * and whether the shadow stage runs at all.
+	 */
+	public static int shadowDistanceChunks() {
+		return forcedShadowDistanceChunks().orElseGet(PackChain::shadowDistance);
+	}
+
+	/**
+	 * How far the loaded pack itself insists the light gathers, in chunks, or empty where it leaves
+	 * the distance to the player. What the video settings grey their slider out on.
+	 */
+	public static OptionalInt forcedShadowDistanceChunks() {
+		TerrainDraw self = PackChain.terrain();
+
+		return self == null ? OptionalInt.empty() : self.values.forcedShadowRenderDistanceChunks();
+	}
+
+	/**
+	 * As far as there is a world to gather, in chunks. Zero where the game has no options yet, which
+	 * bounds nothing and is what a frame drawn before there is a world should get.
+	 */
+	private static int renderDistanceChunks() {
+		Minecraft minecraft = Minecraft.getInstance();
+
+		return minecraft == null ? 0 : minecraft.options.getEffectiveRenderDistance();
 	}
 
 	/**
@@ -416,7 +465,21 @@ public final class TerrainDraw {
 		}
 
 		ShadowTargets shadow = self.targets.shadow();
-		if (!shadows() || !self.shadowsServed()) {
+		if (!shadows() || !self.shadowsServed() || shadowDistanceChunks() == 0) {
+			// A shadow distance of nought is not a very short walk, it is no stage at all, and the
+			// test is on the CHUNKS rather than on the blocks the walk is bounded by. That is Iris's
+			// own: renderShadows returns at its first line when the distance the pack or the player
+			// settled on is zero (shadows/ShadowRenderer.java:384-387), before a frustum is built or
+			// a target is touched. Bounding the walk at zero blocks instead would cost a full walk
+			// and a full clear to draw nothing.
+			//
+			// What the pack reads then is the DEPTH emptied to the far plane, both names of it,
+			// because the clear below empties the depth whichever way the pack's own keep directive
+			// reads (ShadowTargets.java:236-241). A shadowcolor the pack asked to KEEP is a
+			// different matter and is NOT emptied (:243-248 through :256-264): it holds the last
+			// frame the stage drew, for as long as the setting stays at nought. Iris returns before
+			// touching any of its targets, so there both halves keep the last frame.
+			//
 			// A pack that serves no shadow program gets no shadow pass, which is Iris's rule, and
 			// at the end of a frame it is also the only safe answer: with nothing of ours to hand
 			// the renderer, the pass it opens for itself is the game's own target, and the stage

--- a/common/src/main/java/dev/vitrail/screen/ScreenText.java
+++ b/common/src/main/java/dev/vitrail/screen/ScreenText.java
@@ -30,6 +30,17 @@ public final class ScreenText {
 	 */
 	public static final String PACKS_TITLE = "options.vitrail.packs_title";
 
+	/**
+	 * How far the light reaches, on the video settings page this engine owns, with its two
+	 * tooltips: what the setting does, and what it says instead while a pack has taken the distance
+	 * out of the player's hands. Iris's {@code options.iris.shadowDistance} and its
+	 * {@code .enabled} and {@code .disabled}. The page's own name is the game's
+	 * {@code options.videoTitle} and is not repeated here.
+	 */
+	public static final String SHADOW_DISTANCE = "options.vitrail.shadow_distance";
+	public static final String SHADOW_DISTANCE_TOOLTIP = "options.vitrail.shadow_distance_tooltip";
+	public static final String SHADOW_DISTANCE_FORCED = "options.vitrail.shadow_distance_forced";
+
 	/** The grey line under the title, one per view. */
 	public static final String SELECT_TITLE = "pack.vitrail.select_title";
 	public static final String CONFIGURE_TITLE = "pack.vitrail.configure_title";

--- a/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
@@ -971,11 +971,15 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 	/**
 	 * Writes the whole file name rather than the fragment {@code pack.txt} also accepts, so that two
 	 * packs sharing a word cannot swap under the player.
+	 * <p>
+	 * Over what the file already says rather than over a record built here: the shadow distance
+	 * lives in that same file and is moved from the video settings, so a choice written from a
+	 * record this screen assembled would put it back to its default every time a pack is picked.
 	 */
 	private boolean writePackFile(String chosen, boolean enabled) {
 		Path file = PackChain.packFile(gameDirectory());
 		try {
-			PackFile.write(file, new PackFile(chosen, enabled));
+			PackFile.write(file, PackFile.read(file).withChoice(chosen, enabled));
 			this.error = null;
 		} catch (IOException | RuntimeException e) {
 			this.error = String.valueOf(e.getMessage());

--- a/common/src/main/java/dev/vitrail/settings/PackFile.java
+++ b/common/src/main/java/dev/vitrail/settings/PackFile.java
@@ -7,7 +7,15 @@ import java.nio.file.Path;
 import java.util.Locale;
 
 /**
- * What {@code vitrail/pack.txt} carries: which pack was chosen, and whether shaders are on at all.
+ * What {@code vitrail/pack.txt} carries: which pack was chosen, whether shaders are on at all, and
+ * how far the player asked the light to reach.
+ * <p>
+ * <b>The third one is not about a pack, and it is here for the reason the other two are.</b> Iris
+ * keeps its own in the same properties file as {@code shaderPack} and {@code enableShaders},
+ * {@code maxShadowRenderDistance} in {@code config/IrisConfig.java:178,206}, because it is the same
+ * kind of thing: one number the player set once, that outlives whichever pack is loaded and has to
+ * be there before one is. A file of its own would be a second file to find, to write and to keep in
+ * step.
  * <p>
  * <b>Two facts and not one, and that is what the screen's toggle needs.</b> Iris keeps
  * {@code shaderPack} and {@code enableShaders} apart in its own properties file, so turning shaders
@@ -23,24 +31,39 @@ import java.util.Locale;
  * Nothing here touches Minecraft, which is the rule for this whole package: it is what lets the
  * settings be run against the pack corpus without starting the game.
  */
-public record PackFile(String name, boolean enabled) {
+public record PackFile(String name, boolean enabled, int shadowDistance) {
 
 	/** The word that means no pack rather than the name of one, kept from the one line format. */
 	public static final String NONE = "none";
 
 	private static final String NAME_KEY = "pack";
 	private static final String ENABLED_KEY = "enabled";
+	private static final String SHADOW_DISTANCE_KEY = "shadowdistance";
+
+	/**
+	 * The range the shadow distance is offered and stored over, in CHUNKS, and Iris's own: zero to
+	 * thirty-two, thirty-two being both the default and the largest render distance the game has
+	 * ({@code gui/option/IrisVideoSettings.java:15,50}). At the top the setting bounds nothing,
+	 * which is what makes an untouched one free; at the bottom the light gathers nothing at all.
+	 */
+	public static final int MIN_SHADOW_DISTANCE = 0;
+	public static final int MAX_SHADOW_DISTANCE = 32;
+	public static final int DEFAULT_SHADOW_DISTANCE = MAX_SHADOW_DISTANCE;
 
 	/** Nothing chosen. Shaders are on, so choosing a pack is all it takes to draw one. */
-	public static final PackFile EMPTY = new PackFile("", true);
+	public static final PackFile EMPTY = new PackFile("", true, DEFAULT_SHADOW_DISTANCE);
 
 	public PackFile {
 		name = name.trim();
+		// Clamped here rather than where the file is read, so that a number typed by hand and a
+		// number arriving from a screen are held to the same range: the value is served to the
+		// culling as a distance and a negative one there means something else entirely.
+		shadowDistance = Math.clamp(shadowDistance, MIN_SHADOW_DISTANCE, MAX_SHADOW_DISTANCE);
 	}
 
 	/**
 	 * What the file says, or {@link #EMPTY} when it is not there. A line that is neither a comment nor
-	 * one of the two keys is ignored rather than refused: this file is edited by hand.
+	 * one of the three keys is ignored rather than refused: this file is edited by hand.
 	 * <p>
 	 * Handed the file rather than the game directory, so that where it lives stays the render layer's
 	 * business: this package names no folder of the installation and imports nothing that does.
@@ -57,11 +80,14 @@ public record PackFile(String name, boolean enabled) {
 		if (!content.contains("=")) {
 			String bare = content.trim();
 
-			return NONE.equalsIgnoreCase(bare) ? new PackFile("", false) : new PackFile(bare, true);
+			return NONE.equalsIgnoreCase(bare)
+					? new PackFile("", false, DEFAULT_SHADOW_DISTANCE)
+					: new PackFile(bare, true, DEFAULT_SHADOW_DISTANCE);
 		}
 
 		String name = "";
 		boolean enabled = true;
+		int shadowDistance = DEFAULT_SHADOW_DISTANCE;
 		for (String line : content.lines().toList()) {
 			String trimmed = line.trim();
 			if (trimmed.isEmpty() || trimmed.startsWith("#")) {
@@ -80,17 +106,34 @@ public record PackFile(String name, boolean enabled) {
 				// Anything that is not the word for true is false, which is how the pack format's own
 				// booleans read and what keeps a typo from turning shaders on by accident.
 				case ENABLED_KEY -> enabled = Boolean.parseBoolean(value);
+				// A number that does not parse keeps the default rather than refusing the file, which
+				// is how every other line here is read: this file is edited by hand, and one bad
+				// character must not cost the player the pack they had chosen.
+				case SHADOW_DISTANCE_KEY -> shadowDistance = number(value, shadowDistance);
 				default -> {
 				}
 			}
 		}
 
-		return new PackFile(name, enabled);
+		return new PackFile(name, enabled, shadowDistance);
+	}
+
+	private static int number(String value, int fallback) {
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException e) {
+			return fallback;
+		}
 	}
 
 	/**
-	 * Writes both keys, always, so that the file a player opens says what state it is in rather than
-	 * leaving one of the two to be inferred from its absence.
+	 * Writes every key, always, so that the file a player opens says what state it is in rather than
+	 * leaving any of them to be inferred from its absence.
+	 * <p>
+	 * <b>Two things write this file and neither owns all of it</b>, the settings screen picking a
+	 * pack and the video settings moving the shadow distance. Whichever writes has to carry the
+	 * other's line through, which is why both go through a read of the file first rather than
+	 * building a record out of what they happen to hold.
 	 * <p>
 	 * In LF and without a byte order mark, like every other file this mod writes.
 	 */
@@ -98,7 +141,8 @@ public record PackFile(String name, boolean enabled) {
 		Files.createDirectories(file.getParent());
 		Files.writeString(file,
 				NAME_KEY + "=" + chosen.name() + "\n"
-						+ ENABLED_KEY + "=" + chosen.enabled() + "\n",
+						+ ENABLED_KEY + "=" + chosen.enabled() + "\n"
+						+ SHADOW_DISTANCE_KEY + "=" + chosen.shadowDistance() + "\n",
 				StandardCharsets.UTF_8);
 	}
 
@@ -120,10 +164,19 @@ public record PackFile(String name, boolean enabled) {
 	}
 
 	public PackFile withName(String name) {
-		return new PackFile(name, this.enabled);
+		return new PackFile(name, this.enabled, this.shadowDistance);
 	}
 
 	public PackFile withEnabled(boolean enabled) {
-		return new PackFile(this.name, enabled);
+		return new PackFile(this.name, enabled, this.shadowDistance);
+	}
+
+	/** Both halves of a pack choice at once, leaving whatever else the file carries where it is. */
+	public PackFile withChoice(String name, boolean enabled) {
+		return new PackFile(name, enabled, this.shadowDistance);
+	}
+
+	public PackFile withShadowDistance(int chunks) {
+		return new PackFile(this.name, this.enabled, chunks);
 	}
 }

--- a/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
+++ b/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
@@ -1,15 +1,21 @@
 package dev.vitrail.sodium;
 
-import dev.vitrail.Vitrail;
+import dev.vitrail.render.PackChain;
 import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.screen.ScreenText;
 import dev.vitrail.screen.SettingsScreen;
+import dev.vitrail.settings.PackFile;
+import dev.vitrail.Vitrail;
 
 import net.caffeinemc.mods.sodium.api.config.ConfigEntryPoint;
 import net.caffeinemc.mods.sodium.api.config.ConfigState;
+import net.caffeinemc.mods.sodium.api.config.option.OptionImpact;
+import net.caffeinemc.mods.sodium.api.config.option.Range;
 import net.caffeinemc.mods.sodium.api.config.structure.ConfigBuilder;
+import net.caffeinemc.mods.sodium.api.config.structure.OptionBuilder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.TextureFilteringMethod;
+import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 
@@ -25,10 +31,11 @@ import java.util.Set;
  * <p>
  * This is the same entry the reference takes, {@code IrisConfig} in its own tree, and by the same
  * public API rather than by reaching into Sodium: one page under the mod's own name, which opens
- * this screen with the video settings as the screen to come back to. What the reference has and this
- * does not is a second page of its own video options, because everything this engine has to offer is
- * the pack's own and lives on the pack's pages. The one thing registered here that is not a page is
- * an overlay over an option of Sodium's own, whose reason is written where it is registered.
+ * this screen with the video settings as the screen to come back to, and a second page for the
+ * settings that are this engine's own rather than a pack's. That second page is thin on purpose:
+ * almost everything this engine has to offer is the pack's and lives on the pack's pages, and only
+ * what a player sets over every pack belongs here. The one thing registered that is not a page is an
+ * overlay over an option of Sodium's own, whose reason is written where it is registered.
  * <p>
  * Each loader's metadata names this class, and each reaches it its own way: on NeoForge Sodium is
  * handed the name and builds an instance by reflection, on Fabric the loader's own entry point
@@ -58,6 +65,10 @@ public final class ConfigEntry implements ConfigEntryPoint {
 	/** Sodium's own texture filtering selector, the one option here has anything to say about. */
 	private static final Identifier FILTERING = Identifier.parse("sodium:quality.filtering_mode");
 
+	/** What this engine's own option is known by, to Sodium and to anything overlaying it later. */
+	private static final Identifier SHADOW_DISTANCE =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "shadow_distance");
+
 	/** What the selector offers while the pack draws the world, and what it offers otherwise. */
 	private static final Set<TextureFilteringMethod> WITHOUT_RGSS =
 			Set.of(TextureFilteringMethod.NONE, TextureFilteringMethod.ANISOTROPIC);
@@ -75,6 +86,11 @@ public final class ConfigEntry implements ConfigEntryPoint {
 						.setName(Component.translatable(ScreenText.PACKS_TITLE))
 						.setScreenConsumer(parent ->
 								Minecraft.getInstance().gui.setScreen(new SettingsScreen(parent))))
+				// Named by the game's own key rather than by one of ours: it is the words the game
+				// already writes over its video settings, translated everywhere this mod is not.
+				.addPage(builder.createOptionPage()
+						.setName(Component.translatable("options.videoTitle"))
+						.addOptionGroup(builder.createOptionGroup().addOption(shadowDistance(builder))))
 				// RGSS is shader code, written into the game's own terrain shader and into Sodium's,
 				// so it is worth nothing while the pack's terrain program is the one drawing: the
 				// player moves the selector and the image does not move. ANISOTROPIC keeps working,
@@ -99,5 +115,48 @@ public final class ConfigEntry implements ConfigEntryPoint {
 								.setAllowedValuesProvider(
 										state -> TerrainDraw.asked() ? WITHOUT_RGSS : EVERY_METHOD,
 										ConfigState.UPDATE_ON_REBUILD));
+	}
+
+	/**
+	 * How far the light reaches, in CHUNKS, which is the one video setting this engine has of its
+	 * own and the cheapest thing a player can trade for frames.
+	 * <p>
+	 * It is the reference's option, built the same way and over the same range,
+	 * {@code compat/sodium/config/IrisConfig.java:54-76}: zero to thirty-two, thirty-two by default,
+	 * greyed out while the pack forces a distance of its own, and shown as the pack's number then
+	 * rather than as the player's. What the two numbers mean and which of them wins is
+	 * {@code PackValues.shadowRenderDistance}, and the conversion into blocks lives there too.
+	 * <p>
+	 * <strong>The forced number is clamped into the slider's range before it is shown.</strong> Not
+	 * cosmetic: Sodium validates whatever the binding hands back, and writes the correction out
+	 * through the same binding when it has to ({@code StatefulOption.resetFromBinding}). A pack
+	 * asking for more than thirty-two chunks would come back clamped and be SAVED over the player's
+	 * own number, which they never touched and cannot see.
+	 */
+	private static OptionBuilder shadowDistance(ConfigBuilder builder) {
+		return builder.createIntegerOption(SHADOW_DISTANCE)
+				.setName(Component.translatable(ScreenText.SHADOW_DISTANCE))
+				.setTooltip(_ -> Component.translatable(
+						TerrainDraw.forcedShadowDistanceChunks().isPresent()
+								? ScreenText.SHADOW_DISTANCE_FORCED
+								: ScreenText.SHADOW_DISTANCE_TOOLTIP))
+				.setDefaultValue(PackFile.DEFAULT_SHADOW_DISTANCE)
+				.setRange(new Range(PackFile.MIN_SHADOW_DISTANCE, PackFile.MAX_SHADOW_DISTANCE, 1))
+				.setBinding(chunks -> PackChain.shadowDistance(Vitrail.platform().gameDirectory(),
+								chunks),
+						() -> Math.clamp(TerrainDraw.shadowDistanceChunks(),
+								PackFile.MIN_SHADOW_DISTANCE, PackFile.MAX_SHADOW_DISTANCE))
+				// Zero is not a short distance, it is no shadow map worth drawing, so it is named
+				// rather than counted. Both the word and the unit are the game's own strings, so
+				// they read in the player's language on a client this mod ships no translation for.
+				.setValueFormatter(chunks -> chunks <= 0
+						? CommonComponents.OPTION_OFF
+						: Component.translatable("options.chunks", chunks))
+				// Asked again whenever the screen rebuilds, like the overlay above and for the same
+				// reason: a pack loaded or dropped while the game is up decides whether this slider
+				// still belongs to the player.
+				.setEnabledProvider(_ -> TerrainDraw.forcedShadowDistanceChunks().isEmpty(),
+						ConfigState.UPDATE_ON_REBUILD)
+				.setImpact(OptionImpact.HIGH);
 	}
 }

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
@@ -1,0 +1,80 @@
+package dev.vitrail.sodium;
+
+import net.caffeinemc.mods.sodium.client.render.viewport.frustum.Frustum;
+import net.caffeinemc.mods.sodium.client.render.viewport.frustum.SimpleFrustum;
+
+import org.joml.FrustumIntersection;
+
+/**
+ * The light's frustum with a box around the camera cut out of it, which is how a shadow distance
+ * bounds a walk that is otherwise the pack's own volume.
+ * <p>
+ * <strong>A box and not a shorter frustum, and that is the whole reason this class exists.</strong>
+ * The light's volume is built from the pack's half plane and is what the shadow map is DRAWN with;
+ * narrowing it would move every texel of the map and change the picture. What a shadow distance
+ * asks for is different and cheaper: keep the volume, and stop walking the world beyond a cube of
+ * that many blocks around the player. Iris draws the same distinction with the same shape, an
+ * axis-aligned cube tested on each axis independently, {@code shadows/frustum/BoxCuller.java}.
+ * <p>
+ * <strong>The coordinates are relative to the camera, and nothing here converts them.</strong>
+ * Sodium subtracts the camera before it asks ({@code Viewport.isBoxVisibleDirect}, which is where
+ * the float origin is made), so a cube centred on the player is a comparison against the distance
+ * itself with no position to keep in step. Iris has a second method for exactly this reason,
+ * {@code isCulledSodium} beside {@code isCulled}, and this class only ever needs the first.
+ * <p>
+ * <strong>Two of the four tests carry the box and two do not, which is Iris's placement and not a
+ * shortcut.</strong> Its own frustum boxes {@code testAab} and {@code intersectAab}
+ * ({@code shadows/frustum/advanced/AdvancedShadowCullingFrustum.java:423,428}) and leaves
+ * {@code testSection} and {@code testSectionExpanded} to the planes alone ({@code :459-505}). It
+ * costs nothing here because those two are not on this walk at all: the shadow stage asks
+ * {@code finalizeRenderLists} to update immediately, which takes Sodium's out-of-graph road
+ * ({@code RenderSectionManager.finalizeRenderLists} into {@code renderOutOfGraph}), and the
+ * traversal there asks the viewport through {@code getBoxIntersectionDirect} and
+ * {@code isBoxVisibleDirect} only ({@code tree/TraversableTree.java:212,262}). Boxing the section
+ * tests would be dead weight on this path and a divergence on any other.
+ */
+public final class ShadowCull implements Frustum {
+
+	private final Frustum planes;
+	private final float distance;
+
+	/**
+	 * @param light    the light's own view projection, the volume the map is drawn with
+	 * @param distance how far from the camera the walk still gathers, in blocks
+	 */
+	public ShadowCull(FrustumIntersection light, float distance) {
+		this.planes = new SimpleFrustum(light);
+		this.distance = distance;
+	}
+
+	@Override
+	public boolean testAab(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+		return inside(minX, minY, minZ, maxX, maxY, maxZ)
+				&& this.planes.testAab(minX, minY, minZ, maxX, maxY, maxZ);
+	}
+
+	@Override
+	public int intersectAab(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+		return inside(minX, minY, minZ, maxX, maxY, maxZ)
+				? this.planes.intersectAab(minX, minY, minZ, maxX, maxY, maxZ)
+				: FrustumIntersection.OUTSIDE;
+	}
+
+	@Override
+	public boolean testSection(float x, float y, float z) {
+		return this.planes.testSection(x, y, z);
+	}
+
+	@Override
+	public boolean testSectionExpanded(float x, float y, float z, float extend) {
+		return this.planes.testSectionExpanded(x, y, z, extend);
+	}
+
+	/** Whether any part of a camera-relative box is still within the distance, on all three axes. */
+	private boolean inside(float minX, float minY, float minZ,
+			float maxX, float maxY, float maxZ) {
+		return maxX >= -this.distance && minX <= this.distance
+				&& maxY >= -this.distance && minY <= this.distance
+				&& maxZ >= -this.distance && minZ <= this.distance;
+	}
+}

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -160,7 +160,15 @@ public final class ShadowTerrain {
 		manager.prepareRender();
 		try {
 			FogParameters fog = ((MixinSodiumWorldRenderer) renderer).vitrail$lastFogParameters();
-			Viewport viewport = new Viewport(new SimpleFrustum(new FrustumIntersection(light)),
+			// The light's own volume, and a box around the camera cut out of it wherever a shadow
+			// distance bounds the walk. Negative means nothing bounds it, and then the walk is the
+			// volume alone. Which of the two happens is the pack's business at least as often as the
+			// player's: most of the corpus declares a render multiplier and is bounded at its own
+			// half plane whatever the slider says.
+			float bound = TerrainDraw.shadowRenderDistance();
+			FrustumIntersection volume = new FrustumIntersection(light);
+			Viewport viewport = new Viewport(
+					bound < 0.0F ? new SimpleFrustum(volume) : new ShadowCull(volume, bound),
 					new Vector3d(camera.x, camera.y, camera.z));
 			manager.finalizeRenderLists(minecraft.gameRenderer.mainCamera(), viewport,
 					fog == null ? FogParameters.NONE : fog, true);

--- a/common/src/main/resources/assets/vitrail/lang/de_de.json
+++ b/common/src/main/resources/assets/vitrail/lang/de_de.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Shaderpakete",
+	"options.vitrail.shadow_distance": "Max. Schattendistanz",
+	"options.vitrail.shadow_distance_tooltip": "Erlaubt es dir, die maximale Distanz für Schatten zu ändern. Gelände und Objekte, die weiter entfernt sind als die eingestellte Distanz, werden keine Schatten werfen. Das Senken der Distanz kann die Leistung erheblich verbessern.",
+	"options.vitrail.shadow_distance_forced": "Dein aktuelles Shaderpaket hat bereits eine Distanz für Schatten gesetzt; du kannst sie nicht ändern.",
 	"pack.vitrail.select_title": "Auswählen",
 	"pack.vitrail.configure_title": "Konfigurieren",
 	"options.vitrail.title": "Shader-Einstellungen",

--- a/common/src/main/resources/assets/vitrail/lang/en_us.json
+++ b/common/src/main/resources/assets/vitrail/lang/en_us.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Shader Packs",
+	"options.vitrail.shadow_distance": "Max Shadow Distance",
+	"options.vitrail.shadow_distance_tooltip": "Allows you to change the maximum distance for shadows. Terrain and entities beyond this distance will not cast shadows. Lowering the shadow distance can significantly increase performance.",
+	"options.vitrail.shadow_distance_forced": "Your current shader pack has already set a render distance for shadows; you cannot change it.",
 	"pack.vitrail.select_title": "Select",
 	"pack.vitrail.configure_title": "Configure",
 	"options.vitrail.title": "Shader Pack Settings",

--- a/common/src/main/resources/assets/vitrail/lang/es_es.json
+++ b/common/src/main/resources/assets/vitrail/lang/es_es.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Shader Packs",
+	"options.vitrail.shadow_distance": "Máxima Distancia de Sombras",
+	"options.vitrail.shadow_distance_tooltip": "Te permite cambiar la distáncia máxima para las sombras. El terreno y las entidades tras esta distáncia no emitirán sombras. Reducir la distáncia de sombras puede incrementar el rendimiento significativamente.",
+	"options.vitrail.shadow_distance_forced": "Tu shader pack ya ha establecido una distáncia de renderizado para las sombreas; no puedes cambiarla.",
 	"pack.vitrail.select_title": "Seleccionar",
 	"pack.vitrail.configure_title": "Configurar",
 	"options.vitrail.title": "Configuración del Shader Pack",

--- a/common/src/main/resources/assets/vitrail/lang/fr_fr.json
+++ b/common/src/main/resources/assets/vitrail/lang/fr_fr.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Packs de shaders",
+	"options.vitrail.shadow_distance": "Distance maximale des ombres",
+	"options.vitrail.shadow_distance_tooltip": "Permet de changer la distance maximale des ombres. Le terrain et les entités au-delà de cette distance ne projettent pas d'ombre. Baisser la distance des ombres peut améliorer nettement les performances.",
+	"options.vitrail.shadow_distance_forced": "Votre pack de shaders a déjà fixé sa propre distance de rendu des ombres; vous ne pouvez pas la changer.",
 	"pack.vitrail.select_title": "Sélectionner",
 	"pack.vitrail.configure_title": "Configure",
 	"options.vitrail.title": "Options du pack de shaders",

--- a/common/src/main/resources/assets/vitrail/lang/it_it.json
+++ b/common/src/main/resources/assets/vitrail/lang/it_it.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Pacchetti di shader",
+	"options.vitrail.shadow_distance": "Massima Distanza delle ombre",
+	"options.vitrail.shadow_distance_tooltip": "Permette di cambiare la massima distanza per le ombre. Terreno ed entità oltre questa distanza non creeranno ombre. Abbassare questa opzione può aumentare la tua performance di molto.",
+	"options.vitrail.shadow_distance_forced": "La tua shader pack corrente ha già una distanza per le ombre e non puoi cambiarla.",
 	"pack.vitrail.select_title": "Seleziona",
 	"pack.vitrail.configure_title": "Configura",
 	"options.vitrail.title": "Impostazioni del pacchetto di shader",

--- a/common/src/main/resources/assets/vitrail/lang/ja_jp.json
+++ b/common/src/main/resources/assets/vitrail/lang/ja_jp.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "シェーダーパック",
+	"options.vitrail.shadow_distance": "影の最大描画距離",
+	"options.vitrail.shadow_distance_tooltip": "影が描画される最大の距離を設定できます。 指定された値より遠くの地形やエンティティには影が描画されません。 最大描画距離を下げることで、パフォーマンスが向上することがあります。",
+	"options.vitrail.shadow_distance_forced": "お使いのシェーダーパックでは既に最大描画距離が設定されているため、ここでは変更できません。",
 	"pack.vitrail.select_title": "シェーダー選択",
 	"pack.vitrail.configure_title": "シェーダー設定",
 	"options.vitrail.title": "シェーダーパックの設定",

--- a/common/src/main/resources/assets/vitrail/lang/ko_kr.json
+++ b/common/src/main/resources/assets/vitrail/lang/ko_kr.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "셰이더 팩",
+	"options.vitrail.shadow_distance": "그림자 렌더링 거리",
+	"options.vitrail.shadow_distance_tooltip": "그림자가 표시되는 최대 거리를 조정할 수 있습니다. 이 거리보다 멀리 있는 개체와 지형은 그림자를 표시하지 않습니다. 그림자 거리를 줄이면 성능을 향상시킬 수 있습니다.",
+	"options.vitrail.shadow_distance_forced": "현재 사용하고 있는 셰이더 팩은 이미 그림자 렌더링 거리가 설정되어 있어 바꿀 수 없습니다.",
 	"pack.vitrail.select_title": "선택",
 	"pack.vitrail.configure_title": "설정",
 	"options.vitrail.title": "셰이더 팩 설정",

--- a/common/src/main/resources/assets/vitrail/lang/nl_nl.json
+++ b/common/src/main/resources/assets/vitrail/lang/nl_nl.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Shader Packs",
+	"options.vitrail.shadow_distance": "Maximale Schaduwafstand",
+	"options.vitrail.shadow_distance_tooltip": "Hiermee kunt u de maximale afstand voor schaduwen wijzigen. Terrein en entiteiten buiten deze afstand zullen geen schaduwen werpen. Het verkleinen van de Schaduwafstand kan de prestaties aanzienlijk verbeteren.",
+	"options.vitrail.shadow_distance_forced": "Uw huidig shader-pack heeft al een weergaveafstand voor schaduwen ingesteld; je kunt het niet veranderen.",
 	"pack.vitrail.select_title": "Selecteren",
 	"pack.vitrail.configure_title": "Configureer",
 	"options.vitrail.title": "Shader Pack-instellingen",

--- a/common/src/main/resources/assets/vitrail/lang/pl_pl.json
+++ b/common/src/main/resources/assets/vitrail/lang/pl_pl.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Pakiety shaderów",
+	"options.vitrail.shadow_distance": "Maksymalna odległość cieni",
+	"options.vitrail.shadow_distance_tooltip": "Umożliwia zmianę maksymalnej odległości wyświetlania cieni. Teren i obiekty znajdujące się poza tą odległością nie będą rzucać cieni. Zmniejszenie odległości cieni może znacznie zwiększyć wydajność.",
+	"options.vitrail.shadow_distance_forced": "Twój aktualny pakiet Shaderów ma już ustawioną odległość renderowania cieni; nie możesz jej zmienić.",
 	"pack.vitrail.select_title": "Wybierz",
 	"pack.vitrail.configure_title": "Konfiguracja",
 	"options.vitrail.title": "Ustawienia pakietu shaderów",

--- a/common/src/main/resources/assets/vitrail/lang/pt_br.json
+++ b/common/src/main/resources/assets/vitrail/lang/pt_br.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Pacotes de sombreadores",
+	"options.vitrail.shadow_distance": "Distância das sombras",
+	"options.vitrail.shadow_distance_tooltip": "Permite alterar a distância máxima das sombras. O terreno e as entidades além dessa distância não projetarão sombras. O desempenho do jogo pode ser melhorado significativamente ao reduzir este valor.",
+	"options.vitrail.shadow_distance_forced": "Seu pacote de sombreadores já definiu um valor da distância das sombras e você não poderá alterá-lo.",
 	"pack.vitrail.select_title": "Selecionar um pacote",
 	"pack.vitrail.configure_title": "Configurando um pacote",
 	"options.vitrail.title": "Configurações do pacote de sombreadores",

--- a/common/src/main/resources/assets/vitrail/lang/ru_ru.json
+++ b/common/src/main/resources/assets/vitrail/lang/ru_ru.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Наборы шейдеров",
+	"options.vitrail.shadow_distance": "Дальность теней",
+	"options.vitrail.shadow_distance_tooltip": "Позволяет изменять максимальное расстояние видимости теней. Блоки и сущности за его пределами не будут иметь теней. Снижая этот параметр, вы можете значительно улучшить производительность.",
+	"options.vitrail.shadow_distance_forced": "Ваш текущий набор шейдеров уже установил своё расстояние для теней; вы не сможете его изменить.",
 	"pack.vitrail.select_title": "Список",
 	"pack.vitrail.configure_title": "Настройки",
 	"options.vitrail.title": "Настройки набора шейдеров",

--- a/common/src/main/resources/assets/vitrail/lang/tr_tr.json
+++ b/common/src/main/resources/assets/vitrail/lang/tr_tr.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Shader Paketleri",
+	"options.vitrail.shadow_distance": "Mak. Gölge Uzaklığı",
+	"options.vitrail.shadow_distance_tooltip": "Gölgeler için maksimum ucaklığı değiştirmeye yarar. Bu uzaklığın ötesindeki araziye ve varlıklara gölge uygulanmaz. Gölge uzaklığını azaltmak, performansı önemli ölçüde arttırabilir.",
+	"options.vitrail.shadow_distance_forced": "Mevcut shader paketiniz, zaten gölgeler için ayarlı bir görüntüleme uzaklığına sahip; bunu değiştiremezsin.",
 	"pack.vitrail.select_title": "Seç",
 	"pack.vitrail.configure_title": "Ayarla",
 	"options.vitrail.title": "Shader Paketi Ayarları",

--- a/common/src/main/resources/assets/vitrail/lang/uk_ua.json
+++ b/common/src/main/resources/assets/vitrail/lang/uk_ua.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "Пакети шейдерів",
+	"options.vitrail.shadow_distance": "Макс. відстань тіней",
+	"options.vitrail.shadow_distance_tooltip": "Дозволяє змінювати максимальну відстань для тіней. Місцевість та сутності за межами цієї відстані не відкидають тіні. Зменшення відстані тіней може значно підвищити продуктивність.",
+	"options.vitrail.shadow_distance_forced": "Ваш поточний пакет шейдерів уже встановив відстань візуалізації для тіней; ви не можете змінити це.",
 	"pack.vitrail.select_title": "Виберіть шейдери",
 	"pack.vitrail.configure_title": "Налаштувати",
 	"options.vitrail.title": "Налаштування пакета шейдерів",

--- a/common/src/main/resources/assets/vitrail/lang/zh_cn.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_cn.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "光影包",
+	"options.vitrail.shadow_distance": "最大阴影距离",
+	"options.vitrail.shadow_distance_tooltip": "允许更改阴影的最远距离。超出此距离的地形和实体不会投射阴影。降低阴影距离可以显著提高性能。",
+	"options.vitrail.shadow_distance_forced": "你不能改变当前的光影包已经为阴影设置的渲染距离。",
 	"pack.vitrail.select_title": "选择",
 	"pack.vitrail.configure_title": "配置",
 	"options.vitrail.title": "光影包设置",

--- a/common/src/main/resources/assets/vitrail/lang/zh_tw.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_tw.json
@@ -1,5 +1,8 @@
 {
 	"options.vitrail.packs_title": "光影包",
+	"options.vitrail.shadow_distance": "最大陰影距離",
+	"options.vitrail.shadow_distance_tooltip": "能讓您變更陰影的最大距離。超出此距離的地形和實體將不會有陰影。降低陰影距離能顯著提升效能。",
+	"options.vitrail.shadow_distance_forced": "您無法變更目前光影包所設定的陰影顯示距離。",
 	"pack.vitrail.select_title": "選擇",
 	"pack.vitrail.configure_title": "設定",
 	"options.vitrail.title": "光影包設定",

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -213,6 +213,12 @@ declared and simply no longer be on a page.
 `vitrail/pack.txt`. They have to be: a single line cannot switch shaders off and still remember which
 pack to come back to. A file holding one bare word is still read the way it always was.
 
+A third line of that same file is not this screen's at all: `shadowdistance=` is how far the shadow
+map reaches, in chunks, and it is written by the Max Shadow Distance slider in the video settings.
+It sits there because it is the same kind of thing as the other two, one number a player sets once
+that outlives whichever pack is loaded, which is where the reference keeps its own. Both writers
+read the file before writing it, so neither drops the other's line.
+
 `vitrail/options.txt` keeps its own job and is never written by this screen.
 
 ## The layers


### PR DESCRIPTION
## What changes

Two things the engine could not do. `shadowDistanceRenderMul` was read by no part of it, so the
light gathered whatever its volume could see however tightly a pack had asked it not to; and there
was no user setting at all. Both are served from one point, `PackValues.shadowRenderDistance`, which
turns a multiplier into blocks the way Iris's `createShadowFrustum` does
(`shadows/ShadowRenderer.java:333-345`) and is the only place the two units meet, blocks for the
pack and chunks for the player. The sign of the multiplier is the whole switch (`:336`): declared
and not negative means the pack decides, anything else means the player does, and the default is
minus one so a pack that never wrote the line falls to the player automatically. The slider is 0 to
32 chunks in Sodium's video settings, greyed out while a pack decides, stored in `vitrail/pack.txt`
beside the pack choice the way Iris stores `maxShadowRenderDistance` beside `shaderPack`
(`config/IrisConfig.java:178,206`). At zero the shadow stage does not run at all, which is Iris's
first line (`shadows/ShadowRenderer.java:384-387`). The bound reaches the terrain through a new
`ShadowCull`, the light's planes ANDed with an axis-aligned box about the camera, and it reaches the
casters that move through `PackValues.entityShadowDistance`, which multiplies the two multipliers
together exactly as Iris does (`:540`) so that a pack's entity multiplier vanishes when the player
governs. The projection is never narrowed: it stays the pack's half plane, so no texel moves.

## How it differs from the reference, and for what obstacle

Two, both small and both written where they live.

`PackValues.forcedShadowRenderDistanceChunks` answers empty for a pack that declares a NEGATIVE
multiplier. Iris fills it with minus one there (`pipeline/IrisRenderingPipeline.java:292`), so its
slider greys out while `ShadowRenderer` goes on reading the player's number: the screen says the
pack decides and the image says otherwise. Costs the image nothing.

At a distance of zero, `TerrainDraw.openShadowStage` refuses the stage and clears on the way out.
What Iris does: returns at `shadows/ShadowRenderer.java:384-387`, before a target is touched, so
both halves of its map keep the last frame drawn. What stops that here: the refusal branch is a
single shared exit, `common/.../render/TerrainDraw.java:468-494`, whose own comment records why it
must clear - a stage that stops mid-session and leaves the map standing hands the pack a half drawn
map for the rest of the run, and half a map looks exactly like a shadow. What it costs the image:
the depth goes to the far plane whichever way the pack's keep directive reads
(`render/ShadowTargets.java:236-241`), so `shadowtex0` and `shadowtex1` read fully lit rather than
frozen; a `shadowcolor` the pack asked to keep is not cleared (`:243-248`, `:256-264`) and does stay
on its last frame, as it does in Iris.

## What proves it

- `gradlew build` green, `-PlintReport` clean on every file touched.
- Seven of the eight test packs declare `shadowDistanceRenderMul`, six of them at one: Mellow and
  Body Camera at 96 blocks, Complementary and Reverie at 192, BSL at 256, Bliss behind its own
  macro. Sildur's declares none and is the player's to move. **This is a change on those packs, not
  a no-op**, though how many of them it bites on depends on the render distance, since the sentinel
  at `render/PackValues.java:345` drops the bound once it reaches the loaded world: at 12 chunks
  only the three shorter packs are bounded, at 32 all of them are.
- Worked example, Sildur's, render distance 12 chunks: slider at 8 gives 8 x 16 = 128 blocks of
  walk; at 32 it gives 512, which is past the loaded world, so no box is built and the walk is the
  light's frustum alone (Iris drops its own culler on the same test, `:341-345`).
- **Not verified in the game.** Nothing here has been looked at on screen.

## What it leaves owing

The in-game pass: that the slider moves the picture, that zero really empties the depth, that the
greying follows a pack loaded while the game is up, and that the value survives a restart. And the
`shadowcullstate` families are still unread, so the pack-forced branch is served by the box alone
rather than by Iris's choice between a box, a non-culling frustum and a safe zone.
