### PR TITLE
build: ship one jar that runs under either loader

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,18 +6,15 @@
 # stops before anything is uploaded when they disagree: that is the one mistake that would otherwise
 # ship a jar under a version number nothing inside it agrees with.
 #
-# There are two jars, one per loader, and both go everywhere: the same engine reaches the same
-# stages of the same frame on either, so a release that carried one of them would be a release that
-# left half its users on the version before. They are found rather than named. Each name is built
-# out of archivesName and archiveVersion in that module's build.gradle, and spelling either a second
-# time here would be a second home for it, out of step from whichever of the two moved first.
+# What ships is ONE jar, the merged one the root build assembles, and it runs under either loader:
+# each loader reads its own metadata file and ignores the other's, so the union of the two loader
+# jars is a mod to both of them. It is found rather than named. Its name is built out of
+# archivesName and archiveVersion on the mergedJar task in the root build.gradle, and spelling it a
+# second time here would be a second home for it, out of step the day the first one moves.
 #
-# What is NOT shared between them is the loader a store files the upload under, and that is the
-# whole reason the mirroring is two steps rather than one. The action takes one list of loaders per
-# invocation and hangs it on every file it is given, so a single step would tell both stores that
-# the NeoForge jar runs on Fabric. Two steps, one jar each, and the version number carries the
-# loader after a plus so that the two versions of one release are told apart on a store that has no
-# other place to put the distinction.
+# One upload per store, filed under both loaders at once, which both stores take on a single file.
+# That also unties the version number: with one upload per release there are no two rows on a store
+# left to tell apart, so nothing is added after a plus any more.
 #
 # **The stores are mirrored from HERE and not from a workflow of their own**, and that is not a
 # matter of taste. A release this job creates is authored by the token the job runs under, and a
@@ -136,40 +133,41 @@ jobs:
       # on the day this runs.
       - run: ./gradlew build
 
-      # One per loader, and a missing one stops the run rather than shipping the other on its own.
-      # The root build gathers both here through collectJars, which assemble depends on.
-      - name: Find the jars
+      # The merged jar is the one that ships; the loader jars are its inputs and sit beside it in
+      # build/libs, gathered by collectJars, which assemble depends on. All three are counted, so
+      # a jar that stopped being built and a jar this list does not know are both a stop rather
+      # than a green run: a module added to settings.gradle looks like a fourth jar on the day it
+      # lands, and until this file and the mergedJar task both know it, refusing loses nothing.
+      - name: Find the jar
         id: jars
         run: |
-          # The loaders a release is expected to carry, named once. Adding a third is this word
-          # plus a mirror step of its own further down, since a store files a loader per upload.
           shopt -s nullglob
