### PR TITLE
docs: correct twenty sentences the code has moved past

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -178,9 +178,9 @@ have: an inverted octagonal cone between the two planes, drawn with the pack's o
 program. If you see the line, that geometry is not reaching your pack's shader.
 
 There are two cases where it is deliberately not drawn, and the log says so in the second: a pack
-that switches the sky disc off has taken away the pass the cone rides in, and a frame where the
-world's own geometry has not marked the pixels it wrote gets no cone, because one drawn there would
-cut the ground out of the picture instead.
+that wrote `sky=false` has said it draws the sky itself and is not handed a cone it did not ask for,
+and a frame where the world's own geometry has not marked the pixels it wrote gets no cone, because
+one drawn there would cut the ground out of the picture instead.
 
 The full mechanism is in [Sky and shadows](sky-and-shadows.md#the-horizon-gap).
 
@@ -246,8 +246,10 @@ and the second is the shorter list.
 It is a video setting of its own, which the Fabulous preset turns on everywhere except macOS. With
 it on, the game draws both of those into targets of its own and composes them itself, and this
 engine hands them back rather than attach the pack's targets beside an image it does not read. The
-log says so in those words, once for the rain and once for the particles. The entities are
-unaffected.
+log says so in those words, once for the rain and once for the particles. The entities are affected
+too, but by row rather than by family: with the setting on, the translucent half of a living entity,
+an experience orb, a translucent item sheet and the glint of an enchantment go back to the game the
+same way, while the opaque half is untouched.
 
 Two consequences follow from how that geometry reaches the pack, and both are worth recognising
 rather than reporting as separate bugs:
@@ -389,10 +391,11 @@ A short reference, if you are writing a pack or wondering why yours is treated d
   shafts there and reads it back for every ray that reaches through something translucent, so a
   buffer it could not write filled every body of water with white.
 - **A pack can ask the engine not to draw a piece of the sky** because it draws that piece itself,
-  inside one of its own programs. Four such requests are honoured (the sun, the moon, the stars and
-  the sky disc), and honouring the last two is a **deviation from both references**, which take out
-  only the sun and the moon. It costs some packs the stars the references leave them,
-  and the NOTICE says so. The fifth request in that family is not one of those four and reads the
+  inside one of its own programs. Four such requests are read, and two of them take a piece away:
+  the sun and the moon, which is where both references stand. `stars=false` takes nothing, the
+  game's star field being drawn with the pack's own `gbuffers_skybasic` in the first place, and
+  `sky=false` costs the horizon cone alone rather than the game's disc, which is again what the
+  references do, and the NOTICE says so. The fifth request in that family is not one of those four and reads the
   other way round: `clouds` takes `off`, `fast` or `fancy` rather than a boolean, and it overrules
   the user's own cloud setting so that the pack's cloud program is handed the geometry it was
   written for. It is honoured only where this engine really draws the clouds, because with the

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -90,8 +90,9 @@ of the corpus translates, or what each target resolves to) never fail at all by 
 what they produce is a number to compare against the last one rather than a yes or a no. Running one
 of those and seeing no error means nothing was asserted, not that everything held.
 
-**Every invariant has a negative control, and the control ships with it.** Each is a flag on the
-tool it belongs to, documented as *must exit non-zero*, naming the packs it is expected to break on.
+**Every invariant has a negative control.** Two of them ship as a flag on the tool they belong to,
+documented as *must exit non-zero* and naming the packs they are expected to break on; the rest are
+gestures spelled out beside the tool, a forced setting or a line put back, to be taken by hand.
 Run them: if a control reports nothing, the checker has stopped reading, and the green run beside it
 meant nothing. What controls exist is in what the tools print, which cannot fall out of date the way
 a list here would.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -36,7 +36,7 @@ than an error.
 A pack's passes are not all run at the same moment. The chain is split, and each half hangs off one
 of the seams above:
 
-- the setup, begin and prepare stages, the seed, and the deferred stages run at **after opaque
+- the begin and prepare stages, the seed, and the deferred stages run at **after opaque
   features**, which is before the world's translucent geometry;
 - the composite stages and the final pass run at **after level**, once the whole world render is
   done.
@@ -51,9 +51,9 @@ world with translucents in it. Placing an effect in the wrong stage is not a sub
 ## Colour targets, and the rule that governs every read
 
 A pack declares colour targets and writes into them by naming attachments in its fragment stages.
