### PR TITLE
ci: refuse a counted pre-release

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -26,7 +26,9 @@ types='feat|fix|perf|refactor|docs|test|build|ci|chore'
 subject_re="^($types)(\([a-z0-9-]+\))?!?: [a-z].*[^.]$"
 # `release` is a branch prefix and not a commit type: what lands from such a branch is the version
 # bump, which is a chore. The version itself is the name, so this is the one branch carrying dots.
-branch_re="^(($types)/[a-z0-9]+(-[a-z0-9]+)*|release/[0-9]+\.[0-9]+\.[0-9]+(-[0-9a-z.]+)?)$"
+# Three numbers, then either `-alpha`, or `-beta`, or nothing: a counted pre-release is refused here
+# rather than at the tag, where the repair costs a branch already pushed under the wrong name.
+branch_re="^(($types)/[a-z0-9]+(-[a-z0-9]+)*|release/[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta))?)$"
 
 die() {
 	echo "commit-msg: $1" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,21 @@ jobs:
             exit 1
           fi
 
+          # Three numbers, then either -alpha, or -beta, or nothing, which is the shape CONTRIBUTING
+          # describes under Branches. Asked of a tag push alone: a release already out was named
+          # under whatever rule stood on its day, and this job is dispatched again on old tags to
+          # resend a corrected body, which refusing the shape would take away.
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta))?$'; then
+              echo "::error::$version is not three numbers followed by -alpha, -beta or nothing"
+              exit 1
+            fi
+          fi
+
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
           # What marks a release as a pre-release is the version itself: an identifier after a dash
-          # is what 0.1.0-alpha.1 has and what a finished version does not.
+          # is what 0.5.0-beta has and what a finished version does not.
           case "$version" in
             *-*) echo "prerelease=true" >> "$GITHUB_OUTPUT" ;;
             *) echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ carry no prefix, being the only two that are not about one thing.
     fix/hand-bob-frame
     ci/commit-and-branch-format
 
-`release/0.3.0-alpha.1` is the one shape that departs from it, and the version is the whole of the
+`release/0.5.0-beta` is the one shape that departs from it, and the version is the whole of the
 name: such a branch carries the version bump and nothing else, so there is nothing else to say
 about it.
 
@@ -123,6 +123,14 @@ and comes from the same file.
 
 A tag is pushed on `main` and on nothing else, which is what keeps the sentence above true.
 
+A version is three numbers, and after them either `-alpha`, or `-beta`, or nothing at all. Those
+three are one version reached in order: `0.5.0-alpha`, then `0.5.0-beta`, then `0.5.0`. Nothing
+follows the word, and a counter least of all, so `0.5.0-beta.1` is not a version here. What that
+costs is worth saying, because it is the whole of the rule: there is no second beta of a version.
+A beta that needs a fix is a new version and the patch number moves, `0.5.1-beta`, which is also
+what a reader of the two numbers would have assumed. The hook refuses a release branch named
+otherwise, and the release workflow refuses such a tag before it builds anything.
+
 ## Changelog
 
 `CHANGELOG.md` carries an `Unreleased` section, and a change a player would notice is written into
@@ -191,7 +199,7 @@ the one that can quietly stop being true without anything here changing.
 feat(render): read entityColor off the entity mesh overlay
 fix(pack)!: refuse a customTexture path that leaves the pack
 docs: correct five sentences against the source
-chore(release): raise the version to 0.3.0-alpha.1
+chore(release): raise the version to 0.5.0-beta
 ```
 
 A commit that changes a mechanism and the paragraph describing it is one commit under the type of
@@ -389,8 +397,8 @@ means a changelog corrected on the second attempt quietly never lands. On the Gi
 the same run replaces the asset rather than adding one, which resets what the old asset had
 counted.
 
-A version carrying an identifier after a dash, `0.2.0-rc.1` and the like, is published
-as a pre-release. One without is published as a release.
+A version carrying `-alpha` or `-beta` is published as a pre-release. One carrying neither is
+published as a release.
 
 The release body is this version's entry in `CHANGELOG.md`, and the run refuses the tag when that
 entry is missing rather than publishing an empty one. It was GitHub's own generated notes until


### PR DESCRIPTION
## What changes

Fixes the shape of a version, forward: three numbers, then either `-alpha`, or `-beta`, or
nothing, and those three are one version reached in order. Nothing follows the word, so
`0.5.0-beta.1` stops being a version here and there is no second beta of one: a beta that needs a
fix moves the patch number. `CONTRIBUTING.md` is where the rule lives, and it is asked at both
ends of the road it governs, the hook at the commit and the release job at the tag. Releases
already out are untouched and stay dispatchable.

## How it differs from the reference, and for what obstacle

It does not. Nothing here reaches the engine or a pack.

## What proves it

- `gradlew build` green locally.
- The hook run by hand over six branch names: `release/0.6.0`, `-alpha` and `-beta` accepted,
  `release/0.6.0-beta.1` and `release/0.6.0-rc.1` refused, an ordinary topic branch accepted.
- The release job's pattern run by hand over the same six versions, plus `0.6.0-BETA`, which it
  refuses.

## What it leaves owing

The two issue templates still offer `Vitrail 0.3.0-alpha.1` as the placeholder for the version a
reporter is running. That is a real past release rather than a statement of the rule, so it is left
alone here; it wants raising to whatever is current, which is its own small lot.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
      Nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. The three that
      stated the old shape are the three this branch touches, and the two examples inside
      `CONTRIBUTING.md` are raised with it.
