### PR TITLE
docs: say a version bump is a build

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -25,7 +25,8 @@ set -eu
 types='feat|fix|perf|refactor|docs|test|build|ci|chore'
 subject_re="^($types)(\([a-z0-9-]+\))?!?: [a-z].*[^.]$"
 # `release` is a branch prefix and not a commit type: what lands from such a branch is the version
-# bump, which is a chore. The version itself is the name, so this is the one branch carrying dots.
+# bump, which is a `build`, that line of gradle.properties being the build's own. The version itself
+# is the name, so this is the one branch carrying dots.
 # Three numbers, then either `-alpha`, or `-beta`, or nothing: a counted pre-release is refused here
 # rather than at the tag, where the repair costs a branch already pushed under the wrong name.
 branch_re="^(($types)/[a-z0-9]+(-[a-z0-9]+)*|release/[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta))?)$"

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Versions
       description: Vitrail and its loader, Minecraft, Sodium, Chloride, and anything else in `mods/`.
-      placeholder: Vitrail 0.3.0-alpha.1 for NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
+      placeholder: Vitrail 0.5.0-beta.1 on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/pack-report.yml
+++ b/.github/ISSUE_TEMPLATE/pack-report.yml
@@ -72,7 +72,7 @@ body:
     attributes:
       label: Versions
       description: Vitrail and its loader, Minecraft, Sodium, Chloride, and anything else in `mods/`.
-      placeholder: Vitrail 0.3.0-alpha.1 for NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
+      placeholder: Vitrail 0.5.0-beta.1 on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
     validations:
       required: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,9 +162,9 @@ two years later, in a log where `git log --oneline` is the only thing they will 
 | `refactor` | no change of behaviour at all, dead code removed included |
 | `docs` | `docs/`, the changelog, this file, javadoc on its own |
 | `test` | the out-of-game harness and the corpus it runs over |
-| `build` | Gradle, the JDK, loader versions, what the build refuses |
+| `build` | Gradle, the JDK, loader versions, what the build refuses, the version bump |
 | `ci` | `.github/workflows` |
-| `chore` | whatever none of the others is, and the version bump, which is `chore(release):` |
+| `chore` | whatever none of the others is |
 
 The scope is optional and names a tree of code: `pack`, `glsl`, `uniform`, `render`, `screen`,
 `settings`, `sodium`, `mixin`, `platform`, or `neoforge` and `fabric` for a whole module. It is left
@@ -199,7 +199,7 @@ the one that can quietly stop being true without anything here changing.
 feat(render): read entityColor off the entity mesh overlay
 fix(pack)!: refuse a customTexture path that leaves the pack
 docs: correct five sentences against the source
-chore(release): raise the version to 0.5.0-beta
+build: raise the version to 0.5.0-beta
 ```
 
 A commit that changes a mechanism and the paragraph describing it is one commit under the type of


### PR DESCRIPTION
## What changes

Two sentences that had stopped being true. The types table promised `chore(release):` for a version
bump and nothing has ever used it: the three bumps since the convention started are all `build:`,
which is also what the table's own description of `build` covers, that line being
`gradle.properties`. The document follows the practice here rather than the other way round, since
renaming three commits already in the public history buys nothing. And both issue templates offered
`Vitrail 0.3.0-alpha.1 for NeoForge` as the example version a reporter fills in, two releases back
and describing a download that has not been per loader since 0.5.0-beta.1.

## How it differs from the reference, and for what obstacle

It does not. Nothing here reaches the engine or a pack.

## What proves it

- `gradlew build` green locally.
- `git log --grep "raise the version"` over the whole history: three bumps since the convention,
  `build:` on all three, `chore(release):` on none.

## What it leaves owing

Nothing. The branch prefix `release/` is untouched, being a branch name rather than a commit type,
and the hook's comment about it now names the right type.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
      Nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. The type is stated
      in the table, in the example under it, and in the hook's comment on the `release/` prefix; all
      three move together here.
