### PR TITLE
fix(pack): keep a pack's own temporal reads out of the warnings

### DIFF
--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -420,11 +420,17 @@ public final class ChainPlan {
 
 		/**
 		 * What a caller with no {@code options.txt} to read gets, which is the harness and the corpus
-		 * measurements: the entities off and the three others on, which is what {@code EngineOptions}
-		 * defaults those four lines to. Written out here rather than read, nothing in this package
-		 * having a game directory to read it from.
+		 * measurements: all four on, which is what {@code EngineOptions} defaults those four lines
+		 * to. Written out here rather than read, nothing in this package having a game directory to
+		 * read it from.
+		 * <p>
+		 * The entities stood false here long after their own line had gone on by default, so every
+		 * verdict taken without an {@code options.txt} was taken on a configuration nobody ships: a
+		 * target the entity programs write was read as one no geometry of this engine fills. BSL's
+		 * {@code colortex3} carried that note in all three of its places. The game itself never saw
+		 * it, {@code render/PackChain} handing the plan the lines that were really written.
 		 */
-		public static final Families DEFAULT = new Families(true, false, true, true);
+		public static final Families DEFAULT = new Families(true, true, true, true);
 	}
 
 	/** What a caller with no {@code options.txt} to read gets. See {@link Families#DEFAULT}. */

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -291,10 +291,12 @@ public final class ChainPlan {
 	private final List<Integer> swapBack;
 	private final List<String> refusals;
 	private final List<String> notes;
+	private final List<String> history;
 
 	private ChainPlan(String place, List<Pass> passes, Pass last, Seed seed,
 			Map<Key, Pass> attachments, Map<TerrainPass, Key> terrainKeys, Map<String, Key> skyKeys,
-			List<Integer> swapBack, List<String> refusals, List<String> notes) {
+			List<Integer> swapBack, List<String> refusals, List<String> notes,
+			List<String> history) {
 		this.place = place;
 		this.passes = List.copyOf(passes);
 		this.last = last;
@@ -305,6 +307,7 @@ public final class ChainPlan {
 		this.swapBack = List.copyOf(swapBack);
 		this.refusals = List.copyOf(refusals);
 		this.notes = List.copyOf(notes);
+		this.history = List.copyOf(history);
 	}
 
 	public record Attachment(int target, TargetSchedule.Side side) {
@@ -445,6 +448,7 @@ public final class ChainPlan {
 		List<Pass> passes = new ArrayList<>();
 		List<String> refusals = new ArrayList<>(refused);
 		List<String> notes = new ArrayList<>();
+		List<String> history = new ArrayList<>();
 		Pass last = null;
 
 		for (String program : plan.running()) {
@@ -593,7 +597,7 @@ public final class ChainPlan {
 			}
 		}
 
-		verdicts(plan, painted, world, passes, last, notes);
+		verdicts(plan, painted, world, passes, last, notes, history);
 
 		Set<Integer> back = new TreeSet<>(plan.schedule().flippedAtEnd());
 		back.retainAll(plan.persistent());
@@ -610,7 +614,7 @@ public final class ChainPlan {
 		});
 
 		return new ChainPlan(plan.place(), passes, last, seed, answered, terrainKeys, skyKeys,
-				List.copyOf(back), refusals, notes);
+				List.copyOf(back), refusals, notes, history);
 	}
 
 	/**
@@ -879,9 +883,12 @@ public final class ChainPlan {
 	 *              clear colour where that family has just written, and a map holding a family that
 	 *              was switched off says the target is filled where nothing wrote it. The first is
 	 *              the one these lines exist to rule out; the second leaves no trace at all
+	 * @param notes what the picture will be wrong about
+	 * @param history the reads that land on what the frame before wrote, which is the pack's own
+	 *                doing rather than a fault of this engine. See {@link #history()}
 	 */
 	private static void verdicts(TargetPlan plan, Seed seed, Map<Key, Pass> world,
-			List<Pass> passes, Pass last, List<String> notes) {
+			List<Pass> passes, Pass last, List<String> notes, List<String> history) {
 		List<Pass> ordered = new ArrayList<>(passes);
 		if (last != null) {
 			ordered.add(last);
@@ -935,7 +942,8 @@ public final class ChainPlan {
 					continue;
 				}
 
-				notes.add(verdict(plan, undrawn, ordered, drawn, at, half, pass.program()));
+				Verdict said = verdict(plan, undrawn, ordered, drawn, at, half, pass.program());
+				(said.temporal() ? history : notes).add(said.text());
 			}
 
 			filled.addAll(pass.attachments());
@@ -964,8 +972,9 @@ public final class ChainPlan {
 	 * @param undrawn the targets geometry writes and no pass of this engine fills
 	 * @param drawn   the world's own passes, by the point of the frame they are drawn at
 	 */
-	private static String verdict(TargetPlan plan, Set<Integer> undrawn, List<Pass> ordered,
+	private static Verdict verdict(TargetPlan plan, Set<Integer> undrawn, List<Pass> ordered,
 			Map<Integer, Set<Pass>> drawn, int at, Attachment half, String reader) {
+		boolean kept = plan.persistent().contains(half.target());
 		String name = TargetName.canonical(half.target());
 		String clear = ", so " + reader + " reads what the clear left there";
 		String before = ", so " + reader + " reads the frame before, and the clear colour on the "
@@ -983,13 +992,14 @@ public final class ChainPlan {
 			// Which of the two the reader really gets is the clear directive's answer and never the
 			// order's: a target the pack clears is emptied on BOTH halves at the top of every frame,
 			// so nothing of the frame before is left there to be read.
-			return name + " is not written until " + later + ", later in the same frame"
-					+ (plan.persistent().contains(half.target()) ? before : clear);
+			return new Verdict(name + " is not written until " + later + ", later in the same frame"
+					+ (kept ? before : clear), kept);
 		}
 
 		String off = disabledWriter(plan, half.target());
 		if (off != null) {
-			return name + " is written by " + off + ", which this place does not run" + clear;
+			return new Verdict(name + " is written by " + off + ", which this place does not run"
+					+ clear, false);
 		}
 
 		if (undrawn.contains(half.target())) {
@@ -1010,17 +1020,28 @@ public final class ChainPlan {
 			// The tail is flat, and it is flat because of where this branch now sits: nothing later in
 			// the frame writes this half, so the pack keeping the target between frames buys the
 			// reader nothing - the frame before had nothing written there either.
-			return name + " is written by geometry, none of which this engine draws into the pack's "
-					+ "targets" + clear;
+			return new Verdict(name + " is written by geometry, none of which this engine draws into "
+					+ "the pack's targets" + clear, false);
 		}
 
 		// Nothing fills this half at any point of the frame. Whether that is a hole or a history
 		// buffer is decided by the pack's own clear directive and by nothing else.
-		return plan.persistent().contains(half.target())
-				? "nothing writes the half of " + name + " that " + reader + " reads, and the pack "
-						+ "keeps that target between frames" + before
-				: name + " is written by no program of this place, so it holds its clear colour for "
-						+ "ever, and " + reader + " reads that";
+		return kept
+				? new Verdict("nothing writes the half of " + name + " that " + reader + " reads, and "
+						+ "the pack keeps that target between frames" + before, true)
+				: new Verdict(name + " is written by no program of this place, so it holds its clear "
+						+ "colour for ever, and " + reader + " reads that", false);
+	}
+
+	/**
+	 * One verdict about a half nothing has filled by the time it is read.
+	 *
+	 * @param temporal whether the pack keeps that target between frames, so the read lands on what
+	 *                 the frame before wrote there rather than on a clear colour. That is a
+	 *                 mechanism of the pack, and Iris hands it the same one, so it belongs with the
+	 *                 facts and not with what the picture will be wrong about
+	 */
+	private record Verdict(String text, boolean temporal) {
 	}
 
 	/**
@@ -1193,5 +1214,20 @@ public final class ChainPlan {
 	/** What will be wrong once it is drawn, in the pack's own terms. */
 	public List<String> notes() {
 		return this.notes;
+	}
+
+	/**
+	 * The reads that land on what the frame before wrote, in the pack's own terms. Facts about the
+	 * pack and not faults of this engine, which is why they are handed back apart from
+	 * {@link #notes()}.
+	 * <p>
+	 * They used to be in that list, and the list is introduced to the reader as what the picture
+	 * will be wrong about. BSL's {@code colortex2} is the case that proved the cost: its line says
+	 * the target is not written until {@code composite7} and that {@code composite5} therefore reads
+	 * the frame before, which is exactly the temporal chain the pack is built on and exactly what
+	 * Iris gives it. Read among the faults it became a suspect, and stayed one for a fortnight.
+	 */
+	public List<String> history() {
+		return this.history;
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2276,6 +2276,14 @@ public final class PackChain {
 					back.size(), back);
 		}
 
+		// Beside the copy above, which is the other half of the same subject: what this pack carries
+		// from one frame to the next. Said at info and not with the warnings below, though they are
+		// the same walk's answers, because a pack reading a target it keeps is a mechanism of the
+		// pack rather than a hole in this engine, and Iris hands it exactly the same one. Read among
+		// the warnings, BSL's colortex2 line was taken for a defect of the temporal antialiasing and
+		// stayed a suspect for a fortnight.
+		unfolded.history().forEach(note -> Vitrail.logger().info("{}", note));
+
 		// The values the pack declares for itself, once for the whole chain: every program was
 		// built against the one catalogue, so a pass saying it would say it once per program.
 		this.values.notes().forEach(note -> Vitrail.logger().info("{}", note));


### PR DESCRIPTION
## What changes

A read that lands on what the frame before wrote is a mechanism of the pack, not a fault of this engine, and Iris hands it exactly the same one. The chain plan filed those reads with what the picture will be wrong about, and the renderer logged that whole list at warning level: on the eight packs of the corpus, 87 lines out of 138. BSL's `colortex2` is among them, and its line was read as a defect of that pack's temporal antialiasing for a fortnight. The verdicts now come back in two lists, the second said at info beside the copy back, which is the other half of the same subject. The second commit is smaller and unrelated to the image: the families the plan is handed when there is no `options.txt` still had the entities off, months after that line went on by default.

## How it differs from the reference, and for what obstacle

It does not. Iris has no equivalent report, so there is nothing to diverge from; what the note describes is Iris's own behaviour, the pack reading the half its previous frame wrote.

## What proves it

- `gradlew build` green.
- The out-of-game harness, `Verdicts` over the eight packs of the corpus, before and after: the same 138 notes to the line, 87 of them now in the second list and 51 left as warnings. Nothing is silenced and nothing is added.
- No launch. Nothing here changes what is drawn: the two lists are the same strings the one list carried, and the families default is read by no path the game takes, the renderer handing the plan the lines really written.

## What it leaves owing

Nothing of its own. It comes out of an investigation into BSL's foliage that is written up in the workshop notes; the remaining lead there still needs the eye.
