### PR TITLE
docs: say three stores where the release job writes to three

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
-# Normalise line endings in the repository, keep native ones in the working tree.
+# Normalise line endings to LF, in the repository and in the working tree alike, apart from the
+# batch scripts named below.
 * text=auto eol=lf
 
 *.java   text diff=java

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Versions
       description: Vitrail and its loader, Minecraft, Sodium, Chloride, and anything else in `mods/`.
-      placeholder: Vitrail 0.5.0-beta.1 on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
+      placeholder: Vitrail 0.6.0-beta on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/pack-report.yml
+++ b/.github/ISSUE_TEMPLATE/pack-report.yml
@@ -72,7 +72,7 @@ body:
     attributes:
       label: Versions
       description: Vitrail and its loader, Minecraft, Sodium, Chloride, and anything else in `mods/`.
-      placeholder: Vitrail 0.5.0-beta.1 on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
+      placeholder: Vitrail 0.6.0-beta on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
     validations:
       required: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ replay_pid*.log
 # but none of it is part of what the project ships. Matched by shape rather than
 # listed by name: any Markdown at the root that is not one of the published pages,
 # any table of measurements written there, and any dotted directory that is not the
-# workflow definitions.
+# workflow definitions or the commit hooks.
 #
 # The tables earn their line the hard way: two of them sat at the root untracked for
 # a week, and every one is measured on shader packs that may not be redistributed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -378,17 +378,19 @@ anyone runs, then creates a GitHub release under the tag's own name and attaches
 that build produced, so what is downloaded is what this history compiles rather than what
 a machine had lying in `build/libs`.
 
