### PR TITLE
fix(fabric): read the pack clear of the boot resource reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ what the next one holds.
   stop leaning on a workaround for a renderer bug this engine never had, and reflections drop a
   workaround for a texture bug fixed before the release this engine mirrors.
 
+- **On Fabric, the game no longer throws away every selected resource pack at boot when a slow
+  mod set is installed.** Reading the shader pack used to hold up the very first frame, and when
+  the boot's resource reload finished inside that pause the game stitched its atlases before it
+  had a frame's uniforms to do it with: "Missing uniform Globals", and every resource pack was
+  deselected. Seen with Distant Horizons installed, whose extra programs made the pack read long
+  enough to lose the race. The pack is now read once the boot reload is over, which is where
+  NeoForge always effectively had it.
+
 ### Changed
 
 - **One download for both loaders.** The release now carries a single jar,

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -36,7 +36,11 @@ public final class EngineStages {
 	}
 
 	/**
-	 * Once, as soon as the loader has a game to look at, and before any frame.
+	 * Once, with the game and its device up, and before any world is entered. Not before any frame:
+	 * a pack takes seconds to read, and the one thing this moment must not do is hold up the render
+	 * thread between the boot's resource reload and the first frame, where the game uploads its
+	 * atlases against uniforms only a drawn frame provides. Each loader module says how it gets
+	 * there; the Fabric mixin carries the measurement.
 	 */
 	public static void clientSetup() {
 		// The backend rides on the line that was already here rather than taking one of its own. It

--- a/fabric/src/main/java/dev/vitrail/fabric/VitrailFabric.java
+++ b/fabric/src/main/java/dev/vitrail/fabric/VitrailFabric.java
@@ -10,7 +10,7 @@ import net.fabricmc.api.ClientModInitializer;
  * Only the platform is set here. Fabric calls a client entry point from near the top of the
  * {@code Minecraft} constructor, long before the graphics device is up and before the options are
  * read, so nothing that looks at the game belongs here; what does is in
- * {@code dev.vitrail.fabric.mixin.ClientSetupMixin}, at the tail of that same constructor.
+ * {@code dev.vitrail.fabric.mixin.ClientSetupMixin}, once the boot's resource reload is behind.
  */
 public final class VitrailFabric implements ClientModInitializer {
 

--- a/fabric/src/main/java/dev/vitrail/fabric/mixin/ClientSetupMixin.java
+++ b/fabric/src/main/java/dev/vitrail/fabric/mixin/ClientSetupMixin.java
@@ -17,13 +17,29 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * pack's own reading needs for the language. That is a different moment from NeoForge's client
  * setup, and reading a pack there gives a backend called {@code unknown} and a chain that throws.
  * <p>
- * The tail of the same constructor is the moment that matches: the device is up, the options are
- * read, the level renderer exists, and no frame has been drawn.
+ * The tail of the same constructor is not the moment either, and it was until it cost every resource
+ * pack of an install. The constructor starts the initial resource reload before it returns, so a
+ * pack read at its tail blocks the render thread AFTER that reload's background preparation has
+ * begun. When the read outlasts the preparation, the first {@code runAllTasks} of
+ * the first tick uploads the stitched atlases before the first {@code GameRenderer.render}
+ * ({@code Minecraft.runTick} queues tasks above the frame), and
+ * {@code TextureAtlas.uploadInitialContents} binds default uniforms that only
+ * {@code GameRenderer.render} writes: "Missing uniform Globals", and the game throws away every
+ * selected resource pack. Measured on 0.4.1-beta.1 with Distant Horizons installed, whose
+ * {@code dh_} programs lengthen the read past the preparation; NeoForge never sees it because its
+ * client setup runs on a mod loading worker, off the render thread and before the reload exists.
+ * <p>
+ * {@code onGameLoadFinished} is the moment that matches: reached at most once, on the render thread
+ * with no pass open ({@code LoadingOverlay.tick} calls it, not the overlay's render), after the
+ * game has drawn frames for the whole of the initial reload, and before {@code buildInitialScreens}
+ * hands the player a screen or a quick play world. At most and not exactly: a boot whose reload
+ * fails twice over gives up through {@code abortResourcePackRecovery} and never comes this way,
+ * but that boot never draws a level either, so a pack unread is nothing it would have shown.
  */
 @Mixin(Minecraft.class)
 public abstract class ClientSetupMixin {
 
-	@Inject(method = "<init>", at = @At("TAIL"), require = 1)
+	@Inject(method = "onGameLoadFinished", at = @At("HEAD"), require = 1)
 	private void vitrail$clientSetup(CallbackInfo ci) {
 		EngineStages.clientSetup();
 	}


### PR DESCRIPTION
## What changes

On Fabric, `EngineStages.clientSetup` (and with it the reading of the shader pack) moves from the tail of the `Minecraft` constructor to the head of `onGameLoadFinished`. The constructor tail sits after the boot's resource reload has started, so a pack that takes seconds to read blocked the render thread long enough for the reload's background preparation to finish; the first tick then uploaded the stitched atlases before the first `GameRenderer.render` (`runTick` drains tasks above the frame), and `TextureAtlas.uploadInitialContents` binds default uniforms only a drawn frame provides. The game answered "Missing uniform Globals" and threw away every selected resource pack, at every boot. Measured on the Fabric test instance with Distant Horizons installed, whose `dh_` programs lengthen the read past the preparation; NeoForge never sees it because `FMLClientSetupEvent` runs on a modloading worker before the reload exists. `onGameLoadFinished` is reached exactly once, on the render thread with no pass open, after the reload and before the first screen or quick play world.

## How it differs from the reference, and for what obstacle

It does not. This is loader wiring, upstream of anything a pack defines; Iris has no Vulkan boot to compare against, and the moment chosen matches what NeoForge's own event ordering already gave the other module.

## What proves it

- `gradlew build` green, after the rebase.
- In the game: the Fabric instance with Vitrail + Distant Horizons both installed, which crashed at every boot before this branch, boots without one occurrence of the error; NeoForge instance unchanged. Complementary Unbound loads as before.

## What it leaves owing

The game itself will still drop resource packs if any other mod blocks the render thread between the boot reload and the first frame; that is the game's fragility, not ours to fix, and this branch only takes this mod off that path.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.