-          expected=0
+
+          # The merged jar is the one whose version begins right after the name; the loader jars
+          # carry their loader between the two. Naming the pattern and listing the directory on
+          # failure, because the way this fails is a rename in the root build.gradle, and "found 0"
+          # beside a folder that visibly holds jars sends whoever reads it looking for a build
+          # that did not happen.
+          jars=(build/libs/vitrail-[0-9]*.jar)
+          if [ ${#jars[@]} -ne 1 ]; then
+            echo "::error::build/libs/vitrail-[0-9]*.jar matched ${#jars[@]} files, and build/libs holds: $(ls build/libs)"
+            exit 1
+          fi
+
+          echo "merged=${jars[0]}" >> "$GITHUB_OUTPUT"
 
           for loader in neoforge fabric; do
             glob="build/libs/vitrail-$loader-*.jar"
-            jars=($glob)
-            if [ ${#jars[@]} -ne 1 ]; then
-              # Naming the pattern and listing the directory, because the way this fails is a rename
-              # in that module's build.gradle, and "found 0" beside a folder that visibly holds a jar
-              # sends whoever reads it looking for a build that did not happen.
-              echo "::error::$glob matched ${#jars[@]} files, and build/libs holds: $(ls build/libs)"
+            inputs=($glob)
+            if [ ${#inputs[@]} -ne 1 ]; then
+              echo "::error::$glob matched ${#inputs[@]} files, and build/libs holds: $(ls build/libs)"
               exit 1
             fi
-
-            expected=$((expected + 1))
-            echo "$loader=${jars[0]}" >> "$GITHUB_OUTPUT"
           done
 
-          # The same silence read from the other end. The check above catches a jar that stopped
-          # being built; this one catches a jar that is built and answers to no loader on the list,
-          # which is what a module added to settings.gradle looks like on the day it lands. Without
-          # it that jar reaches neither store and nothing says so, the run ending as green as one
-          # where everything shipped. Counting is enough to find it: the patterns above share the
-          # vitrail- prefix and part at the loader, so no jar is claimed by two of them.
           built=(build/libs/*.jar)
-          if [ ${#built[@]} -ne "$expected" ]; then
-            echo "::error::the list names $expected jars, and build/libs holds: $(ls build/libs)"
+          if [ ${#built[@]} -ne 3 ]; then
+            echo "::error::the list names 3 jars, and build/libs holds: $(ls build/libs)"
             exit 1
           fi
 
@@ -178,8 +176,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PRERELEASE: ${{ steps.version.outputs.prerelease }}
           TAG: ${{ steps.which.outputs.tag }}
-          NEOFORGE_JAR: ${{ steps.jars.outputs.neoforge }}
-          FABRIC_JAR: ${{ steps.jars.outputs.fabric }}
+          MERGED_JAR: ${{ steps.jars.outputs.merged }}
         run: |
           # Creating refuses a tag that already carries a release, so a re-run of a job that died
           # after the release was made would have no way back other than deleting a public release.
@@ -191,14 +188,14 @@ jobs:
           # that carries no release, this makes one, which is the same thing the tag push would
           # have done and is why it is not guarded against.
           if gh release view "$TAG" > /dev/null 2>&1; then
-            gh release upload "$TAG" "$NEOFORGE_JAR" "$FABRIC_JAR" --clobber
+            gh release upload "$TAG" "$MERGED_JAR" --clobber
             gh release edit "$TAG" --draft=false
           else
             # The body is this version's changelog entry and not the API's generated list of merged
             # pull requests. There are none to generate from here, the history being linear and
             # pushed rather than merged, so what that flag produced was a bare compare link under a
             # heading; and a body written by hand is the whole point of keeping the file.
-            gh release create "$TAG" "$NEOFORGE_JAR" "$FABRIC_JAR" \
+            gh release create "$TAG" "$MERGED_JAR" \
               --title "$TAG" \
               --notes-file changelog.md \
               --prerelease="$PRERELEASE"
@@ -247,14 +244,6 @@ jobs:
       # were learned the hard way on another mod of this account, each added in a commit of its own
       # after a first upload had gone out without them, are `environment` and `java`.
       #
-      # `version` is given now, and only because there are two uploads per release. Modrinth files a
-      # version number per version and has nowhere else to say which loader a version is for, so two
-      # versions carrying the same number would be two rows a reader has to open to tell apart, and
-      # would rest besides on that store accepting a duplicate, which is not written down anywhere
-      # this file could check. The loader goes after a plus, which is build metadata and leaves the
-      # number itself the one this job checked the tag against. CurseForge has no version object at
-      # all, only files, so there the line changes nothing and `name` is what a reader sees.
-      #
       # The version type is the one thing NOT left to the action, which would read the word out of
       # the version and file an alpha. CurseForge hides an alpha behind a filter its own navigation
       # sets, `showAlphaFiles=hide` on the Files link of every project page, so this one sat behind
@@ -266,7 +255,7 @@ jobs:
       #
       # `java` is CurseForge's alone. Modrinth has no field for it and the action never sends it
       # there, so the line is not the pair of a missing one.
-      - name: Mirror the NeoForge jar
+      - name: Mirror the jar
         if: steps.mirror.outputs.curseforge == 'true' || steps.mirror.outputs.modrinth == 'true'
         uses: Kir-Antipov/mc-publish@v3.3
         with:
@@ -276,51 +265,26 @@ jobs:
           curseforge-token: ${{ steps.mirror.outputs.curseforge == 'true' && secrets.CURSEFORGE_TOKEN || '' }}
           modrinth-id: ${{ secrets.MODRINTH_ID || vars.MODRINTH_ID }}
           modrinth-token: ${{ steps.mirror.outputs.modrinth == 'true' && secrets.MODRINTH_TOKEN || '' }}
-          files: ${{ steps.jars.outputs.neoforge }}
-          name: ${{ steps.which.outputs.tag }} (NeoForge)
-          version: ${{ steps.version.outputs.version }}+neoforge
+          files: ${{ steps.jars.outputs.merged }}
+          name: ${{ steps.which.outputs.tag }}
+          version: ${{ steps.version.outputs.version }}
           version-type: beta
           changelog-file: changelog.md
-          loaders: neoforge
+          loaders: |
+            neoforge
+            fabric
           game-versions: "26.2"
           environment: client
           java: 25
-          # Left to the action, which reads the jar's own neoforge.mods.toml, so Sodium and Chloride
-          # go up as relations of the FILE as well, beside whatever Default Relations the project
-          # itself carries. Their names there are the mod ids, and a name the store does not know is
-          # dropped rather than failing the upload. On Modrinth the drop is what happens to
-          # `minecraft` and `neoforge`, which are no projects of that store, while `sodium` and
-          # `chloride` are its slugs for them as well.
-
-      # The same release, the other loader. Everything that differs between the two steps differs
-      # because a store files it per upload: the file, the loader it is filed under, the version
-      # number that tells the two apart, and the dependencies.
-      - name: Mirror the Fabric jar
-        if: steps.mirror.outputs.curseforge == 'true' || steps.mirror.outputs.modrinth == 'true'
-        uses: Kir-Antipov/mc-publish@v3.3
-        with:
-          curseforge-id: ${{ secrets.CURSEFORGE_ID }}
-          curseforge-token: ${{ steps.mirror.outputs.curseforge == 'true' && secrets.CURSEFORGE_TOKEN || '' }}
-          modrinth-id: ${{ secrets.MODRINTH_ID || vars.MODRINTH_ID }}
-          modrinth-token: ${{ steps.mirror.outputs.modrinth == 'true' && secrets.MODRINTH_TOKEN || '' }}
-          files: ${{ steps.jars.outputs.fabric }}
-          name: ${{ steps.which.outputs.tag }} (Fabric)
-          version: ${{ steps.version.outputs.version }}+fabric
-          version-type: beta
-          changelog-file: changelog.md
-          loaders: fabric
-          game-versions: "26.2"
-          environment: client
-          java: 25
-          # Written out here, where the NeoForge step is left to read its jar, and the difference is
-          # not a change of mind: fabric.mod.json names the three Fabric API modules this mod uses
-          # one by one, and no store has a project under any of those three names. Read off the jar
-          # they would each be dropped in silence and the file would go up declaring no Fabric API
-          # at all, which is the one dependency a Fabric player is most likely to be missing. Both
-          # stores call the whole of it `fabric-api`. `fabricloader` and `minecraft` are dropped the
-          # same way and are meant to be: what stands for them is the loader and the game version
-          # the upload is filed under.
+          # Written out rather than read off the jar, which carries TWO metadata files: whichever
+          # one the action read, its list would be wrong for half the audience. Both stores call
+          # the whole of Fabric API `fabric-api`; the two modules fabric.mod.json names one by one
+          # are projects of neither store and would be dropped in silence. And fabric-api is
+          # optional here while that file says required, both on purpose: a store hangs a
+          # dependency on the upload as a whole, so `required` would send a NeoForge install
+          # chasing a mod that has no NeoForge build, while on Fabric the metadata inside the jar
+          # is what refuses to boot without it, which is where the requirement actually bites.
           dependencies: |
             sodium(required)
             chloride(required)
-            fabric-api(required)
+            fabric-api(optional)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,23 @@ it is in `docs/`.
 
 A version number here, the tag that released it and the number inside the jar are one number: the
 release workflow refuses a tag that disagrees with `mod_version` in `gradle.properties` rather than
-publishing a jar named after one thing and built from another. The stores add the loader after a
-plus, because each of them files an upload per loader and has nowhere else to put the distinction.
+publishing a jar named after one thing and built from another.
 
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
+
+## Unreleased
+
+### Changed
+
+- **One download for both loaders.** The release now carries a single jar,
+  `vitrail-<version>+mc<minecraft>`, that runs on NeoForge and on Fabric alike; each loader reads
+  its own metadata out of it and ignores the rest. It is the same engine the two per-loader jars
+  carried, in one file, and the per-loader downloads stop being published. Nothing changes in
+  game, and nothing changes about what has to sit next to it: Sodium, Chloride, and on Fabric the
+  Fabric API. Upgrading means replacing: delete the old `vitrail-neoforge-*` or `vitrail-fabric-*`
+  jar when this one goes in, because the two carry the same mod and a loader that finds it twice
+  refuses to start.
 
 ## 0.4.1-beta.1
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,10 +5,10 @@ installed on one.
 
 ## Getting the jar
 
-Built jars are attached to the [releases](https://github.com/avpbynf/Vitrail-Shaders/releases),
+The built jar is attached to the [releases](https://github.com/avpbynf/Vitrail-Shaders/releases),
 one per tag, built by the tag itself rather than uploaded by hand, and mirrored to
 [CurseForge](https://www.curseforge.com/minecraft/mc-mods/vitrail-shaders) by that
-same run, so whichever of the two you take is the same file. A version
+same run, so whichever of the two places you take it from serves the same file. A version
 carrying an identifier after a dash is marked as a pre-release, which is what it
 is. Building from source is below and gives the same thing for whatever commit you
 are on.
@@ -24,11 +24,11 @@ are on.
 | Chloride | any 26.2 build, to run on the Vulkan backend at all |
 | Java | 25, to build (the game brings its own runtime) |
 
-One jar per loader, and they carry the same engine: `vitrail-neoforge` and
-`vitrail-fabric`. On Fabric, three modules of Fabric API are declared as
+One jar for both loaders: each loader reads its own metadata out of it and
+ignores the rest. On Fabric, two modules of Fabric API are declared as
 required, and they are the whole of what this mod takes from it: the key
-mapping, the screen and the client tick, which is what the settings screen is
-opened by. Nothing of the world's rendering goes through Fabric API.
+mapping and the client tick, which is what the settings screen is opened by.
+Nothing of the world's rendering goes through Fabric API.
 
 Sodium and Chloride are both declared as required dependencies, so the game will
 refuse to start without either of them. Do not update Sodium past 0.9.x: it has
@@ -106,17 +106,19 @@ gradlew.bat build
 ```
 
 The first build decompiles Minecraft and takes a couple of minutes. After that it
-is a few seconds. Both jars are built, and each lands in two places that are
-identical, named for the version in `gradle.properties` and the Minecraft version
-beside it:
+is a few seconds. Three jars land in `build/libs`, named for the version in
+`gradle.properties` and the Minecraft version beside it. The first is the one a
+release ships and runs on either loader; the other two are the slices it is
+merged from, one per loader, kept beside it for whoever wants only theirs:
 
 ```
+build/libs/vitrail-<version>+mc<minecraft>.jar
 build/libs/vitrail-<loader>-<version>+mc<minecraft>.jar
-<loader>/build/libs/vitrail-<loader>-<version>+mc<minecraft>.jar
 ```
 
-`gradlew.bat :neoforge:build` builds that one alone, and `:fabric:build` the
-other.
+`gradlew.bat :neoforge:build` builds the NeoForge slice alone, into that
+module's own `neoforge/build/libs`, and `:fabric:build` the other; only the
+full build refreshes `build/libs`.
 
 To run the mod in a development client instead of installing it:
 
@@ -126,15 +128,17 @@ gradlew.bat :neoforge:runClient
 
 ## Installing into an instance
 
-Copy the jar into the `mods` folder of a NeoForge 26.2 instance, next to Sodium.
-For a CurseForge instance that is:
+Copy the jar into the `mods` folder of a NeoForge or Fabric 26.2 instance, next
+to Sodium. For a CurseForge instance that is:
 
 ```
 <instances>/<instance name>/mods/
 ```
 
 Remove any other shader engine from that folder first. Iris and Vitrail both want
-to own the frame, and there is no reason to have both.
+to own the frame, and there is no reason to have both. An older Vitrail goes too:
+the per-loader `vitrail-neoforge-*` and `vitrail-fabric-*` jars carry the same
+mod as the merged one, and a loader that finds it twice refuses to start.
 
 Shader packs go into the `shaderpacks/` folder at the root of the instance, the
 same folder OptiFine and Iris use, zipped or unpacked. The mod keeps its own

--- a/README.md
+++ b/README.md
@@ -82,13 +82,12 @@ quality for it in the meantime.
 
 ## Quick start
 
-There is one jar per loader, NeoForge and Fabric. Both are on
+There is one jar and it runs on both loaders, NeoForge and Fabric. It is on
 [CurseForge](https://www.curseforge.com/minecraft/mc-mods/vitrail-shaders) and
 attached to every [release](https://github.com/avpbynf/Vitrail-Shaders/releases)
-here, put there by the same run, so whichever of the two you take is the same
-file.
+here, put there by the same run, so both places serve the same file.
 
-Put the one for your loader in `mods/` next to Sodium and Chloride, and switch
+Put it in `mods/` next to Sodium and Chloride, and switch
 the game to Vulkan: `preferredGraphicsBackend:"vulkan"` in `options.txt`, or
 Options, then Video Settings, in game. Nothing enforces that switch, though the
 mod says at startup which backend the game came up on, and says so as an error
@@ -105,7 +104,8 @@ To build from source:
 gradlew build
 ```
 
-Both jars land in `build/libs`.
+Three jars land in `build/libs`; the one to install is the plain
+`vitrail-<version>` one, the other two being its per-loader slices.
 
 ## How it works
 

--- a/build.gradle
+++ b/build.gradle
@@ -202,8 +202,77 @@ tasks.named("check") {
 	dependsOn tasks.named("checkText")
 }
 
-// Loader jars are what gets shipped, so gather them at the root rather than making
-// people dig through each module.
+// One jar that runs under either loader. Each loader opens its own metadata file and walks past
+// the other's - NeoForge reads META-INF/neoforge.mods.toml, Fabric reads fabric.mod.json - so a
+// jar carrying both is a mod to each of them, and the other loader's classes lie fallow: Fabric
+// instantiates only what fabric.mod.json names, and FML, which scans every class in the jar,
+// acts on its own annotations, which the Fabric-side classes do not carry. Merging takes nothing
+// more than the union of the two loader jars: from 26.2 on there is one set of names, so neither
+// jar is remapped and nothing has to be relocated or rewritten on the way in.
+def loaderJars = ["neoforge", "fabric"].collect { module ->
+	project(":$module").tasks.named("jar", Jar)
+}
+
+tasks.register("mergedJar", Jar) {
+	group = "build"
+	description = "Assembles the one jar that runs under either loader."
+
+	archiveBaseName = "vitrail"
+	archiveVersion = "${project.mod_version}+mc${project.minecraft_version}"
+
+	// Aimed at build/libs itself, because the base plugin's home for a root archive is
+	// build/distributions, and everything this build makes is read out of one directory.
+	destinationDirectory = layout.buildDirectory.dir("libs")
+
+	// The subprojects block pins these on every archive a module builds. This task is the root's
+	// own, outside that block, so it says the same thing itself.
+	preserveFileTimestamps = false
+	reproducibleFileOrder = true
+
+	loaderJars.each { loaderJar ->
+		from(loaderJar.map { zipTree(it.archiveFile) }) {
+			// So that this jar gets a manifest of its own instead of whichever copy was walked
+			// first.
+			exclude "META-INF/MANIFEST.MF"
+		}
+	}
+
+	// What the two trees share is the common module's output and the licence files, one copy in
+	// each loader jar out of the same build, so keeping the first copy of each is keeping the only
+	// bytes there are. That is an assumption worth a check rather than a comment, and the check is
+	// below: a path present in both jars with different bytes fails the merge, instead of one copy
+	// silently standing in for both.
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+	doFirst {
+		def entries = [:]
+
+		loaderJars.each { loaderJar ->
+			def archive = loaderJar.get().archiveFile.get().asFile
+
+			new java.util.zip.ZipFile(archive).withCloseable { zip ->
+				for (entry in zip.entries()) {
+					// The manifest is excluded from the merge above, so a difference there is not
+					// a difference in what ships.
+					if (entry.directory || entry.name == "META-INF/MANIFEST.MF") {
+						continue
+					}
+
+					def before = entries.put(entry.name, entry.crc)
+					if (before != null && before != entry.crc) {
+						throw new GradleException("${entry.name} differs between the loader jars, "
+								+ "so neither copy can stand for both")
+					}
+				}
+			}
+		}
+	}
+}
+
+// The merged jar is what a release ships, and it lands in build/libs by the line above. The
+// loader jars are copied in beside it because a slice for one loader is still the smaller thing
+// to hand a test instance, and because a reader of build/libs should see everything the build
+// makes without digging through each module.
 tasks.register("collectJars", Copy) {
 	from project(":neoforge").tasks.named("jar")
 	from project(":fabric").tasks.named("jar")
@@ -211,5 +280,5 @@ tasks.register("collectJars", Copy) {
 }
 
 tasks.named("assemble") {
-	dependsOn tasks.named("collectJars")
+	dependsOn tasks.named("mergedJar"), tasks.named("collectJars")
 }


### PR DESCRIPTION
## What changes

The build assembles a merged jar, the plain `vitrail-<version>` beside the two per-loader ones in `build/libs`, and the release ships only it: each loader reads its own metadata file out of the jar and ignores the other's, so the union of the two loader jars is a mod to both, with nothing remapped or relocated since 26.2 has one set of names. The merge carries a guard that fails on any path present in both loader jars with different bytes, instead of letting one copy stand in for both. The release workflow uploads that one file everywhere, filed under both loaders at once; `fabric-api` becomes an optional dependency on the stores, because a store hangs a dependency on the upload as a whole and the jar's own `fabric.mod.json` is what enforces it where it matters.

## How it differs from the reference, and for what obstacle

It does not touch anything a pack sees. Iris distributes one jar per loader, but that is packaging rather than behaviour, and no pack can observe the difference.

## What proves it

- `gradlew build` green locally.
- Out of game: the merged jar's entry list measured equal to the union of the two loader jars, 574 entries, with both metadata files, both mixin configs and a manifest of its own; the conflict guard measured to fire on a planted cross-module conflict and the build green again after its removal.
- In game: nothing yet. The first boot on each loader with the merged jar is owed before this merges.

## What it leaves owing

A boot on each loader with the merged jar in `mods/`, which is the half of the proof no harness covers.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.