-Targets that are both read and written in the same frame are **doubled**: there are two buffers
-behind one name, and passes alternate between them so that a pass never reads the buffer it is
-writing.
+A target is **doubled** when a full-screen pass writes it, or when a flip directive names it: there
+are two buffers behind one name, and passes alternate between them so that a pass never reads the
+buffer it is writing.
 
 One sentence governs the whole mechanism:
 
@@ -275,8 +275,8 @@ seam left. A layer of the kind above cannot help either: what it would catch is 
 already been lit by the game's shader over an image the pack finished.
 
 So the engine does not intercept the hand, it **moves** it. The game's own submission
-is suppressed and the hand is submitted twice from inside the level: the solid pass among the game's
-opaque features, before the deferred stage, and the blending pass at the end of the world, before
+is suppressed and the hand is submitted twice from inside the level: the solid pass just after the
+game's opaque features, before the deferred stage, and the blending pass at the end of the world, before
 the composites. Where each lands is what decides which half of every target it writes, and both are
 in the picture the composites read. This is where the reference puts them too.
 

--- a/docs/internals/material-maps.md
+++ b/docs/internals/material-maps.md
@@ -33,8 +33,8 @@ themselves: the terrain reads the block atlas's companions, a particle reads whi
 layer came off, and neither has to be told which it is.
 
 Only the geometry programs are served, which is what Iris does too. What a composite declaring one
-of the names reads is not the same on both sides: here it reads a flat texel, where Iris leaves the
-sampler unassigned and it falls to whatever texture unit nought holds.
+of the names reads is not the same on both sides: here it reads one black pixel, where Iris leaves
+the sampler unassigned and it falls to whatever texture unit nought holds.
 
 A sprite the resource pack ships no map for reads the same flat value the whole companion is cleared
 to: a normal pointing straight out of the face with nothing occluded, and a material that is nought

--- a/docs/internals/pack-textures.md
+++ b/docs/internals/pack-textures.md
@@ -120,9 +120,10 @@ A declaration whose file is **shorter than the length its own declaration announ
 rather than bound to something. Iris refuses the whole pack there, its reader throwing out of the
 constructor; refusing the one declaration is narrower and keeps the rest of the pack drawable.
 
-A declaration whose file is **missing or unreadable** no longer claims the name at all: the target
-that name would otherwise have carried keeps its ordinary binding, which is what Iris does by leaving
-the sampler out of the stage's map. Claiming the name and binding black was this engine's own answer
+A declaration whose file the pack does not ship no longer claims the name at all: the target that
+name would otherwise have carried keeps its ordinary binding, which is what Iris does by leaving the
+sampler out of the stage's map. A file that is there and cannot be read keeps the name and reads one
+black pixel, and so does a path that points outside the pack. Claiming the name and binding black was this engine's own answer
 and it was worse than either: the pack lost a colour target it had said nothing wrong about.
 
 ## A refusal must still consume the name it claimed

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -28,8 +28,9 @@ that multiplies by the sampled alpha loses the whole target and nothing anywhere
 **That correction applies to the engine's default and not to a colour the pack wrote.** A target the
 pack gave a clear colour to is cleared to exactly that colour, alpha included, promoted or not: the
 pack wrote four components and is handed the four it wrote. The correction only decides the default
-the engine stands in with when the pack named nothing, which is opaque black on a promoted target
-and transparent black otherwise. The shadow colour buffer answers the same way, and it is worth
+the engine stands in with when the pack named nothing. That default follows the reference: the
+first target starts at the frame's fog colour, the second at opaque white, and every other one at
+transparent black, or at opaque black where the format gained an alpha channel. The shadow colour buffer answers the same way, and it is worth
 saying because it was the one place that did not: a correction meant to fill a blank is not a
 correction once it starts overruling something the pack was explicit about.
 

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -90,13 +90,13 @@ one word and fills it from the tint or from the pair according to that same dire
 vertex out of a global its encoder consults, which it can afford because nothing of its own warms up
 over several frames.
 
