### PR TITLE
fix(sodium): hand the slider the storage handler Sodium demands

### DIFF
--- a/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
+++ b/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
@@ -157,6 +157,11 @@ public final class ConfigEntry implements ConfigEntryPoint {
 				// still belongs to the player.
 				.setEnabledProvider(_ -> TerrainDraw.forcedShadowDistanceChunks().isEmpty(),
 						ConfigState.UPDATE_ON_REBUILD)
+				// Sodium refuses to build an option without one, at the loading screen and not at
+				// compile time. It has nothing left to do here: the binding above writes pack.txt
+				// as it is moved, where the reference's binding only moves a field and its handler
+				// saves the whole config file afterwards, IrisConfig.java:67.
+				.setStorageHandler(() -> {})
 				.setImpact(OptionImpact.HIGH);
 	}
 }


### PR DESCRIPTION
Sodium validates built options once the loading screen ends, and an option without a storage handler is refused with "Storage handler must be set": with the new Max Shadow Distance slider registered, the client crashed at every startup. One line: the slider gets an empty storage handler, and the comment says why empty is right here. Our binding writes pack.txt as the slider moves, where the reference binding only moves a field and its storage handler saves the whole config afterwards (IrisConfig.java:67). Verified cause against the crash report stack (StatefulOptionBuilderImpl.validateData, reached from ConfigEntry.registerConfigLate) and the fix against the reference; a clean client startup with the fixed jar is the proof that closes it.