### PR TITLE
perf(shadow): cull the light's walk against the camera, not its box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ what the next one holds.
   three and not on the rest. Those packs decide the distance, so the slider greys out and says so;
   it is the packs that stay silent, Sildur's among them, where it is the player's to move.
 
+### Changed
+
+- **The shadow map stops being drawn from parts of the world that cannot cast into what you are
+  looking at.** The light used to walk everything inside the box its map covers, the ground behind
+  you included, which is a second copy of the world drawn every frame for shadows nothing ever
+  samples. It now walks the camera's own view swept along the sun instead: what stands between the
+  sun and what you can see is kept, what could only ever shade your back is dropped. Expect more
+  frames per second wherever shadows are on, and no change to the picture.
+
+  The shape is the pack's to choose through `shadow.culling`, which is read now where it used to be
+  ignored, together with the `voxelDistance` distance behind one of its states. A pack asking for a
+  box about the camera instead of that sweep, or for no view frustum at all, gets what it asked for.
+  The log line the shadow stage prints on the first frame of a pack now names the shape as well as
+  the two counts, so the gain can be read off it.
+
 ### Fixed
 
 - The texture filtering selector in the video settings no longer offers RGSS while a pack draws the

--- a/NOTICE
+++ b/NOTICE
@@ -361,11 +361,37 @@ GNU Lesser General Public License version 3
   into its shadow map. The set a pack asks for by saying nothing is Iris's own, and the pair of
   directives is tested in the shape Iris tests it in, before anything is extracted.
 
+  common/src/main/java/dev/vitrail/pack/source/ShadowCullState.java carries the four states of
+  net.irisshaders.iris.shaderpack.properties.ShadowCullState together with the mapping from the
+  words a pack writes, which is the switch of
+  net.irisshaders.iris.shaderpack.properties.ShaderProperties, adapted in August 2026. The mapping
+  is reused rather than reasoned out because none of the three words means what it reads as.
+
+  common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java measures a section against the
+  camera's own volume swept along the light, and chooses which shape each state asks for. It is
+  adapted in August 2026 from
+  net.irisshaders.iris.shadows.frustum.advanced.AdvancedShadowCullingFrustum and its neighbours
+  BaseClippingPlanes and NeighboringPlaneSet, from
+  net.irisshaders.iris.shadows.frustum.advanced.SafeZoneCullingFrustum, and from the state machine
+  of ShadowRenderer.createShadowFrustum that picks between them, whose distances live beside every
+  other distance in common/src/main/java/dev/vitrail/render/PackValues.java.
+  The algorithm itself is L. Spiro's, credited in the original and through it here.
+  Three things are this project's own and are marked in the file. The plane extraction is taken as
+  written and is fed the matrix this engine republishes in the original's own clip volume, rather
+  than the reversed Z one it rasterises with; either handing over the drawn matrix or converting the
+  extraction a second time is wrong, and the file works both out. The expanded section test reads
+  its argument the way the Sodium version this engine compiles against reads it, as what is added
+  to a padded radius rather than as the radius itself. And the branch the original takes for a pack
+  that voxelises is not reachable here, no geometry stage being run at all, so it is answered rather
+  than measured.
+
   common/src/main/java/dev/vitrail/uniform/values/CelestialValues.java carries the celestial
   positions of net.irisshaders.iris.uniforms.CelestialUniforms, adapted in August 2026: the single
   step of wrapping, the starting vector of length one hundred, the unread y of the moon, and the w
   of zero on the up vector. Same rewriting of the rotations, and the two calls into Iris's own
