### PR TITLE
docs: add the community health files github asks for

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ replay_pid*.log
 !/INSTALL.md
 !/CONTRIBUTING.md
 !/CHANGELOG.md
+!/CODE_OF_CONDUCT.md
+!/SECURITY.md
 /*.tsv
 /.*/
 !/.github/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+vitrail-shaders@pm.me.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing
 
+Interactions here are covered by the [code of conduct](CODE_OF_CONDUCT.md), and
+anything that looks exploitable goes through [SECURITY.md](SECURITY.md) rather
+than the issue tracker.
+
 ## Branches
 
 Two long-lived branches, and the difference between them is one question: has this been published?

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported versions
+
+Everything under 1.0.0 is a pre-release, and only the most recent release gets
+fixes: a report against an older build is welcome, and is answered on the
+latest one. No older line is maintained beside it.
+
+## What counts as a vulnerability here
+
+Vitrail's attack surface is the shader pack: downloaded content, read, parsed
+and translated by this mod. A pack that can touch anything outside its own
+folder, keep the client from starting without even being selected, or drive
+the engine into unbounded work or memory from a line in a properties file is a
+vulnerability, and the loader is written against exactly that threat. A pack
+that merely renders a wrong image is an ordinary bug and belongs in the
+[issue tracker](https://github.com/avpbynf/Vitrail-Shaders/issues).
+
+## Reporting a vulnerability
+
+Report privately, through GitHub's own channel: the Security tab of this
+repository, then "Report a vulnerability". If that route does not work for
+you, mail vitrail-shaders@pm.me. Either way, do not put something exploitable
+in a public issue before a fix is out.
+
+This is a one-person project, so the honest promise is a modest one: an
+acknowledgement within a few days, a verdict once the report has been
+reproduced or refuted, and credit in the release notes if you want it.


### PR DESCRIPTION
## What this changes

One paragraph: adds the two community health files GitHub's guidelines expect of a public repository. SECURITY.md names what a vulnerability means for a mod whose input is downloaded shader packs, and routes reports through GitHub's private vulnerability channel with a mail fallback; CODE_OF_CONDUCT.md is the Contributor Covenant that had been drafted and never published; CONTRIBUTING.md gains one sentence pointing at both, and the root markdown allow list in .gitignore gains their two lines, which is what had kept both files out.

## How it was verified

Text only, `gradlew build` green locally. Note for the merge: private vulnerability reporting is currently disabled on the repository and SECURITY.md points at it, so the Security tab toggle should be flipped on when this lands.