### PR TITLE
feat(screen): stand in the F3 screen as Iris stands in it

### DIFF
--- a/common/src/main/java/dev/vitrail/mixin/DebugScreenEntriesMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/DebugScreenEntriesMixin.java
@@ -1,0 +1,32 @@
+package dev.vitrail.mixin;
+
+import dev.vitrail.screen.VitrailDebugEntry;
+
+import net.minecraft.client.gui.components.debug.DebugScreenEntries;
+import net.minecraft.client.gui.components.debug.DebugScreenEntry;
+import net.minecraft.resources.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Puts {@link VitrailDebugEntry} into the F3 screen's registry, at the end of the class
+ * initializer that builds it, which is where Iris registers its own two entries: the registry is a
+ * plain map behind a private {@code register}, the game offers no seam for a mod's entry, and
+ * registering as the map is born means being there however early the first F3 opens.
+ */
+@Mixin(DebugScreenEntries.class)
+public abstract class DebugScreenEntriesMixin {
+
+	@Shadow
+	private static Identifier register(Identifier identifier, DebugScreenEntry entry) {
+		throw new AssertionError();
+	}
+
+	@Inject(method = "<clinit>", at = @At("RETURN"))
+	private static void vitrail$register(CallbackInfo ci) {
+		register(VitrailDebugEntry.ID, new VitrailDebugEntry());
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/DebugScreenEntryListMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/DebugScreenEntryListMixin.java
@@ -1,0 +1,35 @@
+package dev.vitrail.mixin;
+
+import dev.vitrail.screen.VitrailDebugEntry;
+
+import net.minecraft.client.gui.components.debug.DebugScreenEntryList;
+import net.minecraft.client.gui.components.debug.DebugScreenEntryStatus;
+import net.minecraft.resources.Identifier;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+/**
+ * Shows {@link VitrailDebugEntry} on the F3 overlay without a hand's turn of configuration, the
+ * way Iris shows its own: registering an entry only lists it on the F3 configuration screen, and a
+ * line nobody has switched on answers no screenshot. The status is written only while the entry
+ * has none, so a player who turns the line off stays obeyed - their choice is a status too, and it
+ * is theirs from then on.
+ */
+@Mixin(DebugScreenEntryList.class)
+public abstract class DebugScreenEntryListMixin {
+
+	@Shadow
+	@Final
+	private Map<Identifier, DebugScreenEntryStatus> allStatuses;
+
+	@Inject(method = "rebuildCurrentList", at = @At("HEAD"))
+	private void vitrail$showByDefault(CallbackInfo ci) {
+		this.allStatuses.putIfAbsent(VitrailDebugEntry.ID, DebugScreenEntryStatus.IN_OVERLAY);
+	}
+}

--- a/common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java
+++ b/common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java
@@ -1,0 +1,68 @@
+package dev.vitrail.screen;
+
+import dev.vitrail.Vitrail;
+import dev.vitrail.render.PackChain;
+
+import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
+import net.minecraft.client.gui.components.debug.DebugScreenEntry;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The engine's lines of the F3 screen: version, the pack being drawn, and the profile it stands
+ * on. They are the heart of what Iris shows, because they answer the questions a screenshot gets asked -
+ * which engine drew this, with which pack, set how - and a capture with the F3 open is how those
+ * questions arrive. Without them a Vitrail frame and an Iris frame of the same pack read as the
+ * same picture.
+ * <p>
+ * A pack that is not being drawn says why in one line, and the three reasons are kept apart the
+ * way {@link PackChain} keeps them: asked off, named but missing, or refused. Saying "none" for a
+ * pack that was refused would send the reader to the settings screen when the log is where the
+ * answer is.
+ * <p>
+ * Registration is {@code DebugScreenEntriesMixin}'s, and the line showing without a hand's turn of
+ * F3 configuration is {@code DebugScreenEntryListMixin}'s; this class only says the words. All
+ * three follow Iris's own construction on the same vanilla seams.
+ */
+public final class VitrailDebugEntry implements DebugScreenEntry {
+
+	/** The entry as the F3 configuration screen lists it. */
+	public static final Identifier ID = Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, Vitrail.MOD_ID);
+
+	/** The group the lines land in, so they hold together instead of scattering between vanilla's. */
+	private static final Identifier GROUP = Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "name");
+
+	private static final String PREFIX = "[" + Vitrail.MOD_NAME + "] ";
+
+	@Override
+	public void display(DebugScreenDisplayer displayer, @Nullable Level level,
+			@Nullable LevelChunk clientChunk, @Nullable LevelChunk serverChunk) {
+		displayer.addToGroup(GROUP, PREFIX + "Version: " + Vitrail.platform().modVersion());
+
+		PackChain.session().ifPresentOrElse(session -> {
+			displayer.addToGroup(GROUP, PREFIX + "Shaderpack: " + session.packFileName());
+			String profile = session.settings().profile();
+			if (!profile.isEmpty()) {
+				displayer.addToGroup(GROUP, PREFIX + "Profile: " + profile);
+			}
+		}, () -> displayer.addToGroup(GROUP, PREFIX + undrawnLine()));
+	}
+
+	/**
+	 * The one line said when no pack is being drawn, naming which of the three reasons it is.
+	 */
+	private static String undrawnLine() {
+		if (PackChain.noPackWanted()) {
+			return "Shaders are disabled";
+		}
+		if (PackChain.packMissing()) {
+			return "Shaderpack: " + PackChain.askedFor().name() + " (missing from the folder)";
+		}
+		return PackChain.lastError()
+				.map(error -> "Shaderpack refused: " + error)
+				.orElse("Shaderpack: none");
+	}
+}

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -18,6 +18,8 @@
 		"CloudRendererMixin",
 		"CustomFeatureRendererMixin",
 		"CustomSubmitMixin",
+		"DebugScreenEntriesMixin",
+		"DebugScreenEntryListMixin",
 		"MixinDefaultChunkRenderer",
 		"DefaultFluidRendererMixin",
 		"EntityRenderDispatcherMixin",


### PR DESCRIPTION
## What changes

The F3 screen gains a Vitrail group: version, the pack being drawn, and the profile it stands on, with one line naming why nothing is drawn when nothing is (asked off, named but missing, or refused). Until now a Vitrail frame and an Iris frame of the same pack read as the same screenshot, and the F3 said nothing to tell them apart. The entry registers at the end of `DebugScreenEntries`' class initializer through a shadow of its private `register`, and shows by default through a `putIfAbsent` on the entry list's statuses, so a player who turns the line off stays obeyed.

## How it differs from the reference, and for what obstacle

It does not: both mixins sit on the same two seams Iris uses (`<clinit>` RETURN of `DebugScreenEntries`, HEAD of `DebugScreenEntryList.rebuildCurrentList`), the status is only written while absent as Iris writes it, and `isAllowed` keeps the vanilla default as Iris keeps it. Iris's colour-space and shadow-chunk lines have no counterpart here yet, so only the shared three are shown.

## What proves it

- `gradlew build` green.
- The seams verified against the decompiled 26.2 sources (`register`'s exact signature, the entry list's field and method names, which carry vanilla names and not NeoForge additions) and against Iris's two mixins on its 26.1 branch.
- Not yet proven in game: the group appearing on a real F3, which the next play session shows in one keypress.