### PR TITLE
feat(render): refuse the pack off Vulkan and say so in chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Changed
+
+- **On a backend other than Vulkan, nothing of the pack is drawn any more.** The pack is still
+  read and still shown in its settings screen, so it can be picked and configured ahead of the
+  restart, but the game keeps its own image: the passes used to run there and draw a picture that
+  was credible and wrong. A chat line the first time a world is shown says so and names the setting
+  to change, Graphics API to "Prefer Vulkan (Experimental)" under Video Settings, beside the error
+  the log already carried.
+
 ## 0.7.3-beta
 
 ### Fixed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,10 +50,11 @@ the same run and keeps your setting, so `options.txt` goes on saying `vulkan`
 while the session is not on it: the file cannot answer the question. And a game
 that dies before it reaches the title screen leaves a mark that the *next* start
 reads, which sets `preferredGraphicsBackend` back to `default` and saves over
-whatever you had written. Either way Vitrail loads without drawing the world's
-passes. It says which backend it came up on at startup, and says it as an error
-when that backend is not Vulkan, so a picture that did not change is answered by
-the log rather than by the file.
+whatever you had written. Either way Vitrail loads, reads the pack and draws
+nothing of it: the game keeps its own image. It says which backend it came up on
+at startup, says it as an error when that backend is not Vulkan, and says it once
+more in chat the first time a world is shown, naming the setting to change, so a
+picture that did not change is answered on the screen rather than by the file.
 
 Some of Chloride's own settings decide what reaches this engine, in
 `config/chloride-client.toml`, and they are entries inside its tables rather than

--- a/common/src/main/java/dev/vitrail/HostReport.java
+++ b/common/src/main/java/dev/vitrail/HostReport.java
@@ -1,7 +1,12 @@
 package dev.vitrail;
 
+import dev.vitrail.screen.ScreenText;
+
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -14,10 +19,14 @@ import java.util.List;
  * graphics backend the game came up on, and which of Chloride's own settings are on.
  * <p>
  * They are said at startup because neither announces itself in the picture. A game running OpenGL
- * loads this mod and draws a picture that is credible and wrong; a mob Chloride culled is simply
- * not there. Both look like this engine failing, and a report about either would be filed against
- * it and read against its code. Said at the moment the log is still short enough to read, and only where there
- * is something to say.
+ * loads this mod and is then drawn by the game alone, the pack read and inert; a mob Chloride culled
+ * is simply not there. Both look like this engine failing, and a report about either would be filed
+ * against it and read against its code. Said at the moment the log is still short enough to read,
+ * and only where there is something to say.
+ * <p>
+ * The backend is the one of the two said a second time, in chat, the first time a world is shown:
+ * the log is read by whoever goes looking, and a player whose pack does nothing at all is not yet
+ * looking. Once a session and not once a world, since the answer cannot change between them.
  * <p>
  * Nothing here is fixed on the player's behalf, and that is the whole shape of it: the backend is
  * the game's to choose and is chosen before this runs, and Chloride's file belongs to Chloride.
