### PR TITLE
fix(pack): announce the iris version packs compare against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ what the next one holds.
 
 ## Unreleased
 
+### Fixed
+
+- **Complementary no longer falls back to its oldest code paths.** The engine told packs it was
+  Iris but never which one, and a pack that asks compares against zero: every "on an old Iris, do
+  it the old way" branch in Complementary Reimagined and Unbound was live. The engine now
+  announces the Iris release it behaves like, so those branches pick the modern side: rain and
+  thunder fade over the pack's own timer instead of a hardcoded three seconds, the sun and moon
+  stop leaning on a workaround for a renderer bug this engine never had, and reflections drop a
+  workaround for a texture bug fixed before the release this engine mirrors.
+
 ### Changed
 
 - **One download for both loaders.** The release now carries a single jar,

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -27,6 +27,16 @@ public final class EngineDefines {
 	 */
 	public static final int DEFAULT_MC_VERSION = 260200;
 
+	/**
+	 * The Iris release whose behaviour this engine mirrors, 1.11.2 on the 26.1 branch, in the
+	 * same packed form. Packs compare against it to pick between an old-Iris workaround and the
+	 * behaviour the mirrored release fixed, so leaving it out sends every such test down the
+	 * workaround: an undefined name reads as zero, which claims an Iris older than any release.
+	 * The number comes alone: the capability symbols Iris posts beside it are promises, and each
+	 * stays unposted until the capability is served, as the note under IS_IRIS says.
+	 */
+	private static final int IRIS_VERSION = 11102;
+
 	/** The game's own default, four levels, until a caller says otherwise. */
 	private static final int DEFAULT_MIPMAP_LEVEL = 4;
 
@@ -102,6 +112,7 @@ public final class EngineDefines {
 		Map<String, String> defines = new LinkedHashMap<>();
 
 		defines.put("MC_VERSION", Integer.toString(environment.mcVersion()));
+		defines.put("IRIS_VERSION", Integer.toString(IRIS_VERSION));
 		defines.put("MC_GL_VERSION", "460");
 		defines.put("MC_GLSL_VERSION", "460");
 		defines.put(osSymbol(environment.os()), "");


### PR DESCRIPTION
## What changes

The engine claimed `IS_IRIS` but never said which Iris, and a pack that asks compares `IRIS_VERSION` against zero: every "on an old Iris, do it the old way" branch in Complementary Reimagined and Unbound (with or without EuphoriaPatches) was live. The define table now carries `IRIS_VERSION 11102`, the release the engine mirrors, so those branches pick the side written for it: rain and thunder fade over the pack's own timer, the sun and moon drop a render-stage workaround this engine never needed, reflections drop a fake-LOD blur for a texture bug fixed before 1.11.2, and the self-player check reads the `current_player` entity id. Everything the modern branches lean on is already served: `cameraPositionInt`/`cameraPositionFract`/`previousCameraPositionFract`, `current_player`, and the sun and moon render stages.

## How it differs from the reference, and for what obstacle

It does not, for the number: Iris computes the same 11102 from its own mod version (`gl/shader/StandardMacros.java:149`). Two deliberate holds stay as they were: the value is a constant naming the mirrored release rather than a live version, and the capability symbols Iris posts beside it (`IRIS_TAG_SUPPORT` and friends) stay unposted until each is served, per the standing `IRIS_FEATURE_` rule the comment now points at.

## What proves it

- `gradlew build` green.
- A survey of the eight test packs: 478 version tests, 89 unique conditions. All 27 distinct `MC_VERSION` thresholds already fall on the same side for 260200 as for what Iris announces, so `MC_VERSION` needed nothing. The five `IRIS_VERSION` test shapes (all Complementary) each take Iris's branch with 11102; with the name undefined, four of five took the wrong one.
- Not yet looked at in game; the visible candidates are the rain fade timer setting and `SUN_MOON_STYLE >= 2`.

## What it leaves owing

Nothing within version tests. The capability symbols above remain a named, deliberate gap.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine prints at load.
