### PR TITLE
build: raise the version to 0.6.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.6.0-beta
 
 ### Added
 
@@ -20,7 +20,8 @@ what the next one holds.
   draws for the camera, so a far hill lays a shadow on the ground instead of only shading itself
   out of its own depth. Packs that write `dhShadow.enabled=false` are taken at their word, which is
   most of them; the one pack tried here that ships the program keeps it behind a setting of its own
-  and it has to be switched on. What the map holds is the distant land the camera can see, which is
+  and it has to be switched on. It also follows the two words that govern the near world in the map,
+  so a pack that keeps the world out of its own shadow map keeps the distant land out with it. What the map holds is the distant land the camera can see, which is
   narrower than under Iris: that mod gets a second list of it, built for the light, and there is no
   second list to be had here.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.5.0-beta.1
+mod_version=0.6.0-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

Closes the changelog's open section as `0.6.0-beta` and moves `mod_version` with it, so the tag, the number inside the jar and the heading the release body is read from are one number. Two entries stand under it: the far terrain drawn into the pack's shadow map, and the two per frame takes that are now skipped for a pack that cannot read them. Nothing else landed since 0.5.0 that somebody running the mod would see.

The counter is dropped from the name. The release workflow refuses a counted pre-release now, so this is `0.6.0-beta` and not `0.6.0-beta.1`.

## How it differs from the reference, and for what obstacle

It does not. Nothing here touches the engine.

## What proves it

- `gradlew build` green, and the jar it writes is `vitrail-0.6.0-beta+mc26.2.jar`.

## What it leaves owing

Nothing.