### PR TITLE
fix(render): recompile the entity pipelines when the stride moves

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -3,8 +3,9 @@
 # label a fact already written in the branch name rather than an opinion about the change. There is
 # nothing to decide here, and that is exactly what makes it forgettable.
 #
-# It was forgotten. Nine of the first eighty-eight requests carry a label and none of the
-# twenty-seven after them do: the rule held for as long as somebody remembered it, and no longer.
+# It was forgotten. Of the requests opened before this workflow existed, nine of the first
+# eighty-eight carry a label and none of the twenty-seven that followed do: the rule held for as
+# long as somebody remembered it, and no longer.
 # Every one of those twenty-seven had its type written in its branch name and at the head of every
 # subject it carried, so nothing was ever missing except the gesture.
 #
@@ -41,8 +42,14 @@ jobs:
           type="${BRANCH%%/*}"
           case "$type" in
             feat|fix|perf|refactor|docs|test|build|ci|chore)
-              gh pr edit "$NUMBER" --repo "$REPOSITORY" --add-label "$type"
-              echo "Labelled $type, which is what the branch $BRANCH opens with."
+              # The fallback keeps the header's promise: a pose that fails, label deleted, API
+              # down or token short, leaves a notice and a green run on a request that broke no
+              # rule. The label can always be put on by hand.
+              if gh pr edit "$NUMBER" --repo "$REPOSITORY" --add-label "$type"; then
+                echo "Labelled $type, which is what the branch $BRANCH opens with."
+              else
+                echo "::notice::Posing the label $type failed, so nothing is posed."
+              fi
               ;;
             release)
               # A release request carries no type. What lands from such a branch is the version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Fixed
+
+- **The hand and the entities no longer stretch into giant triangles after a pack turns on or
+  off.** The 0.7.1 entry below called what its crash fix left behind cosmetic and brief, and it
+  was neither: the game's own entity pipelines keep the previous vertex layout until a resource
+  reload, so anything they drew over the rebuilt mesh, the hand with its switch off, every mob
+  and hand for the seconds a chain takes to compile, smeared across the screen and stayed that
+  way for the rest of the session. The engine now takes those pipelines out of the device's cache
+  the moment the layout moves and compiles them again on the spot; what left the cache is freed
+  at the next reload, the one safe moment the crash fix established, so the crash stays gone.
+
 ## 0.7.1-beta
 
 ### Fixed
@@ -22,11 +35,10 @@ what the next one holds.
   a pack that draws the entities or the hand emptied the graphics device's whole pipeline cache at
   an instant where work already recorded still named what was destroyed. Nothing empties that cache
   any more: the game does it itself on every resource reload, which is the one moment it is safe.
-  What that leaves is cosmetic and brief: after turning a pack on or off in a world, an entity or
-  the hand drawn by the game's own shader can look wrong for the second or two a pack takes to
-  finish compiling, and a resource reload clears it. Tried at length on both loaders, turning packs
-  off and on and switching between four of them, where one to four such gestures used to end the
-  session.
+  What that leaves is visual, and worse than this entry first said: an entity or the hand drawn by
+  the game's own shader can look wrong from then on, until a resource reload clears it, which the
+  entry above is what removed. Tried at length on both loaders, turning packs off and on and
+  switching between four of them, where one to four such gestures used to end the session.
 
 ## 0.7.0-beta
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,9 +256,10 @@ way its name was settled.
 
 **The repository poses that one itself**, off the branch name and at the moment the request is
 opened (`.github/workflows/label.yml`). A label derived rather than decided has no reason to be
-asked of anybody, and this one held only for as long as it was remembered: nine of the first
-eighty-eight requests carry it and none of the twenty-seven after them do. Where it posts nothing,
-the branch opens on a word this convention does not know, and `commits.yml` is what says so.
+asked of anybody, and this one held only for as long as it was remembered: of the requests opened
+before the workflow existed, nine of the first eighty-eight carry it and none of the twenty-seven
+that followed do. Where it posts nothing, the branch either carries a release, which takes no type
+label, or opens on a word this convention does not know, and `commits.yml` is what says so.
 
 **An issue carries what it is about instead**, being a report rather than a change:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,8 +60,8 @@ Some of Chloride's own settings decide what reaches this engine, in
 keys of their own. `tileEntities`, `entities` and `monsters`, under `[culling]`,
 decide on their own which block entities, which mobs and which other entities are
 drawn at all, by distance: what they take out is never handed to the pack, so a
-chest, a sign, a boat or a
-mob that is not there is those settings rather than anything the pack does.
+chest, a sign, a boat or a mob that is not there is those settings rather than
+anything the pack does.
 `chests` and `beds`, under `[fastBlocks]`, draw those blocks by a path this
 engine's final pass then covers over, so they go invisible with no other symptom.
 Which of the five a given Chloride writes on is its own business and changes with
