### PR TITLE
docs: correct the javadoc the code has since contradicted

### DIFF
--- a/common/src/main/java/dev/vitrail/mixin/ProjectionMatrixBufferMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/ProjectionMatrixBufferMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 /**
  * Copies the projection the level is about to be drawn with, and does nothing else.
  * <p>
- * The one mixin in the engine, and it exists because the matrix in question is never stored.
+ * It exists because the matrix in question is never stored.
  * {@code GameRenderer.renderLevel} takes the camera's projection, multiplies in the walk bob, the
  * damage tilt, the nausea rotation and the portal skew, hands the result straight to this method
  * and lets it go. The camera's own field is the version before all four, and the difference is

--- a/common/src/main/java/dev/vitrail/pack/source/DimensionSet.java
+++ b/common/src/main/java/dev/vitrail/pack/source/DimensionSet.java
@@ -117,10 +117,10 @@ public final class DimensionSet {
 	/**
 	 * Which directory this world's programs are read from, the empty string for the root.
 	 * <p>
-	 * The root is the answer for a world the pack says nothing about and has no catch-all for, and
-	 * for a folder named here that is not on disk. A folder that IS on disk answers for itself
-	 * whether or not it holds an entry point, which {@link TargetPlan} decides rather than this: a
-	 * name here is where to look, not what is there.
+	 * The root is the answer for a world the pack says nothing about and has no catch-all for. A
+	 * folder named here answers for itself whether or not it is on disk and whether or not it holds
+	 * an entry point, which {@link TargetPlan} decides rather than this: a name here is where to
+	 * look, not what is there.
 	 *
 	 * @param world the dimension's identifier, {@code minecraft:the_nether}
 	 */

