### PR TITLE
fix(glsl): hash the goldberg idiom instead of a sine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Fixed
+
+- **Grass and leaves no longer skip while they sway under BSL.** Packs that hash their waving
+  with a huge sine were jumping on this backend and smooth on the reference. That hash is now
+  taken from the vertex bits instead. Complementary was already smooth; it never wrote that
+  idiom.
+
 ## 0.7.2-beta
 
 ### Fixed

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -164,25 +164,38 @@ public final class GlslTranslator {
 	private static final String SHADOW_COMPARE = "ofShadowCompare";
 
 	/**
-	 * What a call to {@code sin} or {@code cos} becomes: a sine of this translation's own, exact
-	 * enough to survive the hash idiom, and never the driver's.
+	 * What a call to {@code sin} or {@code cos} becomes: a sine of this translation's own, and
+	 * never the driver's.
 	 * <p>
-	 * The packs feed these two whole world coordinates. BSL's waving noise hashes with
-	 * {@code fract(sin(dot(floor(pos), K)) * 43758.5453)}, hands the sine thousands of radians and
-	 * amplifies whatever the sine got wrong by five orders of magnitude. Under Iris the GL driver's
-	 * sine stands up to that; under the game's shaderc-to-SPIR-V chain it does not, the field the
-	 * hash paints comes out structured instead of white, and foliage riding the field skips as it
-	 * crosses the structure, measured in game on BSL. Nor can a plain reduction feed the driver's
-	 * sine a clean small angle: one fp32 two-pi sheds the low bits of a large argument, and the
-	 * uniformity test rejects the field it leaves at 427 where white noise scores 15. What holds up,
-	 * scored 11 to 14 alongside an exact-sine reference on the same test, is the form emitted here:
-	 * a Cody-Waite reduction through two constants, a fold to the quarter turn, and an odd
-	 * polynomial - no driver sine left anywhere in the call.
+	 * Packs feed these two whole world coordinates. A single fp32 two-pi sheds the low bits of a
+	 * large argument, and the uniformity test rejects the field that reduction leaves at 427 where
+	 * white noise scores 15. The form emitted here, a Cody-Waite reduction through two constants,
+	 * a fold to the quarter turn, and an odd polynomial, scores 11 to 14 alongside an exact-sine
+	 * reference. No driver sine is left anywhere in the call.
+	 * <p>
+	 * The goldberg hash {@code fract(sin(dot(p, K)) * 43758.5453)} is not sent through this helper.
+	 * See {@link #HASH}.
 	 */
 	private static final String REDUCED_SIN = "ofReducedSin";
 
 	/** See {@link #REDUCED_SIN}. */
 	private static final String REDUCED_COS = "ofReducedCos";
+
+	/**
+	 * What the goldberg hash idiom becomes.
+	 * <p>
+	 * Iris leaves {@code fract(sin(dot(p, K)) * 43758.5453)} as written; the GL driver computes it.
+	 * This backend compiles through shaderc to SPIR-V. Feeding that idiom to {@link #REDUCED_SIN}
+	 * still jumps in game on BSL: a time-only waving pack that keeps the hash skips, and the same
+	 * pack with {@code sin} in place of the hash does not. Complementary never writes the idiom and
+	 * was already smooth. Nested {@code fma} on the reduction does not change that. So the call is
+	 * replaced by a hash of the argument's bits, which is stable from frame to frame and
+	 * uncorrelated from one lattice point to the next.
+	 * <p>
+	 * What it costs the image is a different noise field, not Iris's gusts. The interpolation
+	 * around the lattice, and the amplitude the pack asked for, stay the pack's.
+	 */
+	private static final String HASH = "ofHash";
 
 	/** What a lookup on a volume the pack ships is called once the volume has been laid out flat. */
 	private static final String VOLUME_LOOKUP = "ofTexture3D_";
@@ -353,6 +366,9 @@ public final class GlslTranslator {
 
 	/** Calls to {@code sin} or {@code cos} sent through the reduced-argument helpers. */
 	private int trigCalls;
+
+	/** Goldberg hash idioms rewritten onto {@link #HASH} instead of through a sine. */
+	private int hashCalls;
 
 	/**
 	 * Reads of {@code gl_TextureMatrix[0]} sent to the game's own per draw block instead of to the
@@ -540,6 +556,10 @@ public final class GlslTranslator {
 		synthesizeAttributes();
 		dropVersionAndExtensions();
 		rewriteIdentifiers();
+		// After the identifiers, because the goldberg idiom's sine has become ofReducedSin by then
+		// and that is how the site is recognised. Taking it earlier would leave the sine standing
+		// and the helper below would wrap a call this pass was about to erase.
+		rewriteGoldbergHash();
 		// After the identifiers and before the depth, and both halves of that matter: the legacy
 		// spellings have to have become texture() before a lookup can be recognised, and what comes
 		// out of here is a call under a name of ours that the depth pass will not look at twice.
@@ -1104,6 +1124,126 @@ public final class GlslTranslator {
 		for (int at : closings) {
 			this.tokens.add(at, new Token(Kind.RAW, ")", null));
 		}
+	}
+
+	/**
+	 * Replaces {@code fract(sin(dot(p, K)) * 43758.5453)} with a hash of {@code p}'s bits.
+	 * <p>
+	 * The constant is the fingerprint. Packs copy this one number into a hash they mean as white
+	 * noise on a lattice; a sine that then fails is not a sine they asked to see, and feeding it
+	 * to {@link #REDUCED_SIN} still skips in game. The first argument of {@code dot} is the lattice
+	 * point (or the continuous coordinate, for the same idiom on stars and puddles). The second
+	 * argument is thrown away: it exists only to mix those two channels into the sine.
+	 */
+	private void rewriteGoldbergHash() {
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (!token.identifier("fract") || token.directive() != null) {
+				continue;
+			}
+
+			int fractOpen = callOpener(index);
+			int sine = fractOpen < 0 ? -1 : significantAfter(fractOpen);
+			if (sine < 0 || !goldbergSine(this.tokens.get(sine))) {
+				continue;
+			}
+
+			int sineOpen = callOpener(sine);
+			int dot = sineOpen < 0 ? -1 : significantAfter(sineOpen);
+			if (dot < 0 || !this.tokens.get(dot).identifier("dot")) {
+				continue;
+			}
+
+			int dotOpen = callOpener(dot);
+			int comma = firstCallComma(dotOpen);
+			int argStart = dotOpen < 0 ? -1 : significantAfter(dotOpen);
+			int argEnd = comma < 0 ? -1 : significantBefore(comma);
+			int sineClose = matchingBracket(sineOpen);
+			int times = sineClose < 0 ? -1 : significantAfter(sineClose);
+			int scale = times < 0 ? -1 : significantAfter(times);
+			int fractClose = matchingBracket(fractOpen);
+			if (argStart < 0 || argEnd < argStart || times < 0 || scale < 0 || fractClose < 0
+					|| !this.tokens.get(times).operator("*")
+					|| !goldbergScale(this.tokens.get(scale))) {
+				continue;
+			}
+
+			int afterScale = significantAfter(scale);
+			if (afterScale != fractClose) {
+				continue;
+			}
+
+			boolean reduced = this.tokens.get(sine).identifier(REDUCED_SIN);
+			String argument = tokenText(argStart, argEnd);
+			blankRange(index, fractClose);
+			inject(index, HASH + "(" + argument + ")");
+			if (reduced && this.trigCalls > 0) {
+				this.trigCalls--;
+			}
+
+			this.hashCalls++;
+		}
+	}
+
+	private boolean goldbergSine(Token token) {
+		return token.identifier(REDUCED_SIN)
+				|| (token.identifier("sin") && !this.declaredNames.contains("sin"));
+	}
+
+	/**
+	 * The goldberg scale is this one number, copied through the corpus. Anything else multiplied
+	 * by a sine is a sine the pack meant to keep.
+	 */
+	private static boolean goldbergScale(Token token) {
+		if (token.kind() != Kind.NUMBER) {
+			return false;
+		}
+
+		String text = token.text();
+		if (text.endsWith("f") || text.endsWith("F")) {
+			text = text.substring(0, text.length() - 1);
+		}
+
+		try {
+			return Math.abs(Double.parseDouble(text) - 43758.5453) < 2.0;
+		} catch (NumberFormatException ignored) {
+			return false;
+		}
+	}
+
+	/** The comma that separates the first argument of the call that opens here, or -1. */
+	private int firstCallComma(int open) {
+		int close = matchingBracket(open);
+		if (open < 0 || close < 0) {
+			return -1;
+		}
+
+		int depth = 0;
+		for (int scan = open; scan < close; scan++) {
+			Token inner = this.tokens.get(scan);
+			if (inner.kind() != Kind.OPERATOR) {
+				continue;
+			}
+
+			if (inner.operator("(") || inner.operator("[") || inner.operator("{")) {
+				depth++;
+			} else if (inner.operator(")") || inner.operator("]") || inner.operator("}")) {
+				depth--;
+			} else if (inner.operator(",") && depth == 1) {
+				return scan;
+			}
+		}
+
+		return -1;
+	}
+
+	private String tokenText(int start, int end) {
+		StringBuilder text = new StringBuilder();
+		for (int at = start; at <= end; at++) {
+			text.append(this.tokens.get(at).text());
+		}
+
+		return text.toString();
 	}
 
 	/**
@@ -3452,6 +3592,29 @@ public final class GlslTranslator {
 				lines.add(shape + " " + REDUCED_COS + "(" + shape + " ofX) {"
 						+ " return " + REDUCED_SIN + "(ofX + 1.5707964); }");
 			}
+		}
+
+		// One overload per vector the idiom hashes. The bits are hashed rather than the sine of a
+		// huge argument, which is the whole of rewriteGoldbergHash.
+		if (this.hashCalls > 0) {
+			lines.add("float " + HASH + "(vec2 ofP) {"
+					+ " uvec2 ofV = floatBitsToUint(ofP);"
+					+ " uint ofN = (ofV.x * 1597334677u) ^ (ofV.y * 3812015801u);"
+					+ " ofN ^= ofN >> 16u;"
+					+ " ofN *= 2246822519u;"
+					+ " ofN ^= ofN >> 13u;"
+					+ " ofN *= 3266489917u;"
+					+ " ofN ^= ofN >> 16u;"
+					+ " return float(ofN) * 2.3283064365386963e-10; }");
+			lines.add("float " + HASH + "(vec3 ofP) {"
+					+ " uvec3 ofV = floatBitsToUint(ofP);"
+					+ " uint ofN = ofV.x ^ (ofV.y * 1597334677u) ^ (ofV.z * 3812015801u);"
+					+ " ofN ^= ofN >> 16u;"
+					+ " ofN *= 2246822519u;"
+					+ " ofN ^= ofN >> 13u;"
+					+ " ofN *= 3266489917u;"
+					+ " ofN ^= ofN >> 16u;"
+					+ " return float(ofN) * 2.3283064365386963e-10; }");
 		}
 
 		// Only where a lookup was moved. A stage carrying the declaration and never reading it, which

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -35,6 +35,7 @@ rather than guess.
 | A hard straight line across the sky near the horizon | [The horizon line](#the-horizon-line) |
 | Something that moves looks flat, unlit, or the wrong colour | [Anything that moves](#anything-that-moves) |
 | The sky turns into a flat grey sheet at sunrise | [The sky goes flat](#the-sky-goes-flat) |
+| Grass or leaves skip while swaying | [The waving grass jumps](#the-waving-grass-jumps) |
 | Blocks wave, glow or cast wrong shadows after switching packs | [You just changed packs](#you-just-changed-packs) |
 | The terrain is uniformly too dark | [Terrain that is too dark](#terrain-that-is-too-dark) |
 | Distant land is there but reads as sky: no fog, wrong focus | [The far terrain is flat](#the-far-terrain-is-flat) |
@@ -280,34 +281,37 @@ target it never asked for.
 
 ## The waving grass jumps
 
-**Under BSL, grass and leaves sway smoothly, then skip forward or snap back to where the sway
-started, and then go on smoothly again.** The player and the camera stand still, the rest of the
-picture is steady, and nothing else the pack animates does it. It is this engine's defect and not
-the pack's: the reference is smooth on the same pack at the same place, and Complementary is smooth
-here.
-
-**It is a jump in the position of the sway, not a tremble in the pixels it lands on**, and that
-distinction is the whole of the diagnosis. Reading it as a shimmer sends you to the pack's temporal
-anti-aliasing, which has nothing to do with it: giving another pack BSL's exact jitter table, index
-and amplitude leaves that pack smooth.
+**A jump in the sway, not a tremble in the pixels.** Under BSL, grass and leaves used to skip
+forward or snap back while the camera stood still. That was this engine's goldberg hash under
+SPIR-V, not the pack: the reference never jumped, and Complementary was already smooth here because
+it never writes the idiom. The hash is rewritten now. Reading a remaining jump as a shimmer still
+sends you to the pack's temporal anti-aliasing, which has nothing to do with it: giving another
+pack BSL's exact jitter table, index and amplitude leaves that pack smooth.
 
 **Some of what looks like the defect is BSL's own wave.** Its interpolation has a zero derivative at
 every lattice crossing, roughly once a second, so the foliage can sit nearly still for a couple of
 dozen frames, at irregular intervals, entirely by design. Those stillnesses are in the pack and are
 there under any implementation. What is worth reporting is a jump on top of them.
 
-**Nothing a pack setting or a video setting takes away, and none of these is the cause:** the frame
-rate, capped or free running; the clock this engine hands the pack, which advances once per
-presented frame, never repeats and never goes backwards; the rounding of that clock to the
-millisecond, which the reference does identically and which shrinks the frame-to-frame velocity step
-rather than growing it; the world position, which cancels exactly against the camera position; the
-noise hash and the precision it is computed in; the write into the terrain's uniform block, which
-happens once a frame with a fresh value; and the moment a frame is handed to the swapchain against
-the moment its content is dated, which stay rigid to within a fraction of a frame even with the
-frame rate unlocked and nothing pacing the loop.
+**The goldberg hash is rewritten.** BSL (and any pack that copies
+`fract(sin(dot(p, K)) * 43758.5453)`) hashes with a sine of a huge argument. Iris leaves that as
+written and the GL driver computes it. This backend compiles through shaderc to SPIR-V; the same
+idiom, even after a Cody-Waite reduction, still skips in game. A time-only waving pack that keeps
+the hash jumps here and is smooth on the reference; the same pack with `sin` in place of the hash
+is smooth on both. Complementary never writes the idiom and was already smooth here.
 
-So a report about this is only useful if it carries something none of those explain: another pack
-that does it, a machine or a driver where it stops, or a setting that changes its rhythm.
+So the call becomes a hash of the argument's bits. The interpolation around the lattice, and the
+amplitude the pack asked for, stay the pack's. The gusts are not Iris's field.
+
+**None of these is the cause of a jump that remains:** the frame rate, capped or free running; the
+clock this engine hands the pack, which advances once per presented frame, never repeats and never
+goes backwards; the rounding of that clock to the millisecond; the world position, which cancels
+exactly against the camera position; the write into the terrain's uniform block; and the moment a
+frame is handed to the swapchain against the moment its content is dated.
+
+A report about a jump that remains is only useful if it carries something none of those explain:
+another pack that still does it, a machine or a driver where it stops, or a setting that changes
+its rhythm.
 
 ## The sky goes flat
 


### PR DESCRIPTION
## What changes

The translator replaces `fract(sin(dot(p, K)) * 43758.5453)` with a hash of the argument's bits. BSL grass and leaves were skipping on this backend; they do not after this, on the original pack.

## How it differs from the reference, and for what obstacle

Iris leaves the idiom as written: its transformers (`TransformPatcher.java:175-211`) never rewrite `sin`, and `GlShader.java:32-33` compiles that source with the GL driver. This backend goes through shaderc to SPIR-V; feeding the same idiom to `ofReducedSin` still skipped in game (`GlslTranslator.java:184-198`). Complementary never writes the idiom and was already smooth. What it costs the image: a different noise field, not Iris's gusts. Interpolation and amplitude stay the pack's.

## What proves it

`gradlew build` green. In the game: BSL 10.1.3, same world as the report, grass and leaves, no pack setting forced. A sine in place of the hash was already smooth; original BSL with this rewrite is too.

## What it leaves owing

Nothing. Stars and puddles that copy the same idiom get the same hash.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
