### PR TITLE
docs: speak as one person in the pages a reader lands on

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,7 +42,7 @@ OpenGL and the Vulkan surface fails at boot with `GLFW error 65540 ... requires
 the window to have the client API set to GLFW_NO_API`. Chloride is what makes
 that window Vulkan capable. That mechanism is NeoForge's, and whether Fabric's
 window needs the same help has not been measured: Chloride is required on both
-because it is what every session here has run with.
+because it is what every session of mine has run with.
 
 Worth knowing because the failure hides itself, and it hides itself twice over.
 Asked for Vulkan and unable to bring it up, the game falls back to OpenGL within

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -2,16 +2,16 @@
 
 ## The packs this engine is measured against
 
-These are the packs development runs against, and this table says what has actually been seen with
-each rather than what is expected of it. **A pack that is not here is not thereby unsupported**: it
-is a pack nobody here has loaded, and the format is the format. Nothing in this table is a judgement
-of the pack; every line is a note about this engine.
+These are the packs I run against, and this table says what I have actually seen with each rather
+than what is expected of it. **A pack that is not here is not thereby unsupported**: it is a pack I
+have not loaded, and the format is the format. Nothing in this table is a judgement of the pack;
+every line is a note about this engine.
 
-**A row that says nobody has looked means exactly that, and never means it works.** Rewriting this
+**A row that says I have not looked means exactly that, and never means it works.** Rewriting this
 table is one of the steps of cutting a release, which is the only thing that keeps it from going
 quietly stale.
 
-| Pack | What has been seen |
+| Pack | What I have seen |
 | --- | --- |
 | BSL v10.1.3 | Drawn whole, and the one watched most closely. Terrain, water, shadow map, sky, clouds, weather, particles, mobs and the held hand all go through it. |
 | Complementary Unbound r5.8.1 | Drawn whole, and watched as closely. Its colour targets, its deferred chain and its shadow map all come up; the log prints how many targets it allocated and at what size. Its two top profiles are the exception, and the pack announces it itself: see [the pack asks for Iris](#the-pack-asks-for-iris). |


### PR DESCRIPTION
## What changes

The head of the pack table and the Chloride paragraph in `INSTALL.md` were written in a voice
with a "here" behind it: development runs against these packs, nobody here has loaded that one,
every session here has run with Chloride. There is one person behind all three, and the store
descriptions this repository feeds say so now, so the page they link to should not read as a
group. Same sentences, first person singular, including the table's own column header.

## How it differs from the reference, and for what obstacle

It does not. No engine behaviour is touched.

## What proves it

- `gradlew build` green.

## What it leaves owing

Nothing here. The possessive "ours" that runs through `docs/`, `NOTICE` and the javadoc is left
alone on purpose: it contrasts this engine with Iris and with the game rather than claiming a
team, and the singular would make it read worse.