--- a/common/src/main/java/dev/vitrail/render/EngineOptions.java
+++ b/common/src/main/java/dev/vitrail/render/EngineOptions.java
@@ -63,7 +63,8 @@ final class EngineOptions {
 	 * one of {@code solid}, {@code cutout} and {@code translucent} for a chunk pass, two of which are
 	 * usually served by the one file and could not otherwise be told apart. The sky answers the same
 	 * way, by element rather than by file: {@code disc}, {@code dark}, {@code stars},
-	 * {@code sunrise}, {@code sun} and {@code moon}, four of the six being one file. The entities
+	 * {@code sunrise}, {@code sun}, {@code moon}, {@code endsky} and {@code endflash}, four of the
+	 * eight being one file. The entities
 	 * answer the same way, {@code cutout_cull}, {@code armor}, {@code item} and the rest, with the
 	 * block entity half carrying those same names under a {@code block_} in front and the two hand
 	 * passes under a {@code hand_} and a {@code hand_water_}. The weather is
@@ -73,10 +74,10 @@ final class EngineOptions {
 	 * {@code dump=gbuffers_block}, <strong>only where the pack really ships that file</strong>: the
 	 * line is matched against the file that ends up SERVING, so wherever the fallback tree leads
 	 * elsewhere the name matches nothing at all and the element names are the only way in.
-	 * <strong>Two of their element names cannot be reached at
+	 * <strong>Three of their element names cannot be reached at
 	 * all</strong>, and it is a property of the matching rather than a fault: the line is matched on
-	 * the TAIL of a label, the terrain is walked first, and its own passes are called {@code solid}
-	 * and {@code cutout}. Whichever is named, the file the dump writes says in its first line which
+	 * the TAIL of a label, the terrain is walked first, and its own passes are called {@code solid},
+	 * {@code cutout} and {@code translucent}. Whichever is named, the file the dump writes says in its first line which
 	 * program was really read.
 	 * <p>
 	 * One program and not several, because the point is to read the file rather than to search it,
@@ -275,7 +276,7 @@ final class EngineOptions {
 	 * the point: what is left is settings the pack declared.
 	 */
 	static Read take(Map<String, OptionValue> chosen) {
-		// The seed goes through the same reading as the other eight rather than keeping one of its
+		// The seed goes through the same reading as the other nine rather than keeping one of its
 		// own. It had one, and it was the only line here that took an unreadable word in silence:
 		// seed=0 left the seed drawing, and an experiment run to see the clears on their own would
 		// have concluded from a picture the seed had painted.

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -815,12 +815,12 @@ final class GeometryProgram {
 	}
 
 	/**
-	 * Binds this program's block and every sampler it declares, inside the pass Sodium opened.
+	 * Binds this program's block and every sampler it declares, inside the pass the family has just
+	 * opened.
 	 * <p>
 	 * Every name the layout carries has to be bound or the draw throws on the first one missing, so
-	 * a name this step has no answer for gets one pixel rather than being left out. Only two names
-	 * are answered with anything real: the block atlas, and the light map. Everything else is a
-	 * constant, which is why the criterion for this step is the albedo and nothing to do with light.
+	 * a name this step has no answer for gets one pixel rather than being left out. What stands
+	 * behind the rest, the pack's own targets among them, was settled by {@link #resolve}.
 	 * <p>
 	 * <strong>Only the names that follow the draw's own image are worked out here.</strong> The rest
 	 * were settled by {@link #resolve}, at the one point of a pass that stands outside it, and this
@@ -1023,7 +1023,7 @@ final class GeometryProgram {
 
 	/**
 	 * The image a pass draws with, where the pass has one of its own rather than the block atlas
-	 * { #prepare} was handed. Set before the bind and never during it.
+	 * {@link #prepare} was handed. Set before the bind and never during it.
 	 */
 	void atlas(GpuTextureView view) {
 		this.atlas = view;

--- a/common/src/main/java/dev/vitrail/render/ShadowTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowTargets.java
@@ -50,8 +50,10 @@ import java.util.List;
  * that follows from it is in one place each: the {@code FORWARD} pair the shadow programs are given,
  * and the compare op of their pipeline.
  * <p>
- * No texture view is ever held, for the same reason {@link ColorTargets} holds none: a resize closes
- * the views behind it and nothing on this backend notices a view that has outlived its texture.
+ * No caller ever holds a texture view, for the same reason {@link ColorTargets} hands none out: a
+ * resize closes the views behind it and nothing on this backend notices a view that has outlived its
+ * texture. The one view held here is the depth copy without the translucents, and it is safe because
+ * this map is square at the resolution the pack asked for and is never resized.
  */
 final class ShadowTargets {
 

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -330,9 +330,9 @@ public final class ViewMatrices implements ViewSource {
 	}
 
 	/**
-	 * The four shadow matrices, which are worth computing even though no shadow pass runs: they
-	 * are read by the composite stage of all eight packs of the corpus, and everything they need
-	 * is the camera position and the sun angle.
+	 * The four shadow matrices, which are read by the composite stage of all eight packs of the
+	 * corpus whether or not the light's own pass drew anything this frame: everything they need is
+	 * the camera position and the sun angle.
 	 * <p>
 	 * Ported from Iris {@code shadows/ShadowMatrices.java} and {@code shadows/ShadowRenderer.java}
 	 * at b0ae41c, with the pose stack and {@code com.mojang.math.Axis} written out in JOML.

--- a/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
@@ -294,8 +294,8 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 	}
 
 	/**
-	 * The one button with no room for a word: the eye that takes the screen away. Placed in whatever
-	 * space is left to the right of the button rows, which is Iris's arithmetic.
+	 * The eye that takes the screen away, placed in whatever space is left to the right of the
+	 * button rows, which is Iris's arithmetic.
 	 */
 	private Button eye() {
 		int x = besideRows(false);

--- a/common/src/main/java/dev/vitrail/sodium/EntityMeshSerializer.java
+++ b/common/src/main/java/dev/vitrail/sodium/EntityMeshSerializer.java
@@ -48,7 +48,7 @@ public final class EntityMeshSerializer implements VertexSerializer {
 	/** What Sodium writes, which is the game's own entity vertex. */
 	private static final int WRITTEN = DefaultVertexFormat.ENTITY.getVertexSize();
 
-	/** What this engine binds, which is that plus the element. */
+	/** What this engine binds, which is that plus the three elements. */
 	private static final int CARRIED = EntityMesh.format().getVertexSize();
 
 	/** Where the identifiers start inside one of those, taken off the format rather than counted. */

--- a/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
+++ b/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
@@ -378,7 +378,7 @@ public final class TerrainMesh implements ChunkVertexType {
 		 * window to cover, nothing of its own warming up over several frames.
 		 * <p>
 		 * <strong>The one element here whose presence is not a question about the pack's BODY.</strong>
-		 * The five above it are carried when a chunk program names them; this one is carried exactly
+		 * The four above it are carried when a chunk program names them; this one is carried exactly
 		 * when the pack wrote {@code separateAo}, which is what makes every one of its vertex stages
 		 * read it. Two packs of the corpus write nothing, and their meshes carry one colour.
 		 */
@@ -426,8 +426,8 @@ public final class TerrainMesh implements ChunkVertexType {
 		// one of the two pays for both and a pack reading neither pays for neither.
 		int frame = offset(Extra.TANGENT_FRAME) == ABSENT ? 0 : TangentFrame.pack(frame(vertices));
 
-		// The one of the five that is a property of the CORNER, so it is asked for inside the loop
-		// and only the question is hoisted out of it.
+		// One of the two that are a property of the CORNER, so it is asked for inside the loop and
+		// only the question is hoisted out of it.
 		boolean blockMiddle = offset(Extra.MID_BLOCK) != ABSENT;
 
 		// Backwards over the vertices, because a vertex moves up by the difference of the two strides

--- a/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * The fixed function state of a pass drawn over the world rather than over a quad, and the one
  * name outside it whose answer depends on which of the two a program is.
  * <p>
- * Seven names {@link DrawValues} already answers, layered over it, plus two this family alone has
+ * Seven names {@link DrawValues} already answers, layered over it, plus four this family alone has
  * and one it answers with a nought.
  * The seven are answered there with the stand ins a full screen pass needs: an identity model view,
  * the matrix that carries the quad to the screen, and eight identities where the texture matrices


### PR DESCRIPTION
## What changes

Fourteen javadoc and comment sentences are corrected, each read against the body it describes.
Six are counts the code disagrees with: the sky carries eight elements rather than six, three entity
element names are unreachable rather than two, ten lines share the seed's reading rather than nine,
four `Extra` values stand above `TINT_AND_AO` rather than five, `MID_BLOCK` is one of two per corner
values rather than the only one, the entity mesh appends three elements rather than one, and
`GeometryValues` registers four names of its own rather than two. The rest are sentences a later
milestone made false: the one mixin in the engine became fifty-two, a shadow pass does run and is on
by default, a texture view is held after all, `DimensionSet.place` never looks at the disk,
`GeometryProgram.bind` serves seven families rather than the terrain alone, and the eye is not the
only button without room for a word. The malformed `{ #prepare}` is the last tag of its shape in the
tree: javac reads it as ordinary text because the brace is not followed by an at sign, so doclint
had nothing to resolve and the gate stayed green over it.

## How it differs from the reference, and for what obstacle

It does not. No behaviour is touched.

## What proves it

- `gradlew build` green, doclint included.
- Every count was counted again by hand rather than taken from the sentence next to it. The
  malformed tag was found by searching the whole tree for the four shapes that survive a green
  build, `{ #`, `{ @`, `{ code ` and `{ link `; this was the only hit in the three modules.

## What it leaves owing

`render/FeatureLayer.java` is left alone on purpose, and it is the largest one left. Its class
comment still opens on the player's own body and still closes on "the body has to arrive through
`gbuffers_entities`, which is the milestone", while its own middle paragraph already says
`EntityDraw` serves the blending half. Three paragraphs of a written out divergence are at stake and
whether the third person body still reads as water is a question for the game rather than for a
reader, so it is not a mechanical correction and it is not made here.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
