### PR TITLE
fix(dh): drop a camera half piece whose buffer DH has closed

### DIFF
--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -553,6 +553,24 @@ public final class DistantDraw {
 				pass.setUniform(DistantVertex.SECTION_BLOCK, this.corners.slot(device, base + index));
 
 				for (DhLods.Piece piece : sections.get(index).pieces()) {
+					// The shadow half's guard, asked here for what it says as much as for what
+					// it spares. The capture looks at the vertex buffer alone and nothing has
+					// ever looked at the index one, so a piece whose index buffer DH closed
+					// before it handed the set over is drawn from freed memory two submissions
+					// later, which is a device loss with no exception and no line to its name.
+					// Which of the two it names is the whole of what this is here to learn.
+					if (piece.vertices().isClosed() || piece.indices().isClosed()) {
+						String closed = piece.vertices().isClosed() ? "vertex" : "index";
+						if (this.refused.add("closed:" + closed + ":" + element.element())) {
+							Vitrail.logger().warn("A piece of the {} half of the far terrain reached "
+									+ "this frame's draw with its {} buffer closed, and is dropped. "
+									+ "Distant Horizons closed it between its own pass and this one",
+									element.half(), closed);
+						}
+
+						continue;
+					}
+
 					pass.setIndexBuffer(piece.indices(), IndexType.INT);
 					pass.setVertexBuffer(0, piece.vertices().slice());
 					pass.drawIndexed(piece.indexCount(), 1, 0, 0, 0);


### PR DESCRIPTION
## What changes

The camera half of the far terrain draw asks whether Distant Horizons' buffers are still open before
it binds them, which the shadow half already asked and it did not. The capture asks about the vertex
buffer alone, and no site asked about the index one at all, so a piece whose index buffer was closed
before the set was handed over would have been drawn from memory freed two submissions later. When
the guard drops a piece it says so once per load and per buffer, naming which of the two it found
closed.

## How it differs from the reference, and for what obstacle

It does not. Iris gets a second list of the far terrain built for the light and never faces the
question this half faces.

## What proves it

- `gradlew build` green.
- In the game, on the NeoForge bench with Bliss and with Complementary Unbound, over ten pack loads,
  six of which ended in the device loss of #111: **the line never came out**. So this is an
  asymmetry closed rather than a defect observed, and it settles one of the two shapes #111 could
  have had. The ladder that ruled it out is in that issue.

## What it leaves owing

Nothing of its own. It is two comparisons per piece per frame, on a list the shadow half already
walks the same way.
