### PR TITLE
docs: point at the Distant Horizons build that draws here

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,6 +99,18 @@ the world's, which is the arrangement packs are written against. The changelog
 says what that changes and what it does not reach, and the log names each far
 terrain pass as the pack takes it over.
 
+There is such a build, and no published one does it: the far terrain rendering
+that works here is unreleased work in that mod's own tree, and on Fabric the two
+mods together crash at startup without a fix on top of it. So one is built from
+that tree and published, for 26.2, one jar for both loaders:
+[Distant Horizons patched for Vitrail][dh-build]. **It installs by hand**, no
+launcher will pull it: drop the jar in `mods` yourself and leave no other
+Distant Horizons jar beside it. It reports itself as `3.2.1-b-dev`, the version
+string an upstream dev build carries, so bug reports made with it do not belong
+to the Distant Horizons team; its three fixes are offered to them upstream.
+
+[dh-build]: https://gitlab.com/avpbynf/distant-horizons/-/releases/vitrail-26.2-1
+
 ## Building
 
 ```

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ is earlier still. Point it at a pack and it loads it, settings and all,
 translates its programs once, and runs its frame in the order the format
 prescribes: terrain, water, shadows, sky, clouds, weather, particles, mobs,
 block entities and the held hand all go through the pack today, and so does
-the far terrain of Distant Horizons, given a build of that mod that can draw
-on this backend at all. A settings screen reads the pack's own menu layout,
-and a resource pack's normal and specular maps are served beside the blocks
-they belong to.
+the far terrain of Distant Horizons, given a build of that mod that draws on
+this backend; [Other mods](INSTALL.md#other-mods) names one. A settings
+screen reads the pack's own menu layout, and a resource pack's normal and
+specular maps are served beside the blocks they belong to.
 
 What is not through yet comes from the game instead, and that set moves from one
 release to the next, so a list here would go stale: when a place first draws,

--- a/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
@@ -90,13 +90,13 @@ public final class GeometryValues {
 	 * {@code gl_TextureMatrix[1]} on the terrain, {@code SodiumTransformer.java:32}, and on every
 	 * family the game hands over as a render type, {@code VanillaTransformer.java:164}.
 	 * <p>
-	 * <strong>One family of Iris's gets the identity there instead, and it is a divergence this table
-	 * cannot express</strong>: Distant Horizons geometry, {@code DHTerrainTransformer.java:24} and
-	 * {@code DHGenericTransformer.java:24}, both replacing {@code gl_TextureMatrix[1]} with
-	 * {@code mat4(1.0)}. A {@code dh_} program of a pack therefore reads this matrix here and an
-	 * identity under Iris. What it costs is nothing today and the reason is not this file's doing:
-	 * no Distant Horizons pass of this engine runs at all, so no {@code dh_} program is ever handed
-	 * a block. The day one runs, this table has to be asked by family and not once for all of them.
+	 * <strong>One family answers the identity there instead, and on both sides</strong>: Distant
+	 * Horizons geometry, which Iris rewrites both {@code gl_TextureMatrix[0]} and {@code [1]} to
+	 * {@code mat4(1.0)} for ({@code DHTerrainTransformer.java:23-24} and
+	 * {@code DHGenericTransformer.java:23-24}). This engine answers the identity on that family
+	 * too, and hands the light map pair already normalised; the two halves only hold together as a
+	 * pair, and {@link dev.vitrail.glsl.DistantVertex} is where that is written. So the sixteen
+	 * numbers below are what every family reads except that one.
 	 * <p>
 	 * The third axis is scaled and translated with the other two, which is Iris's matrix rather than a
 	 * reading of what a light map needs: nothing samples a third coordinate out of a two dimensional


### PR DESCRIPTION
## What changes

`README.md` and `INSTALL.md` both said the far terrain needs a build of Distant Horizons that draws
on this backend, and named none, because there was none to name. There is one now: built from that
mod's own tree, with three fixes on top, published for 26.2 as one jar for both loaders. `INSTALL`
names it under **Other mods**, says it installs by hand and that no other jar of that mod may sit
beside it, and says where its bug reports do not belong. Second commit, a stale javadoc:
`GeometryValues` parked the far terrain's light map matrix as a divergence it could not express, on
the grounds that no `dh_` program is ever handed a block. Those passes run, and both sides answer
the identity there, so the table points at `DistantVertex` instead of contradicting it.

## How it differs from the reference, and for what obstacle

It does not. The javadoc correction is a reading of Iris rather than a change here:
`DHTerrainTransformer.java:23-24` and `DHGenericTransformer.java:23-24` replace both
`gl_TextureMatrix[0]` and `[1]` with `mat4(1.0)` on that family, which is what this engine already
answers.

## What proves it

`gradlew build` green locally. The published build was run on both loaders on 19 August: Vulkan
confirmed in the log, `dh_terrain` drawn at `TERRAIN_SOLID` and `dh_water` at
`TERRAIN_TRANSLUCENT`, on Complementary Unbound with Euphoria Patches under Fabric and on Body
Camera under NeoForge. No pack setting had to be forced.

## What it leaves owing

The `0.4.0-beta.1` entry of the changelog says the version named in `INSTALL.md` does not draw;
`INSTALL` now names two, the one that dies and the one that draws. A released entry is not
rewritten here. `dh_shadow` is still not served, so the far terrain still does not enter the pack's
shadow map.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