-  pipeline object are replaced by questions to the world state.
+  pipeline object are replaced by questions to the world state. The world space light vector is the
+  same file's getShadowLightPositionInWorldSpace, which is the eye space answer without the model
+  view, and is kept apart from it here for the reason it is kept apart there.
 
   common/src/main/java/dev/vitrail/uniform/values/DrawValues.java takes the quad projection of
   net.irisshaders.iris.pipeline.transform.transformer.CompositeTransformer as a literal, since it

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -85,18 +85,13 @@ public final class ShaderProperties {
 	// writes shadowEntities and shadowBlockEntities once each, under an #ifndef its own settings
 	// file defines, so both lines are dead and a flat read turns the most used pack of the corpus
 	// into one with no entity shadows.
-	//
-	// shadow.culling belongs to the same family by its name and is deliberately NOT read, which is a
-	// refusal rather than a gap, so a pack that writes it is told nothing about it and gets a line
-	// among the keys nothing reads. Six of the eight write it. Its four answers are not four ways of
-	// walking one frustum: they pick between a box culler at the shadow distance, a box culler at
-	// the VOXEL distance, no culling at all and culling everything, each with its own capping
-	// against the render distance (Iris shadows/ShadowRenderer.java:302-355), and each of those
-	// rests on distance directives this engine does not read. Reading the word and walking one
-	// frustum anyway would put casters in a map the pack asked to keep them out of.
 	private static final Pattern SHADOW_CASTER = Pattern.compile(
 			"^\\s*(shadowTerrain|shadowTranslucent|shadowEntities|shadowPlayer|shadowBlockEntities"
 					+ "|shadowLightBlockEntities)\\s*=\\s*(.*)$");
+	// Which shape the light measures a section against. Of the same family by its name, and read on
+	// the live lines for the same reason, but it is not a caster word and it is not a boolean: the
+	// value is one of four states, and ShadowCullState carries what each of the written words means.
+	private static final Pattern SHADOW_CULLING = Pattern.compile("^\\s*shadow\\.culling\\s*=\\s*(.*)$");
 	// Whether the terrain's ambient occlusion is kept out of the vertex colour. Read on the live
 	// lines like every other directive of this file, and the note on RAIN_DEPTH says why that is
 	// what the reference does too.
@@ -358,6 +353,14 @@ public final class ShaderProperties {
 		// see that it was not understood.
 		Matcher caster = SHADOW_CASTER.matcher(line);
 		if (caster.matches() && truth(caster.group(2).trim()) != null) {
+			return;
+		}
+
+		// The culling state goes with separateAo below rather than with the casters above, and for
+		// that entry's reason: a word this cannot read is not stepped over, it is what puts the
+		// state back to the default, so the line is read whether the word is one of the four or not.
+		Matcher culling = SHADOW_CULLING.matcher(line);
+		if (culling.matches()) {
 			return;
 		}
 
@@ -1177,6 +1180,30 @@ public final class ShaderProperties {
 
 		return new ShadowCasters(terrain, translucent, entities, player, blockEntities,
 				lightBlockEntities);
+	}
+
+	/**
+	 * Which shape the pack wants the light to measure a section against, live lines only, and
+	 * {@link ShadowCullState#DEFAULT} unless it says otherwise. Six packs of the eight tested write
+	 * the key.
+	 * <p>
+	 * The last live line decides, and a word this cannot read leaves the default standing rather
+	 * than the line before it. That is Iris's reading and not a simplification of it: it loads the
+	 * preprocessed file into a map and runs its switch once, on the key's last value alone, and the
+	 * arm for an unknown word logs and touches nothing
+	 * ({@code shaderpack/properties/ShaderProperties.java:180-186}). The one thing not carried over
+	 * is that log line, this module having no logger and no business acquiring one.
+	 *
+	 * @param defines the pack's settings, which decide which lines of the file are alive at all
+	 */
+	public ShadowCullState shadowCull(Map<String, String> defines) {
+		ShadowCullState asked = ShadowCullState.DEFAULT;
+		for (Matcher line : live(SHADOW_CULLING, defines)) {
+			ShadowCullState state = ShadowCullState.of(line.group(1).trim());
+			asked = state == null ? ShadowCullState.DEFAULT : state;
+		}
+
+		return asked;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/pack/source/ShadowCullState.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShadowCullState.java
@@ -1,0 +1,50 @@
+package dev.vitrail.pack.source;
+
+/**
+ * What a pack asks of the walk the light makes, through the one key {@code shadow.culling}.
+ * <p>
+ * Four states and not four spellings of one, and the names are Iris's own
+ * ({@code shaderpack/properties/ShadowCullState.java}): each of them picks a DIFFERENT shape to
+ * measure a section against. Which shape each state buys is settled once, where the frustum is
+ * built, and never here.
+ * <p>
+ * <strong>The words a pack writes do not say what they look like they say.</strong>
+ * {@code shadow.culling=false} is not "do not cull", it is {@link #DISTANCE}, which keeps the box
+ * the map is drawn in and adds no view frustum to it; {@code true} is not "cull more", it is
+ * {@link #ADVANCED}, which is what {@link #DEFAULT} already gives. Iris maps them at
+ * {@code shaderpack/properties/ShaderProperties.java:180-185} and this enum keeps that mapping in
+ * {@link #of}.
+ */
+public enum ShadowCullState {
+
+	/**
+	 * The pack said nothing. Iris then decides on whether the pack VOXELISES, which it reads off the
+	 * shadow program shipping a geometry stage, and lands on {@link #ADVANCED} where it does not
+	 * ({@code shadows/ShadowRenderer.java:302}).
+	 */
+	DEFAULT,
+
+	/** The camera's volume swept along the light, which is the tightest of the four. */
+	ADVANCED,
+
+	/** The same, widened by a box at the pack's own {@code voxelDistance} that is never cut. */
+	SAFE_ZONE,
+
+	/** No sweep at all: the volume the map is drawn in, bounded by a distance or not. */
+	DISTANCE;
+
+	/**
+	 * The state a written word means, or null for a word this cannot read.
+	 * <p>
+	 * {@code reversed} and {@code safe_zone} are the same state under two spellings, the first being
+	 * the older one. A null answer is a word Iris logs and steps over, leaving the default standing.
+	 */
+	public static ShadowCullState of(String word) {
+		return switch (word) {
+			case "false" -> DISTANCE;
+			case "true" -> ADVANCED;
+			case "reversed", "safe_zone" -> SAFE_ZONE;
+			default -> null;
+		};
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
+++ b/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
@@ -52,6 +52,7 @@ public final class PackDirectives {
 	private final float shadowDistance;
 	private final float shadowDistanceRenderMul;
 	private final boolean forcesShadowRenderDistance;
+	private final float voxelDistance;
 	private final float entityShadowDistanceMul;
 	private final float shadowNearPlane;
 	private final float shadowFarPlane;
@@ -89,6 +90,7 @@ public final class PackDirectives {
 		this.shadowDistance = builder.shadowDistance;
 		this.shadowDistanceRenderMul = builder.shadowDistanceRenderMul;
 		this.forcesShadowRenderDistance = builder.forcesShadowRenderDistance;
+		this.voxelDistance = builder.voxelDistance;
 		this.entityShadowDistanceMul = builder.entityShadowDistanceMul;
 		this.shadowNearPlane = builder.shadowNearPlane;
 		this.shadowFarPlane = builder.shadowFarPlane;
@@ -227,6 +229,16 @@ public final class PackDirectives {
 	}
 
 	/**
+	 * How far out the pack's own voxel grid reaches, nought unless it says otherwise, and read for
+	 * the one state that needs it: a pack asking for {@code shadow.culling=safe_zone} keeps everything
+	 * within this distance whatever the light's own frustum says of it
+	 * ({@code shaderpack/properties/PackShadowDirectives.java:66,311}).
+	 */
+	public float voxelDistance() {
+		return this.voxelDistance;
+	}
+
+	/**
 	 * How much shorter the light reaches for the casters that MOVE than for the world, one unless the
 	 * pack says otherwise.
 	 * <p>
@@ -328,6 +340,7 @@ public final class PackDirectives {
 		private float shadowDistance = 160.0F;
 		private float shadowDistanceRenderMul = -1.0F;
 		private boolean forcesShadowRenderDistance;
+		private float voxelDistance;
 		private float entityShadowDistanceMul = 1.0F;
 		private float shadowNearPlane = -100.05F;
 		private float shadowFarPlane = 156.0F;
@@ -373,6 +386,7 @@ public final class PackDirectives {
 					this.shadowDistanceRenderMul = value;
 					this.forcesShadowRenderDistance = true;
 				});
+				case "voxelDistance" -> asFloat(directive, value -> this.voxelDistance = value);
 				case "entityShadowDistanceMul" -> asFloat(directive,
 						value -> this.entityShadowDistanceMul = value);
 				case "shadowNearPlane" -> asFloat(directive, value -> this.shadowNearPlane = value);

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -9,16 +9,19 @@ import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.source.ShaderPackSource;
 import dev.vitrail.pack.source.ShaderProperties;
 import dev.vitrail.pack.source.ShadowCasters;
+import dev.vitrail.pack.source.ShadowCullState;
 import dev.vitrail.pack.target.PackDirectives;
 import dev.vitrail.uniform.expr.CustomUniforms;
 import dev.vitrail.uniform.NoiseTexture;
 import dev.vitrail.uniform.UniformCatalog;
 import dev.vitrail.uniform.UniformGaps;
+import dev.vitrail.uniform.values.CelestialValues;
 import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
+import org.joml.Vector3f;
 import org.joml.Vector4fc;
 
 import java.io.IOException;
@@ -76,6 +79,9 @@ public final class PackValues {
 	 */
 	private ShadowCasters shadowCasters = ShadowCasters.DEFAULT;
 
+	/** Which shape this pack asked the light to measure a section against. */
+	private ShadowCullState shadowCull = ShadowCullState.DEFAULT;
+
 	private boolean separateAo;
 	private Optional<String> particleOrdering = Optional.empty();
 	private NoiseTexture.Image noiseImage;
@@ -119,6 +125,7 @@ public final class PackValues {
 			values.weather = properties.weather(settings.globalDefines(options));
 			values.rainDepth = properties.rainDepth(settings.globalDefines(options));
 			values.shadowCasters = properties.shadowCasters(settings.globalDefines(options));
+			values.shadowCull = properties.shadowCull(settings.globalDefines(options));
 			values.separateAo = properties.separateAo(settings.globalDefines(options));
 			values.particleOrdering = properties.particleOrdering(settings.globalDefines(options));
 			values.declare(properties, settings.globalDefines(options));
@@ -257,6 +264,71 @@ public final class PackValues {
 		ViewMatrices view = this.state.view();
 
 		return dest.set(view.drawnShadowProjection()).mul(view.drawnShadowModelView());
+	}
+
+	/**
+	 * What the light's walk needs to choose a shape, all of it read out of the one frame.
+	 * <p>
+	 * <strong>The camera's volume is the PUBLISHED projection and not the drawn one, and that is the
+	 * conversion this whole step turns on.</strong> The game rasterises with a reversed Z over zero
+	 * to one; the plane extraction the frustum performs is Iris's, written against the OpenGL volume;
+	 * and {@code ViewMatrices.gbufferProjection} is the frame's matrix already put into that volume by
+	 * {@link dev.vitrail.uniform.ClipSpace#toLegacyDepth} at {@code ViewMatrices:205}. So Iris's
+	 * lines hold as they stand, and it is the DRAWN matrix that would lose the far plane outright;
+	 * the arithmetic and the second way of getting it wrong are worked through on
+	 * {@code dev.vitrail.sodium.ShadowCullFrustum}.
+	 * <p>
+	 * The frame's own volume and not the distant one, which is Iris's condition and not the absence
+	 * of it: it reaches for {@code DHCompat.getProjection()} only under
+	 * {@code shouldRenderDH && DHCompat.hasRenderingEnabled()}
+	 * ({@code shadows/ShadowRenderer.java:366}), and its left half is the pack asking for the far
+	 * terrain in its SHADOW map ({@code :150}, the {@code dhShadow} directive). Nothing puts the far
+	 * terrain into this engine's shadow map at all, so that half can only be answered false here and
+	 * the branch Iris takes is the frame's own projection. Widening the volume to Distant Horizons'
+	 * would walk further out for casters that have nowhere to be drawn.
+	 *
+	 * <strong>The two distances are settled here and not at the frustum</strong>, because two of the
+	 * four states step outside the arbitration {@link #shadowRenderDistance} performs and the
+	 * arbitration has one home. {@link ShadowCullState#DISTANCE} reads the pack's own product and
+	 * never the player's setting, Iris asking for {@code halfPlaneLength * renderMultiplier} on its
+	 * own at {@code shadows/ShadowRenderer.java:303} and turning the walk loose when that is not
+	 * positive or reaches past the loaded world ({@code :317-322}). The safe zone steps outside it
+	 * the other way: it forces a multiplier the pack never declared to one BEFORE the branch that
+	 * would have read the player's setting ({@code :330-331}), so the player's number cannot reach
+	 * it either, and its two boxes are the pack's own throughout.
+	 *
+	 * @param userChunks           the player's own setting in chunks, for the states that read it
+	 * @param renderDistanceChunks the world that is loaded, which is what every bound is capped
+	 *                             against
+	 * @param light                scratch for the light vector, written and carried into the plan
+	 * @param camera               scratch for the camera's volume, likewise
+	 */
+	public ShadowCullPlan shadowCullPlan(int userChunks, int renderDistanceChunks, Vector3f light,
+			Matrix4f camera) {
+		ViewMatrices view = this.state.view();
+		camera.set(view.gbufferProjection()).mul(view.gbufferModelView());
+
+		PackDirectives directives = this.state.directives();
+		float multiplier = directives.shadowDistanceRenderMul();
+		float bound;
+		float safeZone = -1.0F;
+
+		switch (this.shadowCull) {
+			case DISTANCE -> {
+				float distance = directives.shadowDistance() * multiplier;
+				bound = distance <= 0.0F || distance > renderDistanceChunks * (float) CHUNK_BLOCKS
+						? -1.0F : distance;
+			}
+			case SAFE_ZONE -> {
+				float effective = multiplier < 0.0F ? 1.0F : multiplier;
+				safeZone = directives.voxelDistance() * effective;
+				bound = directives.shadowDistance() * effective;
+			}
+			default -> bound = shadowRenderDistance(userChunks, renderDistanceChunks);
+		}
+
+		return new ShadowCullPlan(this.shadowCull,
+				CelestialValues.shadowLightVector(this.state, light), camera, bound, safeZone);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ShadowCullPlan.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowCullPlan.java
@@ -1,0 +1,35 @@
+package dev.vitrail.render;
+
+import dev.vitrail.pack.source.ShadowCullState;
+
+import org.joml.Matrix4f;
+import org.joml.Vector3f;
+
+/**
+ * Everything the light's walk needs to know before it can choose a shape to measure a section
+ * against, gathered in one reading of the frame.
+ * <p>
+ * One record rather than five calls, and that is not tidiness: the light vector, the camera's volume
+ * and the pack's distances all have to come from the SAME frame. Read one at a time across the
+ * boundary the shadow stage sits on, the camera's volume would be this frame's and the light's
+ * direction the next one's, and a volume swept along a light the map is not drawn from keeps and
+ * drops the wrong sections without a line on screen saying so.
+ * <p>
+ * The two matrices are the caller's own scratch, written into and handed back, because this is built
+ * once a frame at the end of the frame and nothing here is worth an allocation.
+ *
+ * @param state    which of the four shapes the pack asked for
+ * @param light    where the light stands, a unit vector from the origin in world space
+ * @param camera   the camera's view projection, the volume the sweep starts from, in the OpenGL clip
+ *                 convention. See {@code dev.vitrail.sodium.ShadowCullFrustum} for why the
+ *                 convention is load bearing and what reading the drawn matrix would cost
+ * @param bound    how far from the camera the walk still gathers, in blocks, or negative where
+ *                 nothing bounds it. Already arbitrated between the pack and the player by
+ *                 {@link PackValues#shadowCullPlan}, and it is the box
+ *                 {@code dev.vitrail.sodium.ShadowCull} carries whichever shape sits inside it
+ * @param safeZone the inner box of the safe zone state, which is kept whatever the sweep says of it,
+ *                 or negative for the three states that have none
+ */
+public record ShadowCullPlan(ShadowCullState state, Vector3f light, Matrix4f camera, float bound,
+		float safeZone) {
+}

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -20,6 +20,7 @@ import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.client.Minecraft;
 
 import org.joml.Matrix4f;
+import org.joml.Vector3f;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -618,6 +619,22 @@ public final class TerrainDraw {
 		TerrainDraw self = PackChain.terrain();
 
 		return self == null ? null : self.values.shadowFrustum(dest);
+	}
+
+	/**
+	 * What the light's walk needs to choose a shape to measure a section against, or null when no
+	 * pack is drawing. The two scratch objects handed in are written and carried into the answer.
+	 * <p>
+	 * It carries the bound {@link #shadowRenderDistance} would have answered, so the two are never
+	 * asked for separately: the states that step outside that arbitration do it inside
+	 * {@link PackValues#shadowCullPlan}, and a caller taking the shape from one and the distance
+	 * from the other would put a pack's own bound under a shape that asked for the player's.
+	 */
+	public static ShadowCullPlan shadowCullPlan(Vector3f light, Matrix4f camera) {
+		TerrainDraw self = PackChain.terrain();
+
+		return self == null ? null : self.values.shadowCullPlan(PackChain.shadowDistance(),
+				renderDistanceChunks(), light, camera);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
@@ -1,20 +1,21 @@
 package dev.vitrail.sodium;
 
 import net.caffeinemc.mods.sodium.client.render.viewport.frustum.Frustum;
-import net.caffeinemc.mods.sodium.client.render.viewport.frustum.SimpleFrustum;
 
 import org.joml.FrustumIntersection;
 
 /**
- * The light's frustum with a box around the camera cut out of it, which is how a shadow distance
- * bounds a walk that is otherwise the pack's own volume.
+ * Whichever shape the light walks with, with a box around the camera cut out of it, which is how a
+ * shadow distance bounds a walk that is otherwise the pack's own.
  * <p>
  * <strong>A box and not a shorter frustum, and that is the whole reason this class exists.</strong>
- * The light's volume is built from the pack's half plane and is what the shadow map is DRAWN with;
- * narrowing it would move every texel of the map and change the picture. What a shadow distance
- * asks for is different and cheaper: keep the volume, and stop walking the world beyond a cube of
- * that many blocks around the player. Iris draws the same distinction with the same shape, an
- * axis-aligned cube tested on each axis independently, {@code shadows/frustum/BoxCuller.java}.
+ * The shape inside is either the light's own volume, built from the pack's half plane and what the
+ * shadow map is DRAWN with, or the camera's volume swept along the light
+ * ({@link ShadowCullFrustum}), and narrowing either would change which casters reach the map rather
+ * than how far the walk goes. What a shadow distance asks for is different and cheaper: keep the
+ * shape, and stop walking the world beyond a cube of that many blocks around the player. Iris draws
+ * the same distinction with the same shape, an axis-aligned cube tested on each axis independently,
+ * {@code shadows/frustum/BoxCuller.java}, and hangs it off each of its own frustums the same way.
  * <p>
  * <strong>The coordinates are relative to the camera, and nothing here converts them.</strong>
  * Sodium subtracts the camera before it asks ({@code Viewport.isBoxVisibleDirect}, which is where
@@ -39,11 +40,12 @@ public final class ShadowCull implements Frustum {
 	private final float distance;
 
 	/**
-	 * @param light    the light's own view projection, the volume the map is drawn with
+	 * @param planes   the shape the walk measures against before the box is cut out of it, which
+	 *                 {@link ShadowCullFrustum#of} chooses from what the pack asked for
 	 * @param distance how far from the camera the walk still gathers, in blocks
 	 */
-	public ShadowCull(FrustumIntersection light, float distance) {
-		this.planes = new SimpleFrustum(light);
+	public ShadowCull(Frustum planes, float distance) {
+		this.planes = planes;
 		this.distance = distance;
 	}
 

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
@@ -1,0 +1,418 @@
+package dev.vitrail.sodium;
+
+import dev.vitrail.render.ShadowCullPlan;
+
+import net.caffeinemc.mods.sodium.client.render.viewport.frustum.Frustum;
+import net.caffeinemc.mods.sodium.client.render.viewport.frustum.SimpleFrustum;
+import net.caffeinemc.mods.sodium.client.render.viewport.Viewport;
+
+import org.joml.FrustumIntersection;
+import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.joml.Vector4f;
+
+/**
+ * The camera's own volume swept along the light, which is what the world is walked against for the
+ * shadow map instead of the box that map is drawn in.
+ * <p>
+ * The idea is L. Spiro's and it reaches here through Iris
+ * ({@code shadows/frustum/advanced/AdvancedShadowCullingFrustum.java}): if a section cannot drop
+ * anything onto what the camera can see, nothing it casts will ever be sampled, so it need not be
+ * drawn. Take the camera's six clipping planes; keep the ones whose inward normal points towards the
+ * light, since those are the far side of the volume as the light sees it; drop the ones facing the
+ * light, since a caster in front of those still casts into the volume; and close the silhouette with
+ * a plane swept along the light for every edge between a kept plane and a dropped one. The
+ * assumption it rests on is the same one Iris states: the map is sampled for direct shadowing and
+ * for volumetrics, and not for light that bounces off a caster the camera cannot see.
+ * <p>
+ * <strong>The distance is not this class's business.</strong> How far from the camera the walk still
+ * gathers is a box, it is arbitrated between the pack and the player where every other distance is,
+ * and {@link ShadowCull} is what wraps it round whichever shape sits inside. This one carries only
+ * the shape, plus the one box that is not a bound but a keep: the safe zone.
+ *
+ * <h2>The conversion, and what citing Iris word for word would cost</h2>
+ *
+ * The planes are pulled out of a view projection, so the extraction depends entirely on the clip
+ * volume that matrix targets, and the engine draws in one volume while a pack reads another.
+ * <ul>
+ * <li><strong>What Iris supposes</strong>: OpenGL, z from minus one to one, so the volume is
+ * {@code -w <= z_c <= w}, and its two z planes are {@code rowW + rowZ} for the near side and
+ * {@code rowW - rowZ} for the far one ({@code BaseClippingPlanes.java:32-35}, which asks for them by
+ * transposing the matrix and transforming {@code (0,0,-1,1)} and {@code (0,0,1,1)}).</li>
+ * <li><strong>What this engine RASTERISES with</strong>: Vulkan, z from zero to one, and REVERSED,
+ * near at one and far at nought. Iris's two lines are false against that matrix.</li>
+ * <li><strong>What is handed in, and therefore the conversion this file applies</strong>: the
+ * PUBLISHED view projection, which {@code ViewMatrices} has already put into Iris's volume, once a
+ * frame, through {@link dev.vitrail.uniform.ClipSpace#toLegacyDepth} ({@code ViewMatrices:205} for
+ * the frame's own). So the conversion is upstream and is an identity rather than an approximation,
+ * and <strong>this file applies none: Iris's six lines are taken exactly as they stand.</strong>
+ * That is the whole of the answer, and it is written out because both ways of getting it wrong are
+ * inviting.</li>
+ * </ul>
+ *
+ * <h3>Worked, on the frame's own numbers, and on both ways of getting it wrong</h3>
+ *
+ * Take the game's perspective at ninety degrees, aspect one, near a twentieth of a block and far
+ * five hundred and twelve. The drawn matrix, near and far swapped and the zero to one flag set, has
+ * {@code rowZ = (0, 0, 9.7666e-5, 0.0500049)} and {@code rowW = (0, 0, -1, 0)}: a point five
+ * hundredths in front of the eye lands at {@code z_ndc = 1} and one five hundred and twelve blocks
+ * out at {@code z_ndc = 0}, which is the reversal. The published matrix replaces that z row with
+ * {@code rowW - 2 * rowZ}, so what reaches this file is
+ * {@code rowZ = (0, 0, -1.000195, -0.1000098)} beside the same {@code rowW}.
+ * <ul>
+ * <li><strong>As written</strong>: the far plane is {@code rowW - rowZ = (0, 0, 1.95332e-4,
+ * 0.1000098)}, which reads {@code z >= -512}, and the near plane is
+ * {@code rowW + rowZ = (0, 0, -2.000195, -0.1000098)}, which reads {@code z <= -0.05}. Both faces
+ * are where the volume really has them.</li>
+ * <li><strong>Converting a second time</strong>, which is what a reader who knows this engine's
+ * rasteriser will reach for, asks for {@code rowZ} and {@code rowW - rowZ} instead. The far plane
+ * comes out right by accident, being the same {@code 2 * rowZ_drawn} either way; the near plane
+ * becomes {@code rowW - 2 * rowZ_drawn} and reads {@code z <= -0.09999}, which is
+ * {@code 2nf / (n + f)} in place of {@code n}. A band a twentieth of a block thick in front of the
+ * eye is culled that should not be, and nothing on screen is ever going to say so.</li>
+ * <li><strong>Handing the DRAWN matrix to Iris's lines</strong> is the loud one: the far slot holds
+ * {@code rowW - rowZ_drawn}, which reads {@code z <= -0.05} and is the near plane, and the near slot
+ * holds {@code rowW + rowZ_drawn}, which reads {@code z <= +0.05} and is the near plane again,
+ * displaced a tenth of a block. The volume is bounded twice on the side the eye is and not at all on
+ * the other: the far plane is gone, and a section two thousand blocks out, centre
+ * {@code (0, -40, -2000)}, is kept where the published matrix drops it on
+ * {@code 1.95332e-4 * -1990.875 = -0.3888 < -0.1000098}. Keeping a section too many costs a draw and
+ * not a pixel, so the cull silently stops paying for itself.</li>
+ * </ul>
+ *
+ * <h3>Which space each test happens in, and why nothing else needs converting</h3>
+ *
+ * The planes come out in CAMERA RELATIVE WORLD space, because the model view they are pulled through
+ * carries the camera's rotation and no translation, exactly as Iris's does. That is also the space
+ * Sodium hands its boxes in ({@code Viewport.isBoxVisibleDirect}, which is where the float origin is
+ * made), and the space the light vector is asked for. So the sweep, the half space tests and the
+ * safe zone are all one space, and the light's own clip volume never enters any of them. The shadow
+ * map is drawn in a volume of its own, forward over zero to one, and that has no bearing here: no
+ * test below reads the light's projection at all.
+ *
+ * <h3>Worked, on three sections</h3>
+ *
+ * Same camera, at the world origin, looking down {@code -Z}, and the light straight overhead,
+ * {@code (0, 1, 0)}. The bottom face is the only one whose normal points towards the light, so it is
+ * the only back face; the four faces standing across the light are kept as they stand; the top face
+ * looks at the light and is dropped. The four planes swept off the bottom face reproduce the four
+ * kept faces exactly, the sweep of a plane along a direction it already contains being itself. The
+ * volume is therefore the camera's frustum with its lid taken off, which is the right answer with
+ * the sun overhead. Sections are tested at Sodium's padded half size, 9.125.
+ * <ul>
+ * <li>In front and below, centre {@code (0, -40, -100)}: the bottom plane
+ * {@code (0, 0.7071, -0.7071, 0)} takes its highest y, {@code -30.875}, and its nearest z,
+ * {@code -109.125}, giving {@code -21.83 + 77.16 = 55.33 >= 0}. Kept, as it must be, being in plain
+ * sight.</li>
+ * <li>Behind the camera, centre {@code (0, -40, 100)}: the left plane {@code (-0.7071, 0, -0.7071,
+ * 0)} gives {@code 6.45 - 64.25 = -57.80 < 0}. Dropped. Under the box the light was culled with
+ * before this class existed it was kept, and that one section is the whole of what this change
+ * buys.</li>
+ * <li>Above the camera and out of its view, centre {@code (0, 80, -20)}: the camera's own top plane
+ * {@code (0, -0.7071, -0.7071, 0)} gives {@code -50.12 + 20.59 = -29.53 < 0}, so the camera cannot
+ * see it, while the bottom plane gives {@code 63.02 + 20.59 = 83.61 >= 0} and every other kept plane
+ * passes. Kept, and it has to be: with the sun overhead it drops its shadow straight down into what
+ * the camera is looking at.</li>
+ * </ul>
+ *
+ * <h2>Where this parts from Iris</h2>
+ *
+ * <strong>The section tests take Sodium's meaning of the expanded size, and Iris takes another
+ * one.</strong> Iris reads the argument of {@code testSectionExpanded} as the section's half size
+ * ({@code AdvancedShadowCullingFrustum.java}, {@code minX = originX - extend}), while Sodium's own
+ * frustum bakes {@code CHUNK_SECTION_PADDED_RADIUS} into its plane constants and reads the argument
+ * as what is added ON TOP of it ({@code viewport/frustum/SimpleFrustum.java}), which is what the one
+ * caller passes. Sodium's meaning is taken because the contract is Sodium's and this engine compiles
+ * against it. It settles nothing on this walk either way: the shadow stage asks
+ * {@code finalizeRenderLists} to update immediately, and the traversal that takes reaches the
+ * viewport through {@code isBoxVisibleDirect} and {@code getBoxIntersectionDirect} alone, which is
+ * the note {@link ShadowCull} carries about the same pair of methods.
+ */
+public final class ShadowCullFrustum implements Frustum {
+
+	/** Six faces, and one swept plane per edge between a kept face and a dropped one. */
+	private static final int MAX_PLANES = 13;
+
+	/**
+	 * The four faces that share an edge with each face, by axis pair, which is Iris's
+	 * {@code NeighboringPlaneSet} written as a table ({@code shadows/frustum/advanced}). Indexed by
+	 * the face's own index shifted right once, so the two faces of an axis share a row: a face never
+	 * shares an edge with its opposite, and does share one with all four of the others.
+	 */
+	private static final int[][] NEIGHBOURS = {
+		{2, 3, 4, 5},
+		{0, 1, 4, 5},
+		{0, 1, 2, 3},
+	};
+
+	/** What Sodium pads a section's half size to, which is where its own frustum starts. */
+	private static final float SECTION_HALF_SIZE = Viewport.CHUNK_SECTION_PADDED_RADIUS;
+
+	private final float[][] planes = new float[MAX_PLANES][];
+	private final Vector3f light = new Vector3f();
+
+	/** Half the side of the box the safe zone keeps whatever the sweep says, or negative for none. */
+	private final float safeZone;
+
+	private int planeCount;
+
+	private ShadowCullFrustum(Matrix4fc camera, Vector3fc light, float safeZone) {
+		this.safeZone = safeZone;
+		this.light.set(light);
+
+		build(camera);
+	}
+
+	/**
+	 * The frustum the pack's own state asks for, wrapped in whatever distance bounds the walk.
+	 * <p>
+	 * The four arms are Iris's {@code createShadowFrustum}
+	 * ({@code shadows/ShadowRenderer.java:298-372}), split between here and
+	 * {@code PackValues.shadowCullPlan}, which holds the distances because that is where every other
+	 * distance is arbitrated. What is left here is the choice of SHAPE, and one branch of Iris's
+	 * first test is answered rather than measured: <strong>a pack cannot voxelise on this engine,
+	 * because a geometry stage is never run at all.</strong> Iris takes a shadow program that ships
+	 * one as the pack moving its vertices somewhere the camera's volume cannot predict, and turns the
+	 * sweep off for it ({@code :164-165,302}); here every pipeline is built from the vertex and the
+	 * fragment stages alone ({@code render/GeometryProgram}), so a {@code .gsh} is translated and
+	 * never bound, no vertex moves, and the branch Iris takes without voxelisation is the only one
+	 * that can be right.
+	 * <p>
+	 * <strong>{@link dev.vitrail.pack.source.ShadowCullState#DISTANCE} keeps the light's own volume
+	 * where Iris keeps nothing</strong>, its {@code BoxCullingFrustum} carrying a box and no planes
+	 * ({@code shadows/frustum/fallback/BoxCullingFrustum.java}). That is not a shape this engine can
+	 * be asked for and it costs the image nothing: the volume is what the map is DRAWN with, so a
+	 * section outside it is clipped by the rasteriser and cannot reach the map however it is walked,
+	 * and the one thing that could have moved a vertex out from under it, a geometry stage, is the
+	 * thing that never runs. Iris drops the planes there because for IT that is not true.
+	 *
+	 * @param plan  what the pack asked for and what the frame is aimed at
+	 * @param light the light's own view projection, the volume the map is drawn with
+	 */
+	public static Chosen of(ShadowCullPlan plan, FrustumIntersection light) {
+		String shape;
+		Frustum frustum;
+
+		switch (plan.state()) {
+			case DISTANCE -> {
+				shape = "the light's own volume, asked for by the pack";
+				frustum = new SimpleFrustum(light);
+			}
+			case SAFE_ZONE -> {
+				shape = "swept along the light, keeping " + plan.safeZone() + " blocks of safe zone";
+				frustum = new ShadowCullFrustum(plan.camera(), plan.light(), plan.safeZone());
+			}
+			default -> {
+				shape = "swept along the light";
+				frustum = new ShadowCullFrustum(plan.camera(), plan.light(), -1.0F);
+			}
+		}
+
+		return plan.bound() < 0.0F ? new Chosen(frustum, shape)
+				: new Chosen(new ShadowCull(frustum, plan.bound()),
+						shape + ", within " + plan.bound() + " blocks");
+	}
+
+	/**
+	 * What the walk ended up measuring against, and the words for the one line the shadow stage
+	 * prints about it. The two travel together so that the line cannot name a shape the walk did not
+	 * use.
+	 */
+	public record Chosen(Frustum frustum, String culling) {
+	}
+
+	private void build(Matrix4fc camera) {
+		Vector4f[] faces = faces(camera);
+		boolean[] back = new boolean[faces.length];
+
+		// The faces whose inward normal points towards the light, which are the far side of the
+		// camera's volume as the light sees it and the only ones that still bound the casters. A
+		// normal exactly across the light bounds nothing and cuts nothing either, so it is kept
+		// without being counted as back, which is Iris's reading of the degenerate case.
+		for (int index = 0; index < faces.length; index++) {
+			Vector4f face = faces[index];
+			float towards = face.x * this.light.x + face.y * this.light.y + face.z * this.light.z;
+			back[index] = towards > 0.0F;
+
+			if (towards >= 0.0F) {
+				add(face.x, face.y, face.z, face.w);
+			}
+		}
+
+		// And the silhouette: every edge between a kept face and a dropped one, swept along the light.
+		for (int index = 0; index < faces.length; index++) {
+			if (!back[index]) {
+				continue;
+			}
+
+			for (int neighbour : NEIGHBOURS[index >>> 1]) {
+				if (!back[neighbour]) {
+					edge(faces[index], faces[neighbour]);
+				}
+			}
+		}
+	}
+
+	/**
+	 * The camera's six faces, as plane equations in camera relative world space.
+	 * <p>
+	 * {@code (a, b, c, w)} stands for {@code ax + by + cz + w >= 0} being inside, which is what makes
+	 * the test below a dot product against {@code (x, y, z, 1)}. The four sides are Iris's lines as
+	 * they stand; the two z faces are this engine's volume, and the class note carries the difference
+	 * and what ignoring it costs.
+	 * <p>
+	 * The normalisation is over all four components, which is Iris's as well
+	 * ({@code BaseClippingPlanes.java:16}). It scales a plane rather than moving it, so no test
+	 * changes; what it is not is a plane in the metric sense, and no distance may be read off one.
+	 */
+	private static Vector4f[] faces(Matrix4fc camera) {
+		Matrix4f transposed = new Matrix4f(camera).transpose();
+
+		return new Vector4f[] {
+			face(transposed, -1.0F, 0.0F, 0.0F, 1.0F),
+			face(transposed, 1.0F, 0.0F, 0.0F, 1.0F),
+			face(transposed, 0.0F, -1.0F, 0.0F, 1.0F),
+			face(transposed, 0.0F, 1.0F, 0.0F, 1.0F),
+			// The far face, rowW - rowZ, and the near one, rowW + rowZ. Iris's own two lines, and
+			// they are right here because the matrix is already in Iris's volume. The class note
+			// carries what a second conversion would move and what the drawn matrix would lose.
+			face(transposed, 0.0F, 0.0F, -1.0F, 1.0F),
+			face(transposed, 0.0F, 0.0F, 1.0F, 1.0F),
+		};
+	}
+
+	private static Vector4f face(Matrix4fc transposed, float x, float y, float z, float w) {
+		return new Vector4f(x, y, z, w).mul(transposed).normalize();
+	}
+
+	/**
+	 * The plane that sweeps the edge shared by two faces along the light.
+	 * <p>
+	 * Its normal has to stand across the light, which is what makes it a sweep rather than a tilt, so
+	 * it is the edge direction crossed with the light. Its distance is then fixed by asking for a
+	 * point on the edge, which is where the two faces and a third plane through the origin normal to
+	 * the edge meet. That last step is Iris's, itself taken from Graphics Gems by way of a Stack
+	 * Overflow answer it credits in place ({@code AdvancedShadowCullingFrustum.addEdgePlane}).
+	 */
+	private void edge(Vector4f back, Vector4f front) {
+		Vector3f edge = new Vector3f(back.x, back.y, back.z)
+				.cross(front.x, front.y, front.z);
+		Vector3f normal = new Vector3f(edge).cross(this.light);
+
+		Vector3f point = new Vector3f(edge).cross(back.x, back.y, back.z).mul(-front.w)
+				.add(new Vector3f(front.x, front.y, front.z).cross(edge).mul(-back.w))
+				.mul(1.0F / edge.lengthSquared());
+
+		add(normal.x, normal.y, normal.z, -normal.dot(point));
+	}
+
+	private void add(float x, float y, float z, float w) {
+		this.planes[this.planeCount] = new float[] { x, y, z, w };
+		this.planeCount += 1;
+	}
+
+	@Override
+	public boolean testAab(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+		// The safe zone is a KEEP and not a bound, so it stands beside the sweep rather than in front
+		// of it, which is the shape Iris gives it (SafeZoneCullingFrustum.testAab): a section reaching
+		// into the pack's own voxel grid is drawn whatever the sweep says of it, because the pack
+		// samples that grid from places the sweep knows nothing about.
+		return within(minX, minY, minZ, maxX, maxY, maxZ)
+				|| visible(minX, minY, minZ, maxX, maxY, maxZ);
+	}
+
+	@Override
+	public int intersectAab(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+		// Wholly inside the safe zone answers INSIDE and not INTERSECT, which is Iris's own line
+		// (SafeZoneCullingFrustum.intersectAab:76-78). It buys the walk the right to stop testing a
+		// whole subtree; answered INTERSECT it would still keep everything, one test at a time.
+		if (this.safeZone >= 0.0F && minX >= -this.safeZone && maxX <= this.safeZone
+				&& minY >= -this.safeZone && maxY <= this.safeZone
+				&& minZ >= -this.safeZone && maxZ <= this.safeZone) {
+			return FrustumIntersection.INSIDE;
+		}
+
+		if (within(minX, minY, minZ, maxX, maxY, maxZ)) {
+			return FrustumIntersection.INTERSECT;
+		}
+
+		return corners(minX, minY, minZ, maxX, maxY, maxZ);
+	}
+
+	@Override
+	public boolean testSection(float originX, float originY, float originZ) {
+		return testSectionExpanded(originX, originY, originZ, 0.0F);
+	}
+
+	/**
+	 * @param extend what is added to Sodium's own padded half size, and not the half size itself.
+	 *               The class note carries why, and where Iris reads the same argument otherwise
+	 */
+	@Override
+	public boolean testSectionExpanded(float originX, float originY, float originZ, float extend) {
+		float half = SECTION_HALF_SIZE + extend;
+
+		return testAab(originX - half, originY - half, originZ - half, originX + half,
+				originY + half, originZ + half);
+	}
+
+	/**
+	 * Whether a camera relative box reaches into the safe zone at all, which is false outright where
+	 * there is no safe zone: nothing reaches into a cube that is not there.
+	 */
+	private boolean within(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+		return this.safeZone >= 0.0F
+				&& maxX >= -this.safeZone && minX <= this.safeZone
+				&& maxY >= -this.safeZone && minY <= this.safeZone
+				&& maxZ >= -this.safeZone && minZ <= this.safeZone;
+	}
+
+	/**
+	 * Whether a box reaches into the swept volume, which is the hot path: it is what the walk asks,
+	 * once per section per frame, and it stops at the first plane that rejects.
+	 * <p>
+	 * The dot product is written out rather than fused. Iris reaches for {@code Math.fma} and falls
+	 * back to exactly this when the machine has told the virtual machine it has no instruction for
+	 * it, and an unfused machine pays a software emulation for the fused call, so the plain form is
+	 * the one that is never the slow answer. What it costs is a rounding, on a section sitting
+	 * exactly on a plane.
+	 */
+	private boolean visible(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+		for (int index = 0; index < this.planeCount; index++) {
+			float[] plane = this.planes[index];
+			float x = plane[0] < 0.0F ? minX : maxX;
+			float y = plane[1] < 0.0F ? minY : maxY;
+			float z = plane[2] < 0.0F ? minZ : maxZ;
+
+			if (plane[0] * x + plane[1] * y + plane[2] * z < -plane[3]) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/** The same, answering whether the box is wholly inside as well, for the callers that ask. */
+	private int corners(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
+		boolean inside = true;
+
+		for (int index = 0; index < this.planeCount; index++) {
+			float[] plane = this.planes[index];
+			float x = plane[0] < 0.0F ? minX : maxX;
+			float y = plane[1] < 0.0F ? minY : maxY;
+			float z = plane[2] < 0.0F ? minZ : maxZ;
+
+			if (plane[0] * x + plane[1] * y + plane[2] * z < -plane[3]) {
+				return FrustumIntersection.OUTSIDE;
+			}
+
+			inside &= plane[0] * (plane[0] < 0.0F ? maxX : minX)
+					+ plane[1] * (plane[1] < 0.0F ? maxY : minY)
+					+ plane[2] * (plane[2] < 0.0F ? maxZ : minZ) + plane[3] >= 0.0F;
+		}
+
+		return inside ? FrustumIntersection.INSIDE : FrustumIntersection.INTERSECT;
+	}
+}

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -4,6 +4,7 @@ import dev.vitrail.mixin.MixinSodiumWorldRenderer;
 import dev.vitrail.mixin.RenderSectionManagerAccessor;
 import dev.vitrail.pack.source.ShadowCasters;
 import dev.vitrail.render.BlockStateIds;
+import dev.vitrail.render.ShadowCullPlan;
 import dev.vitrail.render.ShadowGeometry;
 import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.Vitrail;
@@ -17,7 +18,6 @@ import net.caffeinemc.mods.sodium.client.render.chunk.ChunkRenderMatrices;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSectionManager;
 import net.caffeinemc.mods.sodium.client.render.chunk.lists.ChunkRenderList;
 import net.caffeinemc.mods.sodium.client.render.chunk.lists.SortedRenderLists;
-import net.caffeinemc.mods.sodium.client.render.viewport.frustum.SimpleFrustum;
 import net.caffeinemc.mods.sodium.client.render.viewport.Viewport;
 import net.caffeinemc.mods.sodium.client.util.FogParameters;
 import net.caffeinemc.mods.sodium.client.util.GameRendererStorage;
@@ -30,13 +30,15 @@ import org.joml.FrustumIntersection;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.joml.Vector3d;
+import org.joml.Vector3f;
 
 /**
  * Draws the chunk renderer once more, at the very end of the frame, into the shadow map the next
  * frame will read.
  * <p>
  * The stage stands at the end of a frame and not at its top, and that placement is the culling
- * design. The world is walked a second time under the light's frustum, which reuses the very lists
+ * design. The world is walked a second time for the light, under the shape
+ * {@link ShadowCullFrustum} chooses for it, which reuses the very lists
  * the camera's walk just filled: {@code ChunkRenderList} is one persistent object per region, so
  * there is nothing to save and restore, only an order to respect. Advancing the frame counter first
  * is what lets the second walk of a frame reset those lists instead of overflowing them, and raising
@@ -72,6 +74,10 @@ public final class ShadowTerrain {
 
 	/** Scratch for the light's cull matrix, one per process rather than one per frame. */
 	private static final Matrix4f LIGHT = new Matrix4f();
+
+	/** The same, for the camera's volume and the light's direction the walk's shape is built from. */
+	private static final Matrix4f CAMERA = new Matrix4f();
+	private static final Vector3f LIGHT_VECTOR = new Vector3f();
 
 	private static Vec3 camera;
 
@@ -138,7 +144,11 @@ public final class ShadowTerrain {
 		RenderSectionManager manager =
 				((MixinSodiumWorldRenderer) renderer).vitrail$renderSectionManager();
 		Matrix4f light = TerrainDraw.shadowFrustum(LIGHT);
-		if (manager == null || light == null) {
+		// Read here, in the same breath as the light's own matrix and off the same frame: the shape
+		// the terrain is walked against is built from the camera's volume and the light's direction,
+		// and the record's own note says what taking one of them a frame later would keep and drop.
+		ShadowCullPlan plan = TerrainDraw.shadowCullPlan(LIGHT_VECTOR, CAMERA);
+		if (manager == null || light == null || plan == null) {
 			return;
 		}
 
@@ -160,15 +170,16 @@ public final class ShadowTerrain {
 		manager.prepareRender();
 		try {
 			FogParameters fog = ((MixinSodiumWorldRenderer) renderer).vitrail$lastFogParameters();
-			// The light's own volume, and a box around the camera cut out of it wherever a shadow
-			// distance bounds the walk. Negative means nothing bounds it, and then the walk is the
-			// volume alone. Which of the two happens is the pack's business at least as often as the
-			// player's: most of the corpus declares a render multiplier and is bounded at its own
-			// half plane whatever the slider says.
-			float bound = TerrainDraw.shadowRenderDistance();
-			FrustumIntersection volume = new FrustumIntersection(light);
-			Viewport viewport = new Viewport(
-					bound < 0.0F ? new SimpleFrustum(volume) : new ShadowCull(volume, bound),
+			// The shape the pack asked for, and a box around the camera cut out of it wherever a
+			// shadow distance bounds the walk. By default that shape is the camera's own volume swept
+			// along the light rather than the light's own: a section that cannot drop anything onto
+			// what the camera can see is thrown away before it is drawn. Whether a bound applies at
+			// all is the pack's business at least as often as the player's, most of the corpus
+			// declaring a render multiplier and being held at its own half plane whatever the slider
+			// says, and the plan carries the arbitration already made.
+			ShadowCullFrustum.Chosen cull =
+					ShadowCullFrustum.of(plan, new FrustumIntersection(light));
+			Viewport viewport = new Viewport(cull.frustum(),
 					new Vector3d(camera.x, camera.y, camera.z));
 			manager.finalizeRenderLists(minecraft.gameRenderer.mainCamera(), viewport,
 					fog == null ? FogParameters.NONE : fog, true);
@@ -193,8 +204,8 @@ public final class ShadowTerrain {
 			if (measured != BlockStateIds.generation() && seen > 0) {
 				measured = BlockStateIds.generation();
 				Vitrail.logger().info("Shadow cull walked {} sections for the light against {} "
-						+ "for the camera, on block table {}", sections(manager.getRenderLists()),
-						seen, measured);
+						+ "for the camera, on block table {}, culling {}",
+						sections(manager.getRenderLists()), seen, measured, cull.culling());
 			}
 
 			draw(renderer, minecraft, camera);

--- a/common/src/main/java/dev/vitrail/uniform/values/CelestialValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/CelestialValues.java
@@ -6,10 +6,12 @@ import dev.vitrail.uniform.Val;
 import dev.vitrail.uniform.WorldState;
 
 import org.joml.Matrix4f;
+import org.joml.Vector3f;
 import org.joml.Vector4f;
 
 /**
- * The sky: where the sun, the moon and the shadow light are, in eye space.
+ * The sky: where the sun, the moon and the shadow light are, in eye space, plus the one answer this
+ * engine needs in world space, {@link #shadowLightVector}.
  * <p>
  * These live before the projection, so no clip space convention touches them and they are the one
  * family that carries over unchanged. Two things about them are counter-intuitive and are in the
@@ -84,6 +86,49 @@ public final class CelestialValues {
 				(world, out) -> out.set(world.endFlashIntensity()));
 		builder.add("previousEndFlashIntensity", UniformShape.FLOAT,
 				(world, out) -> out.set(world.previousEndFlashIntensity()));
+	}
+
+	/**
+	 * Where the light stands in WORLD space, as a unit vector from the origin.
+	 * <p>
+	 * <strong>The same rotations as the {@code shadowLightPosition} uniform, and deliberately
+	 * without the model view.</strong> Iris keeps the pair apart for the same reason and under two
+	 * names, {@code getCelestialPositionInWorldSpace} against {@code getCelestialPosition}
+	 * ({@code uniforms/CelestialUniforms.java:145,165}): a pack reads where the sun is in EYE space,
+	 * because that is the space its lighting is written in, while a cull has to know where it is in
+	 * the world. Handing the eye space answer to the cull would swing the light with the player's
+	 * head, and every shadow caster the light stands behind would be kept or dropped by where the
+	 * player happens to be looking.
+	 * <p>
+	 * The End flash is taken on the same condition the shadow MATRICES are built on rather than on
+	 * Iris's, which tests the dimension and the pack's opt in and not the flash itself
+	 * ({@code uniforms/CelestialUniforms.java:138}). The two have to agree here, or a frame would
+	 * extrude a frustum along one light and draw its map from another.
+	 *
+	 * @param dest the vector to write, returned
+	 */
+	public static Vector3f shadowLightVector(WorldState world, Vector3f dest) {
+		// The shared scratch, on the invariant the field's own note carries: every call fills all of
+		// it before reading any of it, so a reader between two writes is impossible.
+		if (inEndFlash(world) && world.endFlashShadows()) {
+			SCRATCH.identity()
+					.rotateY((float) Math.toRadians(180.0F - world.endFlashYAngleDegrees()))
+					.rotateX((float) Math.toRadians(-90.0F - world.endFlashXAngleDegrees()));
+		} else {
+			SCRATCH.identity()
+					.rotateY((float) Math.toRadians(-90.0F))
+					.rotateZ((float) Math.toRadians(world.sunPathRotation()))
+					.rotateX((float) Math.toRadians(isDay(world)
+							? world.sunAngleDegrees() : world.moonAngleDegrees()));
+		}
+
+		// A direction and not a place, which is why the w is nought: the hundred is a length the
+		// normalisation throws away, and it is kept only so that the rotations are fed the very
+		// vector the uniform feeds them.
+		POSITION.set(0.0F, 100.0F, 0.0F, 0.0F);
+		SCRATCH.transform(POSITION);
+
+		return dest.set(POSITION.x, POSITION.y, POSITION.z).normalize();
 	}
 
 	/** One step of wrapping, not a modulus. See the class note. */

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -156,12 +156,32 @@ used packs of the corpus lose their entity shadows to a line their settings had 
 key of this file. It bounds how far from the camera a caster that moves may stand and still reach
 the map.
 
-`shadow.culling` is not read, and it is not treated as a word this engine knows either: a pack that
-writes it sees it among the keys nothing reads, in the same list as a misspelling. That is
-deliberate rather than half-honoured. Its values do not pick between ways of walking one frustum:
-they pick between different cullers with different distance directives behind them, and reading the
-word while walking one frustum anyway would put casters into a map the pack asked to keep them out
-of.
+`shadow.culling` is read, and **its three written words do not mean what they look like they mean**.
+It is not a switch: it names one of four shapes the light measures a section against, and the
+default is the tightest of them rather than the loosest.
+
+- nothing written, or `true`: the camera's own volume swept along the light. A section that cannot
+  drop anything onto what the camera can see is thrown away before it is drawn.
+- `false`: no sweep. The light walks its own volume, the one the map is drawn in, which is what this
+  engine did for every pack before the sweep existed.
+- `reversed` or `safe_zone`, two spellings of one word: the same sweep, plus a box at the pack's own
+  `voxelDistance` that is kept whatever the sweep says of it, for a pack that samples its map from
+  places the sweep knows nothing about.
+
+A word this cannot read leaves the default standing, which is what the reference does with it.
+
+**How far the walk reaches is a separate question from the shape.** Whichever shape is chosen, a box
+around the camera is cut out of it wherever a distance bounds the walk, and that distance is
+`shadowDistance` times the `const float shadowDistanceRenderMul` of the pack's own source, or the
+player's Max Shadow Distance where the pack declares no multiplier. Two of the four states step
+outside that arbitration and both do so in the reference: `false` reads the pack's product alone and
+never the player's setting, and the safe zone reads neither, its two boxes being the pack's
+throughout.
+
+Iris has a fifth road into the first line, and this engine cannot take it: it drops the sweep for a
+pack whose shadow program ships a geometry stage, on the grounds that such a pack is moving its
+vertices somewhere the camera's volume cannot predict. Nothing here runs a geometry stage at all, so
+no pack can move a vertex that way and the question does not arise.
 
 ## Settings, and how a user changes them
 

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -195,17 +195,56 @@ Finally, per-face batch culling has to be disabled for the shadow pass, and the 
 not enough to do it: batches choose which faces to submit before any pipeline exists, and a face
 the camera cannot see is exactly the face standing between the sun and the ground.
 
+### The shape the light measures a section against
+
+The obvious shape is the box the map is drawn in, and it is the wrong one. The map only ever gets
+sampled where the camera can see, so a section that cannot drop anything onto anything visible pays
+for a draw whose result nothing reads. What replaces it is the camera's own volume swept along the
+light: keep the faces of the camera frustum whose inward normal points towards the light, since they
+are its far side as the light sees it; drop the faces looking at the light, since a caster in front
+of those still casts into view; and close the silhouette with a plane swept along the light for every
+edge between a kept face and a dropped one. With the sun overhead that removes the lid of the camera
+frustum and keeps its floor, which is exactly right: what stands above you casts down into what you
+see, what stands below you does not.
+
+The assumption underneath is worth knowing, because it is where the shape stops being conservative:
+the map is taken to be read for direct shadowing and for volumetrics, not for light bouncing off a
+caster you cannot see. That is the reference's assumption, and packs are written against it.
+
+**The shape is the pack's to choose**, through `shadow.culling`, and the four states and their words
+are described once under [the pack format](pack-format.md). The distance is a separate axis and
+composes with all of them: whichever shape is chosen, the box a shadow distance asks for is cut out
+of it, so the sweep and the bound never have to know about each other.
+
+Two things about the arithmetic are recorded here because a reader will look for them. The planes are
+pulled out of the camera's view projection, and the clip volume that matrix targets decides what
+comes out: the reference works against OpenGL, minus one to one, while this engine rasterises with a
+reversed Z over zero to one. The matrix handed to the extraction is therefore the **published**
+projection, the one already put into the pack's volume once a frame, and not the one the frame was
+drawn with; against the published one the reference's six lines are right exactly as they stand, and
+the extraction converts nothing. Both ways of doubting that cost something and neither shows on
+screen: handed the drawn matrix, those lines lose the far plane outright and keep every section
+behind it, while converting a second time leaves the far plane right by accident and pushes the near
+plane from `n` out to `2nf / (n + f)`. And the planes come out in camera-relative world space rather
+than in the light's clip space, which is also the space the boxes arrive in, so no further conversion
+is owed anywhere: the light's own volume never enters the cull at all.
+
+What this buys has to be read off the log rather than off the screen, and the shadow stage prints it:
+how many sections the light walked, how many the camera walked, and which shape was used. The picture
+is the place it will NOT show, because keeping a section too many costs a draw and not a pixel.
+
 All of the above is about the terrain. What moves is culled separately, and there is an open
 divergence there worth stating plainly, because it is a gap and not a workaround. A caster is
-measured against the light's own frustum, the same matrix the terrain is culled against, and where
-the pack asked for a shorter reach, that reach is cut as an axis-aligned box about the camera tested
-on the caster's position. Iris instead rebuilds a whole second shadow frustum for the movers, at a
-shorter distance, and tests the caster's bounding box against it
+measured against the light's own frustum, the box the map is drawn in, and where the pack asked for a
+shorter reach, that reach is cut as an axis-aligned box about the camera tested on the caster's
+position. Iris instead measures the movers against the same swept shape as the terrain, rebuilt at
+a shorter distance, and tests the caster's bounding box against it
 (`shadows/ShadowRenderer.java:536-541` then `:703`). The two keep-sets are different shapes, so the
 difference runs both ways: a caster inside the light's frustum and inside the box but outside that
 narrower frustum is kept here and dropped there, and one whose box grazes Iris's bound while its
 position sits outside ours is the reverse. Nothing makes Iris's shape impossible here; it has simply
-not been written yet.
+not been written yet, and since the terrain moved to the swept shape the two halves of the walk no
+longer measure against the same thing.
 
 ### The experiment that separates the two failure modes
 


### PR DESCRIPTION
## What changes

By default the light no longer walks the whole box its shadow map covers. It walks the camera's own
volume swept along the light instead: the faces of the camera frustum facing away from the light are
kept, the ones looking at it are dropped, and every edge between the two is closed with a swept
plane, so a section that cannot drop anything onto what the camera can see is thrown away before it
is drawn. `shadow.culling` picks that shape, where it used to be refused. This sits on top of the
shadow distance slider rather than beside it: the distance is still arbitrated in `PackValues`, and
`ShadowCull` now wraps whichever shape was chosen rather than only the light's own volume. The log
line the shadow stage prints now names the shape beside its two counts.

## How it differs from the reference, and for what obstacle

Each state, Iris then here. `DEFAULT`/`ADVANCED` (`ShadowRenderer.java:302,372`): the sweep, which
is `ShadowCullFrustum`, its distance from the default arm of `PackValues.shadowCullPlan`.
`SAFE_ZONE` (`:330-331,370`): the sweep with the voxel box kept whatever it says, which is
`ShadowCullFrustum.testAab`, its multiplier forced to one before the player's branch in the same
method. `DISTANCE` (`:303,317-322`): the pack's own product, no player fallback, and the walk turned
loose past the loaded world; here that arm keeps the light's own volume where Iris keeps nothing
(`shadows/frustum/fallback/BoxCullingFrustum.java` carries a box and no planes). That last one is
free: the volume is what the map is DRAWN with, so a section outside it is clipped by the rasteriser
either way, and the one thing that could have moved a vertex out from under it, a geometry stage,
never runs here (`render/GeometryProgram` builds every pipeline from vertex and fragment alone). The
same fact answers Iris's voxelisation branch (`:164-165`) rather than measuring it.

**The plane extraction is Iris's, taken exactly as written, and that is the conversion.** It is fed
`ViewMatrices.gbufferProjection`, the frame's matrix already republished in Iris's own OpenGL volume
by `ClipSpace.toLegacyDepth` (`ViewMatrices.java:205`), and not the reversed Z matrix the engine
rasterises with. Both ways of doubting that cost something and neither shows on screen: handed the
drawn matrix, those six lines lose the far plane outright; converted a second time, the far plane is
right by accident and the near plane moves from `n` to `2nf / (n + f)`. `ShadowCullFrustum` works
both out on the game's own numbers and on three named sections.

Iris takes Distant Horizons' volume only under `shouldRenderDH && hasRenderingEnabled`
(`ShadowRenderer.java:366`), whose left half is the pack asking for the far terrain in its shadow map
(`:150`). Nothing puts the far terrain into this engine's shadow map, so that half is false here and
the branch Iris takes is the frame's own projection, which is what is used.

`testSectionExpanded` reads its argument as Sodium reads it, an extra on top of
`CHUNK_SECTION_PADDED_RADIUS`, where Iris reads it as the half size. It settles nothing on this
walk, which reaches the viewport through `isBoxVisibleDirect` and `getBoxIntersectionDirect` alone.

## What proves it

`gradlew build` green after the rebase onto `dev`. The conversion is proved on paper in the class
javadoc. **The gain and the image are not measured**: neither has been seen in game, and the log line
is the instrument for the first.

## What it leaves owing

The casters that move are still measured against the light's own box, so the two halves of the walk
no longer measure against the same shape. Iris rebuilds the swept shape for them at
`entityShadowDistanceMul`; that is a branch of its own and `docs/sky-and-shadows.md` says so.
