### PR TITLE
build: raise the version to 0.7.2-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.7.2-beta
 
 ### Fixed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.7.1-beta
+mod_version=0.7.2-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
The number for what dev gathered since 0.7.1-beta: the entity pipelines recompiled when the stride moves (#131), the DH switches handed back whatever the holding threw, the far terrain's rings freed at shutdown, the settings .part dropped on a failed move, and the uniform gaps said as the three things they are. The changelog section is renamed from Unreleased in the same commit.