### PR TITLE
feat(render): draw Distant Horizons' far terrain into the pack's shadow map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ what the next one holds.
 
 ## Unreleased
 
+### Added
+
+- **Distant Horizons' far terrain now casts into the pack's shadow map.** A pack that ships a
+  `dh_shadow` program has it drawn, from the light, over the same distant land its `dh_terrain`
+  draws for the camera, so a far hill lays a shadow on the ground instead of only shading itself
+  out of its own depth. Packs that write `dhShadow.enabled=false` are taken at their word, which is
+  most of them; the one pack tried here that ships the program keeps it behind a setting of its own
+  and it has to be switched on. What the map holds is the distant land the camera can see, which is
+  narrower than under Iris: that mod gets a second list of it, built for the light, and there is no
+  second list to be had here.
+
 ### Changed
 
 - **Two things taken on every frame are no longer taken for a pack that cannot read them.** The

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,8 +94,9 @@ the first frame. This is not something Vitrail can work around: the fix belongs
 to that mod and not to this one.
 
 Given a build of it that draws on this backend, Vitrail hands its far terrain to
-the pack's own `dh_terrain` and `dh_water` programs and serves its depth beside
-the world's, which is the arrangement packs are written against. The changelog
+the pack's own programs, `dh_terrain` and `dh_water` for the picture and
+`dh_shadow` for the shadow map, and serves its depth beside the world's, which is
+the arrangement packs are written against. The changelog
 says what that changes and what it does not reach, and the log names each far
 terrain pass as the pack takes it over.
 

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -515,9 +515,10 @@ public final class PackProgram {
 	 * {@link DistantVertex} says which of its six elements may be left off and why leaving one off is
 	 * forced rather than thrifty.
 	 * <p>
-	 * Both programs together and not one at a time, for the reason {@code loadGeometry} gives: the
-	 * plan reads thirty odd files whatever is asked of it, and the two here are one frame apart at
-	 * most, the opaque half and the one DH defers.
+	 * All of them together and not one at a time, for the reason {@code loadGeometry} gives: the
+	 * plan reads thirty odd files whatever is asked of it, and what is asked for here is drawn
+	 * inside one frame - the two halves the camera sees, the opaque one and the one DH defers, and
+	 * the same two again from the light where the caller asks for those.
 	 *
 	 * @param elements the halves to read, each carrying the name the pack is asked for and the key it
 	 *                 gets its answer back under. Every one of them has to be written against

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -363,6 +363,14 @@ public final class ShaderProperties {
 			return;
 		}
 
+		// The seventh word of that family, on the casters' rule and not the culling state's: a value
+		// this cannot read leaves the default standing, and the default is ON, so a line nothing
+		// could read has to stay visible rather than pass for a refusal that was honoured.
+		Matcher dhShadow = DH_SHADOW.matcher(line);
+		if (dhShadow.matches() && truth(dhShadow.group(1).trim()) != null) {
+			return;
+		}
+
 		// The culling state goes with separateAo below rather than with the casters above, and for
 		// that entry's reason: a word this cannot read is not stepped over, it is what puts the
 		// state back to the default, so the line is read whether the word is one of the four or not.

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -92,6 +92,13 @@ public final class ShaderProperties {
 	// the live lines for the same reason, but it is not a caster word and it is not a boolean: the
 	// value is one of four states, and ShadowCullState carries what each of the written words means.
 	private static final Pattern SHADOW_CULLING = Pattern.compile("^\\s*shadow\\.culling\\s*=\\s*(.*)$");
+	// Whether Distant Horizons' far terrain is drawn into the map. A seventh caster word by what it
+	// decides, kept out of SHADOW_CASTER because its default is the other way round: the six above
+	// are answered by a set the engine ships, and this one is on for a pack that says nothing
+	// (pipeline/IrisRenderingPipeline.java:408). Six of the eight packs of the corpus write it and
+	// five of the six write false, so a flat default would put the far terrain in five maps that
+	// asked to keep it out.
+	private static final Pattern DH_SHADOW = Pattern.compile("^\\s*dhShadow\\.enabled\\s*=\\s*(.*)$");
 	// Whether the terrain's ambient occlusion is kept out of the vertex colour. Read on the live
 	// lines like every other directive of this file, and the note on RAIN_DEPTH says why that is
 	// what the reference does too.
@@ -1125,6 +1132,36 @@ public final class ShaderProperties {
 	public boolean rainDepth(Map<String, String> defines) {
 		boolean asked = false;
 		for (Matcher line : live(RAIN_DEPTH, defines)) {
+			Boolean value = truth(line.group(1).trim());
+			if (value != null) {
+				asked = value;
+			}
+		}
+
+		return asked;
+	}
+
+	/**
+	 * Whether the pack wants Distant Horizons' far terrain drawn into its shadow map, live lines
+	 * only, ON unless it says otherwise.
+	 * <p>
+	 * <strong>The default is the opposite way round from every other word about the map, and it is
+	 * Iris's</strong> ({@code pipeline/IrisRenderingPipeline.java:408} handing
+	 * {@code isDhShadowEnabled().orElse(true)} to the object that builds the program). A pack that
+	 * ships a {@code dh_shadow} and says nothing has asked for it to be drawn; there is no second
+	 * flag it could have meant.
+	 * <p>
+	 * <strong>Live lines are the whole of it here.</strong> Bliss writes the word three times, once
+	 * true and twice false, and the true one stands alone under an {@code #ifdef} of a setting it
+	 * ships commented out ({@code shaders/lib/settings.glsl:721}). Read flat, the answer is whichever
+	 * line the file ends on, which is the {@code #else} arm of a conditional about whether Distant
+	 * Horizons is running at all.
+	 *
+	 * @param defines the pack's settings, which decide which lines of the file are alive at all
+	 */
+	public boolean dhShadow(Map<String, String> defines) {
+		boolean asked = true;
+		for (Matcher line : live(DH_SHADOW, defines)) {
 			Boolean value = truth(line.group(1).trim());
 			if (value != null) {
 				asked = value;

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -124,7 +124,7 @@ public final class DistantDraw {
 	}
 
 	/** One vec3 under std140, which is what one slot HOLDS; how far apart slots start is the
-	 * device's answer and {@link #slotBytes} alone carries it. */
+	 * device's answer and {@link Corners#slotBytes} alone carries it. */
 	private static final int BLOCK_BYTES = 16;
 
 	/** What the far terrain's own depth image holds, which is the format the game's own depth has. */
@@ -170,18 +170,7 @@ public final class DistantDraw {
 	private boolean broken;
 
 	/** The section corners of the halves recorded this frame, one aligned slot each. */
-	private MappableRingBuffer sections;
-	private int slots;
-
-	/** How many of those slots this frame has already written, which is where the next half starts. */
-	private int used;
-
-	/**
-	 * The most slots any one frame has spent, both halves together, so that a frame refused for
-	 * width is refused once: the guess below doubles the OPAQUE half, and a water half wider than
-	 * that would otherwise outgrow the buffer on every frame alike rather than only the first.
-	 */
-	private int peak;
+	private final Corners corners = new Corners("Vitrail far terrain sections");
 
 	DistantDraw(PackChain owner, Path packPath, String place, Map<String, OptionValue> chosen,
 			String profile, PackValues values, int load, ChainPlan plan, TargetPlan chainTargets,
@@ -304,7 +293,11 @@ public final class DistantDraw {
 			encoder.clearDepthTexture(this.depth, 0.0);
 		}
 
-		int base = writeSections(device, sections, minecraft);
+		// The camera is the game's own and not DH's copy of it, although DH hands one in: everything
+		// else this engine places is placed against the game's, and a far terrain placed against a
+		// second reading of the same position would stand a fraction of a block away from the near
+		// terrain it meets.
+		int base = this.corners.write(device, sections, minecraft.gameRenderer.mainCamera().position());
 		if (base < 0) {
 			return refuse(element, "sections", "the far terrain grew wider than the block holding its "
 					+ "section corners between the two halves of one frame, and the wider block cannot "
@@ -319,10 +312,8 @@ public final class DistantDraw {
 			pass.setPipeline(pipeline);
 			program.bind(pass);
 
-			GpuBuffer block = this.sections.currentBuffer();
 			for (int index = 0; index < sections.size(); index++) {
-				pass.setUniform(DistantVertex.SECTION_BLOCK,
-						block.slice((long) (base + index) * slotBytes(device), BLOCK_BYTES));
+				pass.setUniform(DistantVertex.SECTION_BLOCK, this.corners.slot(device, base + index));
 
 				for (DhLods.Piece piece : sections.get(index).pieces()) {
 					pass.setIndexBuffer(piece.indices(), IndexType.INT);
@@ -335,80 +326,6 @@ public final class DistantDraw {
 		this.drew = true;
 
 		return true;
-	}
-
-	/**
-	 * Writes every section's corner, relative to the camera, into one slot each.
-	 * <p>
-	 * <strong>Appended to what this frame has already written rather than written from the
-	 * start</strong>, and the reason is that a frame has two halves and one buffer. The pass of the
-	 * first half is RECORDED and not executed: it holds slices of this buffer, so slots the second
-	 * half wrote over would be the ones the first half draws from, and the two halves do not see the
-	 * same sections - a section carrying only water is in one list and not the other, so slot for slot
-	 * the two lists are not the same sections at all.
-	 * <p>
-	 * The camera is the game's own and not DH's copy of it, although DH hands one in: everything else
-	 * this engine places is placed against the game's, and a far terrain placed against a second
-	 * reading of the same position would stand a fraction of a block away from the near terrain it
-	 * meets.
-	 *
-	 * @return the slot this half's first section landed in, or -1 when there was no room left for it
-	 */
-	private int writeSections(GpuDevice device, List<DhLods.Section> sections, Minecraft minecraft) {
-		int stride = slotBytes(device);
-		// Room for BOTH halves and not for the one at hand, which is the whole reason the wanted count
-		// is doubled at the head of a frame: the second half of a frame cannot be given a wider buffer,
-		// the first half already holding slices of the one that stands. Sized off the half in hand
-		// alone, a frame whose two halves each carry sixty sections would fit the first and refuse the
-		// second on every frame for as long as the horizon stayed that wide. The peak covers the
-		// case the doubling cannot: a water half wider than twice the opaque one is refused once,
-		// and the frame after allocates what the refused frame really spent.
-		int wanted = Math.max(this.peak,
-				this.used == 0 ? 2 * sections.size() : this.used + sections.size());
-		if (this.sections == null || this.slots < wanted) {
-			// Not while a half of this frame is already drawn from it: closing the buffer that pass
-			// holds slices of would pull the ground out from under a recorded draw. The caller says
-			// so, and the refusal itself teaches the width: the next frame allocates what this one
-			// wanted rather than a guess that already fell short once.
-			if (this.used > 0) {
-				this.peak = Math.max(this.peak, wanted);
-				return -1;
-			}
-
-			if (this.sections != null) {
-				this.sections.close();
-			}
-
-			// In steps rather than to the exact count, so that a player walking into a wider horizon
-			// does not reallocate on every frame.
-			this.slots = Math.max(64, Mth.smallestEncompassingPowerOfTwo(wanted));
-			this.sections = new MappableRingBuffer(() -> "Vitrail far terrain sections",
-					GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, this.slots * stride);
-		}
-
-		int base = this.used;
-		Vec3 camera = minecraft.gameRenderer.mainCamera().position();
-		try (GpuBufferSlice.MappedView view = this.sections.currentBuffer().map(false, true)) {
-			ByteBuffer data = view.data();
-			for (int index = 0; index < sections.size(); index++) {
-				DhLods.Section section = sections.get(index);
-				data.position((base + index) * stride);
-				Std140Builder.intoBuffer(data).putVec3(
-						(float) (section.x() - camera.x),
-						(float) (section.y() - camera.y),
-						(float) (section.z() - camera.z));
-			}
-		}
-
-		this.used = base + sections.size();
-
-		return base;
-	}
-
-	/** How far apart two slots stand, which is the device's answer and not a number of ours. */
-	private static int slotBytes(GpuDevice device) {
-		return Mth.roundToward(BLOCK_BYTES,
-				device.getDeviceInfo().limits().minUniformOffsetAlignment());
 	}
 
 	/**
@@ -567,11 +484,7 @@ public final class DistantDraw {
 	/** Rotates the ring buffers. Called once the frame's far terrain draws have been recorded. */
 	void rotate() {
 		this.drew = false;
-		this.used = 0;
-		if (this.sections != null) {
-			this.sections.rotate();
-		}
-
+		this.corners.rotate();
 		this.programs.values().forEach(DistantProgram::rotate);
 	}
 
@@ -583,14 +496,7 @@ public final class DistantDraw {
 		this.read = false;
 		this.drew = false;
 		this.broken = false;
-		if (this.sections != null) {
-			this.sections.close();
-			this.sections = null;
-			this.slots = 0;
-			this.used = 0;
-		}
-
-		this.peak = 0;
+		this.corners.close();
 
 		releaseDepth();
 	}
@@ -604,6 +510,141 @@ public final class DistantDraw {
 		if (this.depth != null) {
 			this.depth.close();
 			this.depth = null;
+		}
+	}
+
+	/**
+	 * One ring of section corners, and the slot bookkeeping the halves that share it need.
+	 * <p>
+	 * A ring rather than one buffer, for the reason every other per frame block of this engine is
+	 * one: the backend keeps two submissions in flight, and a buffer written again while a frame
+	 * that has not finished is still reading it is the far terrain of two frames at once. It turns
+	 * where {@link DistantDraw#rotate} turns.
+	 * <p>
+	 * <strong>One ring cannot serve halves drawn on either side of that turn</strong>, which is
+	 * why there is more than one of these. The camera's two halves are recorded before the frame
+	 * closes and the light's two after it, so a single ring would have the light writing over the
+	 * very slots the camera's recorded passes hold slices of.
+	 */
+	private static final class Corners {
+
+		private final String label;
+
+		private MappableRingBuffer buffer;
+		private int slots;
+
+		/** How many slots this frame has already written, which is where the next half starts. */
+		private int used;
+
+		/**
+		 * The most slots any one frame has spent, both halves together, so that a frame refused for
+		 * width is refused once: the guess below doubles the FIRST half, and a second half wider
+		 * than that would otherwise outgrow the buffer on every frame alike rather than only the
+		 * first.
+		 */
+		private int peak;
+
+		Corners(String label) {
+			this.label = label;
+		}
+
+		/**
+		 * Writes every section's corner, relative to the camera, into one slot each.
+		 * <p>
+		 * <strong>Appended to what this frame has already written rather than written from the
+		 * start</strong>, and the reason is that a frame has two halves and one buffer. The pass of
+		 * the first half is RECORDED and not executed: it holds slices of this buffer, so slots the
+		 * second half wrote over would be the ones the first half draws from, and the two halves do
+		 * not see the same sections - a section carrying only water is in one list and not the
+		 * other, so slot for slot the two lists are not the same sections at all.
+		 *
+		 * @param camera where the pass this belongs to measures its geometry from, which is the
+		 *               game's own camera and not DH's copy of it: everything else this engine
+		 *               places is placed against the game's, and a far terrain placed against a
+		 *               second reading of the same position would stand a fraction of a block away
+		 *               from the near terrain it meets
+		 * @return the slot this half's first section landed in, or -1 when there was no room left
+		 *         for it
+		 */
+		int write(GpuDevice device, List<DhLods.Section> sections, Vec3 camera) {
+			int stride = slotBytes(device);
+			// Room for BOTH halves and not for the one at hand, which is the whole reason the wanted
+			// count is doubled at the head of a frame: the second half of a frame cannot be given a
+			// wider buffer, the first half already holding slices of the one that stands. Sized off
+			// the half in hand alone, a frame whose two halves each carry sixty sections would fit
+			// the first and refuse the second on every frame for as long as the horizon stayed that
+			// wide. The peak covers the case the doubling cannot: a second half wider than twice the
+			// first is refused once, and the frame after allocates what the refused frame really
+			// spent.
+			int wanted = Math.max(this.peak,
+					this.used == 0 ? 2 * sections.size() : this.used + sections.size());
+			if (this.buffer == null || this.slots < wanted) {
+				// Not while a half of this frame is already drawn from it: closing the buffer that
+				// pass holds slices of would pull the ground out from under a recorded draw. The
+				// caller says so, and the refusal itself teaches the width: the next frame allocates
+				// what this one wanted rather than a guess that already fell short once.
+				if (this.used > 0) {
+					this.peak = Math.max(this.peak, wanted);
+
+					return -1;
+				}
+
+				if (this.buffer != null) {
+					this.buffer.close();
+				}
+
+				// In steps rather than to the exact count, so that a player walking into a wider
+				// horizon does not reallocate on every frame.
+				this.slots = Math.max(64, Mth.smallestEncompassingPowerOfTwo(wanted));
+				this.buffer = new MappableRingBuffer(() -> this.label,
+						GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, this.slots * stride);
+			}
+
+			int base = this.used;
+			try (GpuBufferSlice.MappedView view = this.buffer.currentBuffer().map(false, true)) {
+				ByteBuffer data = view.data();
+				for (int index = 0; index < sections.size(); index++) {
+					DhLods.Section section = sections.get(index);
+					data.position((base + index) * stride);
+					Std140Builder.intoBuffer(data).putVec3(
+							(float) (section.x() - camera.x),
+							(float) (section.y() - camera.y),
+							(float) (section.z() - camera.z));
+				}
+			}
+
+			this.used = base + sections.size();
+
+			return base;
+		}
+
+		/** The slot one section was written into, as the pass binds it. */
+		GpuBufferSlice slot(GpuDevice device, int index) {
+			return this.buffer.currentBuffer().slice((long) index * slotBytes(device), BLOCK_BYTES);
+		}
+
+		/** How far apart two slots stand, which is the device's answer and not a number of ours. */
+		private static int slotBytes(GpuDevice device) {
+			return Mth.roundToward(BLOCK_BYTES,
+					device.getDeviceInfo().limits().minUniformOffsetAlignment());
+		}
+
+		void rotate() {
+			this.used = 0;
+			if (this.buffer != null) {
+				this.buffer.rotate();
+			}
+		}
+
+		void close() {
+			if (this.buffer != null) {
+				this.buffer.close();
+				this.buffer = null;
+				this.slots = 0;
+				this.used = 0;
+			}
+
+			this.peak = 0;
 		}
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -51,9 +51,17 @@ import java.util.Set;
  * engines and met at a seam no pack could close. The geometry {@code dh/DhLods} takes over is drawn
  * here instead, once per half of the frame, with {@code dh_terrain} and {@code dh_water} - the two
  * names every pack of the corpus ships, and two of the four Iris serves
- * ({@code compat/dh/DHCompatInternal.java:67-79}; its {@code dh_generic} and {@code dh_shadow},
- * built at {@code :70-72} and {@code :80-89}, are not served here yet and the backlog carries
- * both).
+ * ({@code compat/dh/DHCompatInternal.java:67-79}; the one still missing here is its
+ * {@code dh_generic}, built at {@code :70-72}, and the backlog carries it).
+ * <p>
+ * <strong>The same geometry is drawn a second time from the light, with {@code dh_shadow}</strong>,
+ * which is the third of the four. Without it a far hill shades itself out of its own depth and lays
+ * nothing on the ground in front of it, and the near world lays nothing on the far one either: the
+ * map they are both read out of simply has no LOD in it. Iris builds that program the same way it
+ * builds the other three ({@code compat/dh/DHCompatInternal.java:80-89}), and the shape of this
+ * class comes from where the light's stage stands here: at the tail of the frame, long after DH has
+ * handed its geometry over, so the sections are KEPT for it rather than asked for again. The one
+ * divergence that follows is written where it bites, on {@link #shadow}.
  * <p>
  * <strong>The depth image is this engine's own, and that is what keeps DH out of the picture
  * entirely.</strong> Nothing is drawn into DH's own colour or depth; DH's own apply pass then finds
@@ -78,20 +86,25 @@ import java.util.Set;
 public final class DistantDraw {
 
 	/**
-	 * One half of the far terrain: what the pack is asked for, and where in the frame it falls.
+	 * One draw of the far terrain: which half of DH's geometry it is, which of the two images it
+	 * lands in, and what the pack is asked for to serve it.
 	 *
-	 * @param element       one word for the log and for the shader identifier
-	 * @param program       the bare name the pack is asked for
-	 * @param afterDeferred whether this half is drawn after the deferred stage, which decides the
-	 *                      half of every target it reads and writes. DH calls its own two halves from
-	 *                      the head of the game's opaque chunk group and from the head of its
-	 *                      translucent one ({@code neoforge/mixins/client/MixinChunkSectionsToRender
-	 *                      .java:67-74}, the water half held to the second by the switch
-	 *                      {@code dh/DhLods} throws), which is where the game's own solid and
-	 *                      translucent chunk passes stand, so the two answers are the chunk passes'
-	 *                      own
+	 * @param element one word for the log and for the shader identifier
+	 * @param program the bare name the pack is asked for
+	 * @param water   whether this is the half DH keeps its transparent LODs in rather than its
+	 *                opaque ones. It is the geometry and nothing about the frame: both images take
+	 *                both halves
+	 * @param shadow  whether this draw fills the pack's shadow map rather than its picture. The two
+	 *                images take the same geometry twice, which is what Iris does without a line of
+	 *                its own about it: DH draws its LODs from the head of the game's two chunk
+	 *                groups ({@code neoforge/mixins/client/MixinChunkSectionsToRender.java:67-74}),
+	 *                and Iris's shadow stage runs those very groups a second time
+	 *                ({@code shadows/ShadowRenderer.java:505-507} and {@code :599-601}), so every
+	 *                LOD the camera pass drew is offered again from the light and bound to
+	 *                {@code dh_shadow} there ({@code compat/dh/LodRendererEvents.java:220-222} and
+	 *                {@code :332-334})
 	 */
-	public record Element(String element, String program, boolean afterDeferred) {
+	public record Element(String element, String program, boolean water, boolean shadow) {
 
 		/** What the pack has to be read for to serve this half, in terms the translation knows. */
 		private PackProgram.GeometryElement asked() {
@@ -103,24 +116,60 @@ public final class DistantDraw {
 		}
 
 		/**
+		 * Whether this draw falls after the deferred stage, which decides the half of every target it
+		 * reads and writes.
+		 * <p>
+		 * The water half of the PICTURE does and nothing else does. DH calls its own two halves from
+		 * the head of the game's opaque chunk group and from the head of its translucent one
+		 * ({@code neoforge/mixins/client/MixinChunkSectionsToRender.java:67-74}, the water half held
+		 * to the second by the switch {@code dh/DhLods} throws), which is where the game's own solid
+		 * and translucent chunk passes stand. The light's two halves are drawn in a stage that runs
+		 * once the deferreds are long over, and they take the same answer the world's own shadow
+		 * halves take, which is no: {@code pack/program/TerrainPass.afterDeferred} is true for the
+		 * translucent chunk pass alone.
+		 */
+		boolean afterDeferred() {
+			return this.water && !this.shadow;
+		}
+
+		/**
 		 * What a pack is told it is drawing. The chunk passes' own answer, which is what the geometry
 		 * is: a pack branching on {@code MC_RENDER_STAGE_TERRAIN_SOLID} in a {@code dh_terrain} is
 		 * branching on the stage it was written for.
+		 * <p>
+		 * A shadow half answers the same name as the half it shadows, which is the rule
+		 * {@code TerrainPass.stage} already follows and which is what Iris really hands over: its
+		 * shadow stage names its opaque chunk group {@code TERRAIN_SOLID} and its translucent one
+		 * {@code TERRAIN_TRANSLUCENT} ({@code shadows/ShadowRenderer.java:505-507} and
+		 * {@code :599-601}), and DH's LODs are drawn from inside those two calls.
 		 */
 		RenderStage stage() {
-			return this.afterDeferred ? RenderStage.TERRAIN_TRANSLUCENT : RenderStage.TERRAIN_SOLID;
+			return this.water ? RenderStage.TERRAIN_TRANSLUCENT : RenderStage.TERRAIN_SOLID;
+		}
+
+		/** What the log calls this draw in the middle of a sentence. */
+		String half() {
+			return (this.water ? "translucent" : "opaque") + (this.shadow ? " shadow" : "");
 		}
 	}
 
 	/**
-	 * The two halves, keyed by the word the log uses. Ordered, so that the lines the load may write
+	 * The four draws, keyed by the word the log uses. Ordered, so that the lines the load may write
 	 * about them come out in the order they are drawn.
 	 */
 	private static final Map<String, Element> ELEMENTS = new LinkedHashMap<>();
 
 	static {
-		ELEMENTS.put("distant", new Element("distant", "dh_terrain", false));
-		ELEMENTS.put("distant_water", new Element("distant_water", "dh_water", true));
+		ELEMENTS.put("distant", new Element("distant", "dh_terrain", false, false));
+		ELEMENTS.put("distant_water", new Element("distant_water", "dh_water", true, false));
+		ELEMENTS.put("distant_shadow", new Element("distant_shadow", "dh_shadow", false, true));
+		ELEMENTS.put("distant_shadow_water",
+				new Element("distant_shadow_water", "dh_shadow", true, true));
+	}
+
+	/** The key one half of DH's geometry is drawn under, in each of the two images. */
+	private static String key(boolean water, boolean shadow) {
+		return (shadow ? "distant_shadow" : "distant") + (water ? "_water" : "");
 	}
 
 	/** One vec3 under std140, which is what one slot HOLDS; how far apart slots start is the
@@ -172,6 +221,35 @@ public final class DistantDraw {
 	/** The section corners of the halves recorded this frame, one aligned slot each. */
 	private final Corners corners = new Corners("Vitrail far terrain sections");
 
+	/**
+	 * The same for the light's own two halves, which cannot share the ring above: they are recorded
+	 * once the frame has closed and the ring has turned, so they would be writing over the very
+	 * slots the camera's recorded passes hold slices of.
+	 */
+	private final Corners shadowCorners = new Corners("Vitrail far terrain shadow sections");
+
+	/** What DH has handed over on the frame being drawn, one list per half of its geometry. */
+	private List<DhLods.Section> opaqueSections = List.of();
+	private List<DhLods.Section> waterSections = List.of();
+
+	/**
+	 * The same two once the frame has closed, which is what the light draws.
+	 * <p>
+	 * Moved across by {@link #rotate} rather than read where they are written, and that is what
+	 * bounds them in time: the shadow stage stands after the close, so a frame where DH handed
+	 * nothing over leaves these empty and the light draws no far terrain rather than the last one
+	 * it saw.
+	 */
+	private List<DhLods.Section> shadowOpaque = List.of();
+	private List<DhLods.Section> shadowWater = List.of();
+
+	/**
+	 * Whether the light's own two halves have stopped for the load, which is latched apart from
+	 * {@link #broken}: a failure drawing into the map says nothing about the picture, and the map is
+	 * the half of the two that can be dropped without the far terrain changing colour.
+	 */
+	private boolean shadowBroken;
+
 	DistantDraw(PackChain owner, Path packPath, String place, Map<String, OptionValue> chosen,
 			String profile, PackValues values, int load, ChainPlan plan, TargetPlan chainTargets,
 			boolean chainRuns, ColorTargets targets) {
@@ -207,9 +285,17 @@ public final class DistantDraw {
 			return false;
 		}
 
+		// Kept before anything can refuse the draw, and kept whether or not the pack ends up drawing
+		// it: what the light wants is the geometry DH handed over, and its own stage stands at the
+		// far end of the frame from here.
+		if (opaque) {
+			draw.opaqueSections = sections;
+		} else {
+			draw.waterSections = sections;
+		}
+
 		try {
-			return draw.record(device, minecraft, ELEMENTS.get(opaque ? "distant" : "distant_water"),
-					sections);
+			return draw.record(device, minecraft, ELEMENTS.get(key(!opaque, false)), sections);
 		} catch (RuntimeException e) {
 			// Latched, like every other family the game calls back into: the alternative is one stack
 			// trace a frame for a failure that will not mend itself. What is lost by stopping is only
@@ -222,9 +308,142 @@ public final class DistantDraw {
 		}
 	}
 
+	/**
+	 * Draws one half of the far terrain into the pack's shadow map, with the pack's own
+	 * {@code dh_shadow}.
+	 * <p>
+	 * Called from the light's own stage, at the two moments the world's own chunk groups are drawn
+	 * there, because that is where Iris's are: DH hangs its LOD draws off the head of
+	 * {@code ChunkSectionsToRender.renderGroup}
+	 * ({@code neoforge/mixins/client/MixinChunkSectionsToRender.java:67-74}) and Iris's shadow stage
+	 * calls that very method for its own two groups ({@code shadows/ShadowRenderer.java:505-507} and
+	 * {@code :599-601}), so the water half lands after the copy the pack reads as
+	 * {@code shadowtex1}, exactly as the world's translucent half does.
+	 * <p>
+	 * <strong>The sections are the ones DH culled against the CAMERA, and that is a divergence with
+	 * a cost.</strong> Under Iris the shadow pass makes DH build its list a second time, against a
+	 * frustum of the light's - and against none at all unless something binds one, DH's own default
+	 * being {@code NeverCullFrustum} ({@code core/render/RenderBufferHandler.java:98-103,154-164}) -
+	 * so its map holds far terrain the camera cannot see. Here there is no second list to be had:
+	 * {@code dh/DhLods} stands in for the one interface DH hands its geometry to, and DH walks that
+	 * road once a frame, from the camera. What it costs the image is a hill behind the camera laying
+	 * no shadow on the ground in front of it.
+	 * <p>
+	 * Quiet where there is nothing to draw, which is every frame of every session without that mod,
+	 * and every pack that ships no {@code dh_shadow}.
+	 *
+	 * @param water  which half of DH's geometry this is
+	 * @param camera where the light's stage measures its geometry from, which has to be the position
+	 *               the shadow pair was built around
+	 */
+	public static void shadow(boolean water, Vec3 camera) {
+		DistantDraw draw = PackChain.distant();
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (draw == null || draw.shadowBroken || device == null) {
+			return;
+		}
+
+		try {
+			draw.recordShadow(device, ELEMENTS.get(key(water, true)),
+					water ? draw.shadowWater : draw.shadowOpaque, camera);
+		} catch (RuntimeException e) {
+			// Latched on its own, and the picture keeps going: what stops here is the far terrain's
+			// entry into the map, so the LOD is lit by what the pack computes from its own depth,
+			// which is the whole of what it had before this half existed.
+			draw.shadowBroken = true;
+			Vitrail.logger().error("Vitrail stopped drawing the far terrain into the shadow map after "
+					+ "an error, so nothing of it casts into the map for the rest of this pack", e);
+		}
+	}
+
 	/** The image the far terrain left its depth in, or null when it drew nothing this frame. */
 	GpuTextureView served() {
 		return this.drew ? this.depthView : null;
+	}
+
+	/**
+	 * Records one half of the far terrain into the map, or leaves the map as it stands.
+	 * <p>
+	 * Neither {@code beginFrame} nor the colour targets are touched, and that is not thrift: this
+	 * runs once the chain has closed the frame, so opening either would advance the value store a
+	 * second time and empty targets holding the picture the player is looking at.
+	 * {@code TerrainDraw.openShadowStage} has already made the map exist and emptied it.
+	 */
+	private void recordShadow(GpuDevice device, Element element, List<DhLods.Section> sections,
+			Vec3 camera) {
+		// Never read from here. The reading opens the pack and expands every include of it, which is
+		// not something to do inside the light's own stage; the camera's own halves read at the
+		// first frame the far terrain is drawn, and a map is only worth filling for a far terrain
+		// something is drawing.
+		DistantProgram program = this.programs.get(element.element());
+		if (program == null || sections.isEmpty()) {
+			return;
+		}
+
+		// No volume of its own: this half is drawn in the light's, which the shadow catalogue of the
+		// six fixed function names already answers, and the projection handed to a pass is the
+		// frame's camera one wherever a pack asks for it by its gbuffers name.
+		RenderPipeline pipeline = program.prepare(device, null);
+		if (pipeline == null) {
+			refuseShadow(element, "prepare", "the " + element.element() + " program could not be "
+					+ "prepared, and the line above this one says which of its own reasons it was");
+
+			return;
+		}
+
+		// The two arguments are the camera pass's and a shadow program reads neither: it names the
+		// map's own attachments and the map's own square.
+		RenderPassDescriptor descriptor = program.descriptor(null, null);
+		if (descriptor == null) {
+			refuseShadow(element, "unallocated", "the shadow map had no image yet on some frame, so "
+					+ "the pass this half wanted could not be built then. That comes and goes with "
+					+ "the frame rather than lasting");
+
+			return;
+		}
+
+		int base = this.shadowCorners.write(device, sections, camera);
+		if (base < 0) {
+			refuseShadow(element, "sections", "the far terrain grew wider than the block holding its "
+					+ "section corners between the two halves of one stage, and the wider block "
+					+ "cannot replace the one the half already recorded is drawn from. The next frame "
+					+ "has it");
+
+			return;
+		}
+
+		try (RenderPass pass = device.createCommandEncoder().createRenderPass(descriptor)) {
+			pass.setPipeline(pipeline);
+			program.bind(pass);
+
+			for (int index = 0; index < sections.size(); index++) {
+				pass.setUniform(DistantVertex.SECTION_BLOCK,
+						this.shadowCorners.slot(device, base + index));
+
+				for (DhLods.Piece piece : sections.get(index).pieces()) {
+					// Asked again here and not only where the section was taken, which is the one
+					// thing this half owes to being a frame's width away from its own capture: these
+					// are DH's buffers and DH is free to have closed one between its pass and this
+					// stage. A section short of a piece is a hole in a shadow; a draw against a
+					// closed buffer is the frame.
+					if (piece.vertices().isClosed() || piece.indices().isClosed()) {
+						continue;
+					}
+
+					pass.setIndexBuffer(piece.indices(), IndexType.INT);
+					pass.setVertexBuffer(0, piece.vertices().slice());
+					pass.drawIndexed(piece.indexCount(), 1, 0, 0, 0);
+				}
+			}
+		}
+	}
+
+	/** Says why one half of the far terrain is missing from the map, once per reason and per load. */
+	private void refuseShadow(Element element, String reason, String why) {
+		if (this.refused.add("shadow:" + reason)) {
+			Vitrail.logger().warn("The {} half of the far terrain is not drawn into the shadow map "
+					+ "because {}", element.half(), why);
+		}
 	}
 
 	private boolean record(GpuDevice device, Minecraft minecraft, Element element,
@@ -365,18 +584,20 @@ public final class DistantDraw {
 	}
 
 	/**
-	 * Reads the pack for both halves at once, at the first frame the far terrain is drawn.
+	 * Reads the pack for every half at once, at the first frame the far terrain is drawn.
 	 * <p>
-	 * Both and not the one being asked for, for the reason every other family reads all of its
-	 * pieces: the halves are one frame apart at most, and a reading is an opening and an expansion of
-	 * the whole pack.
+	 * All of them and not the one being asked for, for the reason every other family reads all of
+	 * its pieces: they are one frame apart at most, and a reading is an opening and an expansion of
+	 * the whole pack. It also settles the mesh, which is the union of what they all declare and
+	 * cannot be settled one half at a time.
 	 */
 	private void read() {
 		this.read = true;
 
 		try {
+			List<Element> asked = ELEMENTS.values().stream().filter(this::wanted).toList();
 			PackProgram.Distant distant = PackProgram.loadDistant(this.packPath, this.place,
-					ELEMENTS.values().stream().map(Element::asked).toList(), this.chosen, this.profile);
+					asked.stream().map(Element::asked).toList(), this.chosen, this.profile);
 			if (distant.programs().isEmpty()) {
 				Vitrail.logger().info("{} serves nothing in {} for the far terrain, so Distant "
 						+ "Horizons keeps drawing it with its own shader", this.packPath.getFileName(),
@@ -386,12 +607,18 @@ public final class DistantDraw {
 			}
 
 			this.carried = distant.carried();
-			for (Element element : ELEMENTS.values()) {
+			for (Element element : asked) {
 				PackProgram.Loaded one = distant.programs().get(element.element());
 				if (one == null) {
-					Vitrail.logger().info("{} serves nothing in {} for the {} half of the far terrain",
-							this.packPath.getFileName(), this.place.isEmpty() ? "its root" : this.place,
-							element.afterDeferred() ? "translucent" : "opaque");
+					// Said for the picture's halves alone. The light's two resolve one name between
+					// them, and that name has no parent in the fallback tree, so a pack without a
+					// dh_shadow is the ordinary case rather than a gap: the line further down says it
+					// once for the pair.
+					if (!element.shadow()) {
+						Vitrail.logger().info("{} serves nothing in {} for the {} half of the far "
+								+ "terrain", this.packPath.getFileName(),
+								this.place.isEmpty() ? "its root" : this.place, element.half());
+					}
 
 					continue;
 				}
@@ -404,22 +631,53 @@ public final class DistantDraw {
 				}
 			}
 
-			// The two halves together or not at all. One landscape drawn by two engines does not
-			// compose: whichever went back to DH is composited by DH's apply pass out of an image
-			// holding that half alone, with nothing left in its depth to occlude it, so far water
-			// would show through the hills in front of it. Rarely reached at all: a pack without
-			// one of the two files resolves it through its own fallback tree first.
-			if (this.programs.size() == 1) {
+			// The two halves of the PICTURE together or not at all. One landscape drawn by two
+			// engines does not compose: whichever went back to DH is composited by DH's apply pass
+			// out of an image holding that half alone, with nothing left in its depth to occlude it,
+			// so far water would show through the hills in front of it. Rarely reached at all: a
+			// pack without one of the two files resolves it through its own fallback tree first.
+			//
+			// And the light's halves go back with them, which is Iris's own shape: every road its
+			// events take is behind shouldOverride, so a far terrain handed back whole is handed back
+			// from the map as well (compat/dh/LodRendererEvents.java:216-227 and :251-259).
+			if (served(false) == 1) {
 				Vitrail.logger().info("The far terrain goes back to Distant Horizons whole: the pack "
 						+ "serves one half of it and the two only compose together");
 				this.programs.values().forEach(DistantProgram::release);
 				this.programs.clear();
+			} else if (served(true) == 0) {
+				Vitrail.logger().info("{} serves no dh_shadow in {}, so the far terrain casts nothing "
+						+ "into the pack's shadow map and what shades it is what the pack's own "
+						+ "programs work out of its depth", this.packPath.getFileName(),
+						this.place.isEmpty() ? "its root" : this.place);
 			}
 		} catch (IOException | RuntimeException e) {
 			Vitrail.logger().error("Could not prepare the far terrain programs of "
 					+ this.packPath.getFileName() + ", so Distant Horizons keeps drawing it with its "
 					+ "own shader", e);
 		}
+	}
+
+	/**
+	 * Whether this half is asked of the pack at all.
+	 * <p>
+	 * The picture's two always are. The light's two are asked for where a map is drawn this session
+	 * and the pack has not refused them, which is the pair of questions Iris asks before it builds
+	 * its own shadow program ({@code compat/dh/DHCompatInternal.java:80}, over the flag
+	 * {@code pipeline/IrisRenderingPipeline.java:408} reads out of the directive). Not asking saves
+	 * more than one program: what the mesh carries is the union of what every half declares, so a
+	 * shadow half nothing draws would still widen the vertex the camera's halves are drawn from.
+	 */
+	private boolean wanted(Element element) {
+		return !element.shadow() || (TerrainDraw.shadowsAsked() && this.values.dhShadow());
+	}
+
+	/** How many halves of one image the pack really served, which is what the load's own lines say. */
+	private long served(boolean shadow) {
+		return ELEMENTS.values().stream()
+				.filter(element -> element.shadow() == shadow)
+				.filter(element -> this.programs.containsKey(element.element()))
+				.count();
 	}
 
 	/**
@@ -431,6 +689,13 @@ public final class DistantDraw {
 	 * place whose targets are not the size of the screen, one render pass having one render area.
 	 */
 	private List<ChainPlan.Attachment> writes(Element element, PackProgram.Loaded loaded) {
+		// The light's halves write the map's own colour targets, which no chain plan carries a word
+		// about: GeometryProgram builds their attachments out of the program's own draw buffers and
+		// the map's, and reads nothing of this list.
+		if (element.shadow()) {
+			return List.of();
+		}
+
 		String servedBy = loaded.path().substring(loaded.path().lastIndexOf('/') + 1);
 		Optional<ChainPlan.Pass> geometry = this.plan.geometryOf(servedBy, element.afterDeferred());
 		if (geometry.isEmpty()) {
@@ -441,8 +706,7 @@ public final class DistantDraw {
 		if (!pass.size().equals(TargetSize.ofScreen())) {
 			Vitrail.logger().warn("{} writes targets the pack asked to be scaled, so they cannot share "
 					+ "a pass with the game's own target and Distant Horizons keeps drawing the {} half "
-					+ "of the far terrain", servedBy,
-					element.afterDeferred() ? "translucent" : "opaque");
+					+ "of the far terrain", servedBy, element.half());
 
 			return null;
 		}
@@ -466,8 +730,7 @@ public final class DistantDraw {
 	private boolean refuse(Element element, String reason, String why) {
 		boolean drop = element.afterDeferred() && this.drew;
 		if (this.refused.add((drop ? "dropped:" : "") + reason)) {
-			Vitrail.logger().warn("The {} half of the far terrain {} because {}",
-					element.afterDeferred() ? "water" : "opaque",
+			Vitrail.logger().warn("The {} half of the far terrain {} because {}", element.half(),
 					drop ? "is dropped on such frames, the opaque half being this engine's already"
 							: "went back to Distant Horizons' own shader",
 					why);
@@ -481,10 +744,23 @@ public final class DistantDraw {
 		return this.programs.values();
 	}
 
-	/** Rotates the ring buffers. Called once the frame's far terrain draws have been recorded. */
+	/**
+	 * Rotates the ring buffers. Called once the frame's far terrain draws have been recorded.
+	 * <p>
+	 * <strong>And hands what DH gave this frame to the light</strong>, which is the one thing here
+	 * that is not a turn of a buffer. The light's stage runs after this call, so what it draws is
+	 * what the frame now closing captured; a frame where DH handed nothing over leaves the light
+	 * with nothing rather than with the last far terrain it saw, which is what the two empty lists
+	 * below buy.
+	 */
 	void rotate() {
 		this.drew = false;
+		this.shadowOpaque = this.opaqueSections;
+		this.shadowWater = this.waterSections;
+		this.opaqueSections = List.of();
+		this.waterSections = List.of();
 		this.corners.rotate();
+		this.shadowCorners.rotate();
 		this.programs.values().forEach(DistantProgram::rotate);
 	}
 
@@ -496,7 +772,13 @@ public final class DistantDraw {
 		this.read = false;
 		this.drew = false;
 		this.broken = false;
+		this.shadowBroken = false;
+		this.opaqueSections = List.of();
+		this.waterSections = List.of();
+		this.shadowOpaque = List.of();
+		this.shadowWater = List.of();
 		this.corners.close();
+		this.shadowCorners.close();
 
 		releaseDepth();
 	}

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -99,10 +99,12 @@ public final class DistantDraw {
 	 *                its own about it: DH draws its LODs from the head of the game's two chunk
 	 *                groups ({@code neoforge/mixins/client/MixinChunkSectionsToRender.java:67-74}),
 	 *                and Iris's shadow stage runs those very groups a second time
-	 *                ({@code shadows/ShadowRenderer.java:505-507} and {@code :599-601}), so every
+	 *                ({@code shadows/ShadowRenderer.java:508-511} and {@code :598-601}), so every
 	 *                LOD the camera pass drew is offered again from the light and bound to
 	 *                {@code dh_shadow} there ({@code compat/dh/LodRendererEvents.java:220-222} and
-	 *                {@code :332-334})
+	 *                {@code :332-334}). Each of those two calls sits inside the caster word that
+	 *                governs its own chunk group, and this family is drawn inside them for that
+	 *                reason
 	 */
 	public record Element(String element, String program, boolean water, boolean shadow) {
 
@@ -140,8 +142,8 @@ public final class DistantDraw {
 		 * A shadow half answers the same name as the half it shadows, which is the rule
 		 * {@code TerrainPass.stage} already follows and which is what Iris really hands over: its
 		 * shadow stage names its opaque chunk group {@code TERRAIN_SOLID} and its translucent one
-		 * {@code TERRAIN_TRANSLUCENT} ({@code shadows/ShadowRenderer.java:505-507} and
-		 * {@code :599-601}), and DH's LODs are drawn from inside those two calls.
+		 * {@code TERRAIN_TRANSLUCENT} ({@code shadows/ShadowRenderer.java:508-511} and
+		 * {@code :598-601}), and DH's LODs are drawn from inside those two calls.
 		 */
 		RenderStage stage() {
 			return this.water ? RenderStage.TERRAIN_TRANSLUCENT : RenderStage.TERRAIN_SOLID;
@@ -222,9 +224,14 @@ public final class DistantDraw {
 	private final Corners corners = new Corners("Vitrail far terrain sections");
 
 	/**
-	 * The same for the light's own two halves, which cannot share the ring above: they are recorded
-	 * once the frame has closed and the ring has turned, so they would be writing over the very
-	 * slots the camera's recorded passes hold slices of.
+	 * The same for the light's own two halves, which cannot share the ring above.
+	 * <p>
+	 * <strong>The turn is what forbids it, and not the frame boundary on its own.</strong> The ring
+	 * moves on in {@link #rotate}, which runs before the light's stage, so the light writes a
+	 * different buffer from the one the camera's recorded passes hold slices of - and that is
+	 * exactly the trouble: the ring would then be one turn ahead of itself, and the NEXT frame's
+	 * camera halves would map the buffer the light's own submission is still reading. A ring fences
+	 * a buffer where it turns, and one shared ring would be asked to turn twice a frame.
 	 */
 	private final Corners shadowCorners = new Corners("Vitrail far terrain shadow sections");
 
@@ -316,9 +323,11 @@ public final class DistantDraw {
 	 * there, because that is where Iris's are: DH hangs its LOD draws off the head of
 	 * {@code ChunkSectionsToRender.renderGroup}
 	 * ({@code neoforge/mixins/client/MixinChunkSectionsToRender.java:67-74}) and Iris's shadow stage
-	 * calls that very method for its own two groups ({@code shadows/ShadowRenderer.java:505-507} and
-	 * {@code :599-601}), so the water half lands after the copy the pack reads as
-	 * {@code shadowtex1}, exactly as the world's translucent half does.
+	 * calls that very method for its own two groups ({@code shadows/ShadowRenderer.java:508-511} and
+	 * {@code :598-601}), so the water half lands after the copy the pack reads as
+	 * {@code shadowtex1}, exactly as the world's translucent half does. Both of Iris's calls stand
+	 * inside the caster word that governs their own chunk group, and the caller draws this family
+	 * inside the same two words for that reason.
 	 * <p>
 	 * <strong>The sections are the ones DH culled against the CAMERA, and that is a divergence with
 	 * a cost.</strong> Under Iris the shadow pass makes DH build its list a second time, against a
@@ -385,8 +394,10 @@ public final class DistantDraw {
 		// frame's camera one wherever a pack asks for it by its gbuffers name.
 		RenderPipeline pipeline = program.prepare(device, null);
 		if (pipeline == null) {
-			refuseShadow(element, "prepare", "the " + element.element() + " program could not be "
-					+ "prepared, and the line above this one says which of its own reasons it was");
+			refuseShadow(element, "prepare", "its program could not be prepared. There are two "
+					+ "reasons for that and one of them says so on a line of its own above, the "
+					+ "program refusing to compile; the other is a map that is not allocated yet, "
+					+ "which passes on its own");
 
 			return;
 		}
@@ -438,9 +449,15 @@ public final class DistantDraw {
 		}
 	}
 
-	/** Says why one half of the far terrain is missing from the map, once per reason and per load. */
+	/**
+	 * Says why one half of the far terrain is missing from the map, once per reason and per load.
+	 * <p>
+	 * The half is part of the key and not only of the sentence: the two are refused independently,
+	 * and one line naming the opaque half would otherwise stand for a water half nobody was told
+	 * about.
+	 */
 	private void refuseShadow(Element element, String reason, String why) {
-		if (this.refused.add("shadow:" + reason)) {
+		if (this.refused.add("shadow:" + reason + ":" + element.element())) {
 			Vitrail.logger().warn("The {} half of the far terrain is not drawn into the shadow map "
 					+ "because {}", element.half(), why);
 		}
@@ -646,16 +663,42 @@ public final class DistantDraw {
 				this.programs.values().forEach(DistantProgram::release);
 				this.programs.clear();
 			} else if (served(true) == 0) {
-				Vitrail.logger().info("{} serves no dh_shadow in {}, so the far terrain casts nothing "
-						+ "into the pack's shadow map and what shades it is what the pack's own "
-						+ "programs work out of its depth", this.packPath.getFileName(),
-						this.place.isEmpty() ? "its root" : this.place);
+				sayNothingCastsIntoTheMap();
 			}
 		} catch (IOException | RuntimeException e) {
 			Vitrail.logger().error("Could not prepare the far terrain programs of "
 					+ this.packPath.getFileName() + ", so Distant Horizons keeps drawing it with its "
 					+ "own shader", e);
 		}
+	}
+
+	/**
+	 * Says why the far terrain casts nothing into the map, in the words of the reason it really is.
+	 * <p>
+	 * Three roads reach here and they are not the same fact. A session that draws no map at all is
+	 * SILENT: {@link #wanted} kept the light's halves out before the pack was ever read, and a line
+	 * about a program would send whoever reads it looking through a pack for something no map could
+	 * have used. A pack that ships a {@code dh_shadow} and asks for it not to be drawn is quoted on
+	 * its own directive rather than reported as shipping nothing, which is what this said before it
+	 * was split and which was false of the one pack of the corpus that ships one.
+	 */
+	private void sayNothingCastsIntoTheMap() {
+		if (!TerrainDraw.shadowsAsked()) {
+			return;
+		}
+
+		if (!this.values.dhShadow()) {
+			Vitrail.logger().info("{} asks with dhShadow.enabled that its far terrain stay out of "
+					+ "its shadow map, so nothing of it is drawn there and what shades it is what "
+					+ "the pack's own programs work out of its depth", this.packPath.getFileName());
+
+			return;
+		}
+
+		Vitrail.logger().info("{} serves no dh_shadow in {}, so the far terrain casts nothing into "
+				+ "the pack's shadow map and what shades it is what the pack's own programs work "
+				+ "out of its depth", this.packPath.getFileName(),
+				this.place.isEmpty() ? "its root" : this.place);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/DistantProgram.java
+++ b/common/src/main/java/dev/vitrail/render/DistantProgram.java
@@ -88,6 +88,17 @@ final class DistantProgram implements DumpedProgram {
 	private static final DepthStencilState DEPTH =
 			new DepthStencilState(CompareOp.GREATER_THAN, true);
 
+	/**
+	 * And the window the same geometry is drawn under from the light, which is the other way round.
+	 * <p>
+	 * The map stores the forward window, cleared to one, so its test runs the other way from the
+	 * scene's. It is {@code TerrainProgram.depthState}'s rule word for word, and getting the pair out
+	 * of step does not fail: it fills the map with the geometry FURTHEST from the light, which is a
+	 * shadow map of the far side of the world and reads as shadows in all the wrong places.
+	 */
+	private static final DepthStencilState SHADOW_DEPTH =
+			new DepthStencilState(CompareOp.LESS_THAN_OR_EQUAL, true);
+
 	private final GeometryProgram body;
 
 	private DistantProgram(GeometryProgram body) {
@@ -116,15 +127,19 @@ final class DistantProgram implements DumpedProgram {
 		VertexFormat format = DistantMesh.format(carried);
 
 		return new DistantProgram(new GeometryProgram(new GeometryProgram.Pass(FAMILY,
-				element.element(), NAMESPACE, DistantVertex.ANSWERED, false,
+				element.element(), NAMESPACE, DistantVertex.ANSWERED, element.shadow(),
 				// The half DH defers blends over what stands behind it, exactly as the world's own
 				// water does; the opaque half writes outright. DH's own two pipelines are built the
 				// same way, one withoutBlend and one with TRANSLUCENT
-				// (common/render/blaze/BlazeDhTerrainRenderer.java:140 and :148).
+				// (common/render/blaze/BlazeDhTerrainRenderer.java:140 and :148). Neither of the
+				// light's halves blends: what a map wants from a surface is the depth it stands at
+				// and the colour it tints the light with, both written outright, and Iris declares
+				// every shadow program of its own with BlendModeOverride.OFF.
 				element.afterDeferred() ? Optional.of(BlendFunction.TRANSLUCENT)
 						: Optional.<BlendFunction>empty(),
 				// No coverage mask, and the class comment says what writes those pixels instead.
-				// claimed: nothing of this family marks them either, for the same reason.
+				// claimed: nothing of this family marks them either, for the same reason. The mask
+				// is about the scene seed, which the light's halves are no part of at all.
 				false, false, element.afterDeferred(), PrimitiveTopology.TRIANGLES,
 				// The opaque half is culled, which is DH's own answer, one withFaceCulling(true) on
 				// the shared builder (common/render/blaze/BlazeDhTerrainRenderer.java:101); the
@@ -133,12 +148,24 @@ final class DistantProgram implements DumpedProgram {
 				// (compat/dh/LodRendererEvents.java:346), never re-enabled by Iris itself and put
 				// back by the next state that asks for it. So far water keeps a surface when seen
 				// from underneath or from inside it.
-				!element.afterDeferred(), DEPTH, element.stage(), null,
+				//
+				// Nothing at all is culled in the map, which is the world's own answer there and
+				// Iris's, one _disableCull for the whole of its shadow stage
+				// (shadows/ShadowRenderer.java:500): what matters is which surface is nearest the
+				// light and not which way it faces, and a hill drawn on one side only leaks light
+				// through its back.
+				!element.afterDeferred() && !element.shadow(),
+				element.shadow() ? SHADOW_DEPTH : DEPTH, element.stage(), null,
 				// The one family with a value that belongs to the section rather than to the pass.
 				DistantVertex.SECTION_BLOCK,
-				// And the one family drawn in DH's own volume, so the three dh matrices answer that
-				// volume here and the game's everywhere else.
-				true),
+				// And the one family drawn in DH's own volume - the camera's halves are, and the
+				// light's are not. A dh_shadow writes gl_ProjectionMatrix * gl_ModelViewMatrix like
+				// every other shadow program, and those two answer the shadow pair here because the
+				// pass is a shadow pass; Iris fills the same two names of its own DH shadow program
+				// with ShadowRenderer.PROJECTION and MODELVIEW and not with DH's volume
+				// (compat/dh/LodRendererEvents.java:304-307). The three dhProjection names answer
+				// DH's volume for every pass alike, as Iris serves them.
+				!element.shadow()),
 				bound, values, load, format, writes, targets, chainRuns));
 	}
 
@@ -146,7 +173,10 @@ final class DistantProgram implements DumpedProgram {
 	 * The pipeline the far terrain is drawn with, compiled before the pass is opened.
 	 *
 	 * @param projection the volume DH rasterises in, which both spellings of the projection a
-	 *                   {@code dh_} program may read have to answer
+	 *                   {@code dh_} program may read have to answer, or null for the frame's own.
+	 *                   Null is what the light's halves hand in: they are not drawn in DH's volume,
+	 *                   and what places them is the shadow pair the six fixed function names answer
+	 *                   with
 	 * @see GeometryProgram#prepare
 	 */
 	RenderPipeline prepare(GpuDevice device, Matrix4fc projection) {

--- a/common/src/main/java/dev/vitrail/render/DistantProgram.java
+++ b/common/src/main/java/dev/vitrail/render/DistantProgram.java
@@ -132,9 +132,17 @@ final class DistantProgram implements DumpedProgram {
 				// water does; the opaque half writes outright. DH's own two pipelines are built the
 				// same way, one withoutBlend and one with TRANSLUCENT
 				// (common/render/blaze/BlazeDhTerrainRenderer.java:140 and :148). Neither of the
-				// light's halves blends: what a map wants from a surface is the depth it stands at
-				// and the colour it tints the light with, both written outright, and Iris declares
-				// every shadow program of its own with BlendModeOverride.OFF.
+				// light's halves blends unless the pack says so: what a map wants from a surface is
+				// the depth it stands at and the colour it tints the light with, both written
+				// outright, and that is what the world's own shadow halves do here.
+				//
+				// It is the DEFAULT and not a rule, which is the whole of what this argument is:
+				// a blend directive the pack wrote for this program still wins, GeometryProgram
+				// asking the pack first. Iris has no default of its own to copy here - its
+				// dh_shadow key carries no blend override, alone among the shadow keys, which all
+				// carry BlendModeOverride.OFF (shaderpack/loading/ProgramId.java:13-19 against
+				// :57), so what its DH shadow program blends with is the pack's own directive or
+				// whatever state stands.
 				element.afterDeferred() ? Optional.of(BlendFunction.TRANSLUCENT)
 						: Optional.<BlendFunction>empty(),
 				// No coverage mask, and the class comment says what writes those pixels instead.
@@ -151,7 +159,7 @@ final class DistantProgram implements DumpedProgram {
 				//
 				// Nothing at all is culled in the map, which is the world's own answer there and
 				// Iris's, one _disableCull for the whole of its shadow stage
-				// (shadows/ShadowRenderer.java:500): what matters is which surface is nearest the
+				// (shadows/ShadowRenderer.java:501): what matters is which surface is nearest the
 				// light and not which way it faces, and a hill drawn on one side only leaks light
 				// through its back.
 				!element.afterDeferred() && !element.shadow(),

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -79,6 +79,13 @@ public final class PackValues {
 	 */
 	private ShadowCasters shadowCasters = ShadowCasters.DEFAULT;
 
+	/**
+	 * Whether this pack wants Distant Horizons' far terrain drawn into its shadow map, on until it
+	 * says otherwise. The default is Iris's and is the opposite way round from the six words above,
+	 * which {@code ShaderProperties.dhShadow} says in full.
+	 */
+	private boolean dhShadow = true;
+
 	/** Which shape this pack asked the light to measure a section against. */
 	private ShadowCullState shadowCull = ShadowCullState.DEFAULT;
 
@@ -125,6 +132,7 @@ public final class PackValues {
 			values.weather = properties.weather(settings.globalDefines(options));
 			values.rainDepth = properties.rainDepth(settings.globalDefines(options));
 			values.shadowCasters = properties.shadowCasters(settings.globalDefines(options));
+			values.dhShadow = properties.dhShadow(settings.globalDefines(options));
 			values.shadowCull = properties.shadowCull(settings.globalDefines(options));
 			values.separateAo = properties.separateAo(settings.globalDefines(options));
 			values.particleOrdering = properties.particleOrdering(settings.globalDefines(options));
@@ -527,6 +535,19 @@ public final class PackValues {
 	 */
 	public ShadowCasters shadowCasters() {
 		return this.shadowCasters;
+	}
+
+	/**
+	 * Whether this pack wants the far terrain drawn into its shadow map, read on the same walk and
+	 * with the same settings as the six words above.
+	 * <p>
+	 * It is not one of them and it is not read as one: a pack that ships no {@code dh_shadow} at all
+	 * is answered by the fallback tree rather than by this, {@code dh_shadow} having no parent to
+	 * reach, so what this decides is the one case where a pack ships the program and asks for it not
+	 * to be drawn.
+	 */
+	public boolean dhShadow() {
+		return this.dhShadow;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -376,8 +376,24 @@ public final class ViewMatrices implements ViewSource {
 		snapToGrid(this.shadowModelView, intervalSize, camera);
 		this.shadowModelView.invert(this.shadowModelViewInverse);
 
-		float near = plane(nearPlane, -this.renderDistanceChunks * 16.0F);
-		float far = plane(farPlane, this.renderDistanceChunks * 16.0F);
+		// Both planes off the same reach, and the reach is the one Iris resolves a -1 with:
+		// ShadowMatrices.createOrthoMatrix is handed -DHCompat.getRenderDistance() * 16 and
+		// +the same (shadows/ShadowRenderer.java:429), and that call answers the game's render
+		// distance in CHUNKS while Distant Horizons is not drawing and that mod's own in BLOCKS
+		// while it is (compat/dh/DHCompatInternal.java:100-107). The sixteen therefore multiplies
+		// two different units, which is exactly what dhRenderDistance already carries for the
+		// uniform of the same name, so the two cannot part company here.
+		//
+		// It is not a rounding: without the mod this is the render distance in blocks, as it has
+		// always been, and with it the box along the light grows by that mod's own reach times
+		// sixteen. AND THE PACKS ASK FOR IT. A shadow plane of -1 is what a pack writes to hand the
+		// choice back, and Bliss writes both of them as -1 in the one branch its Distant Horizons
+		// shadow map setting opens: at the game's own render distance the box would be a hundred and
+		// twenty eight blocks deep, and every LOD of a far terrain that begins where the game's
+		// chunks end would be clipped out of the map the pack just asked to have it in.
+		float reach = dhRenderDistance() * 16.0F;
+		float near = plane(nearPlane, -reach);
+		float far = plane(farPlane, reach);
 		// False, and deliberately so. Iris asks the device whether it wants 0..1 here, which is
 		// right for the matrix it draws the shadow map with and wrong for the one it publishes.
 		// We only publish, so this one is always the legacy volume.

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -380,7 +380,8 @@ public final class ViewMatrices implements ViewSource {
 		// ShadowMatrices.createOrthoMatrix is handed -DHCompat.getRenderDistance() * 16 and
 		// +the same (shadows/ShadowRenderer.java:429), and that call answers the game's render
 		// distance in CHUNKS while Distant Horizons is not drawing and that mod's own in BLOCKS
-		// while it is (compat/dh/DHCompatInternal.java:100-107). The sixteen therefore multiplies
+		// while it is (compat/dh/DHCompatInternal.java:102-109, reached through :111-113). The
+		// sixteen therefore multiplies
 		// two different units, which is exactly what dhRenderDistance already carries for the
 		// uniform of the same name, so the two cannot part company here.
 		//
@@ -388,9 +389,9 @@ public final class ViewMatrices implements ViewSource {
 		// always been, and with it the box along the light grows by that mod's own reach times
 		// sixteen. AND THE PACKS ASK FOR IT. A shadow plane of -1 is what a pack writes to hand the
 		// choice back, and Bliss writes both of them as -1 in the one branch its Distant Horizons
-		// shadow map setting opens: at the game's own render distance the box would be a hundred and
-		// twenty eight blocks deep, and every LOD of a far terrain that begins where the game's
-		// chunks end would be clipped out of the map the pack just asked to have it in.
+		// shadow map setting opens: at the game's own render distance the box would reach a hundred
+		// and twenty eight blocks either side of the camera, and a far terrain that BEGINS where the
+		// game's chunks end would be clipped out of the map the pack just asked to have it in.
 		float reach = dhRenderDistance() * 16.0F;
 		float near = plane(nearPlane, -reach);
 		float far = plane(farPlane, reach);

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -4,6 +4,7 @@ import dev.vitrail.mixin.MixinSodiumWorldRenderer;
 import dev.vitrail.mixin.RenderSectionManagerAccessor;
 import dev.vitrail.pack.source.ShadowCasters;
 import dev.vitrail.render.BlockStateIds;
+import dev.vitrail.render.DistantDraw;
 import dev.vitrail.render.ShadowCullPlan;
 import dev.vitrail.render.ShadowGeometry;
 import dev.vitrail.render.TerrainDraw;
@@ -231,6 +232,12 @@ public final class ShadowTerrain {
 
 		ShadowCasters casters = TerrainDraw.shadowCasters();
 
+		// Distant Horizons' far terrain, ahead of the world's own opaque group and outside the word
+		// that governs it. Both halves of that are Iris's: DH hangs its LOD draws off the HEAD of
+		// ChunkSectionsToRender.renderGroup, which is the very call the two lines below make, and
+		// nothing on that road consults shadowTerrain.
+		DistantDraw.shadow(false, camera);
+
 		// Refused by the pack rather than skipped for cheapness.
 		if (casters.terrain()) {
 			TerrainDraw.shadowPass(() -> renderer.drawChunkLayer(ChunkSectionLayerGroup.OPAQUE,
@@ -249,6 +256,11 @@ public final class ShadowTerrain {
 		// draw that comes next. The renderer closes its own render pass before returning, and the
 		// walk above closes its last one, so a copy here is outside one.
 		TerrainDraw.copyShadowDepth();
+
+		// And its water half after that copy, where the world's own translucent group stands, which
+		// is again where DH's own hook puts it: shadowtex1 is the map WITHOUT the translucents, and
+		// far water belongs on the same side of it as near water.
+		DistantDraw.shadow(true, camera);
 
 		if (casters.translucent()) {
 			TerrainDraw.shadowPass(() -> renderer.drawChunkLayer(ChunkSectionLayerGroup.TRANSLUCENT,

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -232,14 +232,16 @@ public final class ShadowTerrain {
 
 		ShadowCasters casters = TerrainDraw.shadowCasters();
 
-		// Distant Horizons' far terrain, ahead of the world's own opaque group and outside the word
-		// that governs it. Both halves of that are Iris's: DH hangs its LOD draws off the HEAD of
-		// ChunkSectionsToRender.renderGroup, which is the very call the two lines below make, and
-		// nothing on that road consults shadowTerrain.
-		DistantDraw.shadow(false, camera);
-
 		// Refused by the pack rather than skipped for cheapness.
 		if (casters.terrain()) {
+			// Distant Horizons' far terrain goes first and INSIDE this word, both of which are
+			// Iris's. DH hangs its LOD draws off the HEAD of ChunkSectionsToRender.renderGroup
+			// (neoforge/mixins/client/MixinChunkSectionsToRender.java:67-74), and the only call to
+			// that method in Iris's shadow stage is the one inside its own shadowTerrain test
+			// (shadows/ShadowRenderer.java:508-511). So a pack that keeps the opaque world out of
+			// its map keeps the far terrain out with it, and getting this wrong is not a nuance: a
+			// pack that asked for neither would see LODs in its map here and none under Iris.
+			DistantDraw.shadow(false, camera);
 			TerrainDraw.shadowPass(() -> renderer.drawChunkLayer(ChunkSectionLayerGroup.OPAQUE,
 					matrices, camera.x, camera.y, camera.z, sampler));
 		}
@@ -257,12 +259,13 @@ public final class ShadowTerrain {
 		// walk above closes its last one, so a copy here is outside one.
 		TerrainDraw.copyShadowDepth();
 
-		// And its water half after that copy, where the world's own translucent group stands, which
-		// is again where DH's own hook puts it: shadowtex1 is the map WITHOUT the translucents, and
-		// far water belongs on the same side of it as near water.
-		DistantDraw.shadow(true, camera);
-
 		if (casters.translucent()) {
+			// And its water half here, after the copy and inside the word that governs the world's
+			// own translucent group, for the two reasons the opaque half is where it is: DH's hook
+			// is the head of this very call, and Iris makes it inside its own shadowTranslucent test
+			// (shadows/ShadowRenderer.java:598-601). shadowtex1 is the map WITHOUT the translucents,
+			// and far water belongs on the same side of it as near water.
+			DistantDraw.shadow(true, camera);
 			TerrainDraw.shadowPass(() -> renderer.drawChunkLayer(ChunkSectionLayerGroup.TRANSLUCENT,
 					matrices, camera.x, camera.y, camera.z, sampler));
 		}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -340,10 +340,21 @@ When the far terrain goes back to that mod instead, the engine says so and names
 same line: a pack serving nothing for it is the common one, and every other refusal has a line of
 its own shape.
 
-Two limits stay whatever the log says. Past Distant Horizons' own far plane there is nothing
-drawn, and the picture there is the pack's sky, exactly as without the mod. And the far terrain
-does not enter the pack's shadow map yet, a pack's `dh_shadow` not being served, so what shades it
-is what its programs compute from the depth rather than a shadow the map carries.
+**The far terrain also enters the pack's shadow map**, where the pack ships a `dh_shadow` program
+and has not turned it off. Two things follow from a pack shipping one, and they are not the same
+thing: a far hill lays a shadow on the ground in front of it, and the far terrain is shaded by the
+map like everything else instead of only by what the pack computes from its own depth. Most packs
+ship none and write `dhShadow.enabled=false`, and the engine says so on its own line at load; one
+of them ships the program behind a setting it leaves switched off, so the setting has to be turned
+on before there is anything to see.
+
+What lands in the map is the distant land the CAMERA can see. Under Iris the mod builds a second
+list of its far terrain for the light, so a hill behind the camera lays a shadow on the ground in
+front of it there and does not here: the mod hands its geometry over once a frame, on its own pass,
+and there is no second list to ask for.
+
+One limit stays whatever the log says: past Distant Horizons' own far plane there is nothing drawn,
+and the picture there is the pack's sky, exactly as without the mod.
 
 ## What packs ask for that is unusual
 

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -152,6 +152,14 @@ two arms of one conditional, and some write a word whose value the pack's own se
 contradicts. Read flat, the answer is whichever line the file happens to end with, and the most
 used packs of the corpus lose their entity shadows to a line their settings had already killed.
 
+**`dhShadow.enabled` belongs to the same family and defaults the other way.** It says whether
+Distant Horizons' far terrain is drawn into the map, and a pack that ships a `dh_shadow` and writes
+nothing has asked for it: there is no second flag it could have meant. It is read through the
+conditionals like the six above, and there it matters more than for any of them, since the one pack
+of the corpus that ships the program writes the key three times, true once under a setting it leaves
+switched off and false twice. A pack that ships no `dh_shadow` needs no key at all, that name having
+no parent in the fallback tree to reach.
+
 `entityShadowDistanceMul` is read too, but as a `const float` of the pack's source rather than as a
 key of this file. It bounds how far from the camera a caster that moves may stand and still reach
 the map.

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -160,10 +160,17 @@ are described once, under [the pack format](pack-format.md); they are not repeat
 
 ### The far terrain is drawn from the light too, out of sections kept from the frame
 
-A seventh family reaches the map and it is not one of those six keys. Where Distant Horizons is
-running and the pack ships a `dh_shadow`, its distant land is drawn into the map with that program,
-at the two moments the world's own chunk groups are drawn there. It is a seventh key of its own,
-`dhShadow.enabled`, and it is the one key of this family that is ON when a pack says nothing.
+A seventh family reaches the map. Where Distant Horizons is running and the pack ships a
+`dh_shadow`, its distant land is drawn into the map with that program, at the two moments the
+world's own chunk groups are drawn there. It has a key of its own, `dhShadow.enabled`, and it is the
+one key of this family that is ON when a pack says nothing.
+
+**It is held by three words rather than one**, and the two extra ones are not its own: its opaque
+half is drawn where `shadowTerrain` lets the opaque world in, and its water half where
+`shadowTranslucent` lets the near water in. That follows from where the mod hangs its own draws.
+They fire off the head of the call the shadow stage makes for each chunk group, and under Iris that
+call is inside the same two tests, so a pack that keeps the world out of its map keeps the distant
+land out with it.
 
 The geometry is not asked for a second time. That mod hands its terrain over once a frame, inside
 its own pass, which stands among the game's opaque chunks and is long over by the time the map is
@@ -172,10 +179,11 @@ light, in the pack's own shadow pair rather than in the volume that mod rasteris
 in.
 
 **What that costs is which sections are in the map**, and it is the one place this engine's map
-holds less than Iris's. Iris gets a second list: its shadow pass makes the mod build one for the
-light, and unless something binds a frustum that mod culls nothing at all for a shadow pass, so its
-map holds distant land the camera cannot see. Kept sections are the camera's list by construction,
-so a hill behind the camera lays no shadow on the ground in front of it.
+holds less than Iris's. Iris gets a second list: its shadow pass makes the mod build one, culled
+against a frustum of the light's that Iris binds for the length of that pass, and that mod culls
+nothing at all for a shadow pass when nobody binds one. Either way its map holds distant land the
+camera cannot see. Kept sections are the camera's list by construction, so a hill behind the camera
+lays no shadow on the ground in front of it.
 
 ### Culling for the light
 

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -158,6 +158,25 @@ Which families reach the map at all is the pack's to decide, through six keys of
 `shaders.properties` and one `const float` of its source. Those keys and the trap in two of them
 are described once, under [the pack format](pack-format.md); they are not repeated here.
 
+### The far terrain is drawn from the light too, out of sections kept from the frame
+
+A seventh family reaches the map and it is not one of those six keys. Where Distant Horizons is
+running and the pack ships a `dh_shadow`, its distant land is drawn into the map with that program,
+at the two moments the world's own chunk groups are drawn there. It is a seventh key of its own,
+`dhShadow.enabled`, and it is the one key of this family that is ON when a pack says nothing.
+
+The geometry is not asked for a second time. That mod hands its terrain over once a frame, inside
+its own pass, which stands among the game's opaque chunks and is long over by the time the map is
+drawn at the tail of the frame. So the sections are kept as they arrive and drawn again from the
+light, in the pack's own shadow pair rather than in the volume that mod rasterises its own picture
+in.
+
+**What that costs is which sections are in the map**, and it is the one place this engine's map
+holds less than Iris's. Iris gets a second list: its shadow pass makes the mod build one for the
+light, and unless something binds a frustum that mod culls nothing at all for a shadow pass, so its
+map holds distant land the camera cannot see. Kept sections are the camera's list by construction,
+so a hill behind the camera lays no shadow on the ground in front of it.
+
 ### Culling for the light
 
 The map should only contain what the light can see, which means a second visibility walk per frame,


### PR DESCRIPTION
## What changes

Distant Horizons' far terrain now enters the pack's shadow map. Where a pack ships a `dh_shadow`
program and has not turned it off, the geometry that mod hands over once a frame is kept and drawn
again from the light with that program, at the two moments the world's own chunk groups are drawn
in the shadow stage and inside the same two caster words. Two things follow, and they are not the
same thing: a far hill lays a shadow on the ground in front of it, and the far terrain is shaded by
the map like everything else instead of only by what the pack works out of its own depth. Half the
branch is elsewhere and was not visible from the outside: a shadow plane of `-1` used to resolve to
the game's own render distance, so the box along the light reached a hundred and twenty eight blocks
either side of the camera and a far terrain that begins where the game's chunks end was clipped out
of the map the pack had just asked to have it in. It resolves the way the reference resolves it now.
The directive `dhShadow.enabled` is read, on the live lines like the rest of that family, and it is
the one key of it that is on when a pack says nothing.

## How it differs from the reference, and for what obstacle

One divergence, in which sections reach the map.

- Iris gets a second list of the far terrain: its shadow pass makes that mod build one, culled
  against a frustum of the light's it binds for the length of the pass
  (`compat/dh/LodRendererEvents.java:253-255`), and that mod culls nothing at all for a shadow pass
  when nobody binds one (`core/render/RenderBufferHandler.java:98-103,154-164` in its own tree).
- Here there is no second list to ask for: `dh/DhLods` stands in for the one interface that mod
  hands its geometry to, and it walks that road once a frame, from the camera. The stage that draws
  the map runs at the tail of the frame, long after.
- What it costs the image: a hill behind the camera lays no shadow on the ground in front of it.

Written up in `docs/sky-and-shadows.md`, under the section this branch adds.

## What proves it

- `gradlew build` green on every commit.
- In the game, under Bliss, which is the only pack of the corpus that ships a `dh_shadow`: the two
  halves announce themselves at load and record their first draw, into the 2048 map and into
  `shadowcolor0`. **A pack setting had to be forced**: Bliss keeps `DISTANT_HORIZONS_SHADOWMAP`
  commented out, which puts its own `dhShadow.enabled` at false, so at a pack's defaults this branch
  changes nothing and says so on one line.
- For the image itself, against a control: a copy of the pack with its two `dh_shadow` files left
  out, everything else identical, swapped hot so that the camera, the clock, the clouds and the
  exposure do not move. Served, the distant relief has faces in the sun and gullies in shadow;
  control, the whole of it is uniformly in shadow. Two separate launches proved nothing and are
  worth saying so: the sun moves several degrees during a load, the pack's auto exposure follows,
  and the band means contradict each other from one pair to the next.

## What it leaves owing

`dh_generic` is still not served, so that mod's own clouds and beacons keep its light. The far
terrain still writes its first draw buffer through the scene seed rather than into the pack's target
outright. Both are in the backlog and neither is touched here.