-So the directive is not a property of the mesh here, and nothing about it is worth a rebuilt world.
-Every vertex carries both colours whether the pack asked or not; what the directive decides is the
-one line of the translated vertex stage that fills `gl_Color`, and a pack that moves the directive is
-a pack whose programs are read again anyway. Two packs that both draw the terrain and disagree about
-it are then no different from any other change of pack. The price is four bytes a vertex on every
-mesh, which is the same bargain the appended elements below already make, and one of the two colour
-elements is declared but never read whichever way the choice falls. That second half is not free: an
+So the directive is not a property of the mesh's contents but of its layout. A pack that wrote
+`separateAo` gets a second colour element and a pack that did not gets none, which is one more answer
+the format takes from the pack and one more reason a change of pack rebuilds the world. What the
+directive decides beside that is the one line of the translated vertex stage that fills `gl_Color`,
+and where the second element is carried it costs four bytes a vertex, which is the same bargain the
+appended elements below already make. The renderer's own word is then declared and never read by the
+pack's stage. That second half is not free: an
 input a stage never reads can be dropped from the compiled module, and dropping one shifts the
 locations after it: the silent failure described in
 [vertex inputs are matched by name](#vertex-inputs-are-matched-by-name-and-one-direction-is-silent).
@@ -334,7 +334,7 @@ offset, the region age and the region id into whatever layout is currently bound
 
 The consequence for a substituted pipeline is severe and easy to miss: a pipeline named outside that
 namespace receives a push into a layout that has no range for it, the region offset never arrives,
-and the entire terrain draws stacked near the world origin. The remedy costs nothing and is not
+and the entire terrain draws stacked on top of the camera. The remedy costs nothing and is not
 another patch: the test is a substring, so any namespace that contains the renderer's name is
 enough.
 

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -181,7 +181,8 @@ A word this cannot read leaves the default standing, which is what the reference
 **How far the walk reaches is a separate question from the shape.** Whichever shape is chosen, a box
 around the camera is cut out of it wherever a distance bounds the walk, and that distance is
 `shadowDistance` times the `const float shadowDistanceRenderMul` of the pack's own source, or the
-player's Max Shadow Distance where the pack declares no multiplier. Two of the four states step
+player's Max Shadow Distance where the pack declares no multiplier or declares a negative one, the
+sign being the whole of the switch. Two of the four states step
 outside that arbitration and both do so in the reference: `false` reads the pack's product alone and
 never the player's setting, and the safe zone reads neither, its two boxes being the pack's
 throughout.
@@ -333,7 +334,9 @@ where it previously brought down every colour target of the pack.
 through, a typo in the pixel type made a sampler name resolve back onto the colour target of the
 same name, so the pack read the scene where it asked for its own lookup table. That is the exact
 shape of a plausible, wrong image. A key naming a stage and a sampler now takes that name whatever
-follows on the line; only an unreadable key takes nothing.
+pixel type follows on the line. Two things take nothing: a key this cannot read that far, and a value
+naming a file the pack does not ship, which the reference drops whole so that the name goes on
+meaning what it meant.
 
 **A three-dimensional volume is flattened onto a two-dimensional atlas**, its declaration rewritten
 under a forged name, and each read replaced by a helper that reads two slices and interpolates.

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -122,7 +122,7 @@ pack. Emptying is what lets somebody watching the file see it go blank.
 ## Dropping files on it
 
 - **On the pack list**, a zip or a folder is copied into the pack folder and, when it is the only one
-  dropped, selected straight away. Anything that is not a pack is refused by name.
+  dropped, selected straight away. Anything that is not a pack is refused, by name when it was the only file dropped.
 - **On a page**, one settings file is imported. More than one at a time is refused, there being no
   sense in importing two.
 
@@ -327,4 +327,6 @@ which is worth knowing before planning around either extreme.
 **A trap worth knowing before measuring any of this yourself**: what Maven serves as Sodium's
 NeoForge artefact is a launcher shim (a few dozen classes, none of them the renderer), and the mod
 is a jar nested inside it. Looking for a package in the outer jar finds nothing and proves nothing.
-This project's own build script unpacks the nested jar for exactly that reason.
+This project compiles its common module against Sodium's plain Fabric artefact for exactly that
+reason: of the 688 classes the NeoForge jar carries, every one this module names is byte for byte
+the Fabric one.

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -313,8 +313,9 @@ texture coordinates would lose them.
 
 The only way to be sure is to compile each sky program once per format it can be drawn against and
 read the disassembly back, checking every element is still at the location its position gives it.
-**That check exists for the entity family and does not exist yet for the sky.** It is written here
-as a debt, not as a guarantee: the sky needs it before it is believed, not after.
+**That check exists for the sky as well as for the entity family**, in the out-of-game harness:
+each sky program is compiled once per format it can be drawn against and the disassembly read back,
+off the game.
 
 ### How a pack tells the elements apart
 
@@ -351,8 +352,8 @@ and uses both at once.
 
 Answer both from the same source and the rotation cancels: the sun sits at noon all night. So the
 pass supplies its own model-view, which feeds the fixed-function model-view, its inverse, the
-combined transform and the normal matrix, and *not* the camera uniform. The sky disc, the one
-element the game pushes nothing for, keeps the frame's matrix.
+combined transform and the normal matrix, and *not* the camera uniform. The sky disc and the End's
+own sky, the two elements the game pushes nothing for, keep the frame's matrix, one per branch.
 
 ### Two pipeline facts that break the world if missed
 
@@ -371,9 +372,9 @@ terrain's pipeline namespace pushes constants the pass cannot satisfy.
 Which buffers a sky program writes is keyed by program name, not by an enumeration of passes, since
 the game's sky passes share a small set of programs.
 
-One thing leaves a piece on the game's own target: a pack serving no program for it at all, in which
-case the game's own shader draws it and the piece reaches the pack's colour target through the
-full-screen layer instead of writing it.
+Two things leave a piece on the game's own target: a pack serving no program for it at all, in which
+case the game's own shader draws it, and a pack serving one the plan has no answer for. Either way
+the piece reaches the pack's colour target through the full-screen layer instead of writing it.
 
 **A program that declares no draw buffers is not that case, and used to be.** It is read as writing
 colortex0, which is what Iris reads it as, so the pack's shader draws and its output lands in the
@@ -383,8 +384,8 @@ nothing had no clouds at all, at any setting, and nothing said why.
 
 It is then all eight or none. If any piece the game still draws would stay behind, the whole sky
 keeps the game's target, because the layer is the only road left to a piece that stayed on it and the
-pieces that claim every pixel they span cut the layer where they land. A pack serving no program for
-the basic sky and one for the textured one (which the format allows) would otherwise get a sky
+pieces that claim every pixel they span cut the layer where they land. A pack serving a program for
+the basic sky and none for the textured one (which the format allows) would otherwise get a sky
 whose disc marks the whole frame and whose sun and moon are cut out of it.
 
 All eight and not the branch in hand, which costs one thing worth naming: a place serving one branch


### PR DESCRIPTION
## What changes

Twenty sentences across ten pages of `docs/` are corrected, each read against the lines it claims to
describe. The heaviest is the sky family: `compatibility.md` said four requests are honoured and
called taking the stars and the sky disc away a deviation from both references, while
`SkyRendererMixin` cancels the sun and the moon alone, `sky=false` costs the horizon cone rather than
the game's disc, and the `NOTICE` already says exactly that in the opposite direction. Then the two
define tables in `pack-format.md`, wrong about constants in both directions at once; the doubling
rule in `frame.md`, which turns on a full-screen write or a flip directive rather than on being read
and written in one frame; the clear colour defaults in `render-targets.md`, which follow the
reference and are neither of the two the page named; and `separateAo` in `terrain.md`, described as
it was before the element became an answer the format takes from the pack.

The rest are counts and names: two sky elements keep the frame's matrix rather than one, two causes
leave a piece on the game's target rather than one, the entities are affected by improved
transparency after all, the sky has its own harness check rather than a debt, the negative controls
are two flags rather than one per invariant, and the build compiles against Sodium's plain Fabric
artefact rather than unpacking the nested jar.

## How it differs from the reference, and for what obstacle

It does not. No behaviour is touched, and two of the corrections bring a page back onto what the
reference does after it had drifted off it on paper only.

## What proves it

- `gradlew build` green, `checkText` included.
- Every corrected sentence was checked at the lines it describes, and the counts counted again by
  hand rather than carried over.

## What it leaves owing

One sentence is deliberately left as it stands. `docs/internals/pack-loading.md:224` says the
continuation join is safe because it never crosses a blank line, and it is not: a preprocessor
directive written directly under a continuation is joined into the value before the text is split
and never reaches the condition stack. Which sentence is the true one depends on whether the parse
order is changed, so it is a question rather than a correction, and no pack of the corpus writes
that shape today.

`docs/translation.md:320` is also left alone. Its rule about insertion-ordered maps was not being
held, but the fault was in `GlslTranslator` rather than in the page, and it is fixed on its own
branch.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
