### PR TITLE
docs: owe Iris the F3 lines

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -245,6 +245,16 @@ GNU Lesser General Public License version 3
   declaration matched and comes back out as the -1 every pack tests against. The reading of
   Sodium's vertex layout in the same file is this project's own and is not from Iris.
 
+  common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java,
+  common/src/main/java/dev/vitrail/mixin/DebugScreenEntriesMixin.java and
+  common/src/main/java/dev/vitrail/mixin/DebugScreenEntryListMixin.java follow the construction of
+  net.irisshaders.iris.gui.debug.IrisDebugEntry, of net.irisshaders.iris.mixin.MixinDebugEntries
+  and of net.irisshaders.iris.mixin.MixinDebugScreenEntriesList: the same two seams into the
+  game's F3 registry, an entry registered as the registry's class initializer returns, a display
+  status written only while the entry has none so that the player's own choice stands, and the
+  wording of the version, shaderpack and shaders-disabled lines. What is said when a pack is not
+  drawn is this project's own, following how its loader keeps the three reasons apart.
+
   common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java reproduces what Iris puts in place of the
   fixed function vertex inputs of a full screen pass, in CompositeTransformer lines 47 to 71: the
   two attributes behind gl_Vertex and gl_MultiTexCoord0, a quad whose coordinates run from (0,0) to


### PR DESCRIPTION
## What changes

The NOTICE gains an entry for the three files of the F3 debug screen lot: they follow the construction of Iris's IrisDebugEntry and its two mixins, down to the seams used and the wording of the version and shaderpack lines, and the file that records what is owed to Iris did not say so yet. The entry also names what is this project's own there, the lines said when no pack is drawn.

## How it differs from the reference, and for what obstacle

Not applicable, this is the attribution file itself.

## What proves it

- `gradlew build` green (the text gates run over NOTICE).
- The claim is checked against Iris's own tree: gui/debug/IrisDebugEntry.java, mixin/MixinDebugEntries.java and mixin/MixinDebugScreenEntriesList.java on its 26.1 branch.