### PR TITLE
perf(render): take three per frame things when something reads them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ what the next one holds.
   nothing was paying for them on every frame. They go back to whatever that menu says the moment a
   pack is unloaded.
 
+- **Three things taken on every frame are now taken when something reads them.** The search for a
+  lightning bolt walked every entity the world would draw, on every frame, to find the one kind of
+  entity that is almost never there; it runs once a tick now, which is the rate the reference
+  publishes that value at. The count of what the camera saw was taken on every frame for a line
+  printed once per pack. And the pack's number for an item was spelt out again at every submission,
+  where the number for a kind of entity had been remembered since it was written.
+
 ### Fixed
 
 - **The same pack now translates to the same text on every start.** Four tables the translator

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -199,6 +199,8 @@ public final class FrameState implements WorldState {
 	private float playerMaxAir = -1.0F;
 	private final Vector3f selectedBlockPos = new Vector3f(NOTHING_SELECTED);
 	private final Vector4f lightningBoltPosition = new Vector4f();
+	/** The tick the position beside this was searched for on, so a frame does not do it again. */
+	private long lightningTick = Long.MIN_VALUE;
 	private int heldBlockLight;
 	private int heldBlockLight2;
 
@@ -366,6 +368,12 @@ public final class FrameState implements WorldState {
 		this.frameCounter = 0;
 		this.frameTime = 0.0F;
 		this.frameTimeCounter = 0.0F;
+		// The bolt with them, and it is the tick beside it that makes this necessary rather than
+		// tidy: a client that leaves a save and rejoins it comes back at the tick it left on, so a
+		// counter kept across that would match, the search would be skipped, and the position of
+		// the session before would be served as this one's.
+		this.lightningTick = Long.MIN_VALUE;
+		this.lightningBoltPosition.zero();
 	}
 
 	/**
@@ -806,7 +814,23 @@ public final class FrameState implements WorldState {
 				|| held.canPlaceOnBlockInAdventureMode(inWorld));
 	}
 
+	/**
+	 * Once a tick and not once a frame, which is the frequency the reference publishes this at
+	 * ({@code uniforms/IrisExclusiveUniforms.java:91}, {@code PER_TICK}) and the whole of what it
+	 * buys: the search is a pass over every entity the level would render, made to find the one
+	 * kind of entity that is almost never there.
+	 * <p>
+	 * What is held between two ticks is what the reference holds too, the camera subtracted
+	 * included: it builds the whole camera relative vector inside that same per tick supplier, so
+	 * a bolt stands still for a walking player on both engines rather than only on this one.
+	 */
 	private void readLightning(ClientLevel level, float pt) {
+		long tick = level.getGameTime();
+		if (tick == this.lightningTick) {
+			return;
+		}
+
+		this.lightningTick = tick;
 		this.lightningBoltPosition.zero();
 		for (Entity entity : level.entitiesForRendering()) {
 			if (entity instanceof LightningBolt) {

--- a/common/src/main/java/dev/vitrail/render/PackNameIds.java
+++ b/common/src/main/java/dev/vitrail/render/PackNameIds.java
@@ -54,6 +54,13 @@ public final class PackNameIds {
 	 */
 	private static volatile Object2IntMap<EntityType<?>> byType = emptyCache();
 
+	/**
+	 * The same for an item, and for the same reason with one more: the table is keyed by the
+	 * name's TEXT, so without this every submission of every item spells one out again, where the
+	 * entity half beside it has never spelt one out twice.
+	 */
+	private static volatile Object2IntMap<Identifier> byName = emptyCache();
+
 	private PackNameIds() {
 	}
 
@@ -62,6 +69,7 @@ public final class PackNameIds {
 		entities = entityIds;
 		items = itemIds;
 		byType = emptyCache();
+		byName = emptyCache();
 	}
 
 	/** Whether the pack named the camera's own player, which is what makes that case worth asking. */
@@ -102,18 +110,33 @@ public final class PackNameIds {
 		return id;
 	}
 
-	/** The pack's number for an item, named by its model identifier or by its registry key. */
+	/**
+	 * The pack's number for an item, named by its model identifier or by its registry key, and
+	 * worked out once each.
+	 * <p>
+	 * A name the pack named nowhere is remembered as {@link NameIds#NONE} as well, which is what
+	 * the lookup tells apart from a real one by asking whether the key is there at all.
+	 */
 	public static int item(Identifier name) {
-		return items.id(name.toString());
+		Object2IntMap<Identifier> cache = byName;
+		int known = cache.getInt(name);
+		if (known != NameIds.NONE || cache.containsKey(name)) {
+			return known;
+		}
+
+		int id = items.id(name.toString());
+		cache.put(name, id);
+
+		return id;
 	}
 
 	/**
-	 * A cache with nothing in it, answering {@link NameIds#NONE} for a type it has not been asked
-	 * about, which is what the lookup above tells apart from a real {@code NONE} by asking whether
+	 * A cache with nothing in it, answering {@link NameIds#NONE} for a key it has not been asked
+	 * about, which is what the lookups above tell apart from a real {@code NONE} by asking whether
 	 * the key is there at all.
 	 */
-	private static Object2IntMap<EntityType<?>> emptyCache() {
-		Object2IntMap<EntityType<?>> cache = new Object2IntOpenHashMap<>();
+	private static <K> Object2IntMap<K> emptyCache() {
+		Object2IntMap<K> cache = new Object2IntOpenHashMap<>();
 		cache.defaultReturnValue(NameIds.NONE);
 
 		return cache;

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -153,7 +153,15 @@ public final class ShadowTerrain {
 			return;
 		}
 
-		int seen = sections(manager.getRenderLists());
+		// Counted only on the frame that will print it. It has to be taken HERE, the walk below
+		// replacing the camera's render lists with the light's, but every other frame was walking
+		// those lists for a line printed once per block table.
+		//
+		// Read once rather than again at the print, so a table installed between the two is named
+		// on the next frame instead of at once. That is the right way round: the count in hand was
+		// taken against the table that was standing when it was taken.
+		boolean measuring = measured != BlockStateIds.generation();
+		int seen = measuring ? sections(manager.getRenderLists()) : 0;
 
 		// Which entities the light can see is worked out here, and for them the position settles
 		// nothing: they are kept or dropped by a frustum and by a section's own state, neither of
@@ -202,7 +210,7 @@ public final class ShadowTerrain {
 			// numbers mean the cull did not happen, and nothing on screen would say so. The table is
 			// named because a second load of the same pack prints this again, word for word: it is
 			// what tells the two readings apart, not a property of the cull itself.
-			if (measured != BlockStateIds.generation() && seen > 0) {
+			if (measuring && seen > 0) {
 				measured = BlockStateIds.generation();
 				Vitrail.logger().info("Shadow cull walked {} sections for the light against {} "
 						+ "for the camera, on block table {}, culling {}",


### PR DESCRIPTION
## What changes

Three costs paid on every frame are now paid when something reads them.

- The search for a lightning bolt walked every entity the level would render, on every frame, to
  find the one kind of entity that is almost never there. It runs once a tick now, and the tick it
  was last run on is forgotten with the rest of the frame state when a world is left, so a client
  that rejoins a save at the tick it left on cannot be served the position of the session before.
- The count of the sections the camera saw was taken on every frame of the shadow stage, for a line
  printed once per block table. It still has to be taken before the light's walk replaces those
  lists, and is now taken only on the frame that will print it.
- The pack's number for an item was spelt out again at every submission, the table being keyed by
  the name's text. It is remembered per name, which is what the entity half of the same file has
  done since it was written.

## How it differs from the reference, and for what obstacle

It does not, and the first one moves TOWARDS it. The reference publishes `lightningBoltPosition` at
`PER_TICK` (`uniforms/IrisExclusiveUniforms.java:91`) and builds the whole camera relative vector
inside that same per tick supplier, camera subtraction included. So what is held between two ticks
here is what is held there: a bolt drifts for a walking player on both engines rather than on
neither. A dimension change inside one game keeps the counter honest by itself, the Nether and the
End deriving `getGameTime()` from the same data as the Overworld.

## What proves it

- `gradlew build` green, after the rebase.
- Read against the reference for the one that changes a published value; the other two change no
  value at all, only when it is worked out.
- **Not measured, and honestly: these are CPU side and small.** Taken beside the shadow culling
  branch on the same six run series, the frame counter did not move on them (406.8 against 406.3
  for the same scene), the machine being held at 100% GPU throughout. They are here because they
  are provable and free, not because they are the win.

## What it leaves owing

Four more of the same review item are untouched, and each wants a proof this one did not need:
the uniform buffer slice allocated per draw in `GeometryProgram.bind`, the two matrices allocated
per read in `GeometryValues`, the reflective survey of the far terrain rebuilt twice a frame in
`DhLods`, and the `float[7]` per quad in `TerrainMesh`, which is on the chunk build path rather
than the frame path and does not belong with these at all.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one. The three javadocs
      say what they now do and why; no page of `docs/` names any of the three.