@@ -95,7 +95,10 @@ pack drawn and without one. On NeoForge that same build unwraps a GPU texture
 into an OpenGL handle as the lightmap renders, its NeoForge wrapper alone doing
 so, and dies on the first frame of a world with a `ClassCastException` naming
 `VulkanGpuTexture`: there the [patched build][dh-build] below is still the one
-to install, by hand and with no other Distant Horizons jar beside it. While a pack
+to install, by hand and with no other Distant Horizons jar beside it. That build
+reports itself as `3.2.1-b-dev`, the same string an upstream development build
+carries, so bug reports made with it belong on this tracker and not with the
+Distant Horizons team. While a pack
 is up, Vitrail hands its far terrain to the pack's own programs, `dh_terrain`
 and `dh_water` for the picture, and `dh_shadow` for the shadow map where the
 pack ships one and has not switched it off, and serves its depth beside the
@@ -105,9 +108,10 @@ terrain pass as the pack takes it over.
 
 With shaders off, that mod draws its far terrain itself and this engine is not
 involved. Beyond the NeoForge death above, the patched build changes one more
-thing: how that mod's own fog and ambient occlusion read an empty depth buffer,
-a divergence seen in its code and never yet in a picture. On Fabric it is
-optional and that is all it would buy.
+thing: how that mod's own fog and ambient occlusion read a reverse depth
+buffer, a divergence seen in its code, reachable only while no pack is drawn,
+and never yet seen in a picture. On Fabric it is optional and that is all it
+would buy.
 
 [dh-build]: https://gitlab.com/avpbynf/distant-horizons/-/releases/vitrail-26.2-1
 
@@ -232,8 +236,8 @@ A settings screen covers all of it in game: the video settings, where it sits
 under Vitrail in the list of pages, the I key, or, on NeoForge, the Config button
 in the mod list. It is the screen of the engine packs are written against, ported rather
 than approximated, so it looks and behaves like that one. It opens on the pack
-list and reads each pack's own menu layout. The row at the head of the list turns shaders off altogether and leaves the
-game drawing its own image. Clicking a pack only selects it: Apply writes what
+list and reads each pack's own menu layout. The row at the head of the list turns shaders off
+altogether and leaves the game drawing its own image. Clicking a pack only selects it: Apply writes what
 you changed and reads the pack again without closing, Done does both and closes,
 and Cancel throws the changes away. A program that fails to compile is reported
 in the log and the game keeps its own rendering rather than crashing.

--- a/NOTICE
+++ b/NOTICE
@@ -571,8 +571,10 @@ GNU Lesser General Public License version 3
   numbers are worked out here from the texel centres rather than read off Iris, and they agree with
   the sixteen it carries; what is taken is the rule that gl_TextureMatrix[1] is answered with them
   at all, which is what a pack expects. One family is answered the identity instead, Distant
-  Horizons geometry, and that is Iris's answer too rather than a divergence: it rewrites both
-  gl_TextureMatrix[0] and [1] to mat4(1.0) there.
+  Horizons geometry, and for units nought and one that is Iris's answer too: it rewrites both
+  to mat4(1.0) there. Unit two is this engine's alone, Iris leaving that read to fail the
+  compile; the javadoc of GlslTranslator.rewriteDistantTextureMatrix spells the divergence and
+  what rests on it, which today is nothing.
 
   common/src/main/java/dev/vitrail/glsl/GlslTranslator.java sends a read of gl_TextureMatrix[0] to
   the game's own per draw transforms on the entity family, which is where

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ will accept. Vitrail rewrites every program into Vulkan GLSL **once, before it
 ever draws**, and hands it to the compiler the game already embeds, which
 turns it into SPIR-V exactly as it does for the game's own shaders. There is no
 translation layer left between the game and the GPU while a frame is drawn:
-this is a compiler that runs at load time, not a shim that runs per frame. What
+this is a compiler that runs before the frame, not a shim that runs inside it. What
 that one idea costs, buys and implies is the opening page of
 [the documentation](docs/README.md).
 

--- a/common/src/main/java/dev/vitrail/dh/DhLods.java
+++ b/common/src/main/java/dev/vitrail/dh/DhLods.java
@@ -219,7 +219,7 @@ public final class DhLods {
 	 * by default ({@code core/config/Config.java:127} and {@code :447}), so an install that changed
 	 * nothing pays for three screens of work a frame that are thrown away one pass later. Iris
 	 * holds off the same two, through the same published config, at
-	 * {@code compat/dh/LodRendererEvents.java:274-275}, and clears them again at {@code :281}.
+	 * {@code compat/dh/LodRendererEvents.java:274-275}, and clears them again at {@code :281-282}.
 	 * <p>
 	 * <strong>What the three cost is the passes and not their bodies, and only one of the three
 	 * even reaches its body.</strong> The image they read is DH's depth as it cleared it, which is
@@ -258,6 +258,15 @@ public final class DhLods {
 						+ "never reads", held, SWITCHES);
 			}
 		} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
