### PR TITLE
docs: install Distant Horizons from the launcher again

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -89,28 +89,20 @@ Sodium has no API for any of that, which is why its version is pinned above.
 Every family drawn since takes one or two more, and the whole list is the mixin
 config shipped in the jar rather than anything summarised here.
 
-Any mod that unwraps a GPU texture into an OpenGL handle will crash on the Vulkan
-backend, with or without Vitrail. Distant Horizons 3.2.0-b does this and dies on
-the first frame. This is not something Vitrail can work around: the fix belongs
-to that mod and not to this one.
-
-Given a build of it that draws on this backend, Vitrail hands its far terrain to
-the pack's own programs, `dh_terrain` and `dh_water` for the picture, and
-`dh_shadow` for the shadow map where the pack ships one and has not switched it
-off, and serves its depth beside the world's, which is
-the arrangement packs are written against. The changelog
-says what that changes and what it does not reach, and the log names each far
+Distant Horizons installs from the launcher like any other mod: 3.2.0-b runs
+beside Vitrail on this backend, with a pack drawn and without one. While a pack
+is up, Vitrail hands its far terrain to the pack's own programs, `dh_terrain`
+and `dh_water` for the picture, and `dh_shadow` for the shadow map where the
+pack ships one and has not switched it off, and serves its depth beside the
+world's, which is the arrangement packs are written against. The changelog says
+what that changes and what it does not reach, and the log names each far
 terrain pass as the pack takes it over.
 
-There is such a build, and no published one does it: the far terrain rendering
-that works here is unreleased work in that mod's own tree, and on Fabric the two
-mods together crash at startup without a fix on top of it. So one is built from
-that tree and published, for 26.2, one jar for both loaders:
-[Distant Horizons patched for Vitrail][dh-build]. **It installs by hand**, no
-launcher will pull it: drop the jar in `mods` yourself and leave no other
-Distant Horizons jar beside it. It reports itself as `3.2.1-b-dev`, the version
-string an upstream dev build carries, so bug reports made with it do not belong
-to the Distant Horizons team; its three fixes are offered to them upstream.
+With shaders off, that mod draws its far terrain itself and this engine is not
+involved. A [patched build][dh-build] stays published from the days this page
+required one; what it still changes is how that mod's own fog and ambient
+occlusion read an empty depth buffer, a divergence seen in its code and never
+yet in a picture. Nothing needs it any more.
 
 [dh-build]: https://gitlab.com/avpbynf/distant-horizons/-/releases/vitrail-26.2-1
 


### PR DESCRIPTION
## What changes

INSTALL.md stops sending every player to the hand-installed patched build. The official 3.2.0-b
runs beside Vitrail, measured today on the Fabric bench with 0.7.1-beta: pack drawn, this engine
substitutes the renderer whole; shaders off, that mod's own renderer draws, no device loss. The
patched build stays linked for the two visual fixes it still carries, which belong to that mod.

## How it differs from the reference, and for what obstacle

Not applicable, text only.

## What proves it

The bench run described above, and the log naming the takeover against the official jar.

## What it leaves owing

The fog and ambient occlusion defects of that mod with shaders off are described but were not
photographed side by side; the patched build's release page still documents them.