### PR TITLE
Release 0.7.0-beta

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
-# Normalise line endings in the repository, keep native ones in the working tree.
+# Normalise line endings to LF, in the repository and in the working tree alike, apart from the
+# batch scripts named below.
 * text=auto eol=lf
 
 *.java   text diff=java

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Versions
       description: Vitrail and its loader, Minecraft, Sodium, Chloride, and anything else in `mods/`.
-      placeholder: Vitrail 0.5.0-beta.1 on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
+      placeholder: Vitrail 0.6.0-beta on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/pack-report.yml
+++ b/.github/ISSUE_TEMPLATE/pack-report.yml
@@ -72,7 +72,7 @@ body:
     attributes:
       label: Versions
       description: Vitrail and its loader, Minecraft, Sodium, Chloride, and anything else in `mods/`.
-      placeholder: Vitrail 0.5.0-beta.1 on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
+      placeholder: Vitrail 0.6.0-beta on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
     validations:
       required: true
 

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,56 @@
+# The label a pull request carries, posed by the repository instead of remembered by whoever opens
+# it. CONTRIBUTING says a request carries the type of its branch and only that, which makes the
+# label a fact already written in the branch name rather than an opinion about the change. There is
+# nothing to decide here, and that is exactly what makes it forgettable.
+#
+# It was forgotten. Nine of the first eighty-eight requests carry a label and none of the
+# twenty-seven after them do: the rule held for as long as somebody remembered it, and no longer.
+# Every one of those twenty-seven had its type written in its branch name and at the head of every
+# subject it carried, so nothing was ever missing except the gesture.
+#
+# It refuses nothing. A branch whose first word is not one of the nine types is already refused, by
+# `.githooks/commit-msg` and by `commits.yml` running that same file, so a second complaint here
+# would be one rule living in two places. What this does when it meets one is say so and stop,
+# leaving the request unlabelled and the other workflow to fail it.
+#
+# `pull_request_target` and not `pull_request`, because a request opened from a fork is given a
+# token that may only read. Nothing of the request is checked out or run here: what is read is the
+# name of its branch, and all that is done with it is a match against nine words written below. A
+# name matching none of them reaches no command at all.
+
+name: label
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: The type in the branch name, on the request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          type="${BRANCH%%/*}"
+          case "$type" in
+            feat|fix|perf|refactor|docs|test|build|ci|chore)
+              gh pr edit "$NUMBER" --repo "$REPOSITORY" --add-label "$type"
+              echo "Labelled $type, which is what the branch $BRANCH opens with."
+              ;;
+            release)
+              # A release request carries no type. What lands from such a branch is the version
+              # bump, and the request itself is the record of a fast-forward rather than a change.
+              echo "A release request carries no type label."
+              ;;
+            *)
+              echo "::notice::$BRANCH opens with no type CONTRIBUTING knows, so nothing is posed."
+              echo "::notice::The branch name itself is answered by commits.yml, not here."
+              ;;
+          esac

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ replay_pid*.log
 # but none of it is part of what the project ships. Matched by shape rather than
 # listed by name: any Markdown at the root that is not one of the published pages,
 # any table of measurements written there, and any dotted directory that is not the
-# workflow definitions.
+# workflow definitions or the commit hooks.
 #
 # The tables earn their line the hard way: two of them sat at the root untracked for
 # a week, and every one is measured on shader packs that may not be redistributed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ what the next one holds.
   way too. That file is also written through a temporary and moved into place, so a crash while it
   is being written can no longer leave half a line behind, which read as no pack chosen at all.
 
+- **The shadow distance now bounds every chunk it is meant to, and not only the ones weighed one by
+  one.** A group of chunks that merely reached into the distance was handed to the walk whole, so
+  everything standing under that group was drawn into the shadow map however far past the distance
+  it stood. Lowering the distance, from the pack or from the video settings, therefore saved less
+  than it should have, on the second walk of the world, which is the most expensive thing a frame
+  does here.
+
 ## 0.6.0-beta
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ what the next one holds.
   nothing was paying for them on every frame. They go back to whatever that menu says the moment a
   pack is unloaded.
 
+### Fixed
+
+- **The same pack now translates to the same text on every start.** Four tables the translator
+  walks to write a shader were handed back in an order the runtime picks afresh each time the game
+  starts: the varyings a stage is owed, the vertex inputs a mesh has not got, and the volume
+  helpers a pack's three dimensional textures need. Two launches on the same pack could therefore
+  produce shaders that differ only in the order of their declarations, which is the same shader to
+  a reader and a different one to the game, so it compiled pipelines it already had. One warning
+  line about mesh elements a program computes from and does not get also listed its names in a
+  different order each run.
+
 ## 0.6.0-beta
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.7.0-beta
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ what the next one holds.
   nothing was paying for them on every frame. They go back to whatever that menu says the moment a
   pack is unloaded.
 
+- **Three things taken on every frame are now taken when something reads them.** The search for a
+  lightning bolt walked every entity the world would draw, on every frame, to find the one kind of
+  entity that is almost never there; it runs once a tick now, which is the rate the reference
+  publishes that value at. The count of what the camera saw was taken on every frame for a line
+  printed once per pack. And the pack's number for an item was spelt out again at every submission,
+  where the number for a kind of entity had been remembered since it was written.
+
 ### Fixed
 
 - **The same pack now translates to the same text on every start.** Four tables the translator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ what the next one holds.
 
 ### Fixed
 
+- **Turning the shaders off and back on, or picking another pack, takes the game down far less
+  often.** Two rings the far terrain writes its section corners into were closed the moment a pack
+  was unloaded, while a pass already recorded still held slices of them, and the graphics device was
+  lost a few seconds later with nothing in the log to say why. They belong to the engine now rather
+  than to the pack, so a load has nothing to close. It is not the whole of that crash: a second
+  fault of the same family survives it, and where the pack could not be put back once before, it now
+  takes somewhere between one and four goes. Issue 111 follows what is left, and until it is closed
+  a pack changed in game remains a thing that can end the session.
+
 - **The same pack now translates to the same text on every start.** Four tables the translator
   walks to write a shader were handed back in an order the runtime picks afresh each time the game
   starts: the varyings a stage is owed, the vertex inputs a mesh has not got, and the volume

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Changed
+
+- **Distant Horizons no longer draws its own ambient occlusion and fog while a pack is drawn.**
+  Between them they are three full screen passes over an image nothing downstream reads, so their
+  work was thrown away one pass later, and two of the three ran over the whole screen rather than
+  leaving it early. Both are on unless the DH menu says otherwise, so an install that changed
+  nothing was paying for them on every frame. They go back to whatever that menu says the moment a
+  pack is unloaded.
+
 ## 0.6.0-beta
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ what the next one holds.
   line about mesh elements a program computes from and does not get also listed its names in a
   different order each run.
 
+- **One character no editor should have written no longer costs the player every pack.**
+  `vitrail/options.txt` was read as strict UTF-8, so a single byte from another encoding stopped
+  ANY pack from loading, under a message that named neither the file nor the encoding. A byte order
+  mark, which several editors add on their own, threw nothing and quietly ate the first setting of
+  the file. Both now cost one character of one value at worst, and `vitrail/pack.txt` is read that
+  way too. That file is also written through a temporary and moved into place, so a crash while it
+  is being written can no longer leave half a line behind, which read as no pack chosen at all.
+
 ## 0.6.0-beta
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -378,17 +378,19 @@ anyone runs, then creates a GitHub release under the tag's own name and attaches
 that build produced, so what is downloaded is what this history compiles rather than what
 a machine had lying in `build/libs`.
 
