### PR TITLE
Skip what no source of the pack names

### DIFF
--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -13,6 +13,7 @@ import dev.vitrail.pack.source.DimensionSet;
 import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
 import dev.vitrail.pack.source.IncludeExpander;
 import dev.vitrail.pack.source.ShaderPackSource;
+import dev.vitrail.pack.source.SourceMentions;
 import dev.vitrail.pack.source.ShaderProperties;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.SamplerPlan;
@@ -49,6 +50,19 @@ public final class PackProgram {
 			List.of(ProgramStage.VERTEX, ProgramStage.GEOMETRY, ProgramStage.FRAGMENT);
 
 	private static final String FINAL = "final";
+
+	/**
+	 * The names the engine has to have an answer about before its first frame, and which it
+	 * therefore reads out of the pack's text rather than out of a program that may not be read
+	 * yet. Both are things paid for every frame and useful only to a pack that reads them.
+	 * <p>
+	 * {@code watershadow} rides with {@code shadowtex1} because it is what moves the meaning of
+	 * the bare {@code shadow}: a program declaring it reads the map WITHOUT the translucents
+	 * under that name, so a pack writing it is a pack that may want the copy even though it
+	 * never spells {@code shadowtex1} ({@code SamplerPlan.withoutTranslucents}).
+	 */
+	private static final Set<String> SETTLED_EARLY =
+			Set.of("shadowtex1", "watershadow", "depthtex2");
 
 	/** The one name of the format the game's clouds are drawn under. */
 	private static final String CLOUD_PROGRAM = "gbuffers_clouds";
@@ -248,13 +262,18 @@ public final class PackProgram {
 	 *
 	 * @param place    where the entry points were read from, {@code ""} at the root
 	 * @param programs by bare name, {@code composite4}, in the order they run, the final last
+	 * @param mentions which of the few names the engine has to settle before the first frame appear
+	 *                 anywhere in this pack's text. Read here because the pack is open here and
+	 *                 every source is walked here anyway; asked because six of the seven geometry
+	 *                 families are read at the first draw of their own kind, so nothing else can
+	 *                 answer for the pack as a whole this early
 	 * @param removed  the full screen programs no pipeline can be built for, by bare name, each with
 	 *                 what did it. They are gone from {@link #programs} and the plan was rebuilt
 	 *                 without them, unless the {@code final} is one of them: nothing is then removed
 	 *                 at all and {@link ChainPlan#refusals()} refuses the whole chain
 	 */
 	public record Chain(String packName, String place, TargetPlan targets, ChainPlan chain,
-			Map<String, Loaded> programs, Map<String, Refusal> removed) {
+			Map<String, Loaded> programs, Map<String, Refusal> removed, SourceMentions mentions) {
 
 		public Chain {
 			// Kept in order rather than Map.copyOf: a reader walking this map is walking the frame,
@@ -974,6 +993,10 @@ public final class PackProgram {
 			}
 
 			PackTextures textures = textures(source, properties, options, settings);
+
+			// Inside the same opening as everything else, for the reason the other readings give: a
+			// zip closed behind us invalidates every path taken from it.
+			SourceMentions mentions = SourceMentions.of(source, SETTLED_EARLY);
 			Map<String, ProgramTranslator.TranslatedProgram> translated = new LinkedHashMap<>();
 			for (String name : targets.running()) {
 				String path = pathOf(place, name);
@@ -1021,7 +1044,8 @@ public final class PackProgram {
 						AlphaTest.OFF, textures));
 			}
 
-			return Optional.of(new Chain(source.packName(), place, targets, chain, loaded, refused));
+			return Optional.of(
+					new Chain(source.packName(), place, targets, chain, loaded, refused, mentions));
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/pack/source/SourceMentions.java
+++ b/common/src/main/java/dev/vitrail/pack/source/SourceMentions.java
@@ -1,0 +1,100 @@
+package dev.vitrail.pack.source;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Which of a handful of names appear anywhere in a pack's own text, read once when the pack is.
+ *
+ * <p><strong>This is a NECESSARY condition and never a sufficient one, and that asymmetry is the
+ * whole of why it is allowed to exist.</strong> A name no source of the pack writes cannot be
+ * declared by any program of it, whichever family that program belongs to and whenever that family
+ * happens to be read; a name that does appear may still be in a comment, behind a branch nothing
+ * takes, or in a file no program includes. So a false answer here can only ever be "the pack might
+ * read this", never "the pack does not", and a guard built on it can only ever do work that turns
+ * out to have been unnecessary.
+ *
+ * <p>That is what makes it a different thing from {@link dev.vitrail.pack.target.SamplerPlan},
+ * which answers what a LINKED program really declares and is the authority wherever the answer
+ * decides what is bound. This one answers a question the plan cannot: the plan speaks for one
+ * program, and only once that program has been read, while six of the seven geometry families are
+ * read at the first draw of their own kind. Anything the engine has to settle before the first
+ * frame, for the pack as a whole, has no other source of truth this cheap.
+ *
+ * <p><strong>Token pasting turns every answer conservative.</strong> A pack that builds a sampler
+ * name out of pieces, {@code shadowtex##N}, would never spell it here, and that is the one way this
+ * reading could say "no" about a name that is really read. Rather than trust that no pack does it,
+ * a {@code ##} anywhere in the sources makes {@link #maybe} answer yes to everything, which costs
+ * exactly what not having a guard costs. No pack of the August 2026 corpus writes one at all.
+ */
+public final class SourceMentions {
+
+	/**
+	 * The preprocessor's pasting operator. Looked for as text, since finding it at all is enough:
+	 * this is not parsing the pack, it is deciding whether parsing it as text can be trusted.
+	 */
+	private static final String PASTING = "##";
+
+	private final Set<String> found;
+
+	private final boolean pasting;
+
+	private SourceMentions(Set<String> found, boolean pasting) {
+		this.found = Set.copyOf(found);
+		this.pasting = pasting;
+	}
+
+	/**
+	 * Walks every source file of the pack once and notes which of {@code names} it writes.
+	 *
+	 * <p>Every file under the shaders root, not the ones a program includes: an include is a file of
+	 * the pack like any other, and walking the tree rather than the include graph is what makes the
+	 * answer hold for families nothing has read yet.
+	 *
+	 * @param names the names to look for, each matched as plain text anywhere in a line
+	 */
+	public static SourceMentions of(ShaderPackSource source, Set<String> names) throws IOException {
+		Set<String> found = new LinkedHashSet<>();
+		boolean pasting = false;
+
+		for (Path file : source.sourceFiles()) {
+			List<String> lines = source.readLines(file);
+			for (String line : lines) {
+				if (line.contains(PASTING)) {
+					pasting = true;
+				}
+
+				for (String name : names) {
+					if (line.contains(name)) {
+						found.add(name);
+					}
+				}
+			}
+
+			// Only once everything is known: the pasting flag makes every name answer yes, so
+			// leaving early on a full set would miss a paste in a file further down and hand back an
+			// answer narrower than the pack deserves.
+			if (found.size() == names.size() && pasting) {
+				break;
+			}
+		}
+
+		return new SourceMentions(found, pasting);
+	}
+
+	/** An empty reading, which answers yes to everything: what a pack nothing was read for gets. */
+	public static SourceMentions unread() {
+		return new SourceMentions(Set.of(), true);
+	}
+
+	/**
+	 * Whether the pack might read this name somewhere. False is a proof and true is a possibility,
+	 * for the reason the class comment gives.
+	 */
+	public boolean maybe(String name) {
+		return this.pasting || this.found.contains(name);
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1607,6 +1607,27 @@ public final class PackChain {
 	}
 
 	/**
+	 * Whether this pack may read the shadow map as it stood before the translucents, which is the
+	 * only thing the copy of it is for.
+	 * <p>
+	 * Answered off the pack's TEXT and not off a sampler plan, because the copy is taken during the
+	 * shadow stage and the programs that read it bind later in the same frame: at the moment the
+	 * decision has to be made, six of the seven geometry families may not have been read at all. A
+	 * name no source of the pack writes cannot be declared by any of them, which is the one half of
+	 * the question that can be settled that early, and it is the safe half: a pack that spells the
+	 * name anywhere keeps the copy it would have had.
+	 */
+	boolean mayReadShadowWithoutTranslucents() {
+		return this.chain.mentions().maybe("shadowtex1")
+				|| this.chain.mentions().maybe("watershadow");
+	}
+
+	/** The same question for the depth taken before the hand, which a pack reads as depthtex2. */
+	boolean mayReadPreHandDepth() {
+		return this.chain.mentions().maybe("depthtex2");
+	}
+
+	/**
 	 * Keeps the world's depth as it stands before the player's own hand is drawn, which is what the
 	 * pack reads as {@code depthtex2}. Called from the event the hand's solid half is drawn at and
 	 * one line ahead of it.
@@ -1644,7 +1665,7 @@ public final class PackChain {
 		GpuDevice device = RenderSystem.tryGetDevice();
 		Minecraft minecraft = Minecraft.getInstance();
 		if (disabled || chain == null || device == null || minecraft == null || !chainWanted
-				|| !HandDraw.draws()) {
+				|| !HandDraw.draws() || !chain.mayReadPreHandDepth()) {
 			return;
 		}
 
@@ -2379,6 +2400,21 @@ public final class PackChain {
 		if (!pastTheHand.isEmpty()) {
 			Vitrail.logger().info("{} read the depth of the world from before the hand was drawn, "
 					+ "which is an image of its own only while this engine draws the hand", pastTheHand);
+		}
+
+		// Said whichever way it went, because what is worth reading here is the work NOT done and
+		// a silence would look the same as a guard that never fired. Off the whole pack's text
+		// rather than off this chain's programs: that is the reading the two guards go by, and a
+		// line quoting a narrower one would send whoever chases a missing shadow to the wrong
+		// place.
+		if (!mayReadShadowWithoutTranslucents()) {
+			Vitrail.logger().info("No source of this pack names shadowtex1 or watershadow, so the "
+					+ "copy of the shadow map taken before its translucents is not taken at all");
+		}
+
+		if (!mayReadPreHandDepth()) {
+			Vitrail.logger().info("No source of this pack names depthtex2, so the depth of the "
+					+ "world from before the hand is neither converted nor kept");
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -435,11 +435,23 @@ public final class TerrainDraw {
 	 * Takes the copy the pack reads as {@code shadowtex1}. The caller invokes it between the opaque
 	 * halves of the shadow map and the translucent one, which is the only moment the two names mean
 	 * different things, and outside any render pass: the renderer closes its own before returning.
+	 * <p>
+	 * <strong>Skipped whole where no source of the pack names what it feeds.</strong> The copy is
+	 * the map at one resolution and four bytes a texel, taken every frame, and it answers exactly
+	 * one name: a pack that never reads it pays sixty-four mebibytes a frame at a shadow map of
+	 * 4096 for an image nothing samples. Two of the eight packs measured are that pack, Bliss
+	 * reading the bare {@code shadow} alone and Mellow only {@code shadowtex0}.
+	 * <p>
+	 * The question is asked of the pack's text rather than of a sampler plan because of WHEN it
+	 * has to be answered: here, during the shadow stage, while the programs that would read the
+	 * copy bind later in the same frame and six of the seven geometry families may not have been
+	 * read at all. What that reading can prove is only ever the absence of a name, which is the
+	 * half that makes this safe.
 	 */
 	public static void copyShadowDepth() {
 		TerrainDraw self = PackChain.terrain();
 		GpuDevice device = RenderSystem.tryGetDevice();
-		if (self != null && device != null) {
+		if (self != null && device != null && self.owner.mayReadShadowWithoutTranslucents()) {
 			self.targets.shadow().copyWithoutTranslucents(device.createCommandEncoder());
 		}
 	}


### PR DESCRIPTION
Two images this engine builds every frame are of use only to a pack that reads them, and it built them for every pack: the copy the shadow map is read from as `shadowtex1`, which at a shadow map of 4096 is sixty-four mebibytes a frame, and the depth taken before the hand, read as `depthtex2`, which is a full screen R32_FLOAT and a full screen draw on every frame the hand is drawn. Measured over the eight packs, one never names the first and five never name the second. Neither question could be put to a sampler plan, and the reason is WHEN it has to be answered rather than what it asks: the copy is taken during the shadow stage and the pre-hand depth one line before the hand's solid pass, while the programs that would read either bind later in the same frame and six of the seven geometry families may not have been read at all, being read at the first draw of their own kind. So both are asked of the pack's text, once, when the pack is read and inside the same opening of it. That reading proves an absence and never a presence, which is what makes guards out of it: a name no source writes cannot be declared by any program of any family, while a pack that spells one anywhere, in a comment or behind a branch nothing takes, keeps what it had. Token pasting turns every answer conservative for the one case text cannot see.

## Proof

`gradlew build` green. In game on Mellow, which names neither, both guards announce themselves and the log carries no compile or prepare failure; on Bliss, which spells `shadowtex1` in eight files without declaring it, neither fires, which is the conservative half working.

The image was compared at a pinned time of day and weather, four frames, same world and point. Two runs of the same jar differ as much as two runs of different jars (mean 2.96 out of 765 within the guarded pair, against 0.65 and 1.08 across the pair of jars), so the variation is run to run drift and no jar-dependent difference stands out of it. The structural half is stronger than the pixels: nothing can sample an image whose name appears nowhere in the pack, and the shadow getter falls back to the live depth whenever no copy stands.

## Not covered

Whether either guard buys a measurable frame time here. What is counted is images, bytes and draws, not milliseconds.