### PR TITLE
build: raise the version to 0.7.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.7.0-beta
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ what the next one holds.
 
 ### Fixed
 
+- **Turning the shaders off and back on, or picking another pack, takes the game down far less
+  often.** Two rings the far terrain writes its section corners into were closed the moment a pack
+  was unloaded, while a pass already recorded still held slices of them, and the graphics device was
+  lost a few seconds later with nothing in the log to say why. They belong to the engine now rather
+  than to the pack, so a load has nothing to close. It is not the whole of that crash: a second
+  fault of the same family survives it, and where the pack could not be put back once before, it now
+  takes somewhere between one and four goes. Issue 111 follows what is left, and until it is closed
+  a pack changed in game remains a thing that can end the session.
+
 - **The same pack now translates to the same text on every start.** Four tables the translator
   walks to write a shader were handed back in an order the runtime picks afresh each time the game
   starts: the varyings a stage is owed, the vertex inputs a mesh has not got, and the volume

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.6.0-beta
+mod_version=0.7.0-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

The version, in the two places it is written, and one changelog entry the corner rings went in
without. Nothing of the engine.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

`gradlew build` green, and the tag this release is cut with is checked against `mod_version` by
the release job before anything is uploaded.

## What it leaves owing

The entry says out loud what issue #111 still holds: a pack changed in game can still end the
session, less often than before.