### PR TITLE
fix(render): keep the scene seed off the far terrain

### DIFF
--- a/common/src/main/java/dev/vitrail/render/DistantProgram.java
+++ b/common/src/main/java/dev/vitrail/render/DistantProgram.java
@@ -55,10 +55,12 @@ import java.util.Optional;
  * this family, and it has to KEEP OFF it: the world's depth holds nothing where an LOD stands, so
  * without a cut of its own the seed reads those pixels as unanswered and paints the game's sky
  * over the albedo this family just wrote. That is what bleached Bliss's far terrain chalk white,
- * and only Bliss's: every other pack's sky claims those pixels into the coverage mask and the
- * seed already kept off, while Bliss's {@code gbuffers_skybasic} is the one sky the translation
- * cannot give a mask to. {@link SceneSeed} carries the cut, against this family's own depth
- * image, so the far terrain no longer depends on the sky in front of it having claimed the mask.
+ * and on the corpus only Bliss's: measured today, its {@code gbuffers_skybasic} is the one sky
+ * left without a coverage mask, so every other pack's sky claims those pixels and the seed
+ * already kept off. The ways a sky loses the mask are structural and not Bliss's
+ * ({@code GeometryProgram.covers} names four), so the observation is the corpus's and not a
+ * rule. {@link SceneSeed} carries the cut, against this family's own depth image, so the far
+ * terrain no longer depends on the sky in front of it having claimed the mask.
  * <p>
  * <strong>Its namespace is ours and has no {@code sodium} in it</strong>, for the reason
  * {@link SkyProgram} gives: the word is what makes Sodium's mixin push twenty bytes of region offset

--- a/common/src/main/java/dev/vitrail/render/DistantProgram.java
+++ b/common/src/main/java/dev/vitrail/render/DistantProgram.java
@@ -52,8 +52,13 @@ import java.util.Optional;
  * <strong>Every draw buffer goes to the pack's own targets, the first included</strong>, which is
  * where Iris puts them: its dh programs are bound over the pack's declared draw buffers exactly as
  * its gbuffers programs are ({@code compat/dh/DHCompatInternal.java:92}). The seed cannot carry
- * this family and does not need to keep off it, and {@link GeometryProgram} says why in the one
- * place that rule is decided.
+ * this family, and it has to KEEP OFF it: the world's depth holds nothing where an LOD stands, so
+ * without a cut of its own the seed reads those pixels as unanswered and paints the game's sky
+ * over the albedo this family just wrote. That is what bleached Bliss's far terrain chalk white,
+ * and only Bliss's: every other pack's sky claims those pixels into the coverage mask and the
+ * seed already kept off, while Bliss's {@code gbuffers_skybasic} is the one sky the translation
+ * cannot give a mask to. {@link SceneSeed} carries the cut, against this family's own depth
+ * image, so the far terrain no longer depends on the sky in front of it having claimed the mask.
  * <p>
  * <strong>Its namespace is ours and has no {@code sodium} in it</strong>, for the reason
  * {@link SkyProgram} gives: the word is what makes Sodium's mixin push twenty bytes of region offset

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2004,8 +2004,13 @@ public final class PackChain {
 		// frame, so a frame no program of the pack drew in is served an empty one rather than the
 		// last one that was written.
 		GpuTextureView covered = this.targets.coverage();
+		// The far terrain's own depth rides the same fallback: a frame it drew nothing in reads as
+		// nothing of the pack's standing there, through the sentinel sitting outside the range on
+		// the clear's side.
+		GpuTextureView distantServed = this.distant.served();
 		this.seed.draw(encoder, this.quad, mainView,
-				covered == null ? this.targets.unwritten() : covered, depthView, this.targets);
+				covered == null ? this.targets.unwritten() : covered, depthView,
+				distantServed == null ? this.targets.unwritten() : distantServed, this.targets);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/SceneSeed.java
+++ b/common/src/main/java/dev/vitrail/render/SceneSeed.java
@@ -41,7 +41,9 @@ import java.util.Optional;
  * Without the cut the two would fight and the game would win, because it is drawn second. The pieces
  * that claim nothing are different again, the translucent chunk pass among them: they draw over what
  * the others left, and whether they blend is not the question - the End's cube of sky blends and
- * claims the frame all the same.
+ * claims the frame all the same. The far terrain writes the target itself as well, but records
+ * nothing the mask could carry, its depth living in DH's own volume; it is cut around through its
+ * own image instead, and the fragment stage says how.
  * <p>
  * <strong>The cut is one comparison, and it is the mask against the world's depth as it stands.</strong>
  * The mask carries a depth and not a flag: what a program of the pack wrote into the depth
