### PR TITLE
fix(uniform): stop reporting a value no engine answers as a debt

### DIFF
--- a/common/src/main/java/dev/vitrail/dh/DhLods.java
+++ b/common/src/main/java/dev/vitrail/dh/DhLods.java
@@ -575,12 +575,18 @@ public final class DhLods {
 	 * Checks that DH really wrote its vertices as wide as the format this engine declares over them,
 	 * once a session, and closes the road when it did not.
 	 * <p>
-	 * <strong>It is the one assumption in this package nothing else would catch.</strong> A buffer's
-	 * own length divided by the vertices DH says are in it IS the stride, so a DH that added an
-	 * element or widened one shows up here as a number; read through the wrong format, the same
-	 * buffer draws a far terrain out of the wrong bytes, which is a picture rather than a failure.
-	 * The road is closed rather than corrected: what a wider vertex means cannot be worked out from
-	 * its width.
+	 * <strong>A buffer's length divided by the vertices DH says are in it IS the stride, and the
+	 * division holds because DH leaves no slack for it to fall over.</strong> One call sets both:
+	 * {@code uploadVertexBuffer} keeps the count it is handed and allocates exactly the bytes the
+	 * builder left in front of it, {@code position} to {@code limit}
+	 * ({@code common/render/blaze/wrappers/buffer/BlazeVertexBufferWrapper.java:110} and
+	 * {@code :133-136}). What the quotient has to be is DH's own constant,
+	 * {@code LodQuadBuilder.BYTES_PER_VERTEX} at {@code :57}, and the six writes of
+	 * {@code putVertex} add up to it ({@code LodQuadBuilder.java:479-518}). So a DH that added an
+	 * element or widened one shows up here as another number; read through the wrong format, the
+	 * same buffer draws a far terrain out of the wrong bytes, which is a picture rather than a
+	 * failure. The road is closed rather than corrected: what a wider vertex means cannot be worked
+	 * out from its width.
 	 */
 	private static void checkStride(GpuBuffer vertices, int count) {
 		if (strideChecked || count <= 0) {

--- a/common/src/main/java/dev/vitrail/dh/DhLods.java
+++ b/common/src/main/java/dev/vitrail/dh/DhLods.java
@@ -375,8 +375,19 @@ public final class DhLods {
 					new Class<?>[] { rendererType }, new Handler());
 
 			usable = true;
+			// And the second half of that sentence, because standing in DH's place takes something
+			// away as well: DH's own pass fires one DhApiBeforeBufferRenderEvent per buffer
+			// (common/render/blaze/BlazeDhTerrainRenderer.java:313-323) and this substitute records
+			// the draws itself, so the event stays quiet for a HALF the pack really draws. The
+			// granularity is the half and not the frame: a half handed back to DH, no program for
+			// it, a broken chain or empty sections (DistantDraw.draw answering false), goes through
+			// DH's own renderer and fires the event as ever, and so does everything while install
+			// has not landed, this line being logged before either of install's early returns.
+			// Said rather than fired: what an outside consumer wants from it is DH's own draw
+			// about to happen, and none is about to happen for a half the pack has taken.
 			Vitrail.logger().info("Distant Horizons found, its far terrain will be read where that "
-					+ "mod hands it to its own renderer");
+					+ "mod hands it to its own renderer; that mod's own per buffer render event "
+					+ "stays quiet for a half a pack draws, and still fires for one handed back");
 		} catch (ClassNotFoundException e) {
 			// The ordinary case: DH is simply not installed. Not worth a line above debug.
 			usable = false;
@@ -581,8 +592,8 @@ public final class DhLods {
 	 * builder left in front of it, {@code position} to {@code limit}
 	 * ({@code common/render/blaze/wrappers/buffer/BlazeVertexBufferWrapper.java:110} and
 	 * {@code :133-136}). What the quotient has to be is DH's own constant,
-	 * {@code LodQuadBuilder.BYTES_PER_VERTEX} at {@code :57}, and the six writes of
-	 * {@code putVertex} add up to it ({@code LodQuadBuilder.java:479-518}). So a DH that added an
+	 * {@code LodQuadBuilder.BYTES_PER_VERTEX} at {@code :57}, and the six vertex elements
+	 * {@code putVertex} writes add up to it ({@code LodQuadBuilder.java:479-518}). So a DH that added an
 	 * element or widened one shows up here as another number; read through the wrong format, the
 	 * same buffer draws a far terrain out of the wrong bytes, which is a picture rather than a
 	 * failure. The road is closed rather than corrected: what a wider vertex means cannot be worked

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -928,6 +928,14 @@ public final class DistantDraw {
 		 * second half wrote over would be the ones the first half draws from, and the two halves do
 		 * not see the same sections - a section carrying only water is in one list and not the
 		 * other, so slot for slot the two lists are not the same sections at all.
+		 * <p>
+		 * <strong>And the second mapping of one frame keeps what the first wrote, which is the
+		 * game's own arithmetic rather than a habit of ours.</strong> The ring hands the same buffer
+		 * object back until it turns, {@code MappableRingBuffer.currentBuffer} indexing an array it
+		 * only advances in {@code rotate}; and mapping one is a {@code vmaMapMemory} onto the live
+		 * allocation, the write flag being tested against the buffer's usage and nothing else
+		 * ({@code com/mojang/blaze3d/vulkan/VulkanGpuBuffer.java:118-146}). There is no orphaning
+		 * and no staging copy for a second mapping to start empty from.
 		 *
 		 * @param camera where the pass this belongs to measures its geometry from, which is the
 		 *               game's own camera and not DH's copy of it: everything else this engine

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -1854,6 +1854,13 @@ final class GeometryProgram {
 					gaps.engine().size(), gaps.engine());
 		}
 
+		// Said apart from those, and at info: the pack reads these under Iris as well and gets the
+		// same nought there, so they are nobody's debt and a warning would read as one.
+		if (!gaps.nobody().isEmpty()) {
+			Vitrail.logger().info("{} reads {} values no engine answers, Iris included, so they are "
+					+ "zeroes there too: {}", this.path, gaps.nobody().size(), gaps.nobody());
+		}
+
 		// Underneath that, and it is not the same list: these are members a source really answered,
 		// with something that is not the value. They count as supplied wherever a count is taken,
 		// which is the whole reason for naming them, and a full screen pass has named them since the

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -685,9 +685,10 @@ final class PackPass {
 					+ "the " + PUSH_DESCRIPTORS + " a device commonly allows pushed at once");
 		}
 
-		// What the block could not be given, said as the two different things it is rather than as
-		// one number. A name the pack declares for itself is ours to resolve and the reason is a
-		// line above this one; only what is left is a value this engine owes.
+		// What the block could not be given, said as the three different things it is rather than
+		// as one number. A name the pack declares for itself is ours to resolve and the reason is a
+		// line above this one; a name no engine answers is nobody's; what is left is a value this
+		// engine owes.
 		PackValues.Gaps gaps = this.values.classify(this.uniforms.unsupplied());
 		if (!gaps.engine().isEmpty()) {
 			this.notes.add(this.path + " reads " + gaps.engine().size() + " values written as "
@@ -700,7 +701,15 @@ final class PackPass {
 					+ "declarations survived: " + gaps.pack());
 		}
 
-		// Underneath the two, the members that count as supplied and are not: a zero that
+		// And beside those, the names that are nobody's debt: the pack reads them under Iris as
+		// well and gets the same nought, so saying this engine owes them would send a reader
+		// looking through Iris for a source that was never written.
+		if (!gaps.nobody().isEmpty()) {
+			this.notes.add(this.path + " reads " + gaps.nobody().size() + " values no engine "
+					+ "answers, Iris included, so they are zeroes there too: " + gaps.nobody());
+		}
+
+		// Underneath the three, the members that count as supplied and are not: a zero that
 		// arrived through a registered source is the one failure a screenshot can never show.
 		PackValues.standIns(this.loaded.program().uniforms().stream()
 						.map(TranslatedUnit.Uniform::name)

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -611,23 +611,27 @@ public final class PackValues {
 	}
 
 	/**
-	 * Sorts the names a program's block could not be given into the two things they can mean. They
+	 * Sorts the names a program's block could not be given into the three things they can mean. They
 	 * read as one list otherwise and they are not one problem: a name the pack declares for itself
-	 * is ours to resolve, and what is left is a value the engine owes.
+	 * is ours to resolve, a name no engine answers is nobody's, and what is left is a value the
+	 * engine owes.
 	 */
 	public Gaps classify(List<String> unanswered) {
 		List<String> engine = new ArrayList<>();
 		List<String> pack = new ArrayList<>();
+		List<String> nobody = new ArrayList<>();
 
 		for (String name : unanswered) {
 			if (this.declared.contains(name)) {
 				pack.add(name);
+			} else if (UniformGaps.unanswerable(name) != null) {
+				nobody.add(name);
 			} else {
 				engine.add(name);
 			}
 		}
 
-		return new Gaps(List.copyOf(engine), List.copyOf(pack));
+		return new Gaps(List.copyOf(engine), List.copyOf(pack), List.copyOf(nobody));
 	}
 
 	/**
@@ -701,7 +705,9 @@ public final class PackValues {
 	 *
 	 * @param engine names the engine owes and does not answer
 	 * @param pack   names the pack declares itself, whose declaration did not survive
+	 * @param nobody names no engine answers, Iris included, so a pack reads the same nought under
+	 *               it. {@link UniformGaps#unanswerable} carries why each one is here
 	 */
-	public record Gaps(List<String> engine, List<String> pack) {
+	public record Gaps(List<String> engine, List<String> pack, List<String> nobody) {
 	}
 }

--- a/common/src/main/java/dev/vitrail/uniform/UniformGaps.java
+++ b/common/src/main/java/dev/vitrail/uniform/UniformGaps.java
@@ -11,7 +11,9 @@ import java.util.Map;
  * itself. It can be a name nothing in the table answers, which {@link UniformBlock#unanswered()}
  * already reports. Or it can be a name the table answers with a stand-in, which reports as supplied
  * and is the dangerous one: a zero that arrived through a registered source looks exactly like a
- * measured value.
+ * measured value. Beside those two stands a name that is not wrong at all, one NO engine answers,
+ * Iris included; naming those here is what keeps the log from claiming them as debts and sending a
+ * reader through Iris for a source that was never written.
  * <p>
  * Nothing here is guessed, and nothing here is in the table merely because it is a constant.
  * {@code renderStage} was in that sentence and has left it: the passes that draw the world and the
@@ -21,7 +23,7 @@ import java.util.Map;
  * that stops being a stand-in has to be taken out, and that is the point: a list somebody has to
  * maintain is a list somebody reads.
  * <p>
- * <strong>There used to be two lists here and there is one, which is what a list like this looks
+ * <strong>The stand-ins used to be two lists and are one, which is what a list like this looks
  * like when it works.</strong> The second held the names that were a right answer under a full
  * screen pass and a stand-in under the entity mesh, so that listing them everywhere would not put a
  * false alarm on every composite: {@code entityColor} first, then the three identifiers. Both are
@@ -35,6 +37,9 @@ public final class UniformGaps {
 	/** Registered, and answered with something that is not the value, whatever pass reads it. */
 	private static final Map<String, String> STAND_INS = standIns();
 
+	/** Read by a pack, answered by nobody, Iris included. */
+	private static final Map<String, String> UNANSWERABLE = unanswerable();
+
 	private UniformGaps() {
 	}
 
@@ -44,6 +49,41 @@ public final class UniformGaps {
 	 */
 	public static String standIn(String name) {
 		return STAND_INS.get(name);
+	}
+
+	/**
+	 * Why no engine answers this name, or null when it is one the engine really owes.
+	 * <p>
+	 * <strong>A name is here to keep the log from claiming a debt that is not one.</strong> What
+	 * the block does with such a name is exactly what it does with a real gap, zeroes, and that is
+	 * right: it is what the pack reads under Iris as well, an unset uniform being nought there. What
+	 * is not right is calling it a value this engine does not supply YET, which reads as work owed
+	 * and sends whoever follows the log looking through Iris for a source that was never written.
+	 * Measured on 19 August 2026: the one line about {@code farPlane} sent a reader through the
+	 * whole Distant Horizons path of two packs.
+	 */
+	public static String unanswerable(String name) {
+		return UNANSWERABLE.get(name);
+	}
+
+	private static Map<String, String> unanswerable() {
+		Map<String, String> reasons = new LinkedHashMap<>();
+
+		// Bliss reads it in the two passes that mix Distant Horizons' depth with the world's,
+		// dimensions/composite1.fsh:777 and dimensions/composite3.fsh:248, both times as the far
+		// argument of a linearisation. Iris registers dhFarPlane, dhNearPlane and dhRenderDistance
+		// beside each other (uniforms/CommonUniforms.java:184-186) and near and far in
+		// uniforms/CameraUniforms.java:26-27; a farPlane UNIFORM is in none of them, the name
+		// living in that repository only as shadow arithmetic and a pack directive
+		// (shaderpack/properties/PackShadowDirectives.java:38 among others). So the pack reads
+		// nought there too, and what that does to it, it does under Iris as well: the guard the
+		// linearisation feeds is a disjunction (composite1.fsh:783), a far plane of nought kills
+		// only the half that compares the linearised depths, and the depthOpaque >= 1.0 half keeps
+		// deciding on both engines alike.
+		reasons.put("farPlane", "no engine answers it, Iris included, so a pack reads the same "
+				+ "nought there");
+
+		return Map.copyOf(reasons);
 	}
 
 	private static Map<String, String> standIns() {


### PR DESCRIPTION
## What changes

Three small corrections written beside the far terrain work and never merged, rebased onto today's
dev.

A name no engine answers, Iris included, is no longer reported as a value this engine does not
supply YET: that wording reads as work owed and sent a reader through the whole Distant Horizons
path of two packs for a source that was never written. The block's gaps are now said as the three
things they are: a name the pack declares for itself, a name that is nobody's debt, and a value
this engine really owes.

The Distant Horizons takeover says what it silences: that mod's own per buffer render event stays
quiet for a half a pack draws, and still fires for one handed back to that mod's renderer.

And the far terrain's two readings, the stride check and the ring mapping, carry the citations
they rest on, into DH's builder and the game's own buffer mapping.