### PR TITLE
Release 0.7.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## 0.7.1-beta
+
+### Fixed
+
+- **Removing, picking or reloading a shader pack in a running world no longer crashes the game.**
+  The 0.7.0 entry below said the crash was reduced and not gone, and this closes what remained,
+  which was two more faults of the same family. A reload freed the pack's images a moment before it
+  stopped answering for them, so a pass of that very frame could still be handed them; and loading
+  a pack that draws the entities or the hand emptied the graphics device's whole pipeline cache at
+  an instant where work already recorded still named what was destroyed. Nothing empties that cache
+  any more: the game does it itself on every resource reload, which is the one moment it is safe.
+  What that leaves is cosmetic and brief: after turning a pack on or off in a world, an entity or
+  the hand drawn by the game's own shader can look wrong for the second or two a pack takes to
+  finish compiling, and a resource reload clears it. Tried at length on both loaders, turning packs
+  off and on and switching between four of them, where one to four such gestures used to end the
+  session.
+
 ## 0.7.0-beta
 
 ### Changed

--- a/common/src/main/java/dev/vitrail/render/EntityMesh.java
+++ b/common/src/main/java/dev/vitrail/render/EntityMesh.java
@@ -4,8 +4,6 @@ import dev.vitrail.glsl.EntityVertex;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.GpuFormat;
-import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
@@ -78,12 +76,12 @@ import org.jspecify.annotations.Nullable;
  * built under one answer bound by a pipeline compiled under the other, which is the same wrong stride
  * by another road.
  * <p>
- * So there is one answer in force, {@link #settle()} is the only thing that moves it, and it discards
- * the game's compiled pipelines on the way. Its instant is the one {@code TerrainMesh.settle} already
- * uses, the head of Sodium's {@code initRenderer}: it is reached from the extract that consumes
- * {@code LevelExtractor.allChanged}, which is after the previous frame was submitted and presented
- * and before this one has bound a single pipeline, so {@code clearPipelineCache} and the
- * {@code waitIdle} inside it have nothing in flight to tear down.
+ * So there is one answer in force and {@link #settle()} is the only thing that moves it. Its
+ * instant is the one {@code TerrainMesh.settle} already uses, the head of Sodium's
+ * {@code initRenderer}, reached from the extract that consumes {@code LevelExtractor.allChanged}.
+ * That instant is safe for moving a format answer and for nothing wider: the game's own compiled
+ * pipelines are NOT discarded here, and the body of {@code settle} says what discarding them cost
+ * and which road pays that debt instead.
  * <p>
  * <strong>Asking is all a switch does</strong>, which is what makes the one place that writes
  * {@code EntityDraw.wanted} directly safe: an entity program that threw stops being offered at once
@@ -229,15 +227,27 @@ public final class EntityMesh {
 		// settles false onto false and has nothing to drop: dropping anyway is a full recompile of
 		// every static pipeline at the first world join, for a stride that did not change.
 		//
-		// Where it did move, the drop is owed. The game precompiles every static pipeline at every
+		// Where it did move, a drop is owed: the game precompiles every static pipeline at every
 		// resource load and caches it by identity (ShaderManager.apply, VulkanDevice.pipelineCache),
-		// so the entity ones standing here were compiled under the other answer, and this backend
-		// bakes the stride into them. Emptying the cache is what ShaderManager itself does before it
-		// recompiles, and what is dropped comes back on demand through the same shader source the
-		// device was built with.
-		GpuDevice device = moved ? RenderSystem.tryGetDevice() : null;
-		if (device != null) {
-			device.clearPipelineCache();
+		// this backend bakes the stride in at compile, so the entity ones standing here carry the
+		// other answer's stride.
+		//
+		// AND NOTHING IS DROPPED HERE ALL THE SAME, which was this engine's half of issue 111. The
+		// cache can only be emptied whole, the emptying waits the device idle and destroys the
+		// game's pipelines with ours, and there is no instant of a running session where that is
+		// safe: this backend records continuously, so at any positional hook something already
+		// recorded still names what the purge destroys. Emptied here, on a pack load in a running
+		// world, the device was lost seconds later with nothing in the log; moved to the head of
+		// the frame, it took the boot's world join down instead. The one road that empties it
+		// safely is the game's own, ShaderManager.apply, which quiesces rendering first - so the
+		// debt is left to it, and it pays at every resource reload. Until then the stale pipelines
+		// cost what a warmup already shows: an entity or hand drawn by the game's own shader over
+		// a mesh of the other stride, for the frames a chain takes to compile, and only after the
+		// answer has moved in a running world.
+		if (moved) {
+			Vitrail.logger().info("The game's entity pipelines keep the previous stride until the "
+					+ "next resource reload, which empties the device's pipeline cache on the one "
+					+ "road that is safe");
 		}
 
 		if (!asked) {

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1119,15 +1119,22 @@ public final class PackChain {
 	 * already forgotten is what decides whether one is printed.
 	 */
 	private static void readAgain(Path gameDirectory) {
+		// The chain stops answering BEFORE anything of it is freed, and the order is the whole
+		// of issue 111. Every accessor below reads this field, and a pass of the frame in
+		// hand asks one of them: the sky asks for its own draw as it opens its render pass.
+		// Freed first, that pass was handed a chain whose colour targets had just been closed
+		// and built its descriptor on the views of them, which is a pointer into freed memory
+		// and a lost device seconds later. Cleared first, the same pass finds nothing, and
+		// falls back to the game's own shader for the one frame it takes to reload.
 		PackChain previous = active;
-		if (previous != null) {
-			previous.release();
-		}
-
 		active = null;
 		// Cleared as well, so that a pack that failed to compile can be fixed and tried again
 		// without leaving the game.
 		disabled = false;
+
+		if (previous != null) {
+			previous.release();
+		}
 		load(gameDirectory);
 		// Taken whatever the load did with them. A pack that cannot be read at all settled nothing,
 		// and without these it would be read again on the very next frame, and every frame after

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.7.0-beta
+mod_version=0.7.1-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What this publishes

The close of the reload crash. 0.7.0-beta, published earlier this evening, said the crash of #111
was reduced and not gone; this carries the two faults that remained, and with them the gesture that
used to end a session somewhere between its first and fourth repetition, removing a pack, picking
one, switching between them, survives everything that was thrown at it tonight, on both loaders.

## The version

- Tag: `v0.7.1-beta`
- `mod_version` in `gradle.properties`: `0.7.1-beta`
- The changelog section is named after it, and `Unreleased` is gone.

## What the release carries that no changelog entry names

Nothing. The range is the two fixes and the bump, and the one debt the fixes take on, entity
pipelines keeping a stale stride between a format move and the next resource reload, is in the
changelog entry where a player will read it.

## What proves it

- `gradlew build` green on the tree being tagged, and on the pull requests that brought it in.
- The gesture of #111, by harness and by hand, on both benches: five automated same-pack gestures
  and four automated pack switches on NeoForge, a hand-driven series of toggles and switches on
  Fabric, all alive, where the code before this range died on the first to fourth. NeoForge
  26.2.0.64.
- Not looked at: the image against Iris. Nothing in this range touches what is drawn while a pack
  is up; the one visual it can change is the game-drawn entity or hand during a chain's warmup
  after a mid-world format move, and the changelog says so.

---

- [x] `main` is an ancestor of `dev`, so this merges by fast-forward.
- [x] `gradlew build` green locally on the commit being tagged.
- [x] The changelog section is named after the tag, and the range was read against it.
- [ ] Merged by fast-forward from a terminal, and by no button.
- [ ] The tag is pushed only once its commits are on `main`, because the tag is what publishes.
