### PR TITLE
fix(glsl): keep the sine when the goldberg hash's second argument moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Fixed
+
+- **Body Camera's film grain moves again.** The 0.7.3 hash rewrite took the frame time out of
+  the grain, which writes it into the second argument of the idiom, and left a pattern stuck to the
+  screen. The rewrite now only fires on a constant second argument; BSL's waving is untouched.
+
 ## 0.7.3-beta
 
 ### Fixed

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -1134,6 +1134,11 @@ public final class GlslTranslator {
 	 * to {@link #REDUCED_SIN} still skips in game. The first argument of {@code dot} is the lattice
 	 * point (or the continuous coordinate, for the same idiom on stars and puddles). The second
 	 * argument is thrown away: it exists only to mix those two channels into the sine.
+	 * <p>
+	 * Only while that second argument is a literal. Body Camera writes the frame time into it,
+	 * {@code vec2(12.9898, 78.233 * frameTimeCounter)}, and means its film grain to move: a hash of
+	 * the first argument alone would freeze it. Such a call is not the lattice idiom and keeps its
+	 * sine.
 	 */
 	private void rewriteGoldbergHash() {
 		for (int index = 0; index < this.tokens.size(); index++) {
@@ -1155,6 +1160,7 @@ public final class GlslTranslator {
 			}
 
 			int dotOpen = callOpener(dot);
+			int dotClose = matchingBracket(dotOpen);
 			int comma = firstCallComma(dotOpen);
 			int argStart = dotOpen < 0 ? -1 : significantAfter(dotOpen);
 			int argEnd = comma < 0 ? -1 : significantBefore(comma);
@@ -1164,7 +1170,8 @@ public final class GlslTranslator {
 			int fractClose = matchingBracket(fractOpen);
 			if (argStart < 0 || argEnd < argStart || times < 0 || scale < 0 || fractClose < 0
 					|| !this.tokens.get(times).operator("*")
-					|| !goldbergScale(this.tokens.get(scale))) {
+					|| !goldbergScale(this.tokens.get(scale))
+					|| !literalVector(comma + 1, dotClose - 1)) {
 				continue;
 			}
 
@@ -1188,6 +1195,33 @@ public final class GlslTranslator {
 	private boolean goldbergSine(Token token) {
 		return token.identifier(REDUCED_SIN)
 				|| (token.identifier("sin") && !this.declaredNames.contains("sin"));
+	}
+
+	/**
+	 * Whether the tokens in this range spell a vector of numbers and nothing else, such as
+	 * {@code vec2(12.9898, 4.1414)}. A name in there is a value that moves.
+	 */
+	private boolean literalVector(int start, int end) {
+		boolean number = false;
+		for (int at = start; at <= end; at++) {
+			Token token = this.tokens.get(at);
+			if (token.trivia() || token.kind() == Kind.NEWLINE) {
+				continue;
+			}
+
+			if (token.kind() == Kind.NUMBER) {
+				number = true;
+			} else if (token.kind() == Kind.IDENTIFIER) {
+				if (!token.identifier("vec2") && !token.identifier("vec3") && !token.identifier("vec4")) {
+					return false;
+				}
+			} else if (!token.operator("(") && !token.operator(")") && !token.operator(",")
+					&& !token.operator("-") && !token.operator("+")) {
+				return false;
+			}
+		}
+
+		return number;
 	}
 
 	/**

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -294,7 +294,7 @@ dozen frames, at irregular intervals, entirely by design. Those stillnesses are 
 there under any implementation. What is worth reporting is a jump on top of them.
 
 **The goldberg hash is rewritten.** BSL (and any pack that copies
-`fract(sin(dot(p, K)) * 43758.5453)`) hashes with a sine of a huge argument. Iris leaves that as
+`fract(sin(dot(p, K)) * 43758.5453)` with a constant `K`) hashes with a sine of a huge argument. Iris leaves that as
 written and the GL driver computes it. This backend compiles through shaderc to SPIR-V; the same
 idiom, even after a Cody-Waite reduction, still skips in game. A time-only waving pack that keeps
 the hash jumps here and is smooth on the reference; the same pack with `sin` in place of the hash


### PR DESCRIPTION
The 0.7.3 rewrite replaced `fract(sin(dot(p, K)) * 43758.5453)` with a hash of `p` alone, and threw `K` away. Body Camera writes the frame time into `K` (`vec2(12.9898, 78.233 * frameTimeCounter)`) and means its film grain to move, so on 0.7.3 the grain is a pattern stuck to the screen, with `GRAIN` on by default.

The rewrite now fires only when `K` is a literal vector. Translating every unit of the ten installed packs before and after (2369 units): only Body Camera's three `final.fsh` change, and they get back the line they had before 0.7.3. BSL and the others are identical byte for byte, so the waving fix is untouched.