### PR TITLE
fix(settings): stop a hand edited file from taking every pack down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ what the next one holds.
   line about mesh elements a program computes from and does not get also listed its names in a
   different order each run.
 
+- **One character no editor should have written no longer costs the player every pack.**
+  `vitrail/options.txt` was read as strict UTF-8, so a single byte from another encoding stopped
+  ANY pack from loading, under a message that named neither the file nor the encoding. A byte order
+  mark, which several editors add on their own, threw nothing and quietly ate the first setting of
+  the file. Both now cost one character of one value at worst, and `vitrail/pack.txt` is read that
+  way too. That file is also written through a temporary and moved into place, so a crash while it
+  is being written can no longer leave half a line behind, which read as no pack chosen at all.
+
 ## 0.6.0-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/settings/PackFile.java
+++ b/common/src/main/java/dev/vitrail/settings/PackFile.java
@@ -2,8 +2,10 @@ package dev.vitrail.settings;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Locale;
 
 /**
@@ -65,6 +67,14 @@ public record PackFile(String name, boolean enabled, int shadowDistance) {
 	 * What the file says, or {@link #EMPTY} when it is not there. A line that is neither a comment nor
 	 * one of the three keys is ignored rather than refused: this file is edited by hand.
 	 * <p>
+	 * Decoded through the {@code String} constructor rather than through {@code Files.readString},
+	 * which THROWS on a byte that is not UTF-8. The rule the three lines below are read under, that
+	 * one bad character must not cost the player the pack they had chosen, does not hold if the read
+	 * itself cannot survive one: what is unreadable is one character of one value, and every other
+	 * line still says what it said. A byte order mark is taken off for the same reason it is in
+	 * {@code SettingsLayers}: nothing throws on it, and left where it is it rides on the first key,
+	 * which here is the pack's own name.
+	 * <p>
 	 * Handed the file rather than the game directory, so that where it lives stays the render layer's
 	 * business: this package names no folder of the installation and imports nothing that does.
 	 */
@@ -73,7 +83,7 @@ public record PackFile(String name, boolean enabled, int shadowDistance) {
 			return EMPTY;
 		}
 
-		String content = Files.readString(file, StandardCharsets.UTF_8);
+		String content = text(file);
 		// The one line format, which is what every file written before this class looks like. Told
 		// apart by having no key at all rather than by counting lines, so that a stray blank line or a
 		// trailing newline does not change which format a file is read as.
@@ -118,6 +128,13 @@ public record PackFile(String name, boolean enabled, int shadowDistance) {
 		return new PackFile(name, enabled, shadowDistance);
 	}
 