@@ -114,6 +116,9 @@ final class SceneSeed {
 	/** The world's depth as it stands, which by now carries the game's own features. */
 	private static final String DEPTH = "DepthSampler";
 
+	/** The far terrain's own depth, in DH's volume, which the world's depth knows nothing of. */
+	private static final String DISTANT = "DistantSampler";
+
 	private static final String LABEL = "Vitrail scene seed";
 
 	private static final String EMPTY_LABEL = "Vitrail scene seed gbuffer";
@@ -134,6 +139,14 @@ final class SceneSeed {
 	 */
 	private static final String WRITTEN = ClipSpace.REVERSED.z < 0.0F ? ">= 0.0" : "<= 1.0";
 
+	/**
+	 * How a depth image says something was really rasterised into it, told from its clear. The
+	 * game clears reversed depth to nought and the far terrain's image follows it, so a real
+	 * fragment is strictly past the clear; the sentinel of an absent image sits outside the range
+	 * on the same side as the clear and reads as nothing drawn through the same test.
+	 */
+	private static final String REAL = ClipSpace.REVERSED.z < 0.0F ? "> 0.0" : "< 1.0";
+
 	/** Two triangles, the same quad the pass itself draws, which is why it is passed in. */
 	private static final int VERTICES = 6;
 
@@ -153,12 +166,23 @@ final class SceneSeed {
 
 	/**
 	 * The cut, and the whole of it: the game's picture goes in wherever the world's depth stands in
-	 * front of the depth the pack's geometry left.
+	 * front of the depth the pack's geometry left, except where the far terrain owns the pixel.
 	 * <p>
-	 * Neither side is converted into the pack's window. The mask is filled by the fragment stage
-	 * from the value it hands the depth attachment, and this reads that attachment back, so the two
-	 * are the same number written by the same draw and a pixel nothing was drawn over compares
-	 * exactly equal however the game encodes its depth.
+	 * Neither side of the first comparison is converted into the pack's window. The mask is filled
+	 * by the fragment stage from the value it hands the depth attachment, and this reads that
+	 * attachment back, so the two are the same number written by the same draw and a pixel nothing
+	 * was drawn over compares exactly equal however the game encodes its depth.
+	 * <p>
+	 * <strong>The far terrain's depth is a third image and cannot enter that comparison</strong>:
+	 * it is rasterised in DH's own volume, whose near plane stands blocks out, so its numbers and
+	 * the world's are two windows onto one scene and comparing them would put a hill a thousand
+	 * blocks off at arm's length. It does not need to. The far terrain begins where the world's
+	 * chunks end, so anything the game really drew stands in front of it, and the one question
+	 * left is yes or no twice: did the far terrain write here, and did the game write anything at
+	 * all. Where the first is yes and the second no, the pixel is the pack's own picture already,
+	 * written by its {@code dh_} programs, and the seed painting the game's sky over it is what
+	 * bleached the far terrain chalk white under Bliss while its water half, drawn after the
+	 * deferred stage, kept its colour.
 	 */
 	private static final String FRAGMENT = String.format(Locale.ROOT, """
 			#version 460 core
@@ -166,21 +190,28 @@ final class SceneSeed {
 			uniform sampler2D InSampler;
 			uniform sampler2D CoverageSampler;
 			uniform sampler2D DepthSampler;
+			uniform sampler2D DistantSampler;
 
 			in vec2 ofTexCoord;
 
 			layout(location = 0) out vec4 ofFragData0;
 
 			void main() {
-				bool infront = texture(DepthSampler, ofTexCoord).r
-						%s texture(CoverageSampler, ofTexCoord).r;
+				float live = texture(DepthSampler, ofTexCoord).r;
+				bool infront = live %s texture(CoverageSampler, ofTexCoord).r;
 				if (!infront) {
+					discard;
+				}
+
+				bool farTerrain = texture(DistantSampler, ofTexCoord).r %s;
+				bool gameDrew = live %s;
+				if (farTerrain && !gameDrew) {
 					discard;
 				}
 
 				ofFragData0 = texture(InSampler, ofTexCoord);
 			}
-			""", CLOSER);
+			""", CLOSER, REAL, REAL);
 
 	/**
 	 * One draw buffer of the geometry program the seed stands in for, past the first, that the seed
@@ -254,6 +285,7 @@ final class SceneSeed {
 						.withSampler(SAMPLER)
 						.withSampler(COVERAGE)
 						.withSampler(DEPTH)
+						.withSampler(DISTANT)
 						.build())
 				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
 				// The format of the target as the pack declared it, not the one of the main
@@ -394,6 +426,9 @@ final class SceneSeed {
 	 *                is a mask that hides nothing and the seed then covers the target whole, which
 	 *                is what the frames with no geometry of the pack's in them have to look like
 	 * @param live    the world's depth as it stands, features included
+	 * @param distant the far terrain's own depth image, judged the same way: a frame it drew
+	 *                nothing in hands the sentinel image instead, and the cut then reads nothing
+	 *                of the pack's standing there, which is what those frames are
 	 * @param targets where the pack's colour targets are looked up, every frame and never held: a
 	 *                resize replaces the images and keeping one across it draws into a texture that
 	 *                has been closed
@@ -404,9 +439,11 @@ final class SceneSeed {
 	 *         the block behind wrote. No caller reads this today
 	 */
 	boolean draw(CommandEncoder encoder, GpuBuffer quad, GpuTextureView scene,
-			GpuTextureView covered, GpuTextureView live, ColorTargets targets) {
+			GpuTextureView covered, GpuTextureView live, GpuTextureView distant,
+			ColorTargets targets) {
 		GpuTextureView into = targets.view(this.seed.target(), this.seed.side());
-		if (quad == null || scene == null || covered == null || live == null || into == null) {
+		if (quad == null || scene == null || covered == null || live == null || distant == null
+				|| into == null) {
 			return false;
 		}
 
@@ -426,6 +463,8 @@ final class SceneSeed {
 			pass.bindTexture(COVERAGE, covered,
 					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
 			pass.bindTexture(DEPTH, live,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+			pass.bindTexture(DISTANT, distant,
 					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
 			pass.draw(VERTICES, 1, 0, 0);
 		}

--- a/common/src/main/java/dev/vitrail/render/SceneSeed.java
+++ b/common/src/main/java/dev/vitrail/render/SceneSeed.java
@@ -141,9 +141,11 @@ final class SceneSeed {
 
 	/**
 	 * How a depth image says something was really rasterised into it, told from its clear. The
-	 * game clears reversed depth to nought and the far terrain's image follows it, so a real
-	 * fragment is strictly past the clear; the sentinel of an absent image sits outside the range
-	 * on the same side as the clear and reads as nothing drawn through the same test.
+	 * game clears reversed depth to nought and the far terrain's image follows it; the sentinel
+	 * of an absent image sits outside the range on the same side as the clear and reads as
+	 * nothing drawn through the same test. A fragment landing exactly on the far plane reads as
+	 * the clear and is missed - DH's own apply stage discards on the same equality - which is a
+	 * set of measure nought and not a case the cut leans on.
 	 */
 	private static final String REAL = ClipSpace.REVERSED.z < 0.0F ? "> 0.0" : "< 1.0";
 
@@ -177,12 +179,21 @@ final class SceneSeed {
 	 * it is rasterised in DH's own volume, whose near plane stands blocks out, so its numbers and
 	 * the world's are two windows onto one scene and comparing them would put a hill a thousand
 	 * blocks off at arm's length. It does not need to. The far terrain begins where the world's
-	 * chunks end, so anything the game really drew stands in front of it, and the one question
-	 * left is yes or no twice: did the far terrain write here, and did the game write anything at
-	 * all. Where the first is yes and the second no, the pixel is the pack's own picture already,
-	 * written by its {@code dh_} programs, and the seed painting the game's sky over it is what
-	 * bleached the far terrain chalk white under Bliss while its water half, drawn after the
-	 * deferred stage, kept its colour.
+	 * chunks end, so anything the game drew AND DEPTH-WROTE stands in front of it, and the one
+	 * question left is yes or no twice: did the far terrain write here, and did the game write any
+	 * depth at all. Where the first is yes and the second no, the pixel is the pack's own picture
+	 * already, written by its {@code dh_} programs, and the seed painting the game's sky over it
+	 * is what bleached the far terrain chalk white under Bliss while its water half, drawn after
+	 * the deferred stage, kept its colour.
+	 * <p>
+	 * <strong>What the depth-write clause costs, and it is paid knowingly:</strong> the game
+	 * paints some things without writing the world's depth, the default rain and snow first among
+	 * them ({@code WeatherDraw} carries why no pack of the corpus asks for the depth writing
+	 * pipeline), and those the cut cannot see. On a run where the seed stands in for the weather,
+	 * the game's rain is therefore cut away exactly where the far terrain is its backdrop, and
+	 * kept over the near world and the sky. The trade is the far terrain's whole picture against
+	 * rain streaks on a pack that serves no weather program, and the far terrain wins; the day a
+	 * depthless family matters more, the cut needs a mask of its own rather than a wider guess.
 	 */
 	private static final String FRAGMENT = String.format(Locale.ROOT, """
 			#version 460 core


### PR DESCRIPTION
## What this branch changes

The scene seed paints the game's frame wherever the world's depth stands in front of what the coverage mask carries, and the world's depth holds nothing where an LOD stands: the game never rasterises the far terrain. The seed read those pixels as unanswered and painted the game's sky over the albedo the dh programs had just written, which bleached Bliss's far terrain chalk white while its water half, drawn behind the deferred stage, kept its colour. On the corpus only Bliss showed it, its gbuffers_skybasic being the one sky currently left without a coverage mask; on every other pack the sky claims those pixels and the seed already kept off. The far terrain's depth lives in DH's own volume and cannot enter the mask comparison; the cut is the family's own depth image against whether the game wrote any depth at all, with the mask sentinel standing in on frames it drew nothing.

What the depth-write clause costs is written where the cut lives: things the game paints without writing depth, the default rain first, are invisible to it, so where the seed stands in for the weather the game's rain is cut away exactly where far terrain is its backdrop. The far terrain's whole picture against rain streaks on a pack serving no weather program.

## How it was verified

Build green. In game on Bliss, same world and jar apart, the far terrain went from a uniform white sheet to its own colours to the horizon, confirmed at the screen. Packs whose sky claims the mask keep their seed behaviour at those pixels; the new cut can only fire where the mask held the sentinel and the game wrote no depth. A reinforced reviewer attacked the conventions, the timing, the empties pass, the null and resize roads; its three surviving finds are folded in as the cost paragraph and two reworded claims.