@@ -54,6 +63,12 @@ public final class HostReport {
 	 * go and edit it.
 	 */
 	private static final String CHLORIDE_CONFIG = "config/chloride-client.toml";
+
+	/**
+	 * Whether the chat line has been said, or found to have nothing to say, which closes it for the
+	 * session either way.
+	 */
+	private static volatile boolean saidInWorld;
 
 	/**
 	 * The entries of Chloride's file this engine has something to say about. Three of them take
@@ -112,6 +127,56 @@ public final class HostReport {
 	}
 
 	/**
+	 * Whether the game is known to have come up on a backend this mod was not written for. No both
+	 * on Vulkan and before the device exists, {@link #UNKNOWN} being a word rather than a backend:
+	 * what answers yes here is refused a picture, and a backend nobody can name is not one to refuse
+	 * it over.
+	 */
+	public static boolean otherBackend() {
+		String backend = backend();
+
+		return !UNKNOWN.equals(backend) && !VULKAN.equals(backend);
+	}
+
+	/**
+	 * Says in chat, once a session, that nothing of the pack is drawn on this backend and which
+	 * setting draws it. Asked every tick and answering nothing until a world is on the screen with
+	 * no screen over it: said from the login packet, the line would land behind the loading
+	 * terrain screen and be fading by the time the world appears.
+	 * <p>
+	 * Added to the chat as a message of the client's own rather than sent to the player the way the
+	 * reload key's line is: {@code LocalPlayer.sendSystemMessage} hands it to the chat listener as
+	 * a server message, and a chat set to hidden drops those, {@code ChatListener.handleSystemMessage}
+	 * checking {@code canReceiveSystemMessages} first. The client's own source is the one
+	 * {@code ChatAbilities.selectVisibleMessages} always lets through, and a line about the whole
+	 * picture being missing is not one to leave to a chat setting.
+	 * <p>
+	 * The setting and its entry are named by the game's own labels rather than by a translation of
+	 * ours, so that the words match the screen the player is sent to whatever language the game is
+	 * in.
+	 */
+	public static void sayInWorld() {
+		if (saidInWorld) {
+			return;
+		}
+
+		Minecraft minecraft = Minecraft.getInstance();
+		if (minecraft.player == null || minecraft.gui.screen() != null) {
+			return;
+		}
+
+		saidInWorld = true;
+		if (!otherBackend()) {
+			return;
+		}
+
+		minecraft.gui.hud.getChat().addClientSystemMessage(Component.translatable(
+				ScreenText.OTHER_BACKEND, backend(), Component.translatable(ScreenText.GRAPHICS_API),
+				Component.translatable(ScreenText.GRAPHICS_API_VULKAN))
+				.withStyle(ChatFormatting.RED));
+	}
+
+	/**
 	 * Says what an install decides for this mod, once, and only where it decides something. A backend
 	 * that is Vulkan and a Chloride with nothing on cost no line at all: the log is read by whoever is
 	 * chasing something else, and a line saying that all is well is one more to step over.
@@ -122,28 +187,27 @@ public final class HostReport {
 	}
 
 	/**
-	 * Said as an error rather than a warning because nothing a pack asks for can be trusted on the
-	 * screen. What the line claims is the symptom this repository has seen and not a mechanism it
-	 * has not: the passes can run on the other backend, and what they drew there was a picture both
-	 * credible and wrong, the programs having been translated against Vulkan's depth and clip
-	 * conventions. Credible and wrong reads as a pack fault, which is worse than a picture the game
-	 * draws alone, so the line owns it before the pack is blamed.
+	 * Said as an error rather than a warning because the pack a player asks for is not drawn at all,
+	 * and that is the engine's doing: {@code PackChain.load} reads whichever one is named, publishes
+	 * it to the settings screen and stops there. It stops because of what the passes drew when they were let run on the
+	 * other backend, the symptom this repository has seen there: a picture both credible and wrong,
+	 * the programs having been translated against Vulkan's depth and clip conventions. Credible and
+	 * wrong reads as a pack fault, which is worse than a picture the game draws alone, so nothing is
+	 * drawn and the line says why.
 	 */
 	private static void sayBackend() {
-		String backend = backend();
-		if (UNKNOWN.equals(backend) || VULKAN.equals(backend)) {
+		if (!otherBackend()) {
 			return;
 		}
 
 		Vitrail.logger().error("This game is running the {} backend and {}'s programs are translated "
-				+ "for {} alone. The mod loads and may draw the pack's passes anyway, and the picture "
-				+ "they make is credible and wrong: the depth and clip conventions they were built "
-				+ "against are not this backend's, so a sky cut in two or a misdrawn hand is this and "
-				+ "not the pack. Set Graphics API to \"Prefer Vulkan (Experimental)\" under Options, "
-				+ "Video Settings, and restart. If it was already set there, either a launch argument "
-				+ "forced this backend, which the game says higher up, or the Vulkan boot failed and "
-				+ "the game fell back: the reason is in the lines the game logged before this one",
-				backend, Vitrail.MOD_NAME, VULKAN);
+				+ "for {} alone. The mod loads, a pack it is asked for is read and shown in its "
+				+ "settings screen, and nothing of it is drawn: the game keeps its own image. Set "
+				+ "Graphics API to \"Prefer Vulkan (Experimental)\" under Options, Video Settings, "
+				+ "and restart. If it was already set there, either a launch argument forced this "
+				+ "backend, which the game says higher up, or the Vulkan boot failed and the game "
+				+ "fell back: the reason is in the lines the game logged before this one",
+				backend(), Vitrail.MOD_NAME, VULKAN);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -8,6 +8,7 @@ import dev.vitrail.render.PbrTextures;
 import dev.vitrail.render.ShadowGeometry;
 import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.sodium.EntityMeshSerializer;
+import dev.vitrail.screen.SettingsKey;
 import dev.vitrail.sodium.ShadowTerrain;
 import dev.vitrail.HostReport;
 import dev.vitrail.Vitrail;
@@ -63,6 +64,16 @@ public final class EngineStages {
 		// The report of the pack goes with the reading of it, in PackChain, where which pack is
 		// being drawn is known.
 		PackChain.load(Vitrail.platform().gameDirectory());
+	}
+
+	/**
+	 * At the end of every client tick, in a world or out of one. The one moment of the engine that
+	 * is not a point of the frame, and it is listed here for the same reason the others are: what
+	 * is asked once a tick has to be the same list on both loaders, and each of them reaches it
+	 * through an event of its own.
+	 */
+	public static void clientTick() {
+		SettingsKey.poll();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -74,6 +74,7 @@ public final class EngineStages {
 	 */
 	public static void clientTick() {
 		SettingsKey.poll();
+		HostReport.sayInWorld();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -19,6 +19,7 @@ import dev.vitrail.settings.SettingsFile;
 import dev.vitrail.settings.SettingsLayers;
 import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.WorldState;
+import dev.vitrail.HostReport;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.buffers.GpuBuffer;
@@ -586,6 +587,25 @@ public final class PackChain {
 			EngineOptions.Read engine = EngineOptions.take(chosen);
 			packsFirst = engine.packsFirst();
 			chainWanted = engine.chain();
+
+			// Read and shown, and not drawn. On a backend this engine is not written for, the pack
+			// is published to the screen above so that it can be picked and configured ahead of the
+			// restart that will draw it, and every switch below stays down so that nothing of it
+			// reaches a mesh or a frame: the programs are translated against Vulkan's depth and
+			// clip conventions, and what they drew when let run elsewhere was a picture credible
+			// and wrong, which reads as a pack fault. The game's own image is the better answer.
+			// HostReport says it once in the log at startup and once in chat on entering a world;
+			// what this road adds is the screen's bottom line, through lastError, and nothing else.
+			if (HostReport.otherBackend()) {
+				TerrainDraw.wanted(false);
+				EntityDraw.wanted(false);
+				HandDraw.wanted(false);
+				lastError = ShaderPackSource.nameOf(pack) + " is not drawn on the "
+						+ HostReport.backend() + " backend: set Graphics API to \"Prefer Vulkan "
+						+ "(Experimental)\" under Options, Video Settings, and restart";
+				return;
+			}
+
 			TerrainDraw.wanted(engine.terrain());
 			TerrainDraw.shadowWanted(engine.shadow());
 			SkyDraw.wanted(engine.sky());

--- a/common/src/main/java/dev/vitrail/screen/ScreenText.java
+++ b/common/src/main/java/dev/vitrail/screen/ScreenText.java
@@ -142,6 +142,18 @@ public final class ScreenText {
 	public static final String RELOAD_FAILED = "options.vitrail.reload_failed";
 
 	/**
+	 * The chat line said once, the first time a world is shown on a backend this engine is not
+	 * written for. Three arguments: the backend's name, then the two labels the game itself ships
+	 * for the setting and for its Vulkan entry. Those two are the game's keys and not ours, the one
+	 * exception to the rule above that a label the game ships is not repeated here: there is no
+	 * constant for them, and naming the setting in the player's own language is the whole of why
+	 * they are passed in rather than written into the sentence.
+	 */
+	public static final String OTHER_BACKEND = "options.vitrail.other_backend";
+	public static final String GRAPHICS_API = "options.graphicsApi";
+	public static final String GRAPHICS_API_VULKAN = "options.graphicsApi.vulkan";
+
+	/**
 	 * The group that key sits in. Nothing names it and nothing can: the game builds it from the
 	 * category's identifier, in {@code KeyMapping.Category.label()}, so what decides this string is
 	 * the path of the identifier {@code VitrailKeys} registers, not the name of the field holding

--- a/common/src/main/resources/assets/vitrail/lang/de_de.json
+++ b/common/src/main/resources/assets/vitrail/lang/de_de.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Shader neu laden",
 	"options.vitrail.pack_reloaded": "Shader neu geladen!",
 	"options.vitrail.reload_failed": "Shader konnte nicht neu geladen werden! Grund: %s",
+	"options.vitrail.other_backend": "Vitrail zeichnet auf dem %s-Backend nichts: seine Shader laufen nur auf Vulkan. Setze %s unter Optionen, Grafikeinstellungen auf \"%s\" und starte das Spiel neu.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/en_us.json
+++ b/common/src/main/resources/assets/vitrail/lang/en_us.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Reload Shaders",
 	"options.vitrail.pack_reloaded": "Shaders Reloaded!",
 	"options.vitrail.reload_failed": "Failed to reload shaders! Reason: %s",
+	"options.vitrail.other_backend": "Vitrail draws nothing on the %s backend: its shaders run on Vulkan only. Set %s to \"%s\" under Options, Video Settings, and restart the game.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/es_es.json
+++ b/common/src/main/resources/assets/vitrail/lang/es_es.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Recargar Shaders",
 	"options.vitrail.pack_reloaded": "¡Shaders recargados!",
 	"options.vitrail.reload_failed": "¡Error al recargar los Shaders! Razón: %s",
+	"options.vitrail.other_backend": "Vitrail no dibuja nada en el backend %s: sus shaders solo funcionan en Vulkan. Ajusta %s a \"%s\" en Opciones, Ajustes de vídeo, y reinicia el juego.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/fr_fr.json
+++ b/common/src/main/resources/assets/vitrail/lang/fr_fr.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Recharger les shaders",
 	"options.vitrail.pack_reloaded": "Shaders rechargés !",
 	"options.vitrail.reload_failed": "Échec lors du rechargement des shaders ! Raison : %s",
+	"options.vitrail.other_backend": "Vitrail ne dessine rien sur le backend %s : ses shaders ne tournent que sur Vulkan. Réglez %s sur \"%s\" dans Options, Paramètres vidéo, puis redémarrez le jeu.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/it_it.json
+++ b/common/src/main/resources/assets/vitrail/lang/it_it.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Riavvia Shaders",
 	"options.vitrail.pack_reloaded": "Shaders Ricaricate!",
 	"options.vitrail.reload_failed": "Impossibile ricaricare le shaders! Motivo: %s",
+	"options.vitrail.other_backend": "Vitrail non disegna nulla sul backend %s: le sue shader funzionano solo su Vulkan. Imposta %s su \"%s\" in Opzioni, Impostazioni video, e riavvia il gioco.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/ja_jp.json
+++ b/common/src/main/resources/assets/vitrail/lang/ja_jp.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "シェーダーを再読み込み",
 	"options.vitrail.pack_reloaded": "シェーダーを再読み込みしました！",
 	"options.vitrail.reload_failed": "シェーダーの再読み込みに失敗しました！ 理由: %s",
+	"options.vitrail.other_backend": "Vitrail は %s バックエンドでは何も描画しません。シェーダーは Vulkan でのみ動作します。設定、ビデオ設定で %s を \"%s\" にしてゲームを再起動してください。",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/ko_kr.json
+++ b/common/src/main/resources/assets/vitrail/lang/ko_kr.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "셰이더 새로고침",
 	"options.vitrail.pack_reloaded": "셰이더를 다시 불러왔습니다.",
 	"options.vitrail.reload_failed": "셰이더를 새로고침하지 못하였습니다: %s",
+	"options.vitrail.other_backend": "Vitrail은 %s 백엔드에서 아무것도 그리지 않습니다. 셰이더는 Vulkan에서만 작동합니다. 설정, 비디오 설정에서 %s을(를) \"%s\"(으)로 설정하고 게임을 다시 시작하세요.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/nl_nl.json
+++ b/common/src/main/resources/assets/vitrail/lang/nl_nl.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Herlaad Shaders",
 	"options.vitrail.pack_reloaded": "Shaders herladen!",
 	"options.vitrail.reload_failed": "Shaders herladen is mislukt! Reden: %s",
+	"options.vitrail.other_backend": "Vitrail tekent niets op de %s-backend: zijn shaders draaien alleen op Vulkan. Zet %s onder Opties, Video-instellingen op \"%s\" en herstart het spel.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/pl_pl.json
+++ b/common/src/main/resources/assets/vitrail/lang/pl_pl.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Przeładuj Shadery",
 	"options.vitrail.pack_reloaded": "Przeładowano Shadery!",
 	"options.vitrail.reload_failed": "Nie udało się przeładować Shaderów! Powód: %s",
+	"options.vitrail.other_backend": "Vitrail nic nie rysuje na backendzie %s: jego shadery działają tylko na Vulkanie. Ustaw %s na \"%s\" w Opcje, Ustawienia grafiki, i uruchom grę ponownie.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/pt_br.json
+++ b/common/src/main/resources/assets/vitrail/lang/pt_br.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Recarregar sombreadores",
 	"options.vitrail.pack_reloaded": "Sombreadores recarregados!",
 	"options.vitrail.reload_failed": "Falha ao recarregar sombreadores! Motivo: %s",
+	"options.vitrail.other_backend": "O Vitrail não desenha nada no backend %s: seus shaders só funcionam em Vulkan. Defina %s como \"%s\" em Opções, Configurações de vídeo, e reinicie o jogo.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/ru_ru.json
+++ b/common/src/main/resources/assets/vitrail/lang/ru_ru.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Перезагрузить шейдеры",
 	"options.vitrail.pack_reloaded": "Шейдеры перезагружены.",
 	"options.vitrail.reload_failed": "Не удалось перезагрузить шейдеры. Причина: %s",
+	"options.vitrail.other_backend": "Vitrail ничего не рисует на бэкенде %s: его шейдеры работают только на Vulkan. Установите %s в значение \"%s\" в меню Настройки, Настройки графики, и перезапустите игру.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/tr_tr.json
+++ b/common/src/main/resources/assets/vitrail/lang/tr_tr.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Shaderları Yenile",
 	"options.vitrail.pack_reloaded": "Shaderlar Yeniden Yüklendi!",
 	"options.vitrail.reload_failed": "Shaderları yenileme başarısız! Sebep: %s",
+	"options.vitrail.other_backend": "Vitrail %s arka ucunda hiçbir şey çizmez: shaderları yalnızca Vulkan üzerinde çalışır. Seçenekler, Görüntü Ayarları altında %s ayarını \"%s\" yapın ve oyunu yeniden başlatın.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/uk_ua.json
+++ b/common/src/main/resources/assets/vitrail/lang/uk_ua.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "Перезавантажити шейдери",
 	"options.vitrail.pack_reloaded": "Шейдери перезавантажено!",
 	"options.vitrail.reload_failed": "Не вдалося перезавантажити шейдери! Причина: %s",
+	"options.vitrail.other_backend": "Vitrail нічого не малює на бекенді %s: його шейдери працюють лише на Vulkan. Установіть %s у значення \"%s\" у меню Налаштування, Налаштування графіки, і перезапустіть гру.",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/zh_cn.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_cn.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "重新加载光影包",
 	"options.vitrail.pack_reloaded": "已重新加载光影包！",
 	"options.vitrail.reload_failed": "重新加载光影包失败！原因：%s",
+	"options.vitrail.other_backend": "Vitrail 在 %s 后端下不绘制任何内容：其光影只能在 Vulkan 上运行。请在选项、视频设置中将 %s 设为 \"%s\"，然后重新启动游戏。",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/zh_tw.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_tw.json
@@ -45,5 +45,6 @@
 	"key.vitrail.reload_pack": "重新載入光影",
 	"options.vitrail.pack_reloaded": "已重新載入光影！",
 	"options.vitrail.reload_failed": "無法重新載入光影！原因：%s",
+	"options.vitrail.other_backend": "Vitrail 在 %s 後端下不會繪製任何內容：其光影只能在 Vulkan 上執行。請在選項、影像設定中將 %s 設為 \"%s\"，然後重新啟動遊戲。",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/fabric/src/main/java/dev/vitrail/fabric/FabricKey.java
+++ b/fabric/src/main/java/dev/vitrail/fabric/FabricKey.java
@@ -1,5 +1,6 @@
 package dev.vitrail.fabric;
 
+import dev.vitrail.platform.EngineStages;
 import dev.vitrail.screen.SettingsKey;
 
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -11,7 +12,8 @@ import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
  * This is the only place in the mod that needs Fabric API at all, and it takes two of its modules
  * because the bare game offers neither of the two things a key needs: the mapping has to be appended
  * to an array the options own, and it has to be asked once a tick. Both are exactly what those
- * modules do, so writing a mixin for either would be reimplementing them.
+ * modules do, so writing a mixin for either would be reimplementing them. The tick carries the
+ * engine's whole tick stage rather than the key alone, since this is the module that reaches it.
  * <p>
  * What a press does is in {@link SettingsKey}, with the mapping itself, because NeoForge registers
  * the same one its own way.
@@ -24,6 +26,6 @@ final class FabricKey {
 	static void register() {
 		KeyMappingHelper.registerKeyMapping(SettingsKey.OPEN);
 		KeyMappingHelper.registerKeyMapping(SettingsKey.RELOAD);
-		ClientTickEvents.END_CLIENT_TICK.register(_ -> SettingsKey.poll());
+		ClientTickEvents.END_CLIENT_TICK.register(_ -> EngineStages.clientTick());
 	}
 }

--- a/neoforge/src/main/java/dev/vitrail/neoforge/VitrailKeys.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/VitrailKeys.java
@@ -3,15 +3,11 @@ package dev.vitrail.neoforge;
 import dev.vitrail.screen.SettingsKey;
 
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
-import net.neoforged.neoforge.common.NeoForge;
 
 /**
- * Registers {@link SettingsKey} and asks it once a tick.
- * <p>
- * On the mod bus and on the game bus respectively, because those are the two buses those events are
- * posted on.
+ * Registers {@link SettingsKey}, on the mod bus because that is the bus the event is posted on.
+ * Asking it once a tick is the tick stage's business, reached from {@code VitrailNeoForge}.
  */
 public final class VitrailKeys {
 
@@ -24,7 +20,5 @@ public final class VitrailKeys {
 			event.register(SettingsKey.OPEN);
 			event.register(SettingsKey.RELOAD);
 		});
-
-		NeoForge.EVENT_BUS.addListener(ClientTickEvent.Post.class, _ -> SettingsKey.poll());
 	}
 }

--- a/neoforge/src/main/java/dev/vitrail/neoforge/VitrailNeoForge.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/VitrailNeoForge.java
@@ -12,6 +12,7 @@ import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.FrameGraphSetupEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import net.neoforged.neoforge.client.event.TextureAtlasStitchedEvent;
@@ -38,6 +39,8 @@ public final class VitrailNeoForge {
 		VitrailKeys.register(modBus);
 
 		modBus.addListener(FMLClientSetupEvent.class, _ -> EngineStages.clientSetup());
+
+		NeoForge.EVENT_BUS.addListener(ClientTickEvent.Post.class, _ -> EngineStages.clientTick());
 
 		// Posted at the end of TextureAtlas.upload, once per atlas and once per resource reload,
 		// with the stitched texture already made and no render pass open. It is where the sprites of


### PR DESCRIPTION
## What changes

On a backend other than Vulkan the engine no longer draws anything of the pack. The pack is still read and published to the settings screen, so it can be picked and configured ahead of the restart, but `PackChain.load` stops before raising a single switch and the game keeps its own image; the screen's bottom line names the backend and the setting to change. The first time a world is shown, once a session, a red chat line says so and names the game's own labels, Graphics API and "Prefer Vulkan (Experimental)", in the player's language. The startup error line is reworded to match, and the client tick now goes through `EngineStages` like every other moment both loaders reach.

## How it differs from the reference, and for what obstacle

It does not. Iris has no backend to refuse: it runs on OpenGL alone. What this branch refuses is this engine's own state, and what it draws instead is what Iris leaves untouched when nothing of a pack runs, the game's picture.

## What proves it

- `gradlew build` green, after the rebase.
- In the game, on both loaders and on the OpenGL backend, two launches each: the error line at startup, the chat line on entering the world, vanilla picture, pack still selected; after switching back to Vulkan the line is gone and the pack draws.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
