### PR TITLE
refactor: drop four members nothing reads

### DIFF
--- a/common/src/main/java/dev/vitrail/pack/menu/MenuValues.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/MenuValues.java
@@ -229,17 +229,6 @@ public final class MenuValues {
 	}
 
 	/**
-	 * The profile the pack was last built with, which is what the world on screen amounts to. A
-	 * screen needs both this and {@link #profile()} to tell a chosen profile from an applied one,
-	 * exactly as it does for a single setting.
-	 */
-	public String appliedProfile() {
-		String over = this.forced.get(PROFILE_KEY);
-
-		return over == null ? match(this::applied) : over;
-	}
-
-	/**
 	 * Back to the value the pack ships, not to the value the profile or the file would give. That
 	 * is what a shift click means, and it is also what makes the line disappear from the file
 	 * rather than being written out with the default in it.

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -192,10 +192,6 @@ public final class EngineDefines {
 		return defines;
 	}
 
-	public static int count() {
-		return table(DEFAULT_MC_VERSION).size();
-	}
-
 	private static String osSymbol(Os os) {
 		return switch (os) {
 			case MAC -> "MC_OS_MAC";

--- a/common/src/main/java/dev/vitrail/platform/VitrailPlatform.java
+++ b/common/src/main/java/dev/vitrail/platform/VitrailPlatform.java
@@ -17,9 +17,6 @@ public interface VitrailPlatform {
 
 	String minecraftVersion();
 
-	/** Directory the shader packs and the engine configuration live in. */
-	Path configDirectory();
-
 	/** Root of the game instance, where the user-editable shader sources live. */
 	Path gameDirectory();
 

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -590,10 +590,6 @@ final class ColorTargets {
 		return this.shadowMap;
 	}
 
-	Set<Integer> doubled() {
-		return this.doubled;
-	}
-
 	long bytes() {
 		return sum(TargetSurface::bytes);
 	}

--- a/fabric/src/main/java/dev/vitrail/fabric/FabricPlatform.java
+++ b/fabric/src/main/java/dev/vitrail/fabric/FabricPlatform.java
@@ -30,11 +30,6 @@ final class FabricPlatform implements VitrailPlatform {
 	}
 
 	@Override
-	public Path configDirectory() {
-		return FabricLoader.getInstance().getConfigDir().resolve(Vitrail.MOD_ID);
-	}
-
-	@Override
 	public Path gameDirectory() {
 		return FabricLoader.getInstance().getGameDir();
 	}

--- a/neoforge/src/main/java/dev/vitrail/neoforge/NeoForgePlatform.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/NeoForgePlatform.java
@@ -31,11 +31,6 @@ final class NeoForgePlatform implements VitrailPlatform {
 	}
 
 	@Override
-	public Path configDirectory() {
-		return FMLPaths.CONFIGDIR.get().resolve(Vitrail.MOD_ID);
-	}
-
-	@Override
 	public Path gameDirectory() {
 		return FMLPaths.GAMEDIR.get();
 	}


### PR DESCRIPTION
## What changes

Four members are removed because nothing calls them, in the three modules or in the out-of-game
harness: `MenuValues.appliedProfile`, `EngineDefines.count`, `ColorTargets.doubled`, and
`VitrailPlatform.configDirectory` with its Fabric and NeoForge implementations. The gate does not
catch these on its own, Error Prone's `UnusedMethod` covering neither a public member nor a package
private one, so they were found by reading. `ColorTargets` keeps the `doubled` field itself, which
the allocation path and the load lines both read; only the accessor goes.

## How it differs from the reference, and for what obstacle

It does not. Nothing here is behaviour.

## What proves it

- `gradlew build` green.
- Every name was searched across `common`, `fabric`, `neoforge` and the private harness before
  being cut, the harness because it is ignored by git and so invisible to a search of the
  repository alone.

## What it leaves owing

One more unread member is left in place on purpose: an unused `java.util.Objects` import in
`pack/target/ChainPlan.java`. That file is being rewritten on another branch and a one line
deletion there buys a conflict for nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