-The same job then mirrors it to CurseForge, which is why there is no second workflow: a
-release this one creates is authored by the token it runs under, and such a release starts
-no further workflow, so a file listening for it would never wake. The mirror needs two
-secrets set in the repository settings, `CURSEFORGE_ID` and `CURSEFORGE_TOKEN`, and without
-either it says so and ends green rather than failing a release over it. The id is not a
-secret in any real sense (it is on the project's own page), and it lives there only so that
-both halves of the same configuration are found in the same place.
+The same job then mirrors it to CurseForge and to Modrinth, which is why there is no second
+workflow: a release this one creates is authored by the token it runs under, and such a
+release starts no further workflow, so a file listening for it would never wake. The mirror
+needs a pair per store set in the repository settings, `CURSEFORGE_ID` with
+`CURSEFORGE_TOKEN` and `MODRINTH_ID` with `MODRINTH_TOKEN`, and a store whose pair is
+incomplete is passed over with a notice rather than failing the release over it. Neither id
+is a secret in any real sense (both are on the project's own page): the CurseForge one lives
+in the secrets tab only so that both halves of the same configuration are found in the same
+place, and the Modrinth one is read from the variables tab as well.
 
-The release body is what CurseForge is given as the changelog, read back at the moment the
-run reaches it. A body written by hand after the tag went out therefore reaches CurseForge
-by running the workflow again on that tag, from the Actions tab, and by no other road.
+The release body is what both stores are given as the changelog, read back at the moment the
+run reaches it. A body written by hand after the tag went out therefore reaches them by
+running the workflow again on that tag, from the Actions tab, and by no other road.
 
 **Run it once for a given tag.** A second run rebuilds the same tag, and the archives here
 are built to be reproducible, so it offers CurseForge a file whose hash it already holds;
@@ -417,4 +419,5 @@ comparison link under a heading. A body corrected by hand on the release page af
 both stores by dispatching the workflow again on the same tag, since what the stores are handed is
 read back off the page rather than rebuilt.
 
-GitHub and CurseForge are the two places a build goes, and nothing else is automated.
+GitHub, CurseForge and Modrinth are the three places a build goes, and nothing else is
+automated.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,8 +58,9 @@ the log rather than by the file.
 Some of Chloride's own settings decide what reaches this engine, in
 `config/chloride-client.toml`, and they are entries inside its tables rather than
 keys of their own. `tileEntities`, `entities` and `monsters`, under `[culling]`,
-decide on their own which block entities and which mobs are drawn at all, by
-distance: what they take out is never handed to the pack, so a chest, a sign or a
+decide on their own which block entities, which mobs and which other entities are
+drawn at all, by distance: what they take out is never handed to the pack, so a
+chest, a sign, a boat or a
 mob that is not there is those settings rather than anything the pack does.
 `chests` and `beds`, under `[fastBlocks]`, draw those blocks by a path this
 engine's final pass then covers over, so they go invisible with no other symptom.
@@ -94,8 +95,9 @@ the first frame. This is not something Vitrail can work around: the fix belongs
 to that mod and not to this one.
 
 Given a build of it that draws on this backend, Vitrail hands its far terrain to
-the pack's own programs, `dh_terrain` and `dh_water` for the picture and
-`dh_shadow` for the shadow map, and serves its depth beside the world's, which is
+the pack's own programs, `dh_terrain` and `dh_water` for the picture, and
+`dh_shadow` for the shadow map where the pack ships one and has not switched it
+off, and serves its depth beside the world's, which is
 the arrangement packs are written against. The changelog
 says what that changes and what it does not reach, and the log names each far
 terrain pass as the pack takes it over.
@@ -230,12 +232,10 @@ is what tells a wrong gbuffer from a wrong composite. `dump=` is the one that
 answers what no picture can, since a value can be non zero, plausible and wrong.
 
 A settings screen covers all of it in game: the video settings, where it sits
-under Vitrail in the list of pages, the I key, or the Config button in the mod
-list. It is the screen of the engine packs are written against, ported rather
+under Vitrail in the list of pages, the I key, or, on NeoForge, the Config button
+in the mod list. It is the screen of the engine packs are written against, ported rather
 than approximated, so it looks and behaves like that one. It opens on the pack
-list, reads each pack's own menu layout, and
-imports the settings file Iris left in `shaderpacks/` when a pack has none here
-yet. The row at the head of the list turns shaders off altogether and leaves the
+list and reads each pack's own menu layout. The row at the head of the list turns shaders off altogether and leaves the
 game drawing its own image. Clicking a pack only selects it: Apply writes what
 you changed and reads the pack again without closing, Done does both and closes,
 and Cancel throws the changes away. A program that fails to compile is reported

--- a/NOTICE
+++ b/NOTICE
@@ -570,8 +570,9 @@ GNU Lesser General Public License version 3
   it, line 12, on the terrain and on every family the game hands over as a render type. The sixteen
   numbers are worked out here from the texel centres rather than read off Iris, and they agree with
   the sixteen it carries; what is taken is the rule that gl_TextureMatrix[1] is answered with them
-  at all, which is what a pack expects. One family is answered the identity here instead, and the
-  file names that as a divergence.
+  at all, which is what a pack expects. One family is answered the identity instead, Distant
+  Horizons geometry, and that is Iris's answer too rather than a divergence: it rewrites both
+  gl_TextureMatrix[0] and [1] to mat4(1.0) there.
 
   common/src/main/java/dev/vitrail/glsl/GlslTranslator.java sends a read of gl_TextureMatrix[0] to
   the game's own per draw transforms on the entity family, which is where

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Three jars land in `build/libs`; the one to install is the plain
 ## How it works
 
 A shader pack is GLSL written against OpenGL conventions that no Vulkan driver
-will accept. Vitrail rewrites every program into Vulkan GLSL **once, when the
-pack is loaded**, and hands it to the compiler the game already embeds, which
+will accept. Vitrail rewrites every program into Vulkan GLSL **once, before it
+ever draws**, and hands it to the compiler the game already embeds, which
 turns it into SPIR-V exactly as it does for the game's own shaders. There is no
 translation layer left between the game and the GPU while a frame is drawn:
 this is a compiler that runs at load time, not a shim that runs per frame. What


### PR DESCRIPTION
## What changes

Twelve sentences in the files at the root, each read against what it describes. `CONTRIBUTING.md`
closed its Publishing section on "GitHub and CurseForge are the two places a build goes" and named
two of the four values the mirror step reads; that step has been handing the same jar and the same
release body to Modrinth as well, and the changelog has said so since `0.2.0-alpha.1`.

Around it: the `NOTICE` called the light map texture matrix on Distant Horizons geometry a
divergence, where the file it points at says in bold that Iris answers the identity there too;
`INSTALL.md` promised the screen imports the settings file Iris left, where the file is simply the
same file and nothing is imported, and offered the Config button on both loaders where only NeoForge
registers one; the `README` said the translation happens when the pack loads, where seven families
are read on demand and `docs/README.md` already spells that out; the two issue templates suggested
`0.5.0-beta.1`, a shape `CONTRIBUTING` declares is not a version here and the release workflow
refuses at a tag push; and `.gitattributes` and `.gitignore` each described one rule fewer than the
line beneath them carries.

## How it differs from the reference, and for what obstacle

It does not. No behaviour is touched.

## What proves it

- `gradlew build` green, `checkText` included.
- The mirror step was read end to end rather than sampled: `release.yml:222-252` for which stores are
  configured and `:269-291` for the single step that writes to both.
- The `NOTICE` sentence was checked against `GeometryValues.java:93-98` and the two Iris
  transformers it names, since that file is an attribution and a wrong sentence there is worse than
  a wrong sentence anywhere else in the tree.

## What it leaves owing

The `README` still says nothing about Modrinth while the release job publishes there, and the badge
row at the top has CurseForge alone. Adding it is a choice about the shape of the page rather than a
correction, so it is left out.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
