### PR TITLE
build: raise the version to 0.7.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## 0.7.1-beta
+
+### Fixed
+
+- **Removing, picking or reloading a shader pack in a running world no longer crashes the game.**
+  The 0.7.0 entry below said the crash was reduced and not gone, and this closes what remained,
+  which was two more faults of the same family. A reload freed the pack's images a moment before it
+  stopped answering for them, so a pass of that very frame could still be handed them; and loading
+  a pack that draws the entities or the hand emptied the graphics device's whole pipeline cache at
+  an instant where work already recorded still named what was destroyed. Nothing empties that cache
+  any more: the game does it itself on every resource reload, which is the one moment it is safe.
+  What that leaves is cosmetic and brief: after turning a pack on or off in a world, an entity or
+  the hand drawn by the game's own shader can look wrong for the second or two a pack takes to
+  finish compiling, and a resource reload clears it. Tried at length on both loaders, turning packs
+  off and on and switching between four of them, where one to four such gestures used to end the
+  session.
+
 ## 0.7.0-beta
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.7.0-beta
+mod_version=0.7.1-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

The version, in the two places it is written, and the changelog entry closing what the 0.7.0 notes
left open. Nothing of the engine.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

`gradlew build` green, and the release job checks the tag against `mod_version` before it
uploads anything.

## What it leaves owing

Nothing.