### PR TITLE
docs: say what BSL's foliage really does, and what it is not

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -276,6 +276,37 @@ mask in falls back on the game's target, and there its own first draw buffer has
 seed paints, or the game keeps its shader for that half rather than carry the pack's albedo into a
 target it never asked for.
 
+## The waving grass jumps
+
+**Under BSL, grass and leaves sway smoothly, then skip forward or snap back to where the sway
+started, and then go on smoothly again.** The player and the camera stand still, the rest of the
+picture is steady, and nothing else the pack animates does it. It is this engine's defect and not
+the pack's: the reference is smooth on the same pack at the same place, and Complementary is smooth
+here.
+
+**It is a jump in the position of the sway, not a tremble in the pixels it lands on**, and that
+distinction is the whole of the diagnosis. Reading it as a shimmer sends you to the pack's temporal
+anti-aliasing, which has nothing to do with it: giving another pack BSL's exact jitter table, index
+and amplitude leaves that pack smooth.
+
+**Some of what looks like the defect is BSL's own wave.** Its interpolation has a zero derivative at
+every lattice crossing, roughly once a second, so the foliage can sit nearly still for a couple of
+dozen frames, at irregular intervals, entirely by design. Those stillnesses are in the pack and are
+there under any implementation. What is worth reporting is a jump on top of them.
+
+**Nothing a pack setting or a video setting takes away, and none of these is the cause:** the frame
+rate, capped or free running; the clock this engine hands the pack, which advances once per
+presented frame, never repeats and never goes backwards; the rounding of that clock to the
+millisecond, which the reference does identically and which shrinks the frame-to-frame velocity step
+rather than growing it; the world position, which cancels exactly against the camera position; the
+noise hash and the precision it is computed in; the write into the terrain's uniform block, which
+happens once a frame with a fresh value; and the moment a frame is handed to the swapchain against
+the moment its content is dated, which stay rigid to within a fraction of a frame even with the
+frame rate unlocked and nothing pacing the loop.
+
+So a report about this is only useful if it carries something none of those explain: another pack
+that does it, a machine or a driver where it stops, or a setting that changes its rhythm.
+
 ## The sky goes flat
 
 **A flat grey or white sheet across the sky, typically at sunrise or sunset.**


### PR DESCRIPTION
## What changes

One new symptom section in `docs/compatibility.md`, on the defect that has been reported as BSL's
foliage shimmering. It is not a shimmer: the sway is smooth, then it jumps forward or snaps back to
where it started, and then goes on smoothly. The section says that in the first line, because
reading it as a shimmer sends the reader straight to the pack's temporal anti-aliasing, which is the
one thing it is provably not. It then lists what has been eliminated by measurement so that a report
about this carries something new, and it warns that BSL's own wave holds still for up to a couple of
dozen frames at every lattice crossing, by design, which is what an eye takes for the defect.

Nothing in the engine changes.

## How it differs from the reference, and for what obstacle

It does not. The page describes a place where this engine differs from the reference in its output,
which is the defect itself; the text takes no position the reference contradicts.

## What proves it

- `gradlew checkText` green, which is the gate this file passes through.
- The eliminations the section states are each backed by a measurement rather than an argument, and
  the last of them is new: the lag between the instant a frame is handed to the swapchain and the
  instant its content is dated was traced frame by frame, free running with no swapchain back
  pressure, and its largest step is about a third of a frame where a visible jump needs an order of
  magnitude more.
- In the game: BSL and a probe pack derived from it that keeps the noise, the hash and the lattice
  intact and makes the sampled coordinate depend on time alone. Same world, same spot. That probe
  jumps here and is smooth under the reference, which is what clears the pack.

## What it leaves owing

The cause. Everything from the system clock to the bytes queued for presentation is measured sound
and the pack is cleared, so what is left needs a frame capture of what the shader reads on the GPU
rather than another counter on what the CPU writes. Issue 62 carries the full list of what has been
ruled out.