+			// hold sets the two switches one after the other, so a throw between them has already
+			// forced the first with muted still false, and nothing later would ever hand it back.
+			// Clearing returns whatever DID take, and a second throw changes nothing.
+			try {
+				hold(null);
+			} catch (ReflectiveOperationException | RuntimeException | LinkageError swallowed) {
+				e.addSuppressed(swallowed);
+			}
+
 			mutable = false;
 			Vitrail.logger().info("Distant Horizons keeps drawing its own ambient occlusion and fog "
 					+ "over an image this engine never reads, which costs a frame and shows "
@@ -491,9 +500,13 @@ public final class DhLods {
 		// one on screen. Handed back to the PLAYER rather than set true: what the menu says is his,
 		// and this engine only ever stood in front of it.
 		if (muted) {
-			muted = false;
 			try {
-				hold(null);
+				// Cleared only where the clearing really ran: a throw leaves the debt standing,
+				// and so does UNREACHED, so the next restore tries again rather than forgetting
+				// that a switch of the player's is still overridden.
+				if (hold(null) != UNREACHED) {
+					muted = false;
+				}
 			} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
 				Vitrail.logger().debug("Distant Horizons' own ambient occlusion and fog cannot be "
 						+ "handed back", e);

--- a/common/src/main/java/dev/vitrail/mixin/GpuDeviceAccessor.java
+++ b/common/src/main/java/dev/vitrail/mixin/GpuDeviceAccessor.java
@@ -1,0 +1,21 @@
+package dev.vitrail.mixin;
+
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.GpuDeviceBackend;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * The backend behind the device the game hands out, which is where the pipeline cache lives.
+ * <p>
+ * {@code RenderSystem.getDevice()} answers with the front, a plain class that forwards every call
+ * and shows the backend to nobody. {@code EntityMesh.settle} needs to ask whether that backend is
+ * one {@code VulkanDeviceMixin} taught to set entity pipelines aside, and an instanceof against a
+ * private field is an accessor's whole job.
+ */
+@Mixin(GpuDevice.class)
+public interface GpuDeviceAccessor {
+
+	@Accessor("backend")
+	GpuDeviceBackend vitrail$backend();
+}

--- a/common/src/main/java/dev/vitrail/mixin/RenderPipelineAccessor.java
+++ b/common/src/main/java/dev/vitrail/mixin/RenderPipelineAccessor.java
@@ -1,0 +1,26 @@
+package dev.vitrail.mixin;
+
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The vertex formats a pipeline DECLARES, as the field spells them, which
+ * {@code getVertexFormatBindings} no longer answers with: {@code RenderPipelineMixin} rewrites that
+ * getter while the entity mesh carries, and it has to, that being how the game's own pipelines
+ * compile against the mesh this engine really builds.
+ * <p>
+ * {@code VulkanDeviceMixin} asks a different question, WHOSE pipeline this is: one that names the
+ * game's entity format was written by the game and is recompiled when the mesh's answer moves, one
+ * that names the extended format was built by a pack's program and follows its chain instead. The
+ * rewritten getter folds those two into one answer, so telling them apart takes the raw field.
+ */
+@Mixin(RenderPipeline.class)
+public interface RenderPipelineAccessor {
+
+	@Accessor("vertexFormatPerBuffer")
+	@Nullable VertexFormat[] vitrail$declaredFormats();
+}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanDeviceMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanDeviceMixin.java
@@ -1,0 +1,105 @@
+package dev.vitrail.mixin;
+
+import dev.vitrail.render.StalePipelines;
+
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Lets the game's compiled entity pipelines leave the cache without dying, which is what
+ * {@code EntityMesh.settle} needs when its answer moves in a running world: the pipelines standing
+ * in {@code pipelineCache} were compiled against the bindings of the OTHER answer, their stride is
+ * baked ({@code VulkanRenderPipeline:99}), and every draw they serve reads the mesh at the wrong
+ * offsets from then on. Giant triangles off the hand and every mob, for as long as the session
+ * lasts, is what that looks like.
+ * <p>
+ * <strong>Dropped from the map, never destroyed here.</strong> Destruction is the half of issue
+ * 111 that lives in this engine: the cache's own emptying waits the device idle and there is no
+ * instant of a running session where that is safe. What leaves the map cannot be looked up again,
+ * so no NEW draw binds it; whatever an already-recorded frame still names stays alive in
+ * {@code vitrail$setAside} until {@code clearPipelineCache}, which the game only reaches after
+ * quiescing rendering, frees the whole cache anyway, and now frees these with it.
+ */
+@Mixin(VulkanDevice.class)
+public abstract class VulkanDeviceMixin implements StalePipelines {
+
+	@Shadow
+	@Final
+	private Map<RenderPipeline, VulkanRenderPipeline> pipelineCache;
+
+	/**
+	 * Compiled pipelines dropped from the cache and owed a destroy, which only the safe purge pays.
+	 * A list and not a set: one pipeline cannot be dropped twice, leaving the map with the drop as
+	 * it does.
+	 * <p>
+	 * It grows one set per answer move and empties only at the next resource reload, and that
+	 * bound is accepted rather than missed: the same move that adds a set also rebuilds the whole
+	 * world mesh and compiles or drops a pack's entire chain, so what waits here is a sliver of
+	 * what the move already paid, and the only earlier instant to free it is the unsafe one this
+	 * class exists to avoid.
+	 */
+	@Unique
+	private final List<VulkanRenderPipeline> vitrail$setAside = new ArrayList<>();
+
+	@Override
+	public List<RenderPipeline> vitrail$dropEntityPipelines() {
+		List<RenderPipeline> dropped = new ArrayList<>();
+		Iterator<Map.Entry<RenderPipeline, VulkanRenderPipeline>> held =
+				this.pipelineCache.entrySet().iterator();
+		while (held.hasNext()) {
+			Map.Entry<RenderPipeline, VulkanRenderPipeline> entry = held.next();
+			if (!declaresGameEntity(entry.getKey())) {
+				continue;
+			}
+
+			this.vitrail$setAside.add(entry.getValue());
+			dropped.add(entry.getKey());
+			held.remove();
+		}
+
+		return dropped;
+	}
+
+	/**
+	 * Whether this is one of the game's entity pipelines, read off the DECLARED formats and not the
+	 * getter: {@code RenderPipelineMixin} rewrites the getter while the mesh carries, which would
+	 * make a pack's own pipelines answer yes here. Those follow their chain, not this cache walk.
+	 * By identity, the same question {@code EntityMesh.binding} asks.
+	 */
+	@Unique
+	private static boolean declaresGameEntity(RenderPipeline pipeline) {
+		@Nullable VertexFormat[] declared = ((RenderPipelineAccessor) pipeline).vitrail$declaredFormats();
+		for (VertexFormat format : declared) {
+			@SuppressWarnings("ReferenceEquality")
+			boolean entity = format == DefaultVertexFormat.ENTITY;
+			if (entity) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Inject(method = "clearPipelineCache", at = @At("TAIL"), require = 1)
+	private void vitrail$destroySetAside(CallbackInfo callback) {
+		this.vitrail$setAside.forEach(VulkanRenderPipeline::destroy);
+		this.vitrail$setAside.clear();
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/source/DimensionSet.java
+++ b/common/src/main/java/dev/vitrail/pack/source/DimensionSet.java
@@ -118,9 +118,10 @@ public final class DimensionSet {
 	 * Which directory this world's programs are read from, the empty string for the root.
 	 * <p>
 	 * The root is the answer for a world the pack says nothing about and has no catch-all for. A
-	 * folder named here answers for itself whether or not it is on disk and whether or not it holds
-	 * an entry point, which {@link TargetPlan} decides rather than this: a name here is where to
-	 * look, not what is there.
+	 * folder named here answers for itself when it is on disk, whatever it holds, an empty one
+	 * drawing nothing rather than falling back; named and absent, the root answers instead. Which
+	 * of the two it is, {@link TargetPlan} decides off the directory's existence and never off its
+	 * contents: a name here is where to look, not what is there.
 	 *
 	 * @param world the dimension's identifier, {@code minecraft:the_nether}
 	 */

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -458,7 +458,7 @@ public final class TargetPlan {
 		return this.dimension;
 	}
 
-	/** Where the entry points were actually read from: the dimension, or the root when it ships none. */
+	/** Where the entry points were read from: the dimension, or the root when the folder is absent. */
 	public String place() {
 		return this.place;
 	}

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -108,7 +108,6 @@ final class ColorTargets {
 	private static final Vector4fc OPAQUE_BLACK = new Vector4f(0.0F, 0.0F, 0.0F, 1.0F);
 	private static final Vector4fc OPAQUE_WHITE = new Vector4f(1.0F, 1.0F, 1.0F, 1.0F);
 	private static final Vector4fc MID_GREY = new Vector4f(0.5F, 0.5F, 0.5F, 1.0F);
-	private static final Vector4fc NOTHING = new Vector4f(0.0F, 0.0F, 0.0F, 0.0F);
 
 	/** The sentinel above as a clear colour: one channel, and the mask reads the first of them. */
 	private static final Vector4fc UNWRITTEN =

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -861,6 +861,17 @@ public final class DistantDraw {
 		releaseDepth();
 	}
 
+	/**
+	 * Frees the two rings that every {@link #release} deliberately kept, at the one instant no
+	 * recorded pass can still hold a slice of them: the client's shutdown, while the device is
+	 * alive. Without this the rings outlive their last frame in silence, which shows as nothing
+	 * in play and as two straggling buffers under validation layers.
+	 */
+	static void close() {
+		CORNERS.close();
+		SHADOW_CORNERS.close();
+	}
+
 	private void releaseDepth() {
 		if (this.depthView != null) {
 			this.depthView.close();
@@ -1003,6 +1014,14 @@ public final class DistantDraw {
 		void forget() {
 			this.used = 0;
 			this.peak = 0;
+		}
+
+		/** Frees the ring itself, which only {@link DistantDraw#close()} may ask for. */
+		void close() {
+			if (this.buffer != null) {
+				this.buffer.close();
+				this.buffer = null;
+			}
 		}
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/EngineOptions.java
+++ b/common/src/main/java/dev/vitrail/render/EngineOptions.java
@@ -63,8 +63,8 @@ final class EngineOptions {
 	 * one of {@code solid}, {@code cutout} and {@code translucent} for a chunk pass, two of which are
 	 * usually served by the one file and could not otherwise be told apart. The sky answers the same
 	 * way, by element rather than by file: {@code disc}, {@code dark}, {@code stars},
-	 * {@code sunrise}, {@code sun}, {@code moon}, {@code endsky} and {@code endflash}, four of the
-	 * eight being one file. The entities
+	 * {@code sunrise}, {@code sun}, {@code moon}, {@code endsky} and {@code endflash}, the eight
+	 * splitting four and four over the two sky files. The entities
 	 * answer the same way, {@code cutout_cull}, {@code armor}, {@code item} and the rest, with the
 	 * block entity half carrying those same names under a {@code block_} in front and the two hand
 	 * passes under a {@code hand_} and a {@code hand_water_}. The weather is

--- a/common/src/main/java/dev/vitrail/render/EntityMesh.java
+++ b/common/src/main/java/dev/vitrail/render/EntityMesh.java
@@ -1,13 +1,19 @@
 package dev.vitrail.render;
 
 import dev.vitrail.glsl.EntityVertex;
+import dev.vitrail.mixin.GpuDeviceAccessor;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
 import net.minecraft.client.Minecraft;
+
+import java.util.List;
 
 import org.jspecify.annotations.Nullable;
 
@@ -79,9 +85,10 @@ import org.jspecify.annotations.Nullable;
  * So there is one answer in force and {@link #settle()} is the only thing that moves it. Its
  * instant is the one {@code TerrainMesh.settle} already uses, the head of Sodium's
  * {@code initRenderer}, reached from the extract that consumes {@code LevelExtractor.allChanged}.
- * That instant is safe for moving a format answer and for nothing wider: the game's own compiled
- * pipelines are NOT discarded here, and the body of {@code settle} says what discarding them cost
- * and which road pays that debt instead.
+ * That instant is safe for moving a format answer and for map work, and destruction is neither: the
+ * game's compiled entity pipelines are dropped from the device's cache and compiled again here, but
+ * what leaves the cache is destroyed only at the next safe purge, and the body of {@code settle}
+ * says why that split is load-bearing.
  * <p>
  * <strong>Asking is all a switch does</strong>, which is what makes the one place that writes
  * {@code EntityDraw.wanted} directly safe: an entity program that threw stops being offered at once
@@ -230,24 +237,53 @@ public final class EntityMesh {
 		// Where it did move, a drop is owed: the game precompiles every static pipeline at every
 		// resource load and caches it by identity (ShaderManager.apply, VulkanDevice.pipelineCache),
 		// this backend bakes the stride in at compile, so the entity ones standing here carry the
-		// other answer's stride.
+		// other answer's stride. Left standing they read the mesh at the wrong offsets from now on,
+		// which on screen is the hand and every fallback entity as triangles stretched across the
+		// picture, and it does not heal: the cache is only emptied at a resource reload, so the
+		// defect holds for the rest of the session. Measured before it was believed: hand=off on a
+		// stock bench, one world join, and the artefacts stood until a pack toggle forced the
+		// reload.
 		//
-		// AND NOTHING IS DROPPED HERE ALL THE SAME, which was this engine's half of issue 111. The
-		// cache can only be emptied whole, the emptying waits the device idle and destroys the
-		// game's pipelines with ours, and there is no instant of a running session where that is
-		// safe: this backend records continuously, so at any positional hook something already
-		// recorded still names what the purge destroys. Emptied here, on a pack load in a running
+		// AND NOTHING IS DESTROYED HERE ALL THE SAME, which was this engine's half of issue 111.
+		// Destruction waits the device idle, and there is no instant of a running session where
+		// that is safe: this backend records continuously, so at any positional hook something
+		// already recorded still names what a purge frees. Freed here, on a pack load in a running
 		// world, the device was lost seconds later with nothing in the log; moved to the head of
-		// the frame, it took the boot's world join down instead. The one road that empties it
-		// safely is the game's own, ShaderManager.apply, which quiesces rendering first - so the
-		// debt is left to it, and it pays at every resource reload. Until then the stale pipelines
-		// cost what a warmup already shows: an entity or hand drawn by the game's own shader over
-		// a mesh of the other stride, for the frames a chain takes to compile, and only after the
-		// answer has moved in a running world.
+		// the frame, it took the boot's world join down instead. So the two halves of eviction are
+		// split along what each one can bear. Leaving the map is map work, safe anywhere, and
+		// enough on its own: what no lookup can answer with, no NEW draw binds. The compiled
+		// pipelines wait in the mixin for clearPipelineCache, the game's one safe road, which
+		// quiesces first and now frees them with the rest. And the recompile happens at once
+		// rather than lazily at the next bind. The null asks the backend's default source, and it
+		// is never read: a source is only consulted on a miss of the device's shader module cache
+		// (VulkanDevice.getOrCompileShader, keyed by id, type and defines), the drop leaves that
+		// cache standing, and the moved answer changes none of the three keys. The recompile
+		// therefore reuses the very modules the last resource load compiled, core shaders a
+		// resource pack replaced included, and only the pipeline around them takes the new stride.
+		//
+		// The GL backend is left exactly as it stood, debt included, and the old line still says
+		// the answer moved there. Whether GL owes the same eviction is UNPROVEN in both
+		// directions: its encoder rebuilds the vertex array from the live getter at every draw
+		// (GlCommandEncoder), which reads as immune, but GlProgram.link binds attribute locations
+		// once from the format it is handed, which reads as the same bake by another name. Nobody
+		// has drawn the artefact there, and an eviction shipped unmeasured would be this fix's own
+		// plausible-and-wrong.
 		if (moved) {
-			Vitrail.logger().info("The game's entity pipelines keep the previous stride until the "
-					+ "next resource reload, which empties the device's pipeline cache on the one "
-					+ "road that is safe");
+			GpuDevice device = RenderSystem.getDevice();
+			if (((GpuDeviceAccessor) device).vitrail$backend() instanceof StalePipelines stale) {
+				List<RenderPipeline> dropped = stale.vitrail$dropEntityPipelines();
+				for (RenderPipeline pipeline : dropped) {
+					device.precompilePipeline(pipeline, null);
+				}
+
+				Vitrail.logger().info("{} entity pipelines of the game carried the previous "
+						+ "stride: compiled again at the one now in force, the old ones set "
+						+ "aside for the next safe purge", dropped.size());
+			} else {
+				Vitrail.logger().info("The game's entity pipelines were compiled under the "
+						+ "previous answer and stand until the next resource reload; this "
+						+ "backend takes no eviction, and what the stand costs it is unmeasured");
+			}
 		}
 
 		if (!asked) {

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1352,6 +1352,10 @@ public final class PackChain {
 		if (chain != null) {
 			chain.release();
 		}
+
+		// The far terrain's two corner rings survive every release on purpose, so the shutdown
+		// is the one caller that really frees them.
+		DistantDraw.close();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/StalePipelines.java
+++ b/common/src/main/java/dev/vitrail/render/StalePipelines.java
@@ -1,0 +1,36 @@
+package dev.vitrail.render;
+
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+
+import java.util.List;
+
+/**
+ * What {@code VulkanDeviceMixin} lets {@link EntityMesh#settle()} do about the game's compiled
+ * entity pipelines when the mesh's answer moves: take them out of the device's cache without
+ * destroying anything.
+ * <p>
+ * Iris never needs the gesture, and the difference says why it exists here.
+ * {@code mixin/MixinRenderPipeline.iris$change} swaps the format live at every call and touches no
+ * cache, because its backend rebuilds the vertex array from the pipeline's bindings at the draw.
+ * This backend bakes the stride into the compiled pipeline ({@code VulkanRenderPipeline:99}) and
+ * caches the result by identity, so here a moved answer leaves compiled objects behind that no
+ * live swap can reach, and they have to leave the cache instead.
+ * <p>
+ * The two halves of that sentence carry the whole design. <strong>Out of the cache</strong>, so
+ * the next bind compiles afresh against the bindings now reported and no draw ever pairs the new
+ * mesh with a pipeline compiled under the old one. <strong>Without destroying</strong>, because
+ * destruction has no safe instant in a running session, which was this engine's half of issue 111:
+ * this backend records continuously, so at any positional hook something already recorded still
+ * names what a purge would free. The compiled pipelines taken out here wait in the mixin and are
+ * freed inside {@code clearPipelineCache}, after the {@code waitIdle} the game's own emptying
+ * already pays for.
+ */
+public interface StalePipelines {
+
+	/**
+	 * Takes every cached pipeline that declares the game's entity format out of the cache, and
+	 * answers with their keys so the caller can compile them again under the answer now in force.
+	 * The compiled objects themselves are kept aside and freed at the next safe purge.
+	 */
+	List<RenderPipeline> vitrail$dropEntityPipelines();
+}

--- a/common/src/main/java/dev/vitrail/settings/PackFile.java
+++ b/common/src/main/java/dev/vitrail/settings/PackFile.java
@@ -169,10 +169,21 @@ public record PackFile(String name, boolean enabled, int shadowDistance) {
 						+ SHADOW_DISTANCE_KEY + "=" + chosen.shadowDistance() + "\n",
 				StandardCharsets.UTF_8);
 		try {
-			Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING,
-					StandardCopyOption.ATOMIC_MOVE);
-		} catch (AtomicMoveNotSupportedException e) {
-			Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING);
+			try {
+				Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING,
+						StandardCopyOption.ATOMIC_MOVE);
+			} catch (AtomicMoveNotSupportedException e) {
+				Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING);
+			}
+		} catch (IOException e) {
+			// A move that failed for any other reason would leave the .part beside the file for
+			// ever, and nothing else ever looks at it.
+			try {
+				Files.deleteIfExists(temporary);
+			} catch (IOException swallowed) {
+				e.addSuppressed(swallowed);
+			}
+			throw e;
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
@@ -79,7 +79,7 @@ public final class ShadowCull implements Frustum {
 	 * ({@code shadows/frustum/advanced/SafeZoneCullingFrustum.java:74-78}), and that order is kept.
 	 * It settles nothing while the safe zone is the shorter of the two, such a box being wholly
 	 * within the distance as well; it is what a pack asking for a voxel grid WIDER than its shadow
-	 * distance is owed, and {@code PackValues:331-332} works the two out apart without bounding
+	 * distance is owed, and {@code PackValues:332-333} works the two out apart without bounding
 	 * either by the other. Four packs of the corpus reach for this shape behind their voxelised
 	 * light, and one of them, Bliss, holds {@code voxelDistance} at 64 while offering a shadow
 	 * distance down to 32.

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -29,6 +29,7 @@
 		"GameRendererBlurMixin",
 		"GameRendererHandMixin",
 		"GameRendererMixin",
+		"GpuDeviceAccessor",
 		"ItemFeatureRendererMixin",
 		"ItemInHandRendererMixin",
 		"ItemModelResolverMixin",
@@ -41,6 +42,7 @@
 		"OptionsCloudsMixin",
 		"ProjectionMatrixBufferMixin",
 		"QuadParticleFeatureRendererMixin",
+		"RenderPipelineAccessor",
 		"RenderPipelineMixin",
 		"RenderSectionManagerAccessor",
 		"RenderTypeFeatureRendererGroupMixin",
@@ -52,6 +54,7 @@
 		"StagedVertexBufferDrawMixin",
 		"TextureManagerAccessor",
 		"VKDrawContextMixin",
+		"VulkanDeviceMixin",
 		"WeatherEffectRendererMixin"
 	]
 }

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -247,9 +247,11 @@ It is a video setting of its own, which the Fabulous preset turns on everywhere 
 it on, the game draws both of those into targets of its own and composes them itself, and this
 engine hands them back rather than attach the pack's targets beside an image it does not read. The
 log says so in those words, once for the rain and once for the particles. The entities are affected
-too, but by row rather than by family: with the setting on, the translucent half of a living entity,
-an experience orb, a translucent item sheet and the glint of an enchantment go back to the game the
-same way, while the opaque half is untouched.
+too, but by row rather than by family: with the setting on, the see-through ghost of an invisible
+mob (the game only draws one where the body is hidden but not hidden from you), an experience orb,
+a translucent item sheet and the translucent glint of an enchantment go back to the game the same
+way. An ordinarily visible mob keeps all of its rows, translucent ones included: its render types
+name no target of their own.
 
 Two consequences follow from how that geometry reaches the pack, and both are worth recognising
 rather than reporting as separate bugs:
@@ -426,8 +428,8 @@ A short reference, if you are writing a pack or wondering why yours is treated d
   the sun and the moon, which is where both references stand. `stars=false` takes nothing, the
   game's star field being drawn with the pack's own `gbuffers_skybasic` in the first place, and
   `sky=false` costs the horizon cone alone rather than the game's disc, which is again what the
-  references do, and the NOTICE says so. The fifth request in that family is not one of those four and reads the
-  other way round: `clouds` takes `off`, `fast` or `fancy` rather than a boolean, and it overrules
+  references do, and the NOTICE says so. The fifth request in that family is not one of those four
+  and reads the other way round: `clouds` takes `off`, `fast` or `fancy` rather than a boolean, and it overrules
   the user's own cloud setting so that the pack's cloud program is handed the geometry it was
   written for. It is honoured only where this engine really draws the clouds, because with the
   game's own shader behind it `off` would take the clouds away and put nothing in their place.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -93,9 +93,10 @@ of those and seeing no error means nothing was asserted, not that everything hel
 **Every invariant has a negative control.** Two of them ship as a flag on the tool they belong to,
 documented as *must exit non-zero* and naming the packs they are expected to break on; the rest are
 gestures spelled out beside the tool, a forced setting or a line put back, to be taken by hand.
-Run them: if a control reports nothing, the checker has stopped reading, and the green run beside it
-meant nothing. What controls exist is in what the tools print, which cannot fall out of date the way
-a list here would.
+Those tools live on the maintainer's bench rather than in this tree, so what a reader here can take
+away is the rule itself: if a control reports nothing, the checker has stopped reading, and the
+green run beside it meant nothing. What controls exist is in what the tools print, which cannot
+fall out of date the way a list here would.
 
 **A rule is confronted with a second, independent reading of itself.** The frame chain is rewritten
 from the specification without consulting the classes that implement it, then the two answers are

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -276,8 +276,8 @@ already been lit by the game's shader over an image the pack finished.
 
 So the engine does not intercept the hand, it **moves** it. The game's own submission
 is suppressed and the hand is submitted twice from inside the level: the solid pass just after the
-game's opaque features, before the deferred stage, and the blending pass at the end of the world, before
-the composites. Where each lands is what decides which half of every target it writes, and both are
+game's opaque features, before the deferred stage, and the blending pass at the end of the world,
+before the composites. Where each lands is what decides which half of every target it writes, and both are
 in the picture the composites read. This is where the reference puts them too.
 
 Moving it costs three things worth knowing. The hand needs a projection of its own (the head-up

--- a/docs/internals/pack-textures.md
+++ b/docs/internals/pack-textures.md
@@ -123,8 +123,9 @@ constructor; refusing the one declaration is narrower and keeps the rest of the 
 A declaration whose file the pack does not ship no longer claims the name at all: the target that
 name would otherwise have carried keeps its ordinary binding, which is what Iris does by leaving the
 sampler out of the stage's map. A file that is there and cannot be read keeps the name and reads one
-black pixel, and so does a path that points outside the pack. Claiming the name and binding black was this engine's own answer
-and it was worse than either: the pack lost a colour target it had said nothing wrong about.
+black pixel, and so does a path that points outside the pack. Claiming the name and binding black
+was this engine's own answer and it was worse than either: the pack lost a colour target it had
+said nothing wrong about.
 
 ## A refusal must still consume the name it claimed
 

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -28,9 +28,12 @@ that multiplies by the sampled alpha loses the whole target and nothing anywhere
 **That correction applies to the engine's default and not to a colour the pack wrote.** A target the
 pack gave a clear colour to is cleared to exactly that colour, alpha included, promoted or not: the
 pack wrote four components and is handed the four it wrote. The correction only decides the default
-the engine stands in with when the pack named nothing. That default follows the reference: the
-first target starts at the frame's fog colour, the second at opaque white, and every other one at
-transparent black, or at opaque black where the format gained an alpha channel. The shadow colour buffer answers the same way, and it is worth
+the engine stands in with when the pack named nothing. That default follows the reference as far as
+the reference goes: the first target starts at the frame's fog colour, the second at opaque white,
+and every other one at transparent black, whatever its format, which is all Iris ever does
+(`ClearPassCreator` hands every later buffer the same four zeroes). Raising that default to opaque
+black where a three-channel format gained an alpha channel is this engine's correction alone, and
+the log names it when it happens. The shadow colour buffer answers the same way, and it is worth
 saying because it was the one place that did not: a correction meant to fill a blank is not a
 correction once it starts overruling something the pack was explicit about.
 

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -122,7 +122,8 @@ pack. Emptying is what lets somebody watching the file see it go blank.
 ## Dropping files on it
 
 - **On the pack list**, a zip or a folder is copied into the pack folder and, when it is the only one
-  dropped, selected straight away. Anything that is not a pack is refused, by name when it was the only file dropped.
+  dropped, selected straight away. Anything that is not a pack is refused, by name when it was the
+  only file dropped.
 - **On a page**, one settings file is imported. More than one at a time is refused, there being no
   sense in importing two.
 
@@ -328,5 +329,5 @@ which is worth knowing before planning around either extreme.
 NeoForge artefact is a launcher shim (a few dozen classes, none of them the renderer), and the mod
 is a jar nested inside it. Looking for a package in the outer jar finds nothing and proves nothing.
 This project compiles its common module against Sodium's plain Fabric artefact for exactly that
-reason: of the 688 classes the NeoForge jar carries, every one this module names is byte for byte
-the Fabric one.
+reason: of the classes the NeoForge jar carries (688 in the build this was measured on), every one
+this module names is byte for byte the Fabric one.


### PR DESCRIPTION
## What changes

The visible half that 0.7.1-beta's crash fix left behind, reported as #131. The purge deferred to
the resource reload left the game's entity pipelines carrying the previous vertex stride for the
rest of the session, so anything they drew over the rebuilt mesh, the hand with its switch off, or
every entity for the seconds a chain takes to compile, smeared across the screen as giant
triangles and stayed that way until a reload.

The pipelines now leave the device's cache the moment the mesh's answer moves and are compiled
again on the spot. Nothing is destroyed outside the game's one safe road: what left the cache
waits and is freed by the next clearPipelineCache, so the crash #111 closed stays closed. The
recompile passes no source of its own, the module cache surviving the drop and answering every
compile from the last resource load. Iris never needs the gesture, its backend swapping the format
live at every call; this one bakes the stride into the compiled pipeline, which is why eviction is
the shape parity takes here.

Beside it, four small faults found on the way: Distant Horizons' two switches are handed back
whatever the holding threw, the far terrain's corner rings are freed at shutdown, a settings move
that fails no longer leaves its .part behind, and a label the repository lost no longer fails the
labelling run. One dead constant dropped, and a documentation pass correcting the claims the
sources contradict.

## How it holds

Proven at the join and through three off-and-on gestures on each loader, NeoForge and Fabric, both
on the Vulkan backend: the hand stays whole with its switch off, the eviction fires in both
directions of every gesture, and the session survives where one to four such gestures used to end
it.