### PR TITLE
build: raise the version to 0.4.1-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ plus, because each of them files an upload per loader and has nowhere else to pu
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.4.1-beta.1
 
 ### Added
 
@@ -54,6 +54,10 @@ what the next one holds.
   those two draws once the pack's own terrain program does, so the setting read as live and moved
   nothing at all. It comes back the moment no pack is drawing the terrain. Anisotropic filtering is
   untouched and goes on working under a pack.
+
+- Naming a pack that is not in the Shader Packs folder now says so, in the chat line the reload key
+  answers, on the settings screen and in the log, with the name that went unanswered. It used to
+  read as if no pack had been asked for at all, so a renamed or deleted pack looked like a choice.
 
 ## 0.4.0-beta.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.4.0-beta.1
+mod_version=0.4.1-beta.1
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
Raises mod_version to 0.4.1-beta.1 and folds the Unreleased section of the CHANGELOG into that number, adding the one player-facing line the missing-pack fix had not written. Everything in it shipped on dev tonight: the shadow distance slider, the pack shadow bounds, the camera-swept shadow culling, the per-pass sampler resolution and the screen fixes. The tag follows once this and the fast-forward of main are in.