### PR TITLE
fix(glsl): hand back the walked tables in the order they were filled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ what the next one holds.
   nothing was paying for them on every frame. They go back to whatever that menu says the moment a
   pack is unloaded.
 
+### Fixed
+
+- **The same pack now translates to the same text on every start.** Four tables the translator
+  walks to write a shader were handed back in an order the runtime picks afresh each time the game
+  starts: the varyings a stage is owed, the vertex inputs a mesh has not got, and the volume
+  helpers a pack's three dimensional textures need. Two launches on the same pack could therefore
+  produce shaders that differ only in the order of their declarations, which is the same shader to
+  a reader and a different one to the game, so it compiled pipelines it already had. One warning
+  line about mesh elements a program computes from and does not get also listed its names in a
+  different order each run.
+
 ## 0.6.0-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -14,6 +14,7 @@ import dev.vitrail.pack.texture.VolumeAtlas;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -438,7 +439,7 @@ public final class GlslTranslator {
 		this.alphaTest = alphaTest;
 		this.coverage = coverage;
 		this.program = program;
-		this.volumes = Map.copyOf(volumes);
+		this.volumes = Collections.unmodifiableMap(new LinkedHashMap<>(volumes));
 
 		// Tokens cost far more than the text they came from, roughly seventy bytes each, so a unit
 		// the expander should never have produced has to be refused before it is read rather than
@@ -607,7 +608,7 @@ public final class GlslTranslator {
 		 * list of what the picture will be wrong about when it is not.
 		 */
 		public Map<String, String> synthesized() {
-			return Map.copyOf(this.translator.synthesized);
+			return Collections.unmodifiableMap(new LinkedHashMap<>(this.translator.synthesized));
 		}
 
 		/**
@@ -740,7 +741,7 @@ public final class GlslTranslator {
 		 * declares it again. Empty until that has run.
 		 */
 		public Map<String, String> unprovided() {
-			return Map.copyOf(this.translator.unprovidedInputs);
+			return Collections.unmodifiableMap(new LinkedHashMap<>(this.translator.unprovidedInputs));
 		}
 
 		/**

--- a/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
@@ -8,6 +8,7 @@ import dev.vitrail.pack.target.TargetName;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -442,7 +443,7 @@ public final class PackTextures {
 			}
 		}
 
-		return Map.copyOf(flat);
+		return Collections.unmodifiableMap(flat);
 	}
 
 	private static boolean flattenable(PackTexture texture) {


### PR DESCRIPTION
## What changes

Four tables the translator walks came back from `Map.copyOf`, which promises no iteration order and
which the runtime shuffles on every start. Three of them are walked to write emitted text (the
volumes a unit reads and the helpers they owe, the vertex inputs a mesh has not got, and the
varyings one stage owes the next), and the fourth feeds a warning line. Two launches on the same
pack could therefore hand the game shaders differing only in declaration order: the same shader to
a reader, a different one to the pipeline cache, so it compiled what it already had. Each becomes
`Collections.unmodifiableMap` over a `LinkedHashMap`, which is the fill order and is stable. The
`declarators` map of a file scope is deliberately left on `Map.copyOf`: nothing walks it, it is
only looked up at `GlslTranslator.java:2216`.

`LegacyGlsl` already carries this rule in its own javadoc, with this exact consequence written out,
and `VertexPrologue` already applies it to its synthesized set after Reverie's terrain stage swapped
two names between two runs. These four sites are the ones the rule had not reached.

## How it differs from the reference, and for what obstacle

It does not. Iris has no equivalent, its patcher working on a token tree rather than on a text it
assembles from maps.

## What proves it

- `gradlew build` green.
- Not proven by the harness. `Traduction` and `Varyings` would be the tools for it, and neither can
  run today: the harness does not compile against `dev`, which is reported separately.
- Not proven in the game. What a launch would have to show is unchanged shaders and no new line in
  the pack's report.

## What it leaves owing

The obvious check is missing and worth writing: translate one pack twice in the same process and
compare the emitted text byte for byte. Nothing in the harness does that today.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
