### PR TITLE
fix(uniform): number biomes in the order iris numbers them

### DIFF
--- a/common/src/main/java/dev/vitrail/mixin/BiomesMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/BiomesMixin.java
@@ -1,0 +1,39 @@
+package dev.vitrail.mixin;
+
+import dev.vitrail.render.BiomeClassifier;
+
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biomes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Hands {@link BiomeClassifier} the vanilla biomes in the order the game's own class declares
+ * them, which is the order Iris numbers them in.
+ * <p>
+ * <strong>The order is the contract, and it is nobody's registry.</strong> Iris counts a static
+ * field upward across {@code Biomes.register} ({@code mixin/MixinBiomes.java:14-22}), so the
+ * numbers a pack compares {@code biome} against are the declaration order of the {@code Biomes}
+ * class: {@code the_void} nought, {@code plains} one, {@code swamp} six. Packs write those numbers
+ * as literals, {@code in(biome, 6, 52, 7)} in Bliss's swamp fog, so any other numbering sends the
+ * fog to whatever biomes happen to sit on those numbers instead. This engine first walked the
+ * level's biome registry, whose iteration order is alphabetical, and paid exactly that: six was
+ * an ocean, and the swamp fog stood over shorelines.
+ * <p>
+ * Same injection point as Iris, and the counter lives in the classifier rather than here so that
+ * the table and the number it hands out cannot drift apart.
+ */
+@Mixin(Biomes.class)
+public abstract class BiomesMixin {
+
+	// require = 1 against this config's defaultRequire of nought: a silently missed injection
+	// here would number every biome nought and write no BIOME_* define at all, which a pack
+	// swallows without a word.
+	@Inject(method = "register", at = @At("TAIL"), require = 1)
+	private static void vitrail$record(String name, CallbackInfoReturnable<ResourceKey<Biome>> cir) {
+		BiomeClassifier.record(cir.getReturnValue());
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/BiomeClassifier.java
+++ b/common/src/main/java/dev/vitrail/render/BiomeClassifier.java
@@ -3,11 +3,9 @@ package dev.vitrail.render;
 import dev.vitrail.uniform.BiomeCategory;
 
 import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.BiomeTags;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 
 import java.util.ArrayList;
@@ -20,83 +18,62 @@ import java.util.Map;
  * Numbers the biomes and sorts them into the categories a pack compares against.
  * <p>
  * This lives on the game's side of the line rather than in the value package, because it is
- * Minecraft from end to end: a cascade of tag tests and a registry walk. The value package only
- * ever sees the two integers that come out.
+ * Minecraft from end to end: an interception of the game's own registration and a cascade of tag
+ * tests. The value package only ever sees the two integers that come out.
  * <p>
  * <b>One table, two readers.</b> The number this hands out is the same one the {@code BIOME_*}
  * defines have to carry, and two tables that agree today and drift tomorrow is the silent failure
  * this class exists to prevent, so {@link #names()} is here for whoever writes those defines.
  * Nobody builds a second one.
  * <p>
- * The cascade is Iris {@code uniforms/BiomeUniforms.java:56-95} at b0ae41c, order included, since
- * that order is what decides a biome that carries two tags. Two things about it are deliberate
- * and not oversights: {@code UNDERGROUND} is never returned, because Iris has no way to detect it
- * on this version and leaves it commented out, and there is no test for {@code IS_SAVANNA}, so a
- * savanna comes out as plains. Packs are written against that behaviour, not against OptiFine's
- * documentation of it.
+ * <b>The numbering is Iris's, the declaration order of the {@code Biomes} class, and nothing
+ * about it is free to vary.</b> Iris counts upward across {@code Biomes.register}
+ * ({@code mixin/MixinBiomes.java:14-22}), and packs write the numbers that come out as literals:
+ * Bliss's swamp fog is {@code in(biome, 6, 52, 7)} in its {@code shaders.properties}, six being
+ * {@code swamp} and seven {@code mangrove_swamp} in that order and nowhere else.
+ * {@link dev.vitrail.mixin.BiomesMixin} is the same interception, and {@link #record} is its
+ * counter. This class first walked the level's biome registry instead, on the argument that it
+ * also covered what a data pack adds; that registry iterates alphabetically, six landed on
+ * {@code cold_ocean}, and Bliss stood its swamp fog over shorelines. A biome the vanilla class
+ * never registers answers nought, which is what Iris's map answers for one it has never seen.
+ * <p>
+ * The category cascade is Iris {@code uniforms/BiomeUniforms.java:56-95} at b0ae41c, order
+ * included, since that order is what decides a biome that carries two tags. Two things about it
+ * are deliberate and not oversights: {@code UNDERGROUND} is never returned, because Iris has no
+ * way to detect it on this version and leaves it commented out, and there is no test for
+ * {@code IS_SAVANNA}, so a savanna comes out as plains. Packs are written against that behaviour,
+ * not against OptiFine's documentation of it.
  */
 public final class BiomeClassifier {
 
-	private final Map<Identifier, Integer> ids = new HashMap<>();
-	private final List<String> names = new ArrayList<>();
+	private static final Map<Identifier, Integer> IDS = new HashMap<>();
+	private static final List<String> NAMES = new ArrayList<>();
 
-	private Object registrySeen;
+	private BiomeClassifier() {
+	}
 
 	/**
-	 * The dense number for a biome, in the registry's own order.
-	 * <p>
-	 * Iris numbers biomes by intercepting the static registration of the vanilla ones, which
-	 * needs a mixin and misses everything a data pack adds. Walking the level's registry costs
-	 * nothing, covers the modded ones, and is stable for as long as the level is loaded, which is
-	 * as long as the number has to mean anything.
+	 * Takes the next vanilla biome as the game's own class declares it. Called by
+	 * {@link dev.vitrail.mixin.BiomesMixin} from {@code Biomes.register}, which runs once per
+	 * biome when that class initialises, before any pack is read and before any world exists.
 	 */
-	public int identify(Level level, Holder<Biome> biome) {
-		refresh(level);
+	public static void record(ResourceKey<Biome> key) {
+		Identifier identifier = key.identifier();
+		IDS.put(identifier, NAMES.size());
+		NAMES.add(identifier.getPath().toUpperCase(Locale.ROOT));
+	}
 
+	/** The dense number for a biome: its place in the declaration order, or nought off the table. */
+	public static int identify(Holder<Biome> biome) {
 		Identifier key = biome.unwrapKey().map(k -> k.identifier()).orElse(null);
-		Integer id = key == null ? null : this.ids.get(key);
+		Integer id = key == null ? null : IDS.get(key);
 
 		return id == null ? 0 : id;
 	}
 
-	/**
-	 * Builds the table against this level's registry, if that registry has not been walked yet.
-	 * Called on its own by whoever writes the {@code BIOME_*} defines, which happens once when a
-	 * pack is read and therefore before anything has asked for a number.
-	 */
-	@SuppressWarnings("ReferenceEquality")
-	public void refresh(Level level) {
-		Registry<Biome> registry = level.registryAccess().lookupOrThrow(Registries.BIOME);
-		if (this.registrySeen != registry) {
-			rebuild(registry);
-		}
-	}
-
-	/** The biome names, in the order their numbers were handed out. Empty until a level loads. */
-	public List<String> names() {
-		return List.copyOf(this.names);
-	}
-
-	/**
-	 * Drops the table and lets go of the registry it was walked from. For a client leaving a world:
-	 * the registry is held by identity, so keeping it is keeping everything the world hung off it.
-	 */
-	public void forget() {
-		this.ids.clear();
-		this.names.clear();
-		this.registrySeen = null;
-	}
-
-	private void rebuild(Registry<Biome> registry) {
-		this.ids.clear();
-		this.names.clear();
-		registry.listElements().forEach(element -> {
-			Identifier key = element.key().identifier();
-			this.ids.put(key, this.names.size());
-			this.names.add(key.getPath().toUpperCase(Locale.ROOT));
-		});
-
-		this.registrySeen = registry;
+	/** The biome names, in the order their numbers were handed out. */
+	public static List<String> names() {
+		return List.copyOf(NAMES);
 	}
 
 	/** The ordinal of {@link BiomeCategory}, which is the number the pack actually compares. */

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -93,7 +93,6 @@ public final class FrameState implements WorldState {
 
 	/** Refilled every frame by the reading of Distant Horizons, and never read outside it. */
 	private final Vector2f distantPlanes = new Vector2f();
-	private final BiomeClassifier biomes = new BiomeClassifier();
 	private final CameraShift shift = new CameraShift();
 
 	private PackDirectives directives = PackDirectives.defaults();
@@ -288,15 +287,6 @@ public final class FrameState implements WorldState {
 	}
 
 	/**
-	 * The biome table. Exposed so that whoever writes the {@code BIOME_*} defines writes them from
-	 * the same numbering the {@code biome} uniform carries, because two tables that agree today is
-	 * the shape of a failure nobody finds.
-	 */
-	public BiomeClassifier biomes() {
-		return this.biomes;
-	}
-
-	/**
 	 * Called once per frame, before anything reads the state. The named point the rest of the
 	 * engine's idea of a frame boundary hangs off.
 	 */
@@ -382,15 +372,13 @@ public final class FrameState implements WorldState {
 	 * Forgets the world as well as the frame, for a client that has left one rather than moved
 	 * between two.
 	 * <p>
-	 * Both things this drops are held by identity, which is what makes them worth dropping: the level
-	 * of the last frame, so that the change is noticed again when one is joined, and the registry the
-	 * biome numbers were walked from. A client sitting in the menu was keeping the whole
-	 * {@code ClientLevel} it had just left alive through the pair of them.
+	 * What this drops is held by identity, which is what makes it worth dropping: the level of the
+	 * last frame, so that the change is noticed again when one is joined. A client sitting in the
+	 * menu was keeping the whole {@code ClientLevel} it had just left alive through it.
 	 */
 	public void leaveWorld() {
 		reset();
 		this.lastLevel = null;
-		this.biomes.forget();
 	}
 
 	/**
@@ -877,7 +865,7 @@ public final class FrameState implements WorldState {
 		// different when the camera has backed through a wall.
 		BlockPos position = player.blockPosition();
 		Holder<Biome> holder = level.getBiome(position);
-		this.biomeId = this.biomes.identify(level, holder);
+		this.biomeId = BiomeClassifier.identify(holder);
 		this.biomeCategory = BiomeClassifier.categoryOf(holder);
 		this.biomePrecipitation =
 				switch (holder.value().getPrecipitationAt(position, level.getSeaLevel())) {

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1047,12 +1047,12 @@ public final class PackChain {
 	 * a file having changed and is the only reload nobody can ask for.
 	 * <p>
 	 * Two moments, and both are the pack being read against something it could not see before. The
-	 * pack is read while the client starts up, with no biome symbol to compile against, so it takes
-	 * the branch meant for an engine that cannot answer them; joining a world is what makes those
-	 * symbols exist. And a dimension directory replaces the root rather than layering over it, so
-	 * walking through a portal changes half of what a pack is.
+	 * pack is read while the client starts up, when the data pack registries do not exist yet, so a
+	 * {@code block.properties} naming a block TAG resolved it against nothing; joining a world is
+	 * what makes those tags resolvable. And a dimension directory replaces the root rather than
+	 * layering over it, so walking through a portal changes half of what a pack is.
 	 * <p>
-	 * The two are asked apart rather than folded together: the registry the symbols hang on is the
+	 * The two are asked apart rather than folded together: the registry the tags hang on is the
 	 * very same object on both sides of a portal in single player, so a dimension change would slip
 	 * past a chain that only watched them.
 	 * <p>
@@ -1078,8 +1078,8 @@ public final class PackChain {
 					+ "the pack is read again against DISTANT_HORIZONS: the symbol is what a pack "
 					+ "branches its distant land on, and it cannot be right for both");
 		} else {
-			Vitrail.logger().info("The world's own symbols are known now, reloading the pack against "
-					+ "them");
+			Vitrail.logger().info("The world's own registries are here now, reloading the pack so "
+					+ "what names a tag resolves against them");
 		}
 
 		// Straight to the reading, without forgetting the report first, and this is the one road
@@ -1141,7 +1141,7 @@ public final class PackChain {
 	 *
 	 * @return whether a pack was drawn, so that the caller knows to fall back to its own chain.
 	 *         The world check runs first and before the refusal below, or a pack that failed to
-	 *         compile would never be read again against the symbols joining a world gives it.
+	 *         compile would never be read again against the registries joining a world gives it.
 	 */
 	public static boolean draw(Path gameDirectory) {
 		reloadIfTheWorldMoved(gameDirectory);
@@ -1361,7 +1361,7 @@ public final class PackChain {
 	 * the terrain and the entities all open the frame while the world is being drawn, whichever of
 	 * the three comes first, so they allocate everything back
 	 * before {@code draw} reaches {@link #reloadIfTheWorldMoved} at the end of it; a world joined
-	 * with symbols this engine has not seen then reloads and makes the same work again. One extra
+	 * with registries this engine has not seen then reloads and makes the same work again. One extra
 	 * allocation and one extra translation, on the frame the world appears, which is the frame
 	 * already carrying every other first cost there is.
 	 */

--- a/common/src/main/java/dev/vitrail/render/PackDefines.java
+++ b/common/src/main/java/dev/vitrail/render/PackDefines.java
@@ -9,12 +9,14 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.util.Util;
+import net.minecraft.world.level.biome.Biomes;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Gathers what the machine is and hands it to {@link EngineDefines}, which is the one thing in
@@ -23,28 +25,26 @@ import java.util.Map;
  * The biome symbols are the reason this exists. A pack writes {@code if (biome == BIOME_DESERT)}
  * in its GLSL and {@code in(biome, BIOME_SAVANNA, BIOME_SAVANNA_PLATEAU)} in its properties, so
  * the number behind the symbol and the number the {@code biome} uniform carries have to be the
- * same one. {@link BiomeClassifier} is that number, and it is asked here rather than copied, which
- * is why this takes the classifier the frame state already holds instead of walking the registry
- * on its own.
+ * same one. {@link BiomeClassifier} is that number, and it is asked here rather than copied. Its
+ * table is filled from the {@code Biomes} class as it initialises, so the symbols exist from the
+ * first read of the first pack, before any world does; that is Iris's arrangement, whose map is
+ * filled the same way ({@code mixin/MixinBiomes.java:14-22}) and whose defines are written from it
+ * ({@code shaderpack/IrisDefines.java:28}).
  * <p>
- * The catch is when. Biomes are a data pack registry, so there is nothing to walk until a world
- * has been joined, which is long after the client finishes starting up and reads its first pack.
- * {@link #stale()} exists for that: it says the installed table was built against a different
- * registry, and the pass that watches {@code options.txt} for changes watches it too, so joining a
- * world costs the same half second reload as editing a setting does and the symbols are right
- * afterwards.
+ * The world-join reload stays even though the biome symbols no longer need it, because the
+ * symbols were never the only thing riding it: {@code block.properties} may name block TAGS, and
+ * {@code BlockStateIds} can only resolve those once the world's own registries exist
+ * ({@code BlockStateIds.java:86-88}, resolving through {@code BuiltInRegistries.BLOCK.getTags()}
+ * at {@code :249}). At startup there are none, so the first read of a session still has to be
+ * made again when a world arrives, and {@link #stale()}'s registry stamp is what notices that.
  * <p>
- * Distant Horizons rides the same road for the same reason. Whether its far terrain reaches the
- * pack is a thing the player changes from that mod's own screen, without leaving the world, so
- * {@link #stale()} watches it beside the registry rather than trusting what was true when the pack
- * was read.
- * <p>
- * Two biomes of different namespaces can carry the same path, and only the first of them gets the
- * symbol. Iris has the same limit, and a pack naming a modded biome is naming its path anyway.
+ * Distant Horizons is the one thing here a player can change without leaving the world, from that
+ * mod's own screen, so {@link #stale()} watches it beside the registry rather than trusting what
+ * was true when the pack was read.
  */
 public final class PackDefines {
 
-	/** Which registry the installed table was built from, so that a change of one is noticed. */
+	/** Which registry the last read was against, so that joining a world is noticed. */
 	private static volatile long installed;
 
 	/** And whether the far terrain was there, which the player can change without leaving. */
@@ -57,15 +57,15 @@ public final class PackDefines {
 	 * Reads the machine and installs it. Called once before a pack is read, and never per frame:
 	 * every symbol here is fixed for as long as the world is.
 	 */
-	public static void install(BiomeClassifier biomes) {
-		EngineDefines.machine(gather(biomes));
+	public static void install() {
+		EngineDefines.machine(gather());
 		settle();
 	}
 
 	/**
-	 * Takes this world's registry as the one the last read was against, without rebuilding the
-	 * table. For a read that could not happen at all: an empty pack folder must not be looked at
-	 * again every second for the rest of the session.
+	 * Takes this world's registry as the one the last read was against, without rebuilding
+	 * anything. For a read that could not happen at all: an empty pack folder must not be looked
+	 * at again every second for the rest of the session.
 	 */
 	public static void settle() {
 		installed = stamp();
@@ -73,9 +73,8 @@ public final class PackDefines {
 	}
 
 	/**
-	 * Whether the symbols the last pack was read against are the ones this world would give it.
-	 * False for the whole of a session that never changes world, which is what keeps this from
-	 * being a reload every second.
+	 * Whether the pack was last read against a world that is not this one, which is what decides
+	 * the one reload nobody can ask for.
 	 */
 	public static boolean stale() {
 		return stamp() != installed || distantHorizonsMoved();
@@ -83,16 +82,17 @@ public final class PackDefines {
 
 	/**
 	 * Whether it is the far terrain that moved rather than the world, which is the other half of
-	 * what Iris does with {@code DISTANT_HORIZONS}: it reads DH's rendering switch every frame and
-	 * reloads on the flip, {@code compat/dh/DHCompatInternal.java:143} and {@code :148}. Without
-	 * this the symbol would be whatever it was when the pack was read, and a player who switches
-	 * that mod's rendering off would keep a pack lighting a far terrain that is no longer drawn.
+	 * what Iris does with {@code DISTANT_HORIZONS}: it reads DH's rendering switch every frame
+	 * and reloads on the flip, {@code compat/dh/DHCompatInternal.java:143} and {@code :148}.
+	 * Without this the symbol would be whatever it was when the pack was read, and a player who
+	 * switches that mod's rendering off would keep a pack lighting a far terrain that is no longer
+	 * drawn.
 	 * <p>
 	 * What {@link #settle()} records is the live answer and not the one {@link #gather} compiled
 	 * with, so a flip inside the half second a pack takes to read is not noticed until the next
 	 * flip. Recording what the read compiled with instead would mean recording nothing when the
-	 * read could not happen at all, and that is the case this whole pair exists to keep out of a
-	 * reload every frame.
+	 * read could not happen at all, and that is the case this pair exists to keep out of a reload
+	 * every frame.
 	 */
 	public static boolean distantHorizonsMoved() {
 		return DhDepth.present() != distant;
@@ -105,7 +105,7 @@ public final class PackDefines {
 		return level == null ? 0L : System.identityHashCode(level.registryAccess());
 	}
 
-	private static EngineDefines.Environment gather(BiomeClassifier biomes) {
+	private static EngineDefines.Environment gather() {
 		Minecraft minecraft = Minecraft.getInstance();
 		GpuDevice device = RenderSystem.tryGetDevice();
 		String vendor = "";
@@ -124,23 +124,20 @@ public final class PackDefines {
 		// image or a projection out, or whose own rendering is switched off, leaves the far terrain
 		// flat, and a pack told otherwise would light a picture that has none.
 		return new EngineDefines.Environment(EngineDefines.DEFAULT_MC_VERSION, os(), vendor,
-				renderer, mipmap, DhDepth.present(), biomeIds(minecraft, biomes), categories());
+				renderer, mipmap, DhDepth.present(), biomeIds(), categories());
 	}
 
-	private static Map<String, Integer> biomeIds(Minecraft minecraft, BiomeClassifier biomes) {
-		ClientLevel level = minecraft == null ? null : minecraft.level;
-		if (level == null) {
-			// No world, no registry, and no symbol either. An invented number here would be a
-			// number the biome uniform never answers with, which is worse than an undefined name:
-			// the pack would compile and compare against nothing.
-			return Map.of();
-		}
+	private static Map<String, Integer> biomeIds() {
+		// Touches the game's class so that its registration has run by now: the table fills as
+		// Biomes initialises, nothing on a client's boot path promises that has happened before
+		// the first pack is read, and an empty table here would write no symbol and notice
+		// nothing later. Initialising it is free of everything but interning some keys.
+		Objects.requireNonNull(Biomes.THE_VOID);
 
-		biomes.refresh(level);
 		Map<String, Integer> ids = new LinkedHashMap<>();
-		List<String> names = biomes.names();
+		List<String> names = BiomeClassifier.names();
 		for (int id = 0; id < names.size(); id++) {
-			ids.putIfAbsent(names.get(id), id);
+			ids.put(names.get(id), id);
 		}
 
 		return ids;

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -109,7 +109,7 @@ public final class PackValues {
 	public static PackValues read(Path packPath, String dimension, Map<String, OptionValue> chosen,
 			String profile) throws IOException {
 		PackValues values = new PackValues();
-		PackDefines.install(values.state.biomes());
+		PackDefines.install();
 
 		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
 			OptionIndex options = OptionIndex.build(source);

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -7,6 +7,7 @@
 		"defaultRequire": 0
 	},
 	"client": [
+		"BiomesMixin",
 		"BlockEntityRenderDispatcherMixin",
 		"BlockEntityRenderStateAccessor",
 		"BlockRendererMixin",


### PR DESCRIPTION
## What this branch changes

The biome uniform numbered biomes by walking the level's registry, whose iteration order is alphabetical. Packs compare raw literals written against Iris's numbering, which is the declaration order of the game's Biomes class intercepted at Biomes.register: six is swamp there and cold_ocean here, so Bliss stood its swamp fog over shorelines instead of swamps. The classifier now takes its table from the same interception, through a mixin on Biomes.register; a biome the vanilla class never registers answers nought, as Iris answers one its map has never seen. The BIOME_* defines follow the same table and exist from the first pack read. The world-join reload stays: block.properties tags still resolve against registries only a world brings.

## How it was verified

Build green. The vanilla declaration order was read in the decompiled 26.2 Biomes class (the_void 0, plains 1, swamp 6, mangrove_swamp 7) and matches the literals Bliss writes for its swamp fog. A reviewer checked each claim against Iris (MixinBiomes, BiomeUniforms, IrisDefines) and the tree; its one blocking find, the world-join reload that block.properties tags ride, is restored and its reason written where the reload lives.