+	/** The file's text, decoded rather than refused, with any byte order mark taken off. */
+	private static String text(Path file) throws IOException {
+		String text = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+
+		return text.startsWith("\uFEFF") ? text.substring(1) : text;
+	}
+
 	private static int number(String value, int fallback) {
 		try {
 			return Integer.parseInt(value);
@@ -135,15 +152,28 @@ public record PackFile(String name, boolean enabled, int shadowDistance) {
 	 * other's line through, which is why both go through a read of the file first rather than
 	 * building a record out of what they happen to hold.
 	 * <p>
+	 * Through a temporary and an {@code ATOMIC_MOVE} in the same folder, so that a crash between the
+	 * two writes cannot leave a truncated file: what this one holds is the pack the player chose,
+	 * and half a line of it reads as no pack at all. {@code SettingsFile.write} has carried the same
+	 * pair since it was written, over a file that matters less.
+	 * <p>
 	 * In LF and without a byte order mark, like every other file this mod writes.
 	 */
 	public static void write(Path file, PackFile chosen) throws IOException {
 		Files.createDirectories(file.getParent());
-		Files.writeString(file,
+
+		Path temporary = file.resolveSibling(file.getFileName() + ".part");
+		Files.writeString(temporary,
 				NAME_KEY + "=" + chosen.name() + "\n"
 						+ ENABLED_KEY + "=" + chosen.enabled() + "\n"
 						+ SHADOW_DISTANCE_KEY + "=" + chosen.shadowDistance() + "\n",
 				StandardCharsets.UTF_8);
+		try {
+			Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING,
+					StandardCopyOption.ATOMIC_MOVE);
+		} catch (AtomicMoveNotSupportedException e) {
+			Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING);
+		}
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/settings/SettingsLayers.java
+++ b/common/src/main/java/dev/vitrail/settings/SettingsLayers.java
@@ -74,7 +74,7 @@ public final class SettingsLayers {
 		}
 
 		Map<String, OptionValue> chosen = new LinkedHashMap<>();
-		for (String line : text(file).split("\\r?\\n", -1)) {
+		for (String line : text(file).lines().toList()) {
 			String trimmed = line.trim();
 			int equals = trimmed.indexOf('=');
 			if (trimmed.isEmpty() || trimmed.startsWith("#") || equals < 1) {
@@ -101,6 +101,12 @@ public final class SettingsLayers {
 	 * A byte order mark is taken off rather than replaced, and that is the half nothing throws on.
 	 * Left where it is it rides on the first key, so a first line naming {@code profile} declares a
 	 * setting no pack has and no reserved line matches.
+	 * <p>
+	 * Cut by {@code lines} and not by a split on {@code \r?\n}, because {@code readAllLines} ends a
+	 * line on a lone carriage return as well ({@code BufferedReader.readLine}) and a split on that
+	 * pattern does not. A file saved with the old Mac endings would come back as ONE line, the
+	 * first key swallowing every value after it in silence. {@code PackFile} reads its own file
+	 * this way for the same reason.
 	 */
 	private static String text(Path file) throws IOException {
 		String text = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);

--- a/common/src/main/java/dev/vitrail/settings/SettingsLayers.java
+++ b/common/src/main/java/dev/vitrail/settings/SettingsLayers.java
@@ -3,6 +3,7 @@ package dev.vitrail.settings;
 import dev.vitrail.pack.option.OptionValue;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -73,7 +74,7 @@ public final class SettingsLayers {
 		}
 
 		Map<String, OptionValue> chosen = new LinkedHashMap<>();
-		for (String line : Files.readAllLines(file)) {
+		for (String line : text(file).split("\\r?\\n", -1)) {
 			String trimmed = line.trim();
 			int equals = trimmed.indexOf('=');
 			if (trimmed.isEmpty() || trimmed.startsWith("#") || equals < 1) {
@@ -85,6 +86,26 @@ public final class SettingsLayers {
 		}
 
 		return Collections.unmodifiableMap(chosen);
+	}
+
+	/**
+	 * The file's text, decoded rather than refused.
+	 * <p>
+	 * Through the {@code String} constructor and not {@code Files.readAllLines}, which THROWS on a
+	 * byte that is not UTF-8. This file is edited by hand, in whichever editor the player has, and
+	 * that throw does not stop at the line it cannot read: it leaves {@code forced}, reaches
+	 * {@code PackChain.open}, and NO PACK LOADS AT ALL, under a message naming neither the file nor
+	 * the encoding. What one stray byte costs instead is one character of one value.
+	 * {@code SettingsFile.lines} reads its own file this way already, for the same reason.
+	 * <p>
+	 * A byte order mark is taken off rather than replaced, and that is the half nothing throws on.
+	 * Left where it is it rides on the first key, so a first line naming {@code profile} declares a
+	 * setting no pack has and no reserved line matches.
+	 */
+	private static String text(Path file) throws IOException {
+		String text = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+
+		return text.startsWith("\uFEFF") ? text.substring(1) : text;
 	}
 
 	/**


### PR DESCRIPTION
## What changes

`vitrail/options.txt` was decoded in strict UTF-8. One byte from another encoding threw out of
`SettingsLayers.forced`, up through `PackChain.open`, and NO pack loaded at all, under a message
naming neither the file nor the encoding. A byte order mark threw nothing and rode on the first
key instead, so the first setting of the file named nothing any pack declares. `vitrail/pack.txt`
was read the same way, against the rule its own three lines are read under, that one bad character
must not cost the player the pack they had chosen. Both now decode the way `SettingsFile.lines`
already does, replacing what they cannot read, and drop a leading byte order mark.

`pack.txt` is also written through a temporary and an `ATOMIC_MOVE` now, like the settings file
beside it: a crash between the two writes left a truncated file, and half a line of that one reads
as no pack chosen.

## How it differs from the reference, and for what obstacle

It does not. Both files are this engine's own, with no counterpart in the reference; what they take
after is the file beside them, `SettingsFile`, which reads and writes this way for the reason
written in its own javadoc.

## What proves it

- `gradlew build` green.
- The remedy is not new code: it is the shape `SettingsFile.lines` and `SettingsFile.write` have
  carried since they were written, moved to the two files that had not got it.
- **Not exercised in the game.** Reproducing it takes one non-UTF-8 byte written into
  `vitrail/options.txt`, which nothing in the corpus does on its own.

## What it leaves owing

Nothing. The reserved lines, the profile layer and every other reader of these two files are
untouched: what changes is how the bytes become text, and a file that decoded before decodes to the
same text.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one. No page of `docs/`
      states an encoding for either file; both javadocs now say what they decode and why.
