### PR TITLE
fix(pack): read every file before deciding a name is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Changed
+
+- **Two things taken on every frame are no longer taken for a pack that cannot read them.** The
+  copy the shadow map is read from as `shadowtex1` is sixty-four mebibytes a frame at a shadow map
+  of 4096, and the depth kept from before the hand is a full screen image and a draw on every frame
+  the hand is drawn. Each is now skipped where no file of the pack writes the name that reads it,
+  which the log says out loud when it happens. Of the eight packs tried here, one skips the shadow
+  copy and five skip the depth.
+
 ## 0.5.0-beta.1
 
 ### Added

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
@@ -1,6 +1,7 @@
 package dev.vitrail.pack.source;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetDecoder;
@@ -47,6 +48,9 @@ public final class ShaderPackSource implements AutoCloseable {
 
 	/** Fifty times the largest source file in the corpus, and a bound on a hostile archive. */
 	private static final long MAX_FILE_BYTES = 8L * 1024 * 1024;
+
+	/** How much of a file is read before it is allowed to be called binary. */
+	private static final int BINARY_PROBE = 4096;
 
 	private final String packName;
 	private final Path shadersRoot;
@@ -161,6 +165,74 @@ public final class ShaderPackSource implements AutoCloseable {
 			files.sort(Comparator.comparing(this::rel));
 
 			return List.copyOf(files);
+		}
+	}
+
+	/**
+	 * Every regular file under the shaders root that {@link #sourceFiles} leaves out, and that is
+	 * small enough to still be read, in the same fixed order.
+	 * <p>
+	 * The pair exists because the two lists answer different questions. That one is settled by
+	 * extension and has to stay that way, the lexical measurements being taken over it; but an
+	 * include is settled by the path it names, so {@code #include "common.h"} reaches a file that
+	 * list never had, and a reader that has to prove a name appears NOWHERE cannot stop at an
+	 * extension.
+	 * <p>
+	 * Past the ceiling a source is allowed is left out rather than refused here. It is the ceiling
+	 * {@link #readLines} throws on, so a file that big cannot be expanded into a program either, and
+	 * nothing can read a name out of it.
+	 */
+	public List<Path> otherFiles() throws IOException {
+		Set<Path> sources = Set.copyOf(sourceFiles());
+
+		try (Stream<Path> tree = Files.walk(this.shadersRoot)) {
+			List<Path> files = new ArrayList<>(tree.filter(Files::isRegularFile)
+					.filter(path -> !sources.contains(path))
+					.filter(this::withinCeiling)
+					.toList());
+			files.sort(Comparator.comparing(this::rel));
+
+			return List.copyOf(files);
+		}
+	}
+
+	/**
+	 * A file's bytes as text to search through, or empty for a file that is not text at all.
+	 * <p>
+	 * Not text is decided on a zero byte in the first {@value #BINARY_PROBE}, which no GLSL source
+	 * can hold and which the head of a compressed texture almost always does. <strong>The test is
+	 * made before the rest is read</strong>, and that is the point of it: the one caller has to
+	 * visit every file of the pack to prove a name appears in none of them, and inflating a few
+	 * megabytes of noise to search it for an identifier would be the whole cost of that walk.
+	 * <p>
+	 * Decoded as Latin-1 where {@link #readLines} decodes UTF-8, which is exact for this and would
+	 * be wrong there: what is searched are ASCII names, and no byte of a multi-byte UTF-8 sequence
+	 * is ever an ASCII letter, so a name is found in the same files either way.
+	 */
+	public String searchableText(Path file) throws IOException {
+		try (InputStream in = Files.newInputStream(file)) {
+			byte[] head = in.readNBytes(BINARY_PROBE);
+			for (byte b : head) {
+				if (b == 0) {
+					return "";
+				}
+			}
+
+			byte[] rest = in.readAllBytes();
+			StringBuilder text = new StringBuilder(head.length + rest.length);
+			text.append(new String(head, StandardCharsets.ISO_8859_1));
+			text.append(new String(rest, StandardCharsets.ISO_8859_1));
+
+			return text.toString();
+		}
+	}
+
+	private boolean withinCeiling(Path file) {
+		try {
+			return Files.size(file) <= MAX_FILE_BYTES;
+		} catch (IOException e) {
+			// A file whose size cannot even be read is one nothing will read either.
+			return false;
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/pack/source/SourceMentions.java
+++ b/common/src/main/java/dev/vitrail/pack/source/SourceMentions.java
@@ -3,7 +3,6 @@ package dev.vitrail.pack.source;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -29,6 +28,12 @@ import java.util.Set;
  * reading could say "no" about a name that is really read. Rather than trust that no pack does it,
  * a {@code ##} anywhere in the sources makes {@link #maybe} answer yes to everything, which costs
  * exactly what not having a guard costs. No pack of the August 2026 corpus writes one at all.
+ *
+ * <p>Reading a name proves it absent only if everything was read, so <strong>every file under the
+ * shaders root is</strong>, and not the ones an extension marks as a source: an include is settled
+ * by the path it names, so a declaration can arrive from a file that list never had. Nothing of the
+ * corpus does it today, every include of the eight packs landing on an extension the list holds; it
+ * is the claim above that has to hold for a pack nobody here has seen.
  */
 public final class SourceMentions {
 
@@ -48,21 +53,32 @@ public final class SourceMentions {
 	}
 
 	/**
-	 * Walks every source file of the pack once and notes which of {@code names} it writes.
+	 * Walks the pack's files once and notes which of {@code names} they write.
 	 *
-	 * <p>Every file under the shaders root, not the ones a program includes: an include is a file of
-	 * the pack like any other, and walking the tree rather than the include graph is what makes the
-	 * answer hold for families nothing has read yet.
+	 * <p>The tree and not the include graph: walking what a program includes would answer for the
+	 * families that have been read, and the whole point is to answer for the ones that have not.
 	 *
-	 * @param names the names to look for, each matched as plain text anywhere in a line
+	 * <p><strong>The walk is in two parts, and they are not asked the same thing.</strong> The
+	 * sources are read first, and they alone settle {@link #PASTING}: what that flag decides is
+	 * whether this pack's GLSL can be trusted to spell its own names, which is a question about
+	 * GLSL. A name, on the other hand, has to be proved absent from the pack ENTIRELY, and an
+	 * include reaches whatever path it names, so anything the source list leaves out is read too
+	 * rather than assumed empty. Reading a texture for a {@code ##} instead would turn the flag on
+	 * for almost every pack, the two bytes falling out of compressed noise on their own, and a flag
+	 * on is a guard off.
+	 *
+	 * <p>The second part is skipped whole once the sources have written every name, which is the
+	 * ordinary case and is why a pack that reads what it is asked about never opens a texture. What
+	 * is left of the cost falls on the packs a guard is about to fire for.
+	 *
+	 * @param names the names to look for, each matched as plain text anywhere in a file
 	 */
 	public static SourceMentions of(ShaderPackSource source, Set<String> names) throws IOException {
 		Set<String> found = new LinkedHashSet<>();
 		boolean pasting = false;
 
 		for (Path file : source.sourceFiles()) {
-			List<String> lines = source.readLines(file);
-			for (String line : lines) {
+			for (String line : source.readLines(file)) {
 				if (line.contains(PASTING)) {
 					pasting = true;
 				}
@@ -78,6 +94,25 @@ public final class SourceMentions {
 			// leaving early on a full set would miss a paste in a file further down and hand back an
 			// answer narrower than the pack deserves.
 			if (found.size() == names.size() && pasting) {
+				break;
+			}
+		}
+
+		if (found.size() == names.size()) {
+			return new SourceMentions(found, pasting);
+		}
+
+		for (Path file : source.otherFiles()) {
+			// Empty for anything that is not text, a pack's own textures included, and decided on
+			// the head of the file rather than on its name.
+			String text = source.searchableText(file);
+			for (String name : names) {
+				if (text.contains(name)) {
+					found.add(name);
+				}
+			}
+
+			if (found.size() == names.size()) {
 				break;
 			}
 		}

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -439,8 +439,11 @@ public final class TerrainDraw {
 	 * <strong>Skipped whole where no source of the pack names what it feeds.</strong> The copy is
 	 * the map at one resolution and four bytes a texel, taken every frame, and it answers exactly
 	 * one name: a pack that never reads it pays sixty-four mebibytes a frame at a shadow map of
-	 * 4096 for an image nothing samples. Two of the eight packs measured are that pack, Bliss
-	 * reading the bare {@code shadow} alone and Mellow only {@code shadowtex0}.
+	 * 4096 for an image nothing samples. Of the eight packs measured, Mellow is the one that gets
+	 * there, naming {@code shadowtex0} and nothing else. Bliss declares the name in no program
+	 * either, its {@code shadowtex1} sitting behind a setting it ships switched off, but it WRITES
+	 * that name in eight files and what is read here is text, so it keeps the copy: the pack turns
+	 * that setting on from its own screen, and the copy is there when it does.
 	 * <p>
 	 * The question is asked of the pack's text rather than of a sampler plan because of WHEN it
 	 * has to be answered: here, during the shadow stage, while the programs that would read the


### PR DESCRIPTION
## What changes

The two guards that landed in `c4ac3e21` decide by proving a name appears in no file of the pack.
The walk proving it stopped at the files an extension marks as a source, while an include is settled
by the path it names: a declaration reaching a program from, say, `lib/common.h` would have been
invisible, and the guard would then have skipped work something reads, which is the one direction it
must not be wrong in. The walk now covers every file under the shaders root, opening each only as
far as it takes to see it is not text. The pasting flag stays answered from the source list alone,
and that split is the point: two hash bytes fall out of compressed noise often enough that reading a
texture for them would raise the flag on nearly every pack, and a raised flag is both guards off.
The second commit corrects what the shadow guard's javadoc claimed about Bliss, and gives both
guards the changelog entry they owed.

## How it differs from the reference, and for what obstacle

It does not. Iris has no guard of this kind: it binds both names off one table every program is
built with and refills them whether anything reads them or not.

## What proves it

- `gradlew build` green in the worktree.
- Out of game, over the corpus, with the harness reading each pack five times and keeping the best:
  the answers are identical to `dev`'s, `depthtex2` for BSL, Bliss and Sildur's, `shadowtex1` for
  every pack but Mellow, `watershadow` nowhere at all. **The pasting flag is never raised**, which
  is the thing a wider walk had to be checked for and the way this change could have silently
  turned both guards off. The wider walk costs at most thirty milliseconds more on the largest pack
  of the corpus and single digits on the rest.
- Every `#include` of the eight packs lands on an extension the source list already held, so the
  hole this closes is one no pack here opens today. Bliss is the pack that proves the correction:
  it writes `shadowtex1` in eight files behind a setting it ships off.
- **Not looked at in the game.** Another session holds the instance. This changes no decision on any
  pack of the corpus, and the guards themselves were verified in the game when they landed.

## What it leaves owing

A `##` written inside an include the source list does not hold stays unseen, the flag being answered
from the sources by design. Nothing of the corpus writes one at all.