-The same job then mirrors it to CurseForge, which is why there is no second workflow: a
-release this one creates is authored by the token it runs under, and such a release starts
-no further workflow, so a file listening for it would never wake. The mirror needs two
-secrets set in the repository settings, `CURSEFORGE_ID` and `CURSEFORGE_TOKEN`, and without
-either it says so and ends green rather than failing a release over it. The id is not a
-secret in any real sense (it is on the project's own page), and it lives there only so that
-both halves of the same configuration are found in the same place.
+The same job then mirrors it to CurseForge and to Modrinth, which is why there is no second
+workflow: a release this one creates is authored by the token it runs under, and such a
+release starts no further workflow, so a file listening for it would never wake. The mirror
+needs a pair per store set in the repository settings, `CURSEFORGE_ID` with
+`CURSEFORGE_TOKEN` and `MODRINTH_ID` with `MODRINTH_TOKEN`, and a store whose pair is
+incomplete is passed over with a notice rather than failing the release over it. Neither id
+is a secret in any real sense (both are on the project's own page): the CurseForge one lives
+in the secrets tab only so that both halves of the same configuration are found in the same
+place, and the Modrinth one is read from the variables tab as well.
 
-The release body is what CurseForge is given as the changelog, read back at the moment the
-run reaches it. A body written by hand after the tag went out therefore reaches CurseForge
-by running the workflow again on that tag, from the Actions tab, and by no other road.
+The release body is what both stores are given as the changelog, read back at the moment the
+run reaches it. A body written by hand after the tag went out therefore reaches them by
+running the workflow again on that tag, from the Actions tab, and by no other road.
 
 **Run it once for a given tag.** A second run rebuilds the same tag, and the archives here
 are built to be reproducible, so it offers CurseForge a file whose hash it already holds;
@@ -417,4 +419,5 @@ comparison link under a heading. A body corrected by hand on the release page af
 both stores by dispatching the workflow again on the same tag, since what the stores are handed is
 read back off the page rather than rebuilt.
 
-GitHub and CurseForge are the two places a build goes, and nothing else is automated.
+GitHub, CurseForge and Modrinth are the three places a build goes, and nothing else is
+automated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,6 +254,12 @@ name and at the head of every subject the branch carries. `docs/correct-a-page` 
 and a branch whose commits are mostly `fix` with a `refactor` among them is labelled `fix`, the same
 way its name was settled.
 
+**The repository poses that one itself**, off the branch name and at the moment the request is
+opened (`.github/workflows/label.yml`). A label derived rather than decided has no reason to be
+asked of anybody, and this one held only for as long as it was remembered: nine of the first
+eighty-eight requests carry it and none of the twenty-seven after them do. Where it posts nothing,
+the branch opens on a word this convention does not know, and `commits.yml` is what says so.
+
 **An issue carries what it is about instead**, being a report rather than a change:
 
 | label | what it marks |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,8 +58,9 @@ the log rather than by the file.
 Some of Chloride's own settings decide what reaches this engine, in
 `config/chloride-client.toml`, and they are entries inside its tables rather than
 keys of their own. `tileEntities`, `entities` and `monsters`, under `[culling]`,
-decide on their own which block entities and which mobs are drawn at all, by
-distance: what they take out is never handed to the pack, so a chest, a sign or a
+decide on their own which block entities, which mobs and which other entities are
+drawn at all, by distance: what they take out is never handed to the pack, so a
+chest, a sign, a boat or a
 mob that is not there is those settings rather than anything the pack does.
 `chests` and `beds`, under `[fastBlocks]`, draw those blocks by a path this
 engine's final pass then covers over, so they go invisible with no other symptom.
@@ -94,8 +95,9 @@ the first frame. This is not something Vitrail can work around: the fix belongs
 to that mod and not to this one.
 
 Given a build of it that draws on this backend, Vitrail hands its far terrain to
-the pack's own programs, `dh_terrain` and `dh_water` for the picture and
-`dh_shadow` for the shadow map, and serves its depth beside the world's, which is
+the pack's own programs, `dh_terrain` and `dh_water` for the picture, and
+`dh_shadow` for the shadow map where the pack ships one and has not switched it
+off, and serves its depth beside the world's, which is
 the arrangement packs are written against. The changelog
 says what that changes and what it does not reach, and the log names each far
 terrain pass as the pack takes it over.
@@ -230,12 +232,10 @@ is what tells a wrong gbuffer from a wrong composite. `dump=` is the one that
 answers what no picture can, since a value can be non zero, plausible and wrong.
 
 A settings screen covers all of it in game: the video settings, where it sits
-under Vitrail in the list of pages, the I key, or the Config button in the mod
-list. It is the screen of the engine packs are written against, ported rather
+under Vitrail in the list of pages, the I key, or, on NeoForge, the Config button
+in the mod list. It is the screen of the engine packs are written against, ported rather
 than approximated, so it looks and behaves like that one. It opens on the pack
-list, reads each pack's own menu layout, and
-imports the settings file Iris left in `shaderpacks/` when a pack has none here
-yet. The row at the head of the list turns shaders off altogether and leaves the
+list and reads each pack's own menu layout. The row at the head of the list turns shaders off altogether and leaves the
 game drawing its own image. Clicking a pack only selects it: Apply writes what
 you changed and reads the pack again without closing, Done does both and closes,
 and Cancel throws the changes away. A program that fails to compile is reported

--- a/NOTICE
+++ b/NOTICE
@@ -570,8 +570,9 @@ GNU Lesser General Public License version 3
   it, line 12, on the terrain and on every family the game hands over as a render type. The sixteen
   numbers are worked out here from the texel centres rather than read off Iris, and they agree with
   the sixteen it carries; what is taken is the rule that gl_TextureMatrix[1] is answered with them
-  at all, which is what a pack expects. One family is answered the identity here instead, and the
-  file names that as a divergence.
+  at all, which is what a pack expects. One family is answered the identity instead, Distant
+  Horizons geometry, and that is Iris's answer too rather than a divergence: it rewrites both
+  gl_TextureMatrix[0] and [1] to mat4(1.0) there.
 
   common/src/main/java/dev/vitrail/glsl/GlslTranslator.java sends a read of gl_TextureMatrix[0] to
   the game's own per draw transforms on the entity family, which is where

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Three jars land in `build/libs`; the one to install is the plain
 ## How it works
 
 A shader pack is GLSL written against OpenGL conventions that no Vulkan driver
-will accept. Vitrail rewrites every program into Vulkan GLSL **once, when the
-pack is loaded**, and hands it to the compiler the game already embeds, which
+will accept. Vitrail rewrites every program into Vulkan GLSL **once, before it
+ever draws**, and hands it to the compiler the game already embeds, which
 turns it into SPIR-V exactly as it does for the game's own shaders. There is no
 translation layer left between the game and the GPU while a frame is drawn:
 this is a compiler that runs at load time, not a shim that runs per frame. What

--- a/common/src/main/java/dev/vitrail/dh/DhLods.java
+++ b/common/src/main/java/dev/vitrail/dh/DhLods.java
@@ -62,6 +62,13 @@ public final class DhLods {
 	private static final String BUFFER_WRAPPER = "com.seibel.distanthorizons.common.render.blaze."
 			+ "wrappers.buffer.BlazeVertexBufferWrapper";
 
+	/** Where DH publishes what is only there once it has started, its proxy and its config alike. */
+	private static final String DELAYED = "com.seibel.distanthorizons.api.DhApi$Delayed";
+
+	/** The two DH post passes this engine holds off, and the answer of a config not published yet. */
+	private static final int SWITCHES = 2;
+	private static final int UNREACHED = -1;
+
 	private static boolean resolved;
 	private static boolean usable;
 
@@ -71,6 +78,17 @@ public final class DhLods {
 
 	/** Whether that switch has been thrown, which sticks until {@link #restore} lets go of it. */
 	private static boolean deferred;
+
+	/**
+	 * Whether the two switches of DH's own post passes have been REACHED, which is what makes
+	 * whatever took among them this engine's to hand back in {@link #restore}. Not whether both
+	 * took: DH answers each one on its own, and one that refused is still one asked once and not
+	 * every frame after.
+	 */
+	private static boolean muted;
+
+	/** False once the road to those two has been walked and failed, which it will fail again. */
+	private static boolean mutable = true;
 
 	/** The renderer DH bound for itself, which everything this engine does not serve falls back on. */
 	private static Object original;
@@ -149,6 +167,11 @@ public final class DhLods {
 				original = standing;
 				rendererField.set(lodRenderer, substitute);
 			}
+
+			// After the substitution and never instead of it: what it holds off is a cost, so a
+			// road to it that cannot be walked leaves the far terrain served all the same. Says so
+			// itself and throws nothing back here.
+			mute();
 		} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
 			usable = false;
 			Vitrail.logger().warn("Distant Horizons' far terrain cannot be taken over, so that mod "
@@ -181,6 +204,120 @@ public final class DhLods {
 				+ "which is where the pack's own dh_water pass stands");
 
 		return true;
+	}
+
+	/**
+	 * Holds off the two passes DH draws over its own image once the terrain is down, neither of
+	 * which anything downstream of here reads.
+	 * <p>
+	 * DH's third one, the apply, is already harmless for the reason {@code render/DistantDraw}
+	 * gives: nothing of this engine lands in DH's colour or depth, so its apply shader finds the
+	 * depth image as it cleared it and discards the whole screen. Its ambient occlusion and its fog
+	 * are not harmless, they are paid: three full screen passes over that same image between them,
+	 * the occlusion taking a second one to blur and apply itself
+	 * ({@code common/render/blaze/postProcessing/BlazeDhSsaoRenderer.java:113-117}), and both are on
+	 * by default ({@code core/config/Config.java:127} and {@code :447}), so an install that changed
+	 * nothing pays for three screens of work a frame that are thrown away one pass later. Iris
+	 * holds off the same two, through the same published config, at
+	 * {@code compat/dh/LodRendererEvents.java:274-275}, and clears them again at {@code :281}.
+	 * <p>
+	 * <strong>What the three cost is the passes and not their bodies, and only one of the three
+	 * even reaches its body.</strong> The image they read is DH's depth as it cleared it, which is
+	 * nought under a reversed Z: the occlusion's own shader tests that correctly and leaves every
+	 * pixel at once, while its apply and the fog both ask whether the depth is under one, which is
+	 * true of nought, so those two run their full body over a screen of sky. That second half is
+	 * DH's reversed Z defect rather than a cost of this engine, and a DH that fixes it would make
+	 * these three passes cheap rather than free. Held off either way: a pass that draws nothing
+	 * still binds, clears and stores its attachments.
+	 * <p>
+	 * Set rather than written: the API keeps its own value beside the player's, and {@link #restore}
+	 * hands it back, so a session that stops drawing a pack finds its DH menu as it left it. Quiet
+	 * about a road it cannot walk beyond one line, this being a cost and not a picture.
+	 */
+	private static void mute() {
+		if (muted || !mutable) {
+			return;
+		}
+
+		try {
+			int held = hold(Boolean.FALSE);
+			if (held == UNREACHED) {
+				return;
+			}
+
+			// Latched on having reached them rather than on their having taken, so that whichever
+			// DID take is handed back later. A switch forced and then forgotten would leave a
+			// player's own menu answering for this engine long after it stopped drawing.
+			muted = true;
+			if (held == SWITCHES) {
+				Vitrail.logger().info("Distant Horizons holds off its own ambient occlusion and "
+						+ "fog, both of which draw over an image this engine never reads");
+			} else {
+				Vitrail.logger().info("Distant Horizons lets {} of its {} post passes be held off "
+						+ "through its API, so it keeps drawing the rest over an image this engine "
+						+ "never reads", held, SWITCHES);
+			}
+		} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
+			mutable = false;
+			Vitrail.logger().info("Distant Horizons keeps drawing its own ambient occlusion and fog "
+					+ "over an image this engine never reads, which costs a frame and shows "
+					+ "nothing: {}", e.toString());
+		}
+	}
+
+	/**
+	 * Sets both switches to one value, or hands both back to the player when it is null.
+	 * <p>
+	 * The road is resolved on the spot rather than kept in fields: it is walked twice for a pack
+	 * rather than once a frame, and one method that both callers share is worth more here than the
+	 * eight fields holding it would save.
+	 * <p>
+	 * A switch answers whether it took: DH refuses through this road any config its own menu keeps
+	 * to itself, and it says so rather than throwing. Counted rather than assumed, so that the line
+	 * this engine writes about the two says what really happened to them.
+	 *
+	 * @return how many of the two took, or {@link #UNREACHED} while DH has published no config yet
+	 */
+	private static int hold(Boolean value) throws ReflectiveOperationException {
+		Field field = Class.forName(DELAYED).getField("configs");
+		Object configs = field.get(null);
+		if (configs == null) {
+			return UNREACHED;
+		}
+
+		// Every step is asked of the type DECLARED at the step above it, which is an interface of
+		// DH's published API, rather than of the object in hand: the classes behind them are its
+		// own and need not be public for this to reach them.
+		Method graphics = field.getType().getMethod("graphics");
+		Object graphicsConfig = graphics.invoke(configs);
+
+		Method ambientOcclusion = graphics.getReturnType().getMethod("ambientOcclusion");
+		Method fog = graphics.getReturnType().getMethod("fog");
+
+		// The fog switch is the one DH points at rather than the one Iris still uses: its drawMode
+		// is deprecated in favour of this since API 4.0.0 and reaches the same config entry through
+		// a converter (core/api/external/methods/config/client/DhApiFogConfig.java:58-62), which is
+		// the entry LodRenderer reads the API's answer out of (render/renderer/LodRenderer.java:189).
+		Method enabled = ambientOcclusion.getReturnType().getMethod("enabled");
+		Method dhFog = fog.getReturnType().getMethod("enableDhFog");
+
+		// Both of DH's own setters answer with a boolean, and both are declared on the one config
+		// value interface, so a null value picks the one that gives a switch back to the player.
+		Class<?> configValue = enabled.getReturnType();
+		Method action = value == null
+				? configValue.getMethod("clearValue")
+				: configValue.getMethod("setValue", Object.class);
+		Object[] arguments = value == null ? new Object[0] : new Object[] { value };
+
+		int held = 0;
+		for (Object one : List.of(enabled.invoke(ambientOcclusion.invoke(graphicsConfig)),
+				dhFog.invoke(fog.invoke(graphicsConfig)))) {
+			if (Boolean.TRUE.equals(action.invoke(one, arguments))) {
+				held++;
+			}
+		}
+
+		return held;
 	}
 
 	/**
@@ -219,8 +356,7 @@ public final class DhLods {
 
 			// The switch is published API, so the road to it is short: the delayed holder and the
 			// one setter on the proxy's interface.
-			renderProxyField = Class.forName("com.seibel.distanthorizons.api.DhApi$Delayed")
-					.getField("renderProxy");
+			renderProxyField = Class.forName(DELAYED).getField("renderProxy");
 			deferTransparentMethod = renderProxyField.getType()
 					.getMethod("setDeferTransparentRendering", boolean.class);
 
@@ -348,6 +484,19 @@ public final class DhLods {
 				}
 			} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
 				Vitrail.logger().debug("Distant Horizons' deferred water switch cannot be put back", e);
+			}
+		}
+
+		// And its own two post passes, which are worth having again the moment their image is the
+		// one on screen. Handed back to the PLAYER rather than set true: what the menu says is his,
+		// and this engine only ever stood in front of it.
+		if (muted) {
+			muted = false;
+			try {
+				hold(null);
+			} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
+				Vitrail.logger().debug("Distant Horizons' own ambient occlusion and fog cannot be "
+						+ "handed back", e);
 			}
 		}
 	}

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -14,6 +14,7 @@ import dev.vitrail.pack.texture.VolumeAtlas;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -438,7 +439,7 @@ public final class GlslTranslator {
 		this.alphaTest = alphaTest;
 		this.coverage = coverage;
 		this.program = program;
-		this.volumes = Map.copyOf(volumes);
+		this.volumes = Collections.unmodifiableMap(new LinkedHashMap<>(volumes));
 
 		// Tokens cost far more than the text they came from, roughly seventy bytes each, so a unit
 		// the expander should never have produced has to be refused before it is read rather than
@@ -607,7 +608,7 @@ public final class GlslTranslator {
 		 * list of what the picture will be wrong about when it is not.
 		 */
 		public Map<String, String> synthesized() {
-			return Map.copyOf(this.translator.synthesized);
+			return Collections.unmodifiableMap(new LinkedHashMap<>(this.translator.synthesized));
 		}
 
 		/**
@@ -740,7 +741,7 @@ public final class GlslTranslator {
 		 * declares it again. Empty until that has run.
 		 */
 		public Map<String, String> unprovided() {
-			return Map.copyOf(this.translator.unprovidedInputs);
+			return Collections.unmodifiableMap(new LinkedHashMap<>(this.translator.unprovidedInputs));
 		}
 
 		/**

--- a/common/src/main/java/dev/vitrail/mixin/ProjectionMatrixBufferMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/ProjectionMatrixBufferMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 /**
  * Copies the projection the level is about to be drawn with, and does nothing else.
  * <p>
- * The one mixin in the engine, and it exists because the matrix in question is never stored.
+ * It exists because the matrix in question is never stored.
  * {@code GameRenderer.renderLevel} takes the camera's projection, multiplies in the walk bob, the
  * damage tilt, the nausea rotation and the portal skew, hands the result straight to this method
  * and lets it go. The camera's own field is the version before all four, and the difference is

--- a/common/src/main/java/dev/vitrail/pack/menu/MenuValues.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/MenuValues.java
@@ -229,17 +229,6 @@ public final class MenuValues {
 	}
 
 	/**
-	 * The profile the pack was last built with, which is what the world on screen amounts to. A
-	 * screen needs both this and {@link #profile()} to tell a chosen profile from an applied one,
-	 * exactly as it does for a single setting.
-	 */
-	public String appliedProfile() {
-		String over = this.forced.get(PROFILE_KEY);
-
-		return over == null ? match(this::applied) : over;
-	}
-
-	/**
 	 * Back to the value the pack ships, not to the value the profile or the file would give. That
 	 * is what a shift click means, and it is also what makes the line disappear from the file
 	 * rather than being written out with the default in it.

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -192,10 +192,6 @@ public final class EngineDefines {
 		return defines;
 	}
 
-	public static int count() {
-		return table(DEFAULT_MC_VERSION).size();
-	}
-
 	private static String osSymbol(Os os) {
 		return switch (os) {
 			case MAC -> "MC_OS_MAC";

--- a/common/src/main/java/dev/vitrail/pack/source/DimensionSet.java
+++ b/common/src/main/java/dev/vitrail/pack/source/DimensionSet.java
@@ -117,10 +117,10 @@ public final class DimensionSet {
 	/**
 	 * Which directory this world's programs are read from, the empty string for the root.
 	 * <p>
-	 * The root is the answer for a world the pack says nothing about and has no catch-all for, and
-	 * for a folder named here that is not on disk. A folder that IS on disk answers for itself
-	 * whether or not it holds an entry point, which {@link TargetPlan} decides rather than this: a
-	 * name here is where to look, not what is there.
+	 * The root is the answer for a world the pack says nothing about and has no catch-all for. A
+	 * folder named here answers for itself whether or not it is on disk and whether or not it holds
+	 * an entry point, which {@link TargetPlan} decides rather than this: a name here is where to
+	 * look, not what is there.
 	 *
 	 * @param world the dimension's identifier, {@code minecraft:the_nether}
 	 */

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -420,11 +420,17 @@ public final class ChainPlan {
 
 		/**
 		 * What a caller with no {@code options.txt} to read gets, which is the harness and the corpus
-		 * measurements: the entities off and the three others on, which is what {@code EngineOptions}
-		 * defaults those four lines to. Written out here rather than read, nothing in this package
-		 * having a game directory to read it from.
+		 * measurements: all four on, which is what {@code EngineOptions} defaults those four lines
+		 * to. Written out here rather than read, nothing in this package having a game directory to
+		 * read it from.
+		 * <p>
+		 * The entities stood false here long after their own line had gone on by default, so every
+		 * verdict taken without an {@code options.txt} was taken on a configuration nobody ships: a
+		 * target the entity programs write was read as one no geometry of this engine fills. BSL's
+		 * {@code colortex3} carried that note in all three of its places. The game itself never saw
+		 * it, {@code render/PackChain} handing the plan the lines that were really written.
 		 */
-		public static final Families DEFAULT = new Families(true, false, true, true);
+		public static final Families DEFAULT = new Families(true, true, true, true);
 	}
 
 	/** What a caller with no {@code options.txt} to read gets. See {@link Families#DEFAULT}. */

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -291,10 +291,12 @@ public final class ChainPlan {
 	private final List<Integer> swapBack;
 	private final List<String> refusals;
 	private final List<String> notes;
+	private final List<String> history;
 
 	private ChainPlan(String place, List<Pass> passes, Pass last, Seed seed,
 			Map<Key, Pass> attachments, Map<TerrainPass, Key> terrainKeys, Map<String, Key> skyKeys,
-			List<Integer> swapBack, List<String> refusals, List<String> notes) {
+			List<Integer> swapBack, List<String> refusals, List<String> notes,
+			List<String> history) {
 		this.place = place;
 		this.passes = List.copyOf(passes);
 		this.last = last;
@@ -305,6 +307,7 @@ public final class ChainPlan {
 		this.swapBack = List.copyOf(swapBack);
 		this.refusals = List.copyOf(refusals);
 		this.notes = List.copyOf(notes);
+		this.history = List.copyOf(history);
 	}
 
 	public record Attachment(int target, TargetSchedule.Side side) {
@@ -445,6 +448,7 @@ public final class ChainPlan {
 		List<Pass> passes = new ArrayList<>();
 		List<String> refusals = new ArrayList<>(refused);
 		List<String> notes = new ArrayList<>();
+		List<String> history = new ArrayList<>();
 		Pass last = null;
 
 		for (String program : plan.running()) {
@@ -593,7 +597,7 @@ public final class ChainPlan {
 			}
 		}
 
-		verdicts(plan, painted, world, passes, last, notes);
+		verdicts(plan, painted, world, passes, last, notes, history);
 
 		Set<Integer> back = new TreeSet<>(plan.schedule().flippedAtEnd());
 		back.retainAll(plan.persistent());
@@ -610,7 +614,7 @@ public final class ChainPlan {
 		});
 
 		return new ChainPlan(plan.place(), passes, last, seed, answered, terrainKeys, skyKeys,
-				List.copyOf(back), refusals, notes);
+				List.copyOf(back), refusals, notes, history);
 	}
 
 	/**
@@ -879,9 +883,12 @@ public final class ChainPlan {
 	 *              clear colour where that family has just written, and a map holding a family that
 	 *              was switched off says the target is filled where nothing wrote it. The first is
 	 *              the one these lines exist to rule out; the second leaves no trace at all
+	 * @param notes what the picture will be wrong about
+	 * @param history the reads that land on what the frame before wrote, which is the pack's own
+	 *                doing rather than a fault of this engine. See {@link #history()}
 	 */
 	private static void verdicts(TargetPlan plan, Seed seed, Map<Key, Pass> world,
-			List<Pass> passes, Pass last, List<String> notes) {
+			List<Pass> passes, Pass last, List<String> notes, List<String> history) {
 		List<Pass> ordered = new ArrayList<>(passes);
 		if (last != null) {
 			ordered.add(last);
@@ -935,7 +942,8 @@ public final class ChainPlan {
 					continue;
 				}
 
-				notes.add(verdict(plan, undrawn, ordered, drawn, at, half, pass.program()));
+				Verdict said = verdict(plan, undrawn, ordered, drawn, at, half, pass.program());
+				(said.temporal() ? history : notes).add(said.text());
 			}
 
 			filled.addAll(pass.attachments());
@@ -964,8 +972,9 @@ public final class ChainPlan {
 	 * @param undrawn the targets geometry writes and no pass of this engine fills
 	 * @param drawn   the world's own passes, by the point of the frame they are drawn at
 	 */
-	private static String verdict(TargetPlan plan, Set<Integer> undrawn, List<Pass> ordered,
+	private static Verdict verdict(TargetPlan plan, Set<Integer> undrawn, List<Pass> ordered,
 			Map<Integer, Set<Pass>> drawn, int at, Attachment half, String reader) {
+		boolean kept = plan.persistent().contains(half.target());
 		String name = TargetName.canonical(half.target());
 		String clear = ", so " + reader + " reads what the clear left there";
 		String before = ", so " + reader + " reads the frame before, and the clear colour on the "
@@ -983,13 +992,14 @@ public final class ChainPlan {
 			// Which of the two the reader really gets is the clear directive's answer and never the
 			// order's: a target the pack clears is emptied on BOTH halves at the top of every frame,
 			// so nothing of the frame before is left there to be read.
-			return name + " is not written until " + later + ", later in the same frame"
-					+ (plan.persistent().contains(half.target()) ? before : clear);
+			return new Verdict(name + " is not written until " + later + ", later in the same frame"
+					+ (kept ? before : clear), kept);
 		}
 
 		String off = disabledWriter(plan, half.target());
 		if (off != null) {
-			return name + " is written by " + off + ", which this place does not run" + clear;
+			return new Verdict(name + " is written by " + off + ", which this place does not run"
+					+ clear, false);
 		}
 
 		if (undrawn.contains(half.target())) {
@@ -1010,17 +1020,28 @@ public final class ChainPlan {
 			// The tail is flat, and it is flat because of where this branch now sits: nothing later in
 			// the frame writes this half, so the pack keeping the target between frames buys the
 			// reader nothing - the frame before had nothing written there either.
-			return name + " is written by geometry, none of which this engine draws into the pack's "
-					+ "targets" + clear;
+			return new Verdict(name + " is written by geometry, none of which this engine draws into "
+					+ "the pack's targets" + clear, false);
 		}
 
 		// Nothing fills this half at any point of the frame. Whether that is a hole or a history
 		// buffer is decided by the pack's own clear directive and by nothing else.
-		return plan.persistent().contains(half.target())
-				? "nothing writes the half of " + name + " that " + reader + " reads, and the pack "
-						+ "keeps that target between frames" + before
-				: name + " is written by no program of this place, so it holds its clear colour for "
-						+ "ever, and " + reader + " reads that";
+		return kept
+				? new Verdict("nothing writes the half of " + name + " that " + reader + " reads, and "
+						+ "the pack keeps that target between frames" + before, true)
+				: new Verdict(name + " is written by no program of this place, so it holds its clear "
+						+ "colour for ever, and " + reader + " reads that", false);
+	}
+
+	/**
+	 * One verdict about a half nothing has filled by the time it is read.
+	 *
+	 * @param temporal whether the pack keeps that target between frames, so the read lands on what
+	 *                 the frame before wrote there rather than on a clear colour. That is a
+	 *                 mechanism of the pack, and Iris hands it the same one, so it belongs with the
+	 *                 facts and not with what the picture will be wrong about
+	 */
+	private record Verdict(String text, boolean temporal) {
 	}
 
 	/**
@@ -1193,5 +1214,20 @@ public final class ChainPlan {
 	/** What will be wrong once it is drawn, in the pack's own terms. */
 	public List<String> notes() {
 		return this.notes;
+	}
+
+	/**
+	 * The reads that land on what the frame before wrote, in the pack's own terms. Facts about the
+	 * pack and not faults of this engine, which is why they are handed back apart from
+	 * {@link #notes()}.
+	 * <p>
+	 * They used to be in that list, and the list is introduced to the reader as what the picture
+	 * will be wrong about. BSL's {@code colortex2} is the case that proved the cost: its line says
+	 * the target is not written until {@code composite7} and that {@code composite5} therefore reads
+	 * the frame before, which is exactly the temporal chain the pack is built on and exactly what
+	 * Iris gives it. Read among the faults it became a suspect, and stayed one for a fortnight.
+	 */
+	public List<String> history() {
+		return this.history;
 	}
 }

--- a/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
@@ -8,6 +8,7 @@ import dev.vitrail.pack.target.TargetName;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -442,7 +443,7 @@ public final class PackTextures {
 			}
 		}
 
-		return Map.copyOf(flat);
+		return Collections.unmodifiableMap(flat);
 	}
 
 	private static boolean flattenable(PackTexture texture) {

--- a/common/src/main/java/dev/vitrail/platform/VitrailPlatform.java
+++ b/common/src/main/java/dev/vitrail/platform/VitrailPlatform.java
@@ -17,9 +17,6 @@ public interface VitrailPlatform {
 
 	String minecraftVersion();
 
-	/** Directory the shader packs and the engine configuration live in. */
-	Path configDirectory();
-
 	/** Root of the game instance, where the user-editable shader sources live. */
 	Path gameDirectory();
 

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -590,10 +590,6 @@ final class ColorTargets {
 		return this.shadowMap;
 	}
 
-	Set<Integer> doubled() {
-		return this.doubled;
-	}
-
 	long bytes() {
 		return sum(TargetSurface::bytes);
 	}

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -221,8 +221,19 @@ public final class DistantDraw {
 	 */
 	private boolean broken;
 
-	/** The section corners of the halves recorded this frame, one aligned slot each. */
-	private final Corners corners = new Corners("Vitrail far terrain sections");
+	/**
+	 * The section corners of the halves recorded this frame, one aligned slot each.
+	 * <p>
+	 * <strong>It outlives the pack, and that is the point.</strong> A recorded pass binds
+	 * slices of this ring, so destroying it is only safe where nothing holds one, which
+	 * {@link Corners#write} already refuses to do while a half of the frame in hand has been
+	 * drawn from it. A pack load has no such knowledge: it tears the chain down in the middle
+	 * of a frame whose passes are already recorded against these very slices, and a ring
+	 * closed there takes the device with it a few frames later. Kept across loads there is
+	 * nothing to close, and it costs a few dozen kilobytes: the ring sizes itself to the
+	 * widest horizon it has seen, and every slot is written again before it is read.
+	 */
+	private static final Corners CORNERS = new Corners("Vitrail far terrain sections");
 
 	/**
 	 * The same for the light's own two halves, which cannot share the ring above.
@@ -233,8 +244,10 @@ public final class DistantDraw {
 	 * exactly the trouble: the ring would then be one turn ahead of itself, and the NEXT frame's
 	 * camera halves would map the buffer the light's own submission is still reading. A ring fences
 	 * a buffer where it turns, and one shared ring would be asked to turn twice a frame.
+	 * <p>
+	 * It outlives the pack for the reason the ring above does.
 	 */
-	private final Corners shadowCorners = new Corners("Vitrail far terrain shadow sections");
+	private static final Corners SHADOW_CORNERS = new Corners("Vitrail far terrain shadow sections");
 
 	/** What DH has handed over on the frame being drawn, one list per half of its geometry. */
 	private List<DhLods.Section> opaqueSections = List.of();
@@ -414,7 +427,7 @@ public final class DistantDraw {
 			return;
 		}
 
-		int base = this.shadowCorners.write(device, sections, camera);
+		int base = SHADOW_CORNERS.write(device, sections, camera);
 		if (base < 0) {
 			refuseShadow(element, "sections", "the far terrain grew wider than the block holding its "
 					+ "section corners between the two halves of one stage, and the wider block "
@@ -430,7 +443,7 @@ public final class DistantDraw {
 
 			for (int index = 0; index < sections.size(); index++) {
 				pass.setUniform(DistantVertex.SECTION_BLOCK,
-						this.shadowCorners.slot(device, base + index));
+						SHADOW_CORNERS.slot(device, base + index));
 
 				for (DhLods.Piece piece : sections.get(index).pieces()) {
 					// Asked again here and not only where the section was taken, which is the one
@@ -534,7 +547,7 @@ public final class DistantDraw {
 		// else this engine places is placed against the game's, and a far terrain placed against a
 		// second reading of the same position would stand a fraction of a block away from the near
 		// terrain it meets.
-		int base = this.corners.write(device, sections, minecraft.gameRenderer.mainCamera().position());
+		int base = CORNERS.write(device, sections, minecraft.gameRenderer.mainCamera().position());
 		if (base < 0) {
 			return refuse(element, "sections", "the far terrain grew wider than the block holding its "
 					+ "section corners between the two halves of one frame, and the wider block cannot "
@@ -550,7 +563,7 @@ public final class DistantDraw {
 			program.bind(pass);
 
 			for (int index = 0; index < sections.size(); index++) {
-				pass.setUniform(DistantVertex.SECTION_BLOCK, this.corners.slot(device, base + index));
+				pass.setUniform(DistantVertex.SECTION_BLOCK, CORNERS.slot(device, base + index));
 
 				for (DhLods.Piece piece : sections.get(index).pieces()) {
 					pass.setIndexBuffer(piece.indices(), IndexType.INT);
@@ -803,8 +816,8 @@ public final class DistantDraw {
 		this.shadowWater = this.waterSections;
 		this.opaqueSections = List.of();
 		this.waterSections = List.of();
-		this.corners.rotate();
-		this.shadowCorners.rotate();
+		CORNERS.rotate();
+		SHADOW_CORNERS.rotate();
 		this.programs.values().forEach(DistantProgram::rotate);
 	}
 
@@ -821,8 +834,11 @@ public final class DistantDraw {
 		this.waterSections = List.of();
 		this.shadowOpaque = List.of();
 		this.shadowWater = List.of();
-		this.corners.close();
-		this.shadowCorners.close();
+		// NOT closed, which is the whole of issue 111: a recorded pass holds slices of these
+		// two rings, and a load tears the chain down in the middle of a frame that has
+		// already bound them. What is dropped here is what this load wrote into them.
+		CORNERS.forget();
+		SHADOW_CORNERS.forget();
 
 		releaseDepth();
 	}
@@ -962,14 +978,12 @@ public final class DistantDraw {
 			}
 		}
 
-		void close() {
-			if (this.buffer != null) {
-				this.buffer.close();
-				this.buffer = null;
-				this.slots = 0;
-				this.used = 0;
-			}
-
+		/**
+		 * Drops what a load wrote here, and destroys nothing: see the two fields this
+		 * stands behind for why a ring is never closed on a reload.
+		 */
+		void forget() {
+			this.used = 0;
 			this.peak = 0;
 		}
 	}

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -67,10 +67,11 @@ import java.util.Set;
  * entirely.</strong> Nothing is drawn into DH's own colour or depth; DH's own apply pass then finds
  * its depth image exactly as it cleared it and discards every pixel of the screen
  * ({@code assets/distanthorizons/shaders/apply/blaze/frag.fsh} discarding on a depth of nought under
- * a reversed Z), so there is no compositing to switch off and no event to bind. What the far terrain
- * leaves here is what {@code render/PackDepth} converts into the pack's window and serves back
- * under {@code dhDepthTex}, in two takes that bracket the water half exactly as the world's own
- * depth is taken around its translucents.
+ * a reversed Z), so there is no compositing to switch off and no event to bind. Its two other post
+ * passes are held off all the same, for a reason that is cost rather than picture, on
+ * {@code dh/DhLods#mute}. What the far terrain leaves here is what {@code render/PackDepth} converts
+ * into the pack's window and serves back under {@code dhDepthTex}, in two takes that bracket the
+ * water half exactly as the world's own depth is taken around its translucents.
  * <p>
  * <strong>One value belongs to the section rather than to the pass</strong>, which is where DH keeps
  * a section's corner: three unsigned shorts cannot hold a world coordinate, so the vertex carries

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -566,6 +566,24 @@ public final class DistantDraw {
 				pass.setUniform(DistantVertex.SECTION_BLOCK, CORNERS.slot(device, base + index));
 
 				for (DhLods.Piece piece : sections.get(index).pieces()) {
+					// The shadow half's guard, asked here for what it says as much as for what
+					// it spares. The capture looks at the vertex buffer alone and nothing has
+					// ever looked at the index one, so a piece whose index buffer DH closed
+					// before it handed the set over is drawn from freed memory two submissions
+					// later, which is a device loss with no exception and no line to its name.
+					// Which of the two it names is the whole of what this is here to learn.
+					if (piece.vertices().isClosed() || piece.indices().isClosed()) {
+						String closed = piece.vertices().isClosed() ? "vertex" : "index";
+						if (this.refused.add("closed:" + closed + ":" + element.element())) {
+							Vitrail.logger().warn("A piece of the {} half of the far terrain reached "
+									+ "this frame's draw with its {} buffer closed, and is dropped. "
+									+ "Distant Horizons closed it between its own pass and this one",
+									element.half(), closed);
+						}
+
+						continue;
+					}
+
 					pass.setIndexBuffer(piece.indices(), IndexType.INT);
 					pass.setVertexBuffer(0, piece.vertices().slice());
 					pass.drawIndexed(piece.indexCount(), 1, 0, 0, 0);

--- a/common/src/main/java/dev/vitrail/render/EngineOptions.java
+++ b/common/src/main/java/dev/vitrail/render/EngineOptions.java
@@ -63,7 +63,8 @@ final class EngineOptions {
 	 * one of {@code solid}, {@code cutout} and {@code translucent} for a chunk pass, two of which are
 	 * usually served by the one file and could not otherwise be told apart. The sky answers the same
 	 * way, by element rather than by file: {@code disc}, {@code dark}, {@code stars},
-	 * {@code sunrise}, {@code sun} and {@code moon}, four of the six being one file. The entities
+	 * {@code sunrise}, {@code sun}, {@code moon}, {@code endsky} and {@code endflash}, four of the
+	 * eight being one file. The entities
 	 * answer the same way, {@code cutout_cull}, {@code armor}, {@code item} and the rest, with the
 	 * block entity half carrying those same names under a {@code block_} in front and the two hand
 	 * passes under a {@code hand_} and a {@code hand_water_}. The weather is
@@ -73,10 +74,10 @@ final class EngineOptions {
 	 * {@code dump=gbuffers_block}, <strong>only where the pack really ships that file</strong>: the
 	 * line is matched against the file that ends up SERVING, so wherever the fallback tree leads
 	 * elsewhere the name matches nothing at all and the element names are the only way in.
-	 * <strong>Two of their element names cannot be reached at
+	 * <strong>Three of their element names cannot be reached at
 	 * all</strong>, and it is a property of the matching rather than a fault: the line is matched on
-	 * the TAIL of a label, the terrain is walked first, and its own passes are called {@code solid}
-	 * and {@code cutout}. Whichever is named, the file the dump writes says in its first line which
+	 * the TAIL of a label, the terrain is walked first, and its own passes are called {@code solid},
+	 * {@code cutout} and {@code translucent}. Whichever is named, the file the dump writes says in its first line which
 	 * program was really read.
 	 * <p>
 	 * One program and not several, because the point is to read the file rather than to search it,
@@ -275,7 +276,7 @@ final class EngineOptions {
 	 * the point: what is left is settings the pack declared.
 	 */
 	static Read take(Map<String, OptionValue> chosen) {
-		// The seed goes through the same reading as the other eight rather than keeping one of its
+		// The seed goes through the same reading as the other nine rather than keeping one of its
 		// own. It had one, and it was the only line here that took an unreadable word in silence:
 		// seed=0 left the seed drawing, and an experiment run to see the clears on their own would
 		// have concluded from a picture the seed had painted.

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -199,6 +199,8 @@ public final class FrameState implements WorldState {
 	private float playerMaxAir = -1.0F;
 	private final Vector3f selectedBlockPos = new Vector3f(NOTHING_SELECTED);
 	private final Vector4f lightningBoltPosition = new Vector4f();
+	/** The tick the position beside this was searched for on, so a frame does not do it again. */
+	private long lightningTick = Long.MIN_VALUE;
 	private int heldBlockLight;
 	private int heldBlockLight2;
 
@@ -366,6 +368,12 @@ public final class FrameState implements WorldState {
 		this.frameCounter = 0;
 		this.frameTime = 0.0F;
 		this.frameTimeCounter = 0.0F;
+		// The bolt with them, and it is the tick beside it that makes this necessary rather than
+		// tidy: a client that leaves a save and rejoins it comes back at the tick it left on, so a
+		// counter kept across that would match, the search would be skipped, and the position of
+		// the session before would be served as this one's.
+		this.lightningTick = Long.MIN_VALUE;
+		this.lightningBoltPosition.zero();
 	}
 
 	/**
@@ -806,7 +814,23 @@ public final class FrameState implements WorldState {
 				|| held.canPlaceOnBlockInAdventureMode(inWorld));
 	}
 
+	/**
+	 * Once a tick and not once a frame, which is the frequency the reference publishes this at
+	 * ({@code uniforms/IrisExclusiveUniforms.java:91}, {@code PER_TICK}) and the whole of what it
+	 * buys: the search is a pass over every entity the level would render, made to find the one
+	 * kind of entity that is almost never there.
+	 * <p>
+	 * What is held between two ticks is what the reference holds too, the camera subtracted
+	 * included: it builds the whole camera relative vector inside that same per tick supplier, so
+	 * a bolt stands still for a walking player on both engines rather than only on this one.
+	 */
 	private void readLightning(ClientLevel level, float pt) {
+		long tick = level.getGameTime();
+		if (tick == this.lightningTick) {
+			return;
+		}
+
+		this.lightningTick = tick;
 		this.lightningBoltPosition.zero();
 		for (Entity entity : level.entitiesForRendering()) {
 			if (entity instanceof LightningBolt) {

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -815,12 +815,12 @@ final class GeometryProgram {
 	}
 
 	/**
-	 * Binds this program's block and every sampler it declares, inside the pass Sodium opened.
+	 * Binds this program's block and every sampler it declares, inside the pass the family has just
+	 * opened.
 	 * <p>
 	 * Every name the layout carries has to be bound or the draw throws on the first one missing, so
-	 * a name this step has no answer for gets one pixel rather than being left out. Only two names
-	 * are answered with anything real: the block atlas, and the light map. Everything else is a
-	 * constant, which is why the criterion for this step is the albedo and nothing to do with light.
+	 * a name this step has no answer for gets one pixel rather than being left out. What stands
+	 * behind the rest, the pack's own targets among them, was settled by {@link #resolve}.
 	 * <p>
 	 * <strong>Only the names that follow the draw's own image are worked out here.</strong> The rest
 	 * were settled by {@link #resolve}, at the one point of a pass that stands outside it, and this
@@ -1023,7 +1023,7 @@ final class GeometryProgram {
 
 	/**
 	 * The image a pass draws with, where the pass has one of its own rather than the block atlas
-	 * { #prepare} was handed. Set before the bind and never during it.
+	 * {@link #prepare} was handed. Set before the bind and never during it.
 	 */
 	void atlas(GpuTextureView view) {
 		this.atlas = view;

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2276,6 +2276,14 @@ public final class PackChain {
 					back.size(), back);
 		}
 
+		// Beside the copy above, which is the other half of the same subject: what this pack carries
+		// from one frame to the next. Said at info and not with the warnings below, though they are
+		// the same walk's answers, because a pack reading a target it keeps is a mechanism of the
+		// pack rather than a hole in this engine, and Iris hands it exactly the same one. Read among
+		// the warnings, BSL's colortex2 line was taken for a defect of the temporal antialiasing and
+		// stayed a suspect for a fortnight.
+		unfolded.history().forEach(note -> Vitrail.logger().info("{}", note));
+
 		// The values the pack declares for itself, once for the whole chain: every program was
 		// built against the one catalogue, so a pass saying it would say it once per program.
 		this.values.notes().forEach(note -> Vitrail.logger().info("{}", note));

--- a/common/src/main/java/dev/vitrail/render/PackNameIds.java
+++ b/common/src/main/java/dev/vitrail/render/PackNameIds.java
@@ -54,6 +54,13 @@ public final class PackNameIds {
 	 */
 	private static volatile Object2IntMap<EntityType<?>> byType = emptyCache();
 
+	/**
+	 * The same for an item, and for the same reason with one more: the table is keyed by the
+	 * name's TEXT, so without this every submission of every item spells one out again, where the
+	 * entity half beside it has never spelt one out twice.
+	 */
+	private static volatile Object2IntMap<Identifier> byName = emptyCache();
+
 	private PackNameIds() {
 	}
 
@@ -62,6 +69,7 @@ public final class PackNameIds {
 		entities = entityIds;
 		items = itemIds;
 		byType = emptyCache();
+		byName = emptyCache();
 	}
 
 	/** Whether the pack named the camera's own player, which is what makes that case worth asking. */
@@ -102,18 +110,33 @@ public final class PackNameIds {
 		return id;
 	}
 
-	/** The pack's number for an item, named by its model identifier or by its registry key. */
+	/**
+	 * The pack's number for an item, named by its model identifier or by its registry key, and
+	 * worked out once each.
+	 * <p>
+	 * A name the pack named nowhere is remembered as {@link NameIds#NONE} as well, which is what
+	 * the lookup tells apart from a real one by asking whether the key is there at all.
+	 */
 	public static int item(Identifier name) {
-		return items.id(name.toString());
+		Object2IntMap<Identifier> cache = byName;
+		int known = cache.getInt(name);
+		if (known != NameIds.NONE || cache.containsKey(name)) {
+			return known;
+		}
+
+		int id = items.id(name.toString());
+		cache.put(name, id);
+
+		return id;
 	}
 
 	/**
-	 * A cache with nothing in it, answering {@link NameIds#NONE} for a type it has not been asked
-	 * about, which is what the lookup above tells apart from a real {@code NONE} by asking whether
+	 * A cache with nothing in it, answering {@link NameIds#NONE} for a key it has not been asked
+	 * about, which is what the lookups above tell apart from a real {@code NONE} by asking whether
 	 * the key is there at all.
 	 */
-	private static Object2IntMap<EntityType<?>> emptyCache() {
-		Object2IntMap<EntityType<?>> cache = new Object2IntOpenHashMap<>();
+	private static <K> Object2IntMap<K> emptyCache() {
+		Object2IntMap<K> cache = new Object2IntOpenHashMap<>();
 		cache.defaultReturnValue(NameIds.NONE);
 
 		return cache;

--- a/common/src/main/java/dev/vitrail/render/ShadowTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowTargets.java
@@ -50,8 +50,10 @@ import java.util.List;
  * that follows from it is in one place each: the {@code FORWARD} pair the shadow programs are given,
  * and the compare op of their pipeline.
  * <p>
- * No texture view is ever held, for the same reason {@link ColorTargets} holds none: a resize closes
- * the views behind it and nothing on this backend notices a view that has outlived its texture.
+ * No caller ever holds a texture view, for the same reason {@link ColorTargets} hands none out: a
+ * resize closes the views behind it and nothing on this backend notices a view that has outlived its
+ * texture. The one view held here is the depth copy without the translucents, and it is safe because
+ * this map is square at the resolution the pack asked for and is never resized.
  */
 final class ShadowTargets {
 

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -330,9 +330,9 @@ public final class ViewMatrices implements ViewSource {
 	}
 
 	/**
-	 * The four shadow matrices, which are worth computing even though no shadow pass runs: they
-	 * are read by the composite stage of all eight packs of the corpus, and everything they need
-	 * is the camera position and the sun angle.
+	 * The four shadow matrices, which are read by the composite stage of all eight packs of the
+	 * corpus whether or not the light's own pass drew anything this frame: everything they need is
+	 * the camera position and the sun angle.
 	 * <p>
 	 * Ported from Iris {@code shadows/ShadowMatrices.java} and {@code shadows/ShadowRenderer.java}
 	 * at b0ae41c, with the pose stack and {@code com.mojang.math.Axis} written out in JOML.

--- a/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
@@ -294,8 +294,8 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 	}
 
 	/**
-	 * The one button with no room for a word: the eye that takes the screen away. Placed in whatever
-	 * space is left to the right of the button rows, which is Iris's arithmetic.
+	 * The eye that takes the screen away, placed in whatever space is left to the right of the
+	 * button rows, which is Iris's arithmetic.
 	 */
 	private Button eye() {
 		int x = besideRows(false);

--- a/common/src/main/java/dev/vitrail/settings/PackFile.java
+++ b/common/src/main/java/dev/vitrail/settings/PackFile.java
@@ -2,8 +2,10 @@ package dev.vitrail.settings;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Locale;
 
 /**
@@ -65,6 +67,14 @@ public record PackFile(String name, boolean enabled, int shadowDistance) {
 	 * What the file says, or {@link #EMPTY} when it is not there. A line that is neither a comment nor
 	 * one of the three keys is ignored rather than refused: this file is edited by hand.
 	 * <p>
+	 * Decoded through the {@code String} constructor rather than through {@code Files.readString},
+	 * which THROWS on a byte that is not UTF-8. The rule the three lines below are read under, that
+	 * one bad character must not cost the player the pack they had chosen, does not hold if the read
+	 * itself cannot survive one: what is unreadable is one character of one value, and every other
+	 * line still says what it said. A byte order mark is taken off for the same reason it is in
+	 * {@code SettingsLayers}: nothing throws on it, and left where it is it rides on the first key,
+	 * which here is the pack's own name.
+	 * <p>
 	 * Handed the file rather than the game directory, so that where it lives stays the render layer's
 	 * business: this package names no folder of the installation and imports nothing that does.
 	 */
@@ -73,7 +83,7 @@ public record PackFile(String name, boolean enabled, int shadowDistance) {
 			return EMPTY;
 		}
 
-		String content = Files.readString(file, StandardCharsets.UTF_8);
+		String content = text(file);
 		// The one line format, which is what every file written before this class looks like. Told
 		// apart by having no key at all rather than by counting lines, so that a stray blank line or a
 		// trailing newline does not change which format a file is read as.
@@ -118,6 +128,13 @@ public record PackFile(String name, boolean enabled, int shadowDistance) {
 		return new PackFile(name, enabled, shadowDistance);
 	}
 
+	/** The file's text, decoded rather than refused, with any byte order mark taken off. */
+	private static String text(Path file) throws IOException {
+		String text = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+
+		return text.startsWith("\uFEFF") ? text.substring(1) : text;
+	}
+
 	private static int number(String value, int fallback) {
 		try {
 			return Integer.parseInt(value);
@@ -135,15 +152,28 @@ public record PackFile(String name, boolean enabled, int shadowDistance) {
 	 * other's line through, which is why both go through a read of the file first rather than
 	 * building a record out of what they happen to hold.
 	 * <p>
+	 * Through a temporary and an {@code ATOMIC_MOVE} in the same folder, so that a crash between the
+	 * two writes cannot leave a truncated file: what this one holds is the pack the player chose,
+	 * and half a line of it reads as no pack at all. {@code SettingsFile.write} has carried the same
+	 * pair since it was written, over a file that matters less.
+	 * <p>
 	 * In LF and without a byte order mark, like every other file this mod writes.
 	 */
 	public static void write(Path file, PackFile chosen) throws IOException {
 		Files.createDirectories(file.getParent());
-		Files.writeString(file,
+
+		Path temporary = file.resolveSibling(file.getFileName() + ".part");
+		Files.writeString(temporary,
 				NAME_KEY + "=" + chosen.name() + "\n"
 						+ ENABLED_KEY + "=" + chosen.enabled() + "\n"
 						+ SHADOW_DISTANCE_KEY + "=" + chosen.shadowDistance() + "\n",
 				StandardCharsets.UTF_8);
+		try {
+			Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING,
+					StandardCopyOption.ATOMIC_MOVE);
+		} catch (AtomicMoveNotSupportedException e) {
+			Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING);
+		}
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/settings/SettingsLayers.java
+++ b/common/src/main/java/dev/vitrail/settings/SettingsLayers.java
@@ -74,7 +74,7 @@ public final class SettingsLayers {
 		}
 
 		Map<String, OptionValue> chosen = new LinkedHashMap<>();
-		for (String line : text(file).split("\\r?\\n", -1)) {
+		for (String line : text(file).lines().toList()) {
 			String trimmed = line.trim();
 			int equals = trimmed.indexOf('=');
 			if (trimmed.isEmpty() || trimmed.startsWith("#") || equals < 1) {
@@ -101,6 +101,12 @@ public final class SettingsLayers {
 	 * A byte order mark is taken off rather than replaced, and that is the half nothing throws on.
 	 * Left where it is it rides on the first key, so a first line naming {@code profile} declares a
 	 * setting no pack has and no reserved line matches.
+	 * <p>
+	 * Cut by {@code lines} and not by a split on {@code \r?\n}, because {@code readAllLines} ends a
+	 * line on a lone carriage return as well ({@code BufferedReader.readLine}) and a split on that
+	 * pattern does not. A file saved with the old Mac endings would come back as ONE line, the
+	 * first key swallowing every value after it in silence. {@code PackFile} reads its own file
+	 * this way for the same reason.
 	 */
 	private static String text(Path file) throws IOException {
 		String text = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);

--- a/common/src/main/java/dev/vitrail/settings/SettingsLayers.java
+++ b/common/src/main/java/dev/vitrail/settings/SettingsLayers.java
@@ -3,6 +3,7 @@ package dev.vitrail.settings;
 import dev.vitrail.pack.option.OptionValue;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -73,7 +74,7 @@ public final class SettingsLayers {
 		}
 
 		Map<String, OptionValue> chosen = new LinkedHashMap<>();
-		for (String line : Files.readAllLines(file)) {
+		for (String line : text(file).split("\\r?\\n", -1)) {
 			String trimmed = line.trim();
 			int equals = trimmed.indexOf('=');
 			if (trimmed.isEmpty() || trimmed.startsWith("#") || equals < 1) {
@@ -85,6 +86,26 @@ public final class SettingsLayers {
 		}
 
 		return Collections.unmodifiableMap(chosen);
+	}
+
+	/**
+	 * The file's text, decoded rather than refused.
+	 * <p>
+	 * Through the {@code String} constructor and not {@code Files.readAllLines}, which THROWS on a
+	 * byte that is not UTF-8. This file is edited by hand, in whichever editor the player has, and
+	 * that throw does not stop at the line it cannot read: it leaves {@code forced}, reaches
+	 * {@code PackChain.open}, and NO PACK LOADS AT ALL, under a message naming neither the file nor
+	 * the encoding. What one stray byte costs instead is one character of one value.
+	 * {@code SettingsFile.lines} reads its own file this way already, for the same reason.
+	 * <p>
+	 * A byte order mark is taken off rather than replaced, and that is the half nothing throws on.
+	 * Left where it is it rides on the first key, so a first line naming {@code profile} declares a
+	 * setting no pack has and no reserved line matches.
+	 */
+	private static String text(Path file) throws IOException {
+		String text = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+
+		return text.startsWith("\uFEFF") ? text.substring(1) : text;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/sodium/EntityMeshSerializer.java
+++ b/common/src/main/java/dev/vitrail/sodium/EntityMeshSerializer.java
@@ -48,7 +48,7 @@ public final class EntityMeshSerializer implements VertexSerializer {
 	/** What Sodium writes, which is the game's own entity vertex. */
 	private static final int WRITTEN = DefaultVertexFormat.ENTITY.getVertexSize();
 
-	/** What this engine binds, which is that plus the element. */
+	/** What this engine binds, which is that plus the three elements. */
 	private static final int CARRIED = EntityMesh.format().getVertexSize();
 
 	/** Where the identifiers start inside one of those, taken off the format rather than counted. */

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
@@ -55,11 +55,40 @@ public final class ShadowCull implements Frustum {
 				&& this.planes.testAab(minX, minY, minZ, maxX, maxY, maxZ);
 	}
 
+	/**
+	 * <strong>A whole answer only from a box wholly within the distance</strong>, which is how Iris
+	 * combines the two ({@code AdvancedShadowCullingFrustum.java:442-444}: {@code INSIDE} from
+	 * both, or {@code INTERSECT}). It reads like a detail and is not one. Sodium takes
+	 * {@code INSIDE} for "this shape holds the whole subtree", raises {@code INSIDE_FRUSTUM} on it,
+	 * and nothing below that node is measured against the shape again
+	 * ({@code chunk/tree/TraversableTree.java:197,210-221}). Its own render distance is still
+	 * tested on every node ({@code :224-243}), which is why the leak is bounded by the tree and not
+	 * by the world; what escapes is every section under such a box, however far past the shadow
+	 * distance it lies, and each one is drawn into the map.
+	 * <p>
+	 * <strong>Where this parts from Iris, and it is the one state that does.</strong> Under
+	 * {@link dev.vitrail.pack.source.ShadowCullState#SAFE_ZONE} a box wholly inside the safe zone
+	 * answers {@code INSIDE} at Iris whatever the distance says short of {@code OUTSIDE}
+	 * ({@code shadows/frustum/advanced/SafeZoneCullingFrustum.java:74-78}), where this downgrades it
+	 * like any other. It costs nothing while the safe zone is the shorter of the two, such a box
+	 * being wholly within the distance as well, and it drops sections Iris would draw once
+	 * {@code voxelDistance} passes {@code shadowDistance}, which {@code PackValues:331-332} works
+	 * out apart without bounding either by the other. <strong>Iris is not of one mind on that box
+	 * itself</strong>: its {@code testAab} cuts by distance FIRST ({@code :54-56}) and drops what
+	 * its own {@code intersectAab} keeps whole, so there is no single behaviour of the reference to
+	 * follow here. What is written is the one the walk can hold to on every one of its four tests.
+	 */
 	@Override
 	public int intersectAab(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
-		return inside(minX, minY, minZ, maxX, maxY, maxZ)
-				? this.planes.intersectAab(minX, minY, minZ, maxX, maxY, maxZ)
-				: FrustumIntersection.OUTSIDE;
+		if (!inside(minX, minY, minZ, maxX, maxY, maxZ)) {
+			return FrustumIntersection.OUTSIDE;
+		}
+
+		int shape = this.planes.intersectAab(minX, minY, minZ, maxX, maxY, maxZ);
+
+		return shape == FrustumIntersection.INSIDE && !within(minX, minY, minZ, maxX, maxY, maxZ)
+				? FrustumIntersection.INTERSECT
+				: shape;
 	}
 
 	@Override
@@ -78,5 +107,13 @@ public final class ShadowCull implements Frustum {
 		return maxX >= -this.distance && minX <= this.distance
 				&& maxY >= -this.distance && minY <= this.distance
 				&& maxZ >= -this.distance && minZ <= this.distance;
+	}
+
+	/** Whether a camera-relative box is wholly within the distance, on all three axes. */
+	private boolean within(float minX, float minY, float minZ,
+			float maxX, float maxY, float maxZ) {
+		return minX >= -this.distance && maxX <= this.distance
+				&& minY >= -this.distance && maxY <= this.distance
+				&& minZ >= -this.distance && maxZ <= this.distance;
 	}
 }

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
@@ -39,14 +39,21 @@ public final class ShadowCull implements Frustum {
 	private final Frustum planes;
 	private final float distance;
 
+	/** Half the side of the box the shape keeps whole whatever the distance says, or negative. */
+	private final float safeZone;
+
 	/**
 	 * @param planes   the shape the walk measures against before the box is cut out of it, which
 	 *                 {@link ShadowCullFrustum#of} chooses from what the pack asked for
 	 * @param distance how far from the camera the walk still gathers, in blocks
+	 * @param safeZone the same pack's {@code voxelDistance}, or negative where it asked for no safe
+	 *                 zone. Carried here and not left to the shape because the two boxes have to be
+	 *                 weighed against each other, which neither can do alone
 	 */
-	public ShadowCull(Frustum planes, float distance) {
+	public ShadowCull(Frustum planes, float distance, float safeZone) {
 		this.planes = planes;
 		this.distance = distance;
+		this.safeZone = safeZone;
 	}
 
 	@Override
@@ -66,17 +73,22 @@ public final class ShadowCull implements Frustum {
 	 * by the world; what escapes is every section under such a box, however far past the shadow
 	 * distance it lies, and each one is drawn into the map.
 	 * <p>
-	 * <strong>Where this parts from Iris, and it is the one state that does.</strong> Under
-	 * {@link dev.vitrail.pack.source.ShadowCullState#SAFE_ZONE} a box wholly inside the safe zone
-	 * answers {@code INSIDE} at Iris whatever the distance says short of {@code OUTSIDE}
-	 * ({@code shadows/frustum/advanced/SafeZoneCullingFrustum.java:74-78}), where this downgrades it
-	 * like any other. It costs nothing while the safe zone is the shorter of the two, such a box
-	 * being wholly within the distance as well, and it drops sections Iris would draw once
-	 * {@code voxelDistance} passes {@code shadowDistance}, which {@code PackValues:331-332} works
-	 * out apart without bounding either by the other. <strong>Iris is not of one mind on that box
-	 * itself</strong>: its {@code testAab} cuts by distance FIRST ({@code :54-56}) and drops what
-	 * its own {@code intersectAab} keeps whole, so there is no single behaviour of the reference to
-	 * follow here. What is written is the one the walk can hold to on every one of its four tests.
+	 * <strong>The safe zone is the one box that outranks the distance</strong>, and only here.
+	 * Under {@link dev.vitrail.pack.source.ShadowCullState#SAFE_ZONE} a box the safe zone holds
+	 * whole answers {@code INSIDE} at Iris the moment the distance is anything but {@code OUTSIDE}
+	 * ({@code shadows/frustum/advanced/SafeZoneCullingFrustum.java:74-78}), and that order is kept.
+	 * It settles nothing while the safe zone is the shorter of the two, such a box being wholly
+	 * within the distance as well; it is what a pack asking for a voxel grid WIDER than its shadow
+	 * distance is owed, and {@code PackValues:331-332} works the two out apart without bounding
+	 * either by the other. Four packs of the corpus reach for this shape behind their voxelised
+	 * light, and one of them, Bliss, holds {@code voxelDistance} at 64 while offering a shadow
+	 * distance down to 32.
+	 * <p>
+	 * <strong>{@link #testAab} does NOT carry that exception, and Iris does not carry it there
+	 * either</strong> ({@code SafeZoneCullingFrustum.java:54-56}, the distance cut first). The two
+	 * tests are therefore asymmetric on one box: wholly in the safe zone and wholly past the
+	 * distance. Nothing reaches it, that box being {@code OUTSIDE} by the distance in both methods
+	 * before either exception is looked at.
 	 */
 	@Override
 	public int intersectAab(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
@@ -86,9 +98,21 @@ public final class ShadowCull implements Frustum {
 
 		int shape = this.planes.intersectAab(minX, minY, minZ, maxX, maxY, maxZ);
 
-		return shape == FrustumIntersection.INSIDE && !within(minX, minY, minZ, maxX, maxY, maxZ)
-				? FrustumIntersection.INTERSECT
-				: shape;
+		if (shape != FrustumIntersection.INSIDE) {
+			return shape;
+		}
+
+		// The safe zone outranks the distance on a box it holds whole, which is Iris's order and not
+		// a softening of the line above: its safe zone frustum answers INSIDE off that box alone the
+		// moment the distance is anything but OUTSIDE (SafeZoneCullingFrustum.java:74-78). It is
+		// reachable and not a corner: four packs of the corpus ask for this shape behind their
+		// voxelised light, and Bliss holds voxelDistance at 64 while offering a shadow distance down
+		// to 32, so a player who lowers one below the other would lose casters Iris draws.
+		return within(this.distance, minX, minY, minZ, maxX, maxY, maxZ)
+				|| (this.safeZone >= 0.0F
+						&& within(this.safeZone, minX, minY, minZ, maxX, maxY, maxZ))
+				? FrustumIntersection.INSIDE
+				: FrustumIntersection.INTERSECT;
 	}
 
 	@Override
@@ -109,11 +133,11 @@ public final class ShadowCull implements Frustum {
 				&& maxZ >= -this.distance && minZ <= this.distance;
 	}
 
-	/** Whether a camera-relative box is wholly within the distance, on all three axes. */
-	private boolean within(float minX, float minY, float minZ,
+	/** Whether a camera-relative box is wholly within a half size, on all three axes. */
+	private static boolean within(float half, float minX, float minY, float minZ,
 			float maxX, float maxY, float maxZ) {
-		return minX >= -this.distance && maxX <= this.distance
-				&& minY >= -this.distance && maxY <= this.distance
-				&& minZ >= -this.distance && maxZ <= this.distance;
+		return minX >= -half && maxX <= half
+				&& minY >= -half && maxY <= half
+				&& minZ >= -half && maxZ <= half;
 	}
 }

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
@@ -211,7 +211,7 @@ public final class ShadowCullFrustum implements Frustum {
 		}
 
 		return plan.bound() < 0.0F ? new Chosen(frustum, shape)
-				: new Chosen(new ShadowCull(frustum, plan.bound()),
+				: new Chosen(new ShadowCull(frustum, plan.bound(), plan.safeZone()),
 						shape + ", within " + plan.bound() + " blocks");
 	}
 

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -153,7 +153,15 @@ public final class ShadowTerrain {
 			return;
 		}
 
-		int seen = sections(manager.getRenderLists());
+		// Counted only on the frame that will print it. It has to be taken HERE, the walk below
+		// replacing the camera's render lists with the light's, but every other frame was walking
+		// those lists for a line printed once per block table.
+		//
+		// Read once rather than again at the print, so a table installed between the two is named
+		// on the next frame instead of at once. That is the right way round: the count in hand was
+		// taken against the table that was standing when it was taken.
+		boolean measuring = measured != BlockStateIds.generation();
+		int seen = measuring ? sections(manager.getRenderLists()) : 0;
 
 		// Which entities the light can see is worked out here, and for them the position settles
 		// nothing: they are kept or dropped by a frustum and by a section's own state, neither of
@@ -202,7 +210,7 @@ public final class ShadowTerrain {
 			// numbers mean the cull did not happen, and nothing on screen would say so. The table is
 			// named because a second load of the same pack prints this again, word for word: it is
 			// what tells the two readings apart, not a property of the cull itself.
-			if (measured != BlockStateIds.generation() && seen > 0) {
+			if (measuring && seen > 0) {
 				measured = BlockStateIds.generation();
 				Vitrail.logger().info("Shadow cull walked {} sections for the light against {} "
 						+ "for the camera, on block table {}, culling {}",

--- a/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
+++ b/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
@@ -378,7 +378,7 @@ public final class TerrainMesh implements ChunkVertexType {
 		 * window to cover, nothing of its own warming up over several frames.
 		 * <p>
 		 * <strong>The one element here whose presence is not a question about the pack's BODY.</strong>
-		 * The five above it are carried when a chunk program names them; this one is carried exactly
+		 * The four above it are carried when a chunk program names them; this one is carried exactly
 		 * when the pack wrote {@code separateAo}, which is what makes every one of its vertex stages
 		 * read it. Two packs of the corpus write nothing, and their meshes carry one colour.
 		 */
@@ -426,8 +426,8 @@ public final class TerrainMesh implements ChunkVertexType {
 		// one of the two pays for both and a pack reading neither pays for neither.
 		int frame = offset(Extra.TANGENT_FRAME) == ABSENT ? 0 : TangentFrame.pack(frame(vertices));
 
-		// The one of the five that is a property of the CORNER, so it is asked for inside the loop
-		// and only the question is hoisted out of it.
+		// One of the two that are a property of the CORNER, so it is asked for inside the loop and
+		// only the question is hoisted out of it.
 		boolean blockMiddle = offset(Extra.MID_BLOCK) != ABSENT;
 
 		// Backwards over the vertices, because a vertex moves up by the difference of the two strides

--- a/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * The fixed function state of a pass drawn over the world rather than over a quad, and the one
  * name outside it whose answer depends on which of the two a program is.
  * <p>
- * Seven names {@link DrawValues} already answers, layered over it, plus two this family alone has
+ * Seven names {@link DrawValues} already answers, layered over it, plus four this family alone has
  * and one it answers with a nought.
  * The seven are answered there with the stand ins a full screen pass needs: an identity model view,
  * the matrix that carries the quad to the screen, and eight identities where the texture matrices

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -276,6 +276,37 @@ mask in falls back on the game's target, and there its own first draw buffer has
 seed paints, or the game keeps its shader for that half rather than carry the pack's albedo into a
 target it never asked for.
 
+## The waving grass jumps
+
+**Under BSL, grass and leaves sway smoothly, then skip forward or snap back to where the sway
+started, and then go on smoothly again.** The player and the camera stand still, the rest of the
+picture is steady, and nothing else the pack animates does it. It is this engine's defect and not
+the pack's: the reference is smooth on the same pack at the same place, and Complementary is smooth
+here.
+
+**It is a jump in the position of the sway, not a tremble in the pixels it lands on**, and that
+distinction is the whole of the diagnosis. Reading it as a shimmer sends you to the pack's temporal
+anti-aliasing, which has nothing to do with it: giving another pack BSL's exact jitter table, index
+and amplitude leaves that pack smooth.
+
+**Some of what looks like the defect is BSL's own wave.** Its interpolation has a zero derivative at
+every lattice crossing, roughly once a second, so the foliage can sit nearly still for a couple of
+dozen frames, at irregular intervals, entirely by design. Those stillnesses are in the pack and are
+there under any implementation. What is worth reporting is a jump on top of them.
+
+**Nothing a pack setting or a video setting takes away, and none of these is the cause:** the frame
+rate, capped or free running; the clock this engine hands the pack, which advances once per
+presented frame, never repeats and never goes backwards; the rounding of that clock to the
+millisecond, which the reference does identically and which shrinks the frame-to-frame velocity step
+rather than growing it; the world position, which cancels exactly against the camera position; the
+noise hash and the precision it is computed in; the write into the terrain's uniform block, which
+happens once a frame with a fresh value; and the moment a frame is handed to the swapchain against
+the moment its content is dated, which stay rigid to within a fraction of a frame even with the
+frame rate unlocked and nothing pacing the loop.
+
+So a report about this is only useful if it carries something none of those explain: another pack
+that does it, a machine or a driver where it stops, or a setting that changes its rhythm.
+
 ## The sky goes flat
 
 **A flat grey or white sheet across the sky, typically at sunrise or sunset.**

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -178,9 +178,9 @@ have: an inverted octagonal cone between the two planes, drawn with the pack's o
 program. If you see the line, that geometry is not reaching your pack's shader.
 
 There are two cases where it is deliberately not drawn, and the log says so in the second: a pack
-that switches the sky disc off has taken away the pass the cone rides in, and a frame where the
-world's own geometry has not marked the pixels it wrote gets no cone, because one drawn there would
-cut the ground out of the picture instead.
+that wrote `sky=false` has said it draws the sky itself and is not handed a cone it did not ask for,
+and a frame where the world's own geometry has not marked the pixels it wrote gets no cone, because
+one drawn there would cut the ground out of the picture instead.
 
 The full mechanism is in [Sky and shadows](sky-and-shadows.md#the-horizon-gap).
 
@@ -246,8 +246,10 @@ and the second is the shorter list.
 It is a video setting of its own, which the Fabulous preset turns on everywhere except macOS. With
 it on, the game draws both of those into targets of its own and composes them itself, and this
 engine hands them back rather than attach the pack's targets beside an image it does not read. The
-log says so in those words, once for the rain and once for the particles. The entities are
-unaffected.
+log says so in those words, once for the rain and once for the particles. The entities are affected
+too, but by row rather than by family: with the setting on, the translucent half of a living entity,
+an experience orb, a translucent item sheet and the glint of an enchantment go back to the game the
+same way, while the opaque half is untouched.
 
 Two consequences follow from how that geometry reaches the pack, and both are worth recognising
 rather than reporting as separate bugs:
@@ -389,10 +391,11 @@ A short reference, if you are writing a pack or wondering why yours is treated d
   shafts there and reads it back for every ray that reaches through something translucent, so a
   buffer it could not write filled every body of water with white.
 - **A pack can ask the engine not to draw a piece of the sky** because it draws that piece itself,
-  inside one of its own programs. Four such requests are honoured (the sun, the moon, the stars and
-  the sky disc), and honouring the last two is a **deviation from both references**, which take out
-  only the sun and the moon. It costs some packs the stars the references leave them,
-  and the NOTICE says so. The fifth request in that family is not one of those four and reads the
+  inside one of its own programs. Four such requests are read, and two of them take a piece away:
+  the sun and the moon, which is where both references stand. `stars=false` takes nothing, the
+  game's star field being drawn with the pack's own `gbuffers_skybasic` in the first place, and
+  `sky=false` costs the horizon cone alone rather than the game's disc, which is again what the
+  references do, and the NOTICE says so. The fifth request in that family is not one of those four and reads the
   other way round: `clouds` takes `off`, `fast` or `fancy` rather than a boolean, and it overrules
   the user's own cloud setting so that the pack's cloud program is handed the geometry it was
   written for. It is honoured only where this engine really draws the clouds, because with the

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -90,8 +90,9 @@ of the corpus translates, or what each target resolves to) never fail at all by 
 what they produce is a number to compare against the last one rather than a yes or a no. Running one
 of those and seeing no error means nothing was asserted, not that everything held.
 
-**Every invariant has a negative control, and the control ships with it.** Each is a flag on the
-tool it belongs to, documented as *must exit non-zero*, naming the packs it is expected to break on.
+**Every invariant has a negative control.** Two of them ship as a flag on the tool they belong to,
+documented as *must exit non-zero* and naming the packs they are expected to break on; the rest are
+gestures spelled out beside the tool, a forced setting or a line put back, to be taken by hand.
 Run them: if a control reports nothing, the checker has stopped reading, and the green run beside it
 meant nothing. What controls exist is in what the tools print, which cannot fall out of date the way
 a list here would.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -36,7 +36,7 @@ than an error.
 A pack's passes are not all run at the same moment. The chain is split, and each half hangs off one
 of the seams above:
 
-- the setup, begin and prepare stages, the seed, and the deferred stages run at **after opaque
+- the begin and prepare stages, the seed, and the deferred stages run at **after opaque
   features**, which is before the world's translucent geometry;
 - the composite stages and the final pass run at **after level**, once the whole world render is
   done.
@@ -51,9 +51,9 @@ world with translucents in it. Placing an effect in the wrong stage is not a sub
 ## Colour targets, and the rule that governs every read
 
 A pack declares colour targets and writes into them by naming attachments in its fragment stages.
-Targets that are both read and written in the same frame are **doubled**: there are two buffers
-behind one name, and passes alternate between them so that a pass never reads the buffer it is
-writing.
+A target is **doubled** when a full-screen pass writes it, or when a flip directive names it: there
+are two buffers behind one name, and passes alternate between them so that a pass never reads the
+buffer it is writing.
 
 One sentence governs the whole mechanism:
 
@@ -275,8 +275,8 @@ seam left. A layer of the kind above cannot help either: what it would catch is 
 already been lit by the game's shader over an image the pack finished.
 
 So the engine does not intercept the hand, it **moves** it. The game's own submission
-is suppressed and the hand is submitted twice from inside the level: the solid pass among the game's
-opaque features, before the deferred stage, and the blending pass at the end of the world, before
+is suppressed and the hand is submitted twice from inside the level: the solid pass just after the
+game's opaque features, before the deferred stage, and the blending pass at the end of the world, before
 the composites. Where each lands is what decides which half of every target it writes, and both are
 in the picture the composites read. This is where the reference puts them too.
 

--- a/docs/internals/material-maps.md
+++ b/docs/internals/material-maps.md
@@ -33,8 +33,8 @@ themselves: the terrain reads the block atlas's companions, a particle reads whi
 layer came off, and neither has to be told which it is.
 
 Only the geometry programs are served, which is what Iris does too. What a composite declaring one
-of the names reads is not the same on both sides: here it reads a flat texel, where Iris leaves the
-sampler unassigned and it falls to whatever texture unit nought holds.
+of the names reads is not the same on both sides: here it reads one black pixel, where Iris leaves
+the sampler unassigned and it falls to whatever texture unit nought holds.
 
 A sprite the resource pack ships no map for reads the same flat value the whole companion is cleared
 to: a normal pointing straight out of the face with nothing occluded, and a material that is nought

--- a/docs/internals/pack-textures.md
+++ b/docs/internals/pack-textures.md
@@ -120,9 +120,10 @@ A declaration whose file is **shorter than the length its own declaration announ
 rather than bound to something. Iris refuses the whole pack there, its reader throwing out of the
 constructor; refusing the one declaration is narrower and keeps the rest of the pack drawable.
 
-A declaration whose file is **missing or unreadable** no longer claims the name at all: the target
-that name would otherwise have carried keeps its ordinary binding, which is what Iris does by leaving
-the sampler out of the stage's map. Claiming the name and binding black was this engine's own answer
+A declaration whose file the pack does not ship no longer claims the name at all: the target that
+name would otherwise have carried keeps its ordinary binding, which is what Iris does by leaving the
+sampler out of the stage's map. A file that is there and cannot be read keeps the name and reads one
+black pixel, and so does a path that points outside the pack. Claiming the name and binding black was this engine's own answer
 and it was worse than either: the pack lost a colour target it had said nothing wrong about.
 
 ## A refusal must still consume the name it claimed

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -28,8 +28,9 @@ that multiplies by the sampled alpha loses the whole target and nothing anywhere
 **That correction applies to the engine's default and not to a colour the pack wrote.** A target the
 pack gave a clear colour to is cleared to exactly that colour, alpha included, promoted or not: the
 pack wrote four components and is handed the four it wrote. The correction only decides the default
-the engine stands in with when the pack named nothing, which is opaque black on a promoted target
-and transparent black otherwise. The shadow colour buffer answers the same way, and it is worth
+the engine stands in with when the pack named nothing. That default follows the reference: the
+first target starts at the frame's fog colour, the second at opaque white, and every other one at
+transparent black, or at opaque black where the format gained an alpha channel. The shadow colour buffer answers the same way, and it is worth
 saying because it was the one place that did not: a correction meant to fill a blank is not a
 correction once it starts overruling something the pack was explicit about.
 

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -90,13 +90,13 @@ one word and fills it from the tint or from the pair according to that same dire
 vertex out of a global its encoder consults, which it can afford because nothing of its own warms up
 over several frames.
 
-So the directive is not a property of the mesh here, and nothing about it is worth a rebuilt world.
-Every vertex carries both colours whether the pack asked or not; what the directive decides is the
-one line of the translated vertex stage that fills `gl_Color`, and a pack that moves the directive is
-a pack whose programs are read again anyway. Two packs that both draw the terrain and disagree about
-it are then no different from any other change of pack. The price is four bytes a vertex on every
-mesh, which is the same bargain the appended elements below already make, and one of the two colour
-elements is declared but never read whichever way the choice falls. That second half is not free: an
+So the directive is not a property of the mesh's contents but of its layout. A pack that wrote
+`separateAo` gets a second colour element and a pack that did not gets none, which is one more answer
+the format takes from the pack and one more reason a change of pack rebuilds the world. What the
+directive decides beside that is the one line of the translated vertex stage that fills `gl_Color`,
+and where the second element is carried it costs four bytes a vertex, which is the same bargain the
+appended elements below already make. The renderer's own word is then declared and never read by the
+pack's stage. That second half is not free: an
 input a stage never reads can be dropped from the compiled module, and dropping one shifts the
 locations after it: the silent failure described in
 [vertex inputs are matched by name](#vertex-inputs-are-matched-by-name-and-one-direction-is-silent).
@@ -334,7 +334,7 @@ offset, the region age and the region id into whatever layout is currently bound
 
 The consequence for a substituted pipeline is severe and easy to miss: a pipeline named outside that
 namespace receives a push into a layout that has no range for it, the region offset never arrives,
-and the entire terrain draws stacked near the world origin. The remedy costs nothing and is not
+and the entire terrain draws stacked on top of the camera. The remedy costs nothing and is not
 another patch: the test is a substring, so any namespace that contains the renderer's name is
 enough.
 

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -181,7 +181,8 @@ A word this cannot read leaves the default standing, which is what the reference
 **How far the walk reaches is a separate question from the shape.** Whichever shape is chosen, a box
 around the camera is cut out of it wherever a distance bounds the walk, and that distance is
 `shadowDistance` times the `const float shadowDistanceRenderMul` of the pack's own source, or the
-player's Max Shadow Distance where the pack declares no multiplier. Two of the four states step
+player's Max Shadow Distance where the pack declares no multiplier or declares a negative one, the
+sign being the whole of the switch. Two of the four states step
 outside that arbitration and both do so in the reference: `false` reads the pack's product alone and
 never the player's setting, and the safe zone reads neither, its two boxes being the pack's
 throughout.
@@ -333,7 +334,9 @@ where it previously brought down every colour target of the pack.
 through, a typo in the pixel type made a sampler name resolve back onto the colour target of the
 same name, so the pack read the scene where it asked for its own lookup table. That is the exact
 shape of a plausible, wrong image. A key naming a stage and a sampler now takes that name whatever
-follows on the line; only an unreadable key takes nothing.
+pixel type follows on the line. Two things take nothing: a key this cannot read that far, and a value
+naming a file the pack does not ship, which the reference drops whole so that the name goes on
+meaning what it meant.
 
 **A three-dimensional volume is flattened onto a two-dimensional atlas**, its declaration rewritten
 under a forged name, and each read replaced by a helper that reads two slices and interpolates.

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -122,7 +122,7 @@ pack. Emptying is what lets somebody watching the file see it go blank.
 ## Dropping files on it
 
 - **On the pack list**, a zip or a folder is copied into the pack folder and, when it is the only one
-  dropped, selected straight away. Anything that is not a pack is refused by name.
+  dropped, selected straight away. Anything that is not a pack is refused, by name when it was the only file dropped.
 - **On a page**, one settings file is imported. More than one at a time is refused, there being no
   sense in importing two.
 
@@ -327,4 +327,6 @@ which is worth knowing before planning around either extreme.
 **A trap worth knowing before measuring any of this yourself**: what Maven serves as Sodium's
 NeoForge artefact is a launcher shim (a few dozen classes, none of them the renderer), and the mod
 is a jar nested inside it. Looking for a package in the outer jar finds nothing and proves nothing.
-This project's own build script unpacks the nested jar for exactly that reason.
+This project compiles its common module against Sodium's plain Fabric artefact for exactly that
+reason: of the 688 classes the NeoForge jar carries, every one this module names is byte for byte
+the Fabric one.

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -313,8 +313,9 @@ texture coordinates would lose them.
 
 The only way to be sure is to compile each sky program once per format it can be drawn against and
 read the disassembly back, checking every element is still at the location its position gives it.
-**That check exists for the entity family and does not exist yet for the sky.** It is written here
-as a debt, not as a guarantee: the sky needs it before it is believed, not after.
+**That check exists for the sky as well as for the entity family**, in the out-of-game harness:
+each sky program is compiled once per format it can be drawn against and the disassembly read back,
+off the game.
 
 ### How a pack tells the elements apart
 
@@ -351,8 +352,8 @@ and uses both at once.
 
 Answer both from the same source and the rotation cancels: the sun sits at noon all night. So the
 pass supplies its own model-view, which feeds the fixed-function model-view, its inverse, the
-combined transform and the normal matrix, and *not* the camera uniform. The sky disc, the one
-element the game pushes nothing for, keeps the frame's matrix.
+combined transform and the normal matrix, and *not* the camera uniform. The sky disc and the End's
+own sky, the two elements the game pushes nothing for, keep the frame's matrix, one per branch.
 
 ### Two pipeline facts that break the world if missed
 
@@ -371,9 +372,9 @@ terrain's pipeline namespace pushes constants the pass cannot satisfy.
 Which buffers a sky program writes is keyed by program name, not by an enumeration of passes, since
 the game's sky passes share a small set of programs.
 
-One thing leaves a piece on the game's own target: a pack serving no program for it at all, in which
-case the game's own shader draws it and the piece reaches the pack's colour target through the
-full-screen layer instead of writing it.
+Two things leave a piece on the game's own target: a pack serving no program for it at all, in which
+case the game's own shader draws it, and a pack serving one the plan has no answer for. Either way
+the piece reaches the pack's colour target through the full-screen layer instead of writing it.
 
 **A program that declares no draw buffers is not that case, and used to be.** It is read as writing
 colortex0, which is what Iris reads it as, so the pack's shader draws and its output lands in the
@@ -383,8 +384,8 @@ nothing had no clouds at all, at any setting, and nothing said why.
 
 It is then all eight or none. If any piece the game still draws would stay behind, the whole sky
 keeps the game's target, because the layer is the only road left to a piece that stayed on it and the
-pieces that claim every pixel they span cut the layer where they land. A pack serving no program for
-the basic sky and one for the textured one (which the format allows) would otherwise get a sky
+pieces that claim every pixel they span cut the layer where they land. A pack serving a program for
+the basic sky and none for the textured one (which the format allows) would otherwise get a sky
 whose disc marks the whole frame and whose sun and moon are cut out of it.
 
 All eight and not the branch in hand, which costs one thing worth naming: a place serving one branch

--- a/fabric/src/main/java/dev/vitrail/fabric/FabricPlatform.java
+++ b/fabric/src/main/java/dev/vitrail/fabric/FabricPlatform.java
@@ -30,11 +30,6 @@ final class FabricPlatform implements VitrailPlatform {
 	}
 
 	@Override
-	public Path configDirectory() {
-		return FabricLoader.getInstance().getConfigDir().resolve(Vitrail.MOD_ID);
-	}
-
-	@Override
 	public Path gameDirectory() {
 		return FabricLoader.getInstance().getGameDir();
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.6.0-beta
+mod_version=0.7.0-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one

--- a/neoforge/src/main/java/dev/vitrail/neoforge/NeoForgePlatform.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/NeoForgePlatform.java
@@ -31,11 +31,6 @@ final class NeoForgePlatform implements VitrailPlatform {
 	}
 
 	@Override
-	public Path configDirectory() {
-		return FMLPaths.CONFIGDIR.get().resolve(Vitrail.MOD_ID);
-	}
-
-	@Override
 	public Path gameDirectory() {
 		return FMLPaths.GAMEDIR.get();
 	}


### PR DESCRIPTION
## What this publishes

A pack put back after being removed no longer ends the session as reliably as it did, which is the
one thing here a player will feel: two ring buffers of the far terrain were closed under a pass that
still held slices of them, and the graphics device was lost seconds later with nothing in the log.
Beside it, a stray byte in `options.txt` no longer stops every pack from loading, a pack now
translates to the same shader text on every start, the shadow distance bounds every chunk it is
meant to, Distant Horizons stops drawing its own ambient occlusion and fog under a pack that throws
their work away, and three things taken on every frame are taken only when something reads them.

## The version

- Tag: `v0.7.0-beta`
- `mod_version` in `gradle.properties`: `0.7.0-beta`
- The changelog section is named after it, and `Unreleased` is gone.

## What the release carries that no changelog entry names

Nothing that changes the picture, and two silences are deliberate rather than missed:

- **the guard on the camera half of the far terrain draw** asks whether Distant Horizons' buffers
  are still open before binding them, as the shadow half already did. Over ten loads it never once
  found a closed buffer, so there is nothing a player could be told;
- **two batches on the chain plan**, the entities counted among the plan's default families and a
  pack's own temporal reads kept out of the warnings, move what the engine says out of game and what
  it logs. The first says in its own message that nothing moves on the eight packs of the corpus.

The rest of the range is documentation, continuous integration, and one refactor that drops four
members nothing reads.

## What proves it

- `gradlew build` green locally on the tree being tagged, and green on the pull request that brought
  it into `dev`.
- In the game, at length, on the NeoForge bench and once on the Fabric one, with Bliss v2.1.2 as a
  zip and Complementary Unbound as a directory: a pack removed and put back in a world used to lose
  the device on the FIRST gesture, six times out of six. It now passes two of the same, and three
  pack switches out of four. That gesture is played by a harness rather than by hand, so the two
  sides differ by the engine and nothing else.
- **What has not been looked at, and it matters here**: the picture itself. Nothing in this range was
  compared against Iris this evening, and the far terrain, whose rings this release changes, was not
  looked at after a reload with Distant Horizons drawing. The change keeps buffers alive that were
  being destroyed, which cannot make a draw read from less than it did, but that is an argument and
  not a screenshot.
- The crash of issue 111 is **not closed**: a second fault of the same family reaches it between the
  first and the fourth pack load, and the changelog says so where a player will read it.

---

- [x] `main` is an ancestor of `dev`, so this merges by fast-forward.
- [x] `gradlew build` green locally on the commit being tagged.
- [x] The changelog section is named after the tag, and the range was read against it.
- [ ] Merged by fast-forward from a terminal, and by no button.
- [ ] The tag is pushed only once its commits are on `main`, because the tag is what publishes.
