### PR TITLE
ci: name the loaders in the store title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,12 @@ jobs:
           modrinth-id: ${{ secrets.MODRINTH_ID || vars.MODRINTH_ID }}
           modrinth-token: ${{ steps.mirror.outputs.modrinth == 'true' && secrets.MODRINTH_TOKEN || '' }}
           files: ${{ steps.jars.outputs.merged }}
-          name: ${{ steps.which.outputs.tag }}
+          # The two loaders are named in the row's own title because the file no longer names
+          # them: what ships is one merged jar, where the pair it replaced said neoforge or
+          # fabric in the file name. A store lists its files under this title and hangs its own
+          # loader tags elsewhere on the page, so the question a reader arrives with is answered
+          # in the list rather than one click further in.
+          name: ${{ steps.which.outputs.tag }} (Neo/Fabric)
           version: ${{ steps.version.outputs.version }}
           version-type: beta
           changelog-file: changelog.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -397,6 +397,15 @@ means a changelog corrected on the second attempt quietly never lands. On the Gi
 the same run replaces the asset rather than adding one, which resets what the old asset had
 counted.
 
+CurseForge holds a fresh file under review before it is public, and an app looking for updates
+does not see a file that is not approved yet. An instance reading the list inside that window
+keeps the release before this one as the newest it knows and offers it as an update, which is a
+downgrade: what it compares is which file is installed against which file is newest, and no
+version number anywhere. Nothing is wrong with the release and there is nothing to repair, the
+instance settling by itself the next time it looks. It is whoever published who meets this,
+having installed the jar minutes after the tag while everybody else arrives once the review is
+over.
+
 A version carrying `-alpha` or `-beta` is published as a pre-release. One carrying neither is
 published as a release.
 


### PR DESCRIPTION
## What changes

A release used to go out as two uploads, and each one said `neoforge` or `fabric` in its own file
name; the merged jar says neither, so a store row reads as a version and nothing else. The title
mc-publish files it under now carries `(Neo/Fabric)`, which is where a reader asks the question,
the loader tags a store hangs on the page being one click further in. The second commit writes
down what a store review does to an update check: a file is under review before it is public, an
app cannot see one it has not approved, and an instance reading the list inside that window keeps
the release before this one as the newest it knows and offers it as an update. It compares which
file is installed against which file is newest and no version number anywhere, so what it offers
is a downgrade. Whoever published is the one who meets it, having installed the jar minutes after
the tag.

## How it differs from the reference, and for what obstacle

It does not. Nothing here touches the engine.

## What proves it

- `gradlew build` green locally, which for this branch means `checkText` over the two files; no
  code changed, so the compiler had nothing to redo.
- The behaviour written down in the second commit was read off the CurseForge app's own records
  for three instances of the same version: the two that took their reading eight minutes after
  the upload cache the previous release as the newest file, and the one that read it forty
  minutes later does not.

## What it leaves owing

Nothing. No changelog entry: a store row title changes nothing a player sees in the game, and the
review window is a fact about the store rather than about this version.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
