### PR TITLE
ci: pose a request's type label from its branch name

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,56 @@
+# The label a pull request carries, posed by the repository instead of remembered by whoever opens
+# it. CONTRIBUTING says a request carries the type of its branch and only that, which makes the
+# label a fact already written in the branch name rather than an opinion about the change. There is
+# nothing to decide here, and that is exactly what makes it forgettable.
+#
+# It was forgotten. Nine of the first eighty-eight requests carry a label and none of the
+# twenty-seven after them do: the rule held for as long as somebody remembered it, and no longer.
+# Every one of those twenty-seven had its type written in its branch name and at the head of every
+# subject it carried, so nothing was ever missing except the gesture.
+#
+# It refuses nothing. A branch whose first word is not one of the nine types is already refused, by
+# `.githooks/commit-msg` and by `commits.yml` running that same file, so a second complaint here
+# would be one rule living in two places. What this does when it meets one is say so and stop,
+# leaving the request unlabelled and the other workflow to fail it.
+#
+# `pull_request_target` and not `pull_request`, because a request opened from a fork is given a
+# token that may only read. Nothing of the request is checked out or run here: what is read is the
+# name of its branch, and all that is done with it is a match against nine words written below. A
+# name matching none of them reaches no command at all.
+
+name: label
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: The type in the branch name, on the request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          type="${BRANCH%%/*}"
+          case "$type" in
+            feat|fix|perf|refactor|docs|test|build|ci|chore)
+              gh pr edit "$NUMBER" --repo "$REPOSITORY" --add-label "$type"
+              echo "Labelled $type, which is what the branch $BRANCH opens with."
+              ;;
+            release)
+              # A release request carries no type. What lands from such a branch is the version
+              # bump, and the request itself is the record of a fast-forward rather than a change.
+              echo "A release request carries no type label."
+              ;;
+            *)
+              echo "::notice::$BRANCH opens with no type CONTRIBUTING knows, so nothing is posed."
+              echo "::notice::The branch name itself is answered by commits.yml, not here."
+              ;;
+          esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,6 +254,12 @@ name and at the head of every subject the branch carries. `docs/correct-a-page` 
 and a branch whose commits are mostly `fix` with a `refactor` among them is labelled `fix`, the same
 way its name was settled.
 
+**The repository poses that one itself**, off the branch name and at the moment the request is
+opened (`.github/workflows/label.yml`). A label derived rather than decided has no reason to be
+asked of anybody, and this one held only for as long as it was remembered: nine of the first
+eighty-eight requests carry it and none of the twenty-seven after them do. Where it posts nothing,
+the branch opens on a word this convention does not know, and `commits.yml` is what says so.
+
 **An issue carries what it is about instead**, being a report rather than a change:
 
 | label | what it marks |


### PR DESCRIPTION
## What changes

A workflow poses the type label on a pull request when it is opened, taken from the first word of
its branch name. CONTRIBUTING has asked for that label since the convention was written and says
plainly that it is the type of the branch and nothing else, which makes it derived rather than
decided; leaving it to be remembered is what made it lapse. Nine of the first eighty-eight requests
carry one, and none of the twenty-seven after them do. The section in CONTRIBUTING now says where
it comes from, so nobody looks for a gesture that is no longer theirs.

## How it differs from the reference, and for what obstacle

It does not. Nothing here touches the engine or what a pack sees.

## What proves it

- Nothing built: the change is one workflow file and one paragraph.
- It refuses nothing, so it cannot be the reason a request goes red. A branch opening on a word
  that is not one of the nine types is already answered by `commits.yml`, which runs the same hook
  a contributor installs; this one says so in a notice and stops.
- `pull_request_target` rather than `pull_request`, so a request opened from a fork gets a token
  that may write the label. Nothing of the request is checked out or run: the branch name is read
  and matched against the nine words in the file, and a name matching none of them reaches no
  command.
- **It cannot label the two requests already open**, this one included: the event it listens for is
  the opening. Those three were labelled by hand.

## What it leaves owing

The nine requests that lapsed are closed and stay unlabelled: a label on a merged request is a
record nobody reads. The issue side of the same section is untouched, an issue carrying what it is
about rather than a type, which no branch name can answer.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
      This changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one: the Labels section
      of CONTRIBUTING is the only one, and it now names the workflow.
