### PR TITLE
build: raise the version to 0.5.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,27 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.5.0-beta.1
+
+### Added
+
+- **The debug screen names the engine, the pack and its profile**, where Iris has always put those
+  three lines. A screenshot taken with F3 open is how the question "what drew this, with what, set
+  how" arrives, and until now a Vitrail frame and an Iris frame of the same pack read as the same
+  picture. A pack that is not being drawn says which of the three reasons it is rather than reading
+  as none at all: shaders switched off, a pack named that is not in the folder, or a pack the
+  engine refused, the last of which sends you to the log rather than to the settings screen.
+
+### Changed
+
+- **One download for both loaders.** The release now carries a single jar,
+  `vitrail-<version>+mc<minecraft>`, that runs on NeoForge and on Fabric alike; each loader reads
+  its own metadata out of it and ignores the rest. It is the same engine the two per-loader jars
+  carried, in one file, and the per-loader downloads stop being published. Nothing changes in
+  game, and nothing changes about what has to sit next to it: Sodium, Chloride, and on Fabric the
+  Fabric API. Upgrading means replacing: delete the old `vitrail-neoforge-*` or `vitrail-fabric-*`
+  jar when this one goes in, because the two carry the same mod and a loader that finds it twice
+  refuses to start.
 
 ### Fixed
 
@@ -31,16 +51,32 @@ what the next one holds.
   enough to lose the race. The pack is now read once the boot reload is over, which is where
   NeoForge always effectively had it.
 
-### Changed
+- **Bliss no longer stands its swamp fog over any shoreline.** Biomes were numbered by walking the
+  level's registry, which hands them out alphabetically, while a pack compares against the numbers
+  Iris hands out, which are the game's own declaration order. Six is swamp there and cold ocean
+  here, so the green followed you along every coast. The numbering is now taken where Iris takes
+  it, and a biome the game's own list never declares answers nought, as it does under Iris.
 
-- **One download for both loaders.** The release now carries a single jar,
-  `vitrail-<version>+mc<minecraft>`, that runs on NeoForge and on Fabric alike; each loader reads
-  its own metadata out of it and ignores the rest. It is the same engine the two per-loader jars
-  carried, in one file, and the per-loader downloads stop being published. Nothing changes in
-  game, and nothing changes about what has to sit next to it: Sodium, Chloride, and on Fabric the
-  Fabric API. Upgrading means replacing: delete the old `vitrail-neoforge-*` or `vitrail-fabric-*`
-  jar when this one goes in, because the two carry the same mod and a loader that finds it twice
-  refuses to start.
+- **Distant Horizons terrain stops washing out flat under packs that read the light raw.** The far
+  terrain family was handed raw light levels scaled by sixteen; Iris hands level i as
+  (i + 0.5) / 16 and answers the fixed function light matrices with the identity, so a pack reading
+  that light through the matrix or raw gets the same number either way. BSL and Complementary
+  multiply the matrix in and were never affected. Bliss reads the pair raw, and from sky level one
+  upward its light map saturated and its far terrain went flat.
+
+- **Under Bliss, the game's sky no longer paints over the far terrain.** The engine fills the
+  game's own frame back in wherever the world's depth stands in front of what a pack claimed, and
+  the world's depth holds nothing where an LOD stands, the game never rasterising the far terrain
+  itself: those pixels read as unanswered and were covered over the colour the Distant Horizons
+  programs had just written. Only Bliss showed it, its sky pass being the one the translation
+  cannot hand a coverage mask to, every other pack's sky claiming those pixels itself. The far
+  terrain's own depth is read now.
+
+- **The line printed when the game came up on OpenGL no longer says the pack draws nothing.** The
+  passes do run on that backend, and what they draw is a picture both credible and wrong: the
+  programs are translated against Vulkan's depth and clip conventions, so a sky cut in two or a
+  misdrawn hand there is the backend and not the pack. The line owns that now, which is the point
+  of it, a report filed against the pack being the one thing it exists to prevent.
 
 ## 0.4.1-beta.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.4.1-beta.1
+mod_version=0.5.0-beta.1
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

Cuts the release: `mod_version` goes to `0.5.0-beta.1` and the `Unreleased` heading becomes that
version's, so the tag, the jar's two metadata files and the release body all name one number. The
fold is not only a rename: five changes landed since 0.4.1 with no entry at all, and they are
written in here, the debug screen lines, the biome numbering, the far terrain's light pair, the
scene seed painting over that terrain, and what the line said on an OpenGL boot.

## How it differs from the reference, and for what obstacle

It does not. No engine code is touched.

## What proves it

- `gradlew build` green locally, and the merged jar it wrote carries `0.5.0-beta.1` in both
  `neoforge.mods.toml` and `fabric.mod.json`.
- The release workflow's own extraction, run by hand over the new heading, returns the entry
  rather than the empty body it refuses on.

## What it leaves owing

Nothing. What follows is the fast-forward of `main` and the tag, neither of which is a branch.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
      The entry is what this branch is: `Unreleased` becomes `0.5.0-beta.1`.
- [x] Every place that states a fact this branch changed now states the new one. The version lives
      in `gradle.properties` alone and is interpolated into both metadata files.
