### PR TITLE
perf(sodium): keep the light's walk inside the shadow distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ what the next one holds.
   way too. That file is also written through a temporary and moved into place, so a crash while it
   is being written can no longer leave half a line behind, which read as no pack chosen at all.
 
+- **The shadow distance now bounds every chunk it is meant to, and not only the ones weighed one by
+  one.** A group of chunks that merely reached into the distance was handed to the walk whole, so
+  everything standing under that group was drawn into the shadow map however far past the distance
+  it stood. Lowering the distance, from the pack or from the video settings, therefore saved less
+  than it should have, on the second walk of the world, which is the most expensive thing a frame
+  does here.
+
 ## 0.6.0-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
@@ -55,11 +55,40 @@ public final class ShadowCull implements Frustum {
 				&& this.planes.testAab(minX, minY, minZ, maxX, maxY, maxZ);
 	}
 
+	/**
+	 * <strong>A whole answer only from a box wholly within the distance</strong>, which is how Iris
+	 * combines the two ({@code AdvancedShadowCullingFrustum.java:442-444}: {@code INSIDE} from
+	 * both, or {@code INTERSECT}). It reads like a detail and is not one. Sodium takes
+	 * {@code INSIDE} for "this shape holds the whole subtree", raises {@code INSIDE_FRUSTUM} on it,
+	 * and nothing below that node is measured against the shape again
+	 * ({@code chunk/tree/TraversableTree.java:197,210-221}). Its own render distance is still
+	 * tested on every node ({@code :224-243}), which is why the leak is bounded by the tree and not
+	 * by the world; what escapes is every section under such a box, however far past the shadow
+	 * distance it lies, and each one is drawn into the map.
+	 * <p>
+	 * <strong>Where this parts from Iris, and it is the one state that does.</strong> Under
+	 * {@link dev.vitrail.pack.source.ShadowCullState#SAFE_ZONE} a box wholly inside the safe zone
+	 * answers {@code INSIDE} at Iris whatever the distance says short of {@code OUTSIDE}
+	 * ({@code shadows/frustum/advanced/SafeZoneCullingFrustum.java:74-78}), where this downgrades it
+	 * like any other. It costs nothing while the safe zone is the shorter of the two, such a box
+	 * being wholly within the distance as well, and it drops sections Iris would draw once
+	 * {@code voxelDistance} passes {@code shadowDistance}, which {@code PackValues:331-332} works
+	 * out apart without bounding either by the other. <strong>Iris is not of one mind on that box
+	 * itself</strong>: its {@code testAab} cuts by distance FIRST ({@code :54-56}) and drops what
+	 * its own {@code intersectAab} keeps whole, so there is no single behaviour of the reference to
+	 * follow here. What is written is the one the walk can hold to on every one of its four tests.
+	 */
 	@Override
 	public int intersectAab(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
-		return inside(minX, minY, minZ, maxX, maxY, maxZ)
-				? this.planes.intersectAab(minX, minY, minZ, maxX, maxY, maxZ)
-				: FrustumIntersection.OUTSIDE;
+		if (!inside(minX, minY, minZ, maxX, maxY, maxZ)) {
+			return FrustumIntersection.OUTSIDE;
+		}
+
+		int shape = this.planes.intersectAab(minX, minY, minZ, maxX, maxY, maxZ);
+
+		return shape == FrustumIntersection.INSIDE && !within(minX, minY, minZ, maxX, maxY, maxZ)
+				? FrustumIntersection.INTERSECT
+				: shape;
 	}
 
 	@Override
@@ -78,5 +107,13 @@ public final class ShadowCull implements Frustum {
 		return maxX >= -this.distance && minX <= this.distance
 				&& maxY >= -this.distance && minY <= this.distance
 				&& maxZ >= -this.distance && minZ <= this.distance;
+	}
+
+	/** Whether a camera-relative box is wholly within the distance, on all three axes. */
+	private boolean within(float minX, float minY, float minZ,
+			float maxX, float maxY, float maxZ) {
+		return minX >= -this.distance && maxX <= this.distance
+				&& minY >= -this.distance && maxY <= this.distance
+				&& minZ >= -this.distance && maxZ <= this.distance;
 	}
 }


### PR DESCRIPTION
## What changes

The box that bounds the light's walk to the shadow distance handed a whole answer back untouched:
a group of chunks that only reached into the cube still carried the shape's own `INSIDE`. Sodium
reads `INSIDE` as "this whole subtree is visible", raises `INSIDE_FRUSTUM` on it and walks every
node below without another test, so sections standing well past the distance were gathered and
drawn into the shadow map. The box now answers `INSIDE` only for a group wholly within the
distance and `INTERSECT` otherwise, which leaves the walk to weigh the children one by one.

## How it differs from the reference, and for what obstacle

It does not. This is the reference's own combination: `shadows/frustum/BoxCuller.java` answers
`INSIDE` only for a box wholly inside the cube, and
`shadows/frustum/advanced/AdvancedShadowCullingFrustum.java:441` answers `INSIDE` only when its
shape and its box both do.

## What proves it

- `gradlew build` green.
- Read against both ends rather than reasoned: the reference's `BoxCuller` and advanced frustum
  above, and Sodium's own traversal, `render/chunk/tree/TraversableTree.java:190-221`, where an
  `INSIDE` raises `INSIDE_FRUSTUM` and everything under that node is walked untested.
- **Measured in the game: +11 frames a second on 408, +2.7%.** Complementary Unbound r5.8.1,
  1024x768, `maxFps` 260 and no vertical sync, Distant Horizons taken out of the instance, twelve
  readings a run after forty seconds of settling, median per run. Six runs alternated A,B,B,A,A,B
  so a drift cannot be read as an effect: 408.5 / 405.0 / 408.0 without it against 419.0 / 421.0 /
  419.0 with it, and the two groups do not overlap. The GPU sits at 100% throughout, so what
  disappears is card work, which is the expected shape: fewer sections drawn into the shadow map.
- **What had to be true for it to run at all, and it is worth knowing before measuring this
  again:** at the pack's own default the fix cannot do anything, because the box is never built.
  Complementary forces `shadowDistance = 192.0` with `shadowDistanceRenderMul = 1.0`, and a render
  distance of 8 is 128 blocks; a bound wider than the loaded world makes `shadowCullPlan` answer a
  negative one and no box is cut at all. The log says so plainly, `culling swept along the light`
  WITHOUT the `, within N blocks` the box adds. The measurement above forces `shadowDistance=64.0`
  so that the bound sits under the render distance. A player sees this fix when their shadow
  distance is shorter than their render distance, and not otherwise.

## What it leaves owing

Nothing of its own. The other half of the review item it comes from, the rank the shadow geometry
reads its colortex snapshot at, is untouched and still owes a decision: no shadow program of the
corpus reads a `colortexN`, so it has no measurable effect either way today.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one. `docs/` states the
      distance composes with the shape, which is what it now does more exactly than before; no page
      described the walk's answer itself.
