### PR TITLE
fix(glsl): hand dh programs the light pair as iris hands it

### DIFF
--- a/common/src/main/java/dev/vitrail/glsl/DistantVertex.java
+++ b/common/src/main/java/dev/vitrail/glsl/DistantVertex.java
@@ -36,13 +36,17 @@ import java.util.Set;
  * light in y, and that is what a pack reads {@code lmCoord} as everywhere else. So the builder is
  * what this head follows.
  * <p>
- * <strong>The pair is handed over RAW, as the chunk mesh hands it, and that is not a divergence from
- * Iris although the two lines look nothing alike.</strong> Iris answers
- * {@code gl_TextureMatrix[1]} with the identity on this family and normalises the pair itself, level
- * {@code i} arriving as {@code (i + 0.5) / 16}; this engine answers that matrix with the sixteen
- * numbers the fixed function pipeline held and hands the level as {@code 16i}, which comes back out
- * of the product as {@code i / 16 + 1 / 32}. The two are the same number. Handing normalised
- * coordinates here would be the divergence, the matrix being scaled either way.
+ * <strong>The pair arrives NORMALISED, level {@code i} as {@code (i + 0.5) / 16}, and every read
+ * of {@code gl_TextureMatrix[0]} or {@code [1]} in a program of this family answers the identity:
+ * both halves are Iris's, and they only hold together.</strong> Iris scales the pair itself
+ * ({@code DHTerrainTransformer.java:135}) and replaces the two matrices with {@code mat4(1.0)}
+ * ({@code :23-24}), so a pack may read the coordinate through the matrix or raw and get the same
+ * number, and the packs really do both: BSL and Complementary multiply the matrix in, Bliss reads
+ * the coordinate raw. This head first handed the level over as {@code 16i} beside the real fixed
+ * function matrix, which is the same product for a pack that multiplies and two hundred and fifty
+ * six times too big for one that does not: every sky level from one upward saturated Bliss's
+ * light map, and its far terrain came out uniformly lit, chalk white against the shaded near
+ * ground.
  * <p>
  * <strong>There is no texture coordinate at all.</strong> Iris answers
  * {@code gl_MultiTexCoord0} with {@code vec4(0.0, 0.0, 0.0, 1.0)} on this family
@@ -194,8 +198,8 @@ public final class DistantVertex {
 		lines.addAll(VertexPrologue.blankTexCoords());
 
 		lines.add("vec2 ofDistantLight() {");
-		lines.add("\treturn vec2(float((" + META + " >> 4u) & 15u), float(" + META
-				+ " & 15u)) * 16.0;");
+		lines.add("\treturn (vec2(float((" + META + " >> 4u) & 15u), float(" + META
+				+ " & 15u)) + 0.5) / 16.0;");
 		lines.add("}");
 
 		// The nudge, out of the six bits above the light: two a coordinate, the low one saying there

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -995,6 +995,11 @@ public final class GlslTranslator {
 				continue;
 			}
 
+			if (name.equals("gl_TextureMatrix") && this.inputs == VertexInputs.DISTANT
+					&& rewriteDistantTextureMatrix(index)) {
+				continue;
+			}
+
 			if (LegacyGlsl.readsDrawModelView(this.program) && rewriteGameModelView(index, name)) {
 				continue;
 			}
@@ -1148,6 +1153,61 @@ public final class GlslTranslator {
 		blank(close);
 		this.injectedNames.add(LegacyGlsl.GAME_TEXTURE_MATRIX);
 		this.gameTextureMatrix++;
+
+		return true;
+	}
+
+	/**
+	 * Answers a far terrain program's read of {@code gl_TextureMatrix[0]}, {@code [1]} or
+	 * {@code [2]} with the identity, which is Iris's answer for this family and the other half of
+	 * the light pair {@link DistantVertex} hands over normalised.
+	 * <p>
+	 * <strong>Iris replaces the first two expressions on its DH road,</strong>
+	 * {@code DHTerrainTransformer.java:23-24}, because the light coordinate its vertex init builds
+	 * is already {@code (i + 0.5) / 16} ({@code :135}) and unit nought's coordinate is a constant:
+	 * neither has a fixed function scale left to undo. The packs split over which way they read the
+	 * light, BSL and Complementary through the matrix and Bliss raw, so the matrix and the
+	 * coordinate have to change convention together or one of the two camps reads a number two
+	 * hundred and fifty six times off.
+	 * <p>
+	 * <strong>Unit two rides along because it is this engine's second name for unit one</strong>,
+	 * {@code of_MultiTexCoord2} answering the same pair in the head and
+	 * {@code GeometryValues.LIGHTMAP_UNITS} holding both, where Iris spells the aliasing on the
+	 * coordinate instead and renames {@code gl_MultiTexCoord2} to one on this family
+	 * ({@code DHTerrainTransformer.java:30}), leaving its {@code gl_TextureMatrix[2]} to fail the
+	 * compile. Leaving two out here would put the light matrix under a coordinate already
+	 * normalised, the exact mismatch this method exists to close. The corpus names neither the
+	 * coordinate nor the matrix of unit two in a {@code dh_} program, so nothing rests on the
+	 * difference from Iris's refusal.
+	 * <p>
+	 * Any other index, and any index that is not one of the three literals spelled plainly, falls
+	 * through to the ordinary rename and reads the engine's real table. Iris leaves those reads
+	 * untouched on this family, where they fail to compile; the corpus never writes one in a
+	 * {@code dh_} program, so nothing rests on that today either, and it is written down here for
+	 * the pack that one day does.
+	 *
+	 * @return whether this was a read of unit nought, one or two, false leaving the name to the
+	 *         ordinary rename
+	 */
+	private boolean rewriteDistantTextureMatrix(int index) {
+		int open = significantAfter(index);
+		if (open < 0 || !this.tokens.get(open).operator("[")) {
+			return false;
+		}
+
+		int unit = significantAfter(open);
+		int close = matchingBracket(open);
+		if (unit < 0 || close < 0 || significantAfter(unit) != close
+				|| !(this.tokens.get(unit).text().equals("0")
+						|| this.tokens.get(unit).text().equals("1")
+						|| this.tokens.get(unit).text().equals("2"))) {
+			return false;
+		}
+
+		inject(index, "mat4(1.0)");
+		blank(open);
+		blank(unit);
+		blank(close);
 
 		return true;
 	}


### PR DESCRIPTION
## What this branch changes

The far terrain family served gl_MultiTexCoord1 as raw light levels scaled 16i beside the real fixed-function lightmap matrix. Iris hands level i as (i + 0.5) / 16 and answers gl_TextureMatrix[0] and [1] with the identity on this family (DHTerrainTransformer), so a pack may read the light through the matrix or raw and get the same number. The packs do both: BSL and Complementary multiply the matrix in, and the product is exactly identical either way (both encodings are dyadic, no rounding); Bliss reads the pair raw, where 16i saturated its light map from sky level one upward and flattened its far terrain's light. Unit two rides along as this engine's second name for unit one, where Iris renames the coordinate and refuses the matrix; the corpus names neither in a dh_ program.

## How it was verified

Build green. A reviewer verified each claim against Iris's DH transformers, the extracted packs and the engine's own uniform table; its finds (unit two's matrix left inconsistent with its coordinate, and the javadoc that miscounted what Iris replaces) are folded in. In game on Bliss the far terrain's own light now follows sky level instead of saturating; BSL and Complementary read bit-identical values by construction.