### PR TITLE
fix(render): close the two remaining doors of the reload crash

### DIFF
--- a/common/src/main/java/dev/vitrail/render/EntityMesh.java
+++ b/common/src/main/java/dev/vitrail/render/EntityMesh.java
@@ -4,8 +4,6 @@ import dev.vitrail.glsl.EntityVertex;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.GpuFormat;
-import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
@@ -78,12 +76,12 @@ import org.jspecify.annotations.Nullable;
  * built under one answer bound by a pipeline compiled under the other, which is the same wrong stride
  * by another road.
  * <p>
- * So there is one answer in force, {@link #settle()} is the only thing that moves it, and it discards
- * the game's compiled pipelines on the way. Its instant is the one {@code TerrainMesh.settle} already
- * uses, the head of Sodium's {@code initRenderer}: it is reached from the extract that consumes
- * {@code LevelExtractor.allChanged}, which is after the previous frame was submitted and presented
- * and before this one has bound a single pipeline, so {@code clearPipelineCache} and the
- * {@code waitIdle} inside it have nothing in flight to tear down.
+ * So there is one answer in force and {@link #settle()} is the only thing that moves it. Its
+ * instant is the one {@code TerrainMesh.settle} already uses, the head of Sodium's
+ * {@code initRenderer}, reached from the extract that consumes {@code LevelExtractor.allChanged}.
+ * That instant is safe for moving a format answer and for nothing wider: the game's own compiled
+ * pipelines are NOT discarded here, and the body of {@code settle} says what discarding them cost
+ * and which road pays that debt instead.
  * <p>
  * <strong>Asking is all a switch does</strong>, which is what makes the one place that writes
  * {@code EntityDraw.wanted} directly safe: an entity program that threw stops being offered at once
@@ -229,15 +227,27 @@ public final class EntityMesh {
 		// settles false onto false and has nothing to drop: dropping anyway is a full recompile of
 		// every static pipeline at the first world join, for a stride that did not change.
 		//
-		// Where it did move, the drop is owed. The game precompiles every static pipeline at every
+		// Where it did move, a drop is owed: the game precompiles every static pipeline at every
 		// resource load and caches it by identity (ShaderManager.apply, VulkanDevice.pipelineCache),
-		// so the entity ones standing here were compiled under the other answer, and this backend
-		// bakes the stride into them. Emptying the cache is what ShaderManager itself does before it
-		// recompiles, and what is dropped comes back on demand through the same shader source the
-		// device was built with.
-		GpuDevice device = moved ? RenderSystem.tryGetDevice() : null;
-		if (device != null) {
-			device.clearPipelineCache();
+		// this backend bakes the stride in at compile, so the entity ones standing here carry the
+		// other answer's stride.
+		//
+		// AND NOTHING IS DROPPED HERE ALL THE SAME, which was this engine's half of issue 111. The
+		// cache can only be emptied whole, the emptying waits the device idle and destroys the
+		// game's pipelines with ours, and there is no instant of a running session where that is
+		// safe: this backend records continuously, so at any positional hook something already
+		// recorded still names what the purge destroys. Emptied here, on a pack load in a running
+		// world, the device was lost seconds later with nothing in the log; moved to the head of
+		// the frame, it took the boot's world join down instead. The one road that empties it
+		// safely is the game's own, ShaderManager.apply, which quiesces rendering first - so the
+		// debt is left to it, and it pays at every resource reload. Until then the stale pipelines
+		// cost what a warmup already shows: an entity or hand drawn by the game's own shader over
+		// a mesh of the other stride, for the frames a chain takes to compile, and only after the
+		// answer has moved in a running world.
+		if (moved) {
+			Vitrail.logger().info("The game's entity pipelines keep the previous stride until the "
+					+ "next resource reload, which empties the device's pipeline cache on the one "
+					+ "road that is safe");
 		}
 
 		if (!asked) {

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1119,15 +1119,22 @@ public final class PackChain {
 	 * already forgotten is what decides whether one is printed.
 	 */
 	private static void readAgain(Path gameDirectory) {
+		// The chain stops answering BEFORE anything of it is freed, and the order is the whole
+		// of issue 111. Every accessor below reads this field, and a pass of the frame in
+		// hand asks one of them: the sky asks for its own draw as it opens its render pass.
+		// Freed first, that pass was handed a chain whose colour targets had just been closed
+		// and built its descriptor on the views of them, which is a pointer into freed memory
+		// and a lost device seconds later. Cleared first, the same pass finds nothing, and
+		// falls back to the game's own shader for the one frame it takes to reload.
 		PackChain previous = active;
-		if (previous != null) {
-			previous.release();
-		}
-
 		active = null;
 		// Cleared as well, so that a pack that failed to compile can be fixed and tried again
 		// without leaving the game.
 		disabled = false;
+
+		if (previous != null) {
+			previous.release();
+		}
 		load(gameDirectory);
 		// Taken whatever the load did with them. A pack that cannot be read at all settled nothing,
 		// and without these it would be read again on the very next frame, and every frame after


### PR DESCRIPTION
## What changes

The two remaining halves of issue #111, found and proven with the corner rings already on `dev`.

First, a reload no longer frees the chain before it stops answering: `readAgain` clears the field
every accessor reads and only then releases, so a pass of the frame in hand finds nothing and falls
back to the game's own shader for the one frame the reload takes, instead of building its
descriptor on colour targets that were just closed.

Second, nothing empties the device's pipeline cache any more. The settle that moves the entity
mesh's format owed a purge, and there is no instant of a running session that can pay it: the cache
only empties whole, the emptying waits the device idle and destroys the game's pipelines with ours,
and this backend records continuously, so at any positional hook something already recorded still
names what the purge destroys. At its old instant it killed the pack reload in a running world; at
the head of the frame it killed the boot's world join instead. The debt is left to the one road that
pays it safely, `ShaderManager.apply` at every resource reload, which quiesces rendering first, and
the log says so once per move.

## How it differs from the reference, and for what obstacle

It does not. Iris never faces either question: its backend rebuilds vertex state at the draw, so no
stride is baked and no purge is owed, and its reload path has no window where a live accessor
answers with freed images.

## What proves it

- `gradlew build` green, `-PlintReport` quiet on the touched files.
- The gesture of #111, played by the harness and by hand, on **both loaders**: Bliss removed and put
  back, packs switched, shaders enabled from off. Before this branch the session ended somewhere
  between the first and fourth repetition, every time; with it, five automated same-pack gestures on
  NeoForge and a hand-driven series of toggles and switches on Fabric all passed. NeoForge 26.2.0.64
  and 26.2.0.32-beta both reproduced the fault before the fix, so the loader version is not what
  moved.

## What it leaves owing

Between a format move in a running world and the next resource reload, the game's entity pipelines
keep the previous stride. What that shows is bounded to what a warmup already shows, an entity or
hand drawn by the game's own shader over a mesh of the other stride for the frames a chain takes to
compile, and a resource reload clears it. The alternative was the crash.
