### PR TITLE
fix(mixin): drop the ground oval while the pack draws a shadow map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ what the next one holds.
   to change, Graphics API to "Prefer Vulkan (Experimental)" under Video Settings, beside the error
   the log already carried.
 
+### Fixed
+
+- **No more dark oval under a mob when the pack draws its own shadows.** The game's flat entity
+  shadow was still drawn, lit as a translucent entity, under every mob the pack was already
+  shading with its shadow map. It now goes away for as long as the pack has a map, which is what
+  Iris does, and stays under a pack without one. The defect only showed with Entity Shadows on in
+  the video settings.
+
 ## 0.7.3-beta
 
 ### Fixed

--- a/common/src/main/java/dev/vitrail/mixin/EntityRenderDispatcherMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/EntityRenderDispatcherMixin.java
@@ -2,7 +2,11 @@ package dev.vitrail.mixin;
 
 import dev.vitrail.render.EntityIdentifiers;
 import dev.vitrail.render.PackNameIds;
+import dev.vitrail.render.TerrainDraw;
 
+import java.util.List;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.AbstractClientPlayer;
@@ -18,7 +22,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
- * Says, for the length of one submission, which kind of entity is being handed in.
+ * Says, for the length of one submission, which kind of entity is being handed in, and keeps the
+ * game's ground oval off a mob while the pack draws a shadow map.
  * <p>
  * <strong>This is the only moment in the frame the answer exists</strong>, which is what
  * {@link EntityIdentifiers} is about: everything submitted here is drawn much later, out of one
@@ -56,6 +61,31 @@ public abstract class EntityRenderDispatcherMixin {
 		// this out would keep the last item's number over everything after it. Iris drops the two
 		// together here for the same reason (MixinEntityRenderDispatcher.java:88-89).
 		EntityIdentifiers.item(0);
+	}
+
+	/**
+	 * Whether the dark oval the game lays under a mob is submitted at all, which it is not while the
+	 * pack draws a shadow map.
+	 * <p>
+	 * Iris's answer, at the same call ({@code mixin/MixinEntityRenderDispatcher.java:48-59}): the
+	 * oval goes for as long as its shadow renderer stands, and the comment on that test says OptiFine
+	 * seems to do the same ({@code pipeline/IrisRenderingPipeline.java:1102}). A pack with a map
+	 * lights the ground under a mob with that map, so the oval on top of it is a second shadow,
+	 * drawn with {@code gbuffers_entities_translucent}, that no pack author ever saw under their own
+	 * pack. Kept as it is where there is no map, which is where Iris keeps it too: there the oval is
+	 * the only shadow a mob has, and the packs that reach that state have a setting for it.
+	 * <p>
+	 * At the submission and not at the draw, because the light's walk submits through this same
+	 * dispatcher: a condition here keeps the oval out of the map as well, and for the same reason.
+	 */
+	@WrapWithCondition(method = "submit",
+			at = @At(value = "INVOKE",
+					target = "Lnet/minecraft/client/renderer/SubmitNodeCollector;"
+							+ "submitShadow(Lcom/mojang/blaze3d/vertex/PoseStack;FLjava/util/List;)V"),
+			require = 1)
+	private static boolean vitrail$keepGroundOval(SubmitNodeCollector collector, PoseStack poseStack,
+			float radius, List<EntityRenderState.ShadowPiece> pieces) {
+		return !TerrainDraw.shadowMapServed();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -88,7 +88,10 @@ import java.util.stream.Stream;
  * had to be proved rather than assumed, its renderer being the one that could have had an
  * {@code executeGroup} of its own as the particles do:
  * {@code ShadowFeatureRenderer extends RenderTypeFeatureRenderer}
- * ({@code feature/ShadowFeatureRenderer.java:19}), inheriting it.
+ * ({@code feature/ShadowFeatureRenderer.java:19}), inheriting it. Where it is submitted at all,
+ * that is: {@code EntityRenderDispatcherMixin} keeps it off a mob for as long as the pack draws a
+ * shadow map, which is Iris's rule, so its row is reached under a pack without one and under no
+ * other.
  * <p>
  * <strong>What that costs the two halves is not the same thing, and it is the whole of why they
  * are two.</strong> The opaque half is drawn before the deferred stage, so it takes its first draw
@@ -833,13 +836,11 @@ public final class EntityDraw {
 	 * The name exists in Iris and only {@code END_PORTAL} and {@code END_GATEWAY} reach it
 	 * ({@code :129-130}), and neither is a row of the table above.
 	 * <p>
-	 * <strong>The ground shadow is left out, and it is left out because Iris leaves it out.</strong>
-	 * {@code ENTITY_SHADOW} is assigned in the main table and appears nowhere in the shadow one, so a
-	 * mob's dark oval keeps the game's own shader when the map is drawn. What serving it would add is
-	 * not an occluder: the pipeline writes no depth at all
-	 * ({@code RenderPipelines.java:375}, {@code DepthStencilState(GREATER_THAN_OR_EQUAL, false)}),
-	 * and this table keeps the write exactly, so nothing of it would reach the depth a pack reads its
-	 * shadows from.
+	 * <strong>The ground shadow has no twin, because nothing submits it while the map is
+	 * drawn.</strong> {@code EntityRenderDispatcherMixin} keeps the oval off a mob for as long as the
+	 * pack draws a shadow map, which is Iris's own rule, and the light's walk goes through that same
+	 * dispatcher: a row here would be a module nobody ever selects. Iris's shadow table has no key
+	 * for {@code ENTITY_SHADOW} either, and for the same reason.
 	 * <p>
 	 * <strong>Every row discards at a tenth and none of them blends</strong>, both read rather than
 	 * chosen: the key carries {@code ONE_TENTH_ALPHA} whatever threshold its main twin had, and every
@@ -1730,22 +1731,12 @@ public final class EntityDraw {
 		}
 
 		// The deliberate one is named apart from the rest, because reporting a parity choice as a
-		// fault is how a reader is sent hunting something that is working. Iris assigns
-		// ENTITY_SHADOW in its main table and nowhere in its shadow one, so a mob's ground oval
-		// keeps the game's shader there. The walk also submits name tags, text and other geometry no
-		// shadow table anywhere has a row for, and those are the same silence the camera's table
-		// gives them.
-		if (pipeline == RenderPipelines.ENTITY_SHADOW) {
-			Vitrail.logger().info("The ground oval under a mob is left out of the shadow map, which "
-					+ "is what Iris does: it has no shadow row for that pipeline either. What a row "
-					+ "would add is worth knowing and is not the obvious answer: the pipeline writes "
-					+ "no depth, so it would lay no occluder under anything and would only paint into "
-					+ "the map's colour, which is what a mob's eyes do there");
-
-			return;
-		}
-
-		// The second deliberate one, and it is nearly a match rather than the gap it first reads as.
+		// fault is how a reader is sent hunting something that is working. The walk also submits
+		// name tags, text and other geometry no shadow table anywhere has a row for, and those are
+		// the same silence the camera's table gives them. A mob's ground oval is not among what
+		// reaches here: EntityRenderDispatcherMixin keeps it off the mob while the map is drawn.
+		//
+		// It is nearly a match rather than the gap it first reads as.
 		// Iris carries a shadow row for the glint (pipeline/IrisPipelines.java:111) and then cancels
 		// the foil while the map is filled (mixin/ItemStackMixin.java:14-17, whose comment is that a
 		// glint is not visible in a shadow anyway). That cancel is on ItemStack.hasFoil, and it

--- a/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
@@ -47,8 +47,8 @@ import org.joml.Matrix4f;
  * <p>
  * <strong>What is not served here is not drawn here, and that is a divergence from Iris.</strong>
  * Iris binds the shadow framebuffer for the whole of its stage, so a pipeline its shadow table has
- * no key for keeps the game's own shader and still writes the map ({@code pipeline/IrisPipelines
- * .java:85-134} names no {@code ENTITY_SHADOW}, and a null key leaves the vanilla shader standing).
+ * no key for keeps the game's own shader and still writes the map (a null key of
+ * {@code pipeline/IrisPipelines.java:85-134} leaves the vanilla shader standing).
  * Here the target is chosen per draw, off {@code PreparedRenderType.outputTarget()}, and the game's
  * pipeline declares one colour state at the main target's format: steering it onto the map's
  * attachments is refused by name at {@code setPipeline}, in the middle of the draw. So a draw the

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -432,6 +432,27 @@ public final class TerrainDraw {
 	}
 
 	/**
+	 * Whether the shadow map is being drawn: the stage is on and every shadow pass has a program
+	 * that can still be served.
+	 * <p>
+	 * What it decides is whether a mob keeps the game's own ground oval. Iris takes that oval away
+	 * for as long as its shadow renderer stands ({@code pipeline/IrisRenderingPipeline.java:1101-1104}),
+	 * and the renderer is made with the shadow targets ({@code :451-469}), whatever the distance is
+	 * set to. Two edges of that condition are not read the same way here, and both are on the side
+	 * of the stage rather than of this line. Iris allocates the targets for a pack that merely
+	 * samples {@code shadowtex} from a composite ({@code :767-768}), with no shadow program at all,
+	 * and takes the oval away under it; here a pack without a shadow program gets no stage and keeps
+	 * its oval. And Iris reads a {@code shadow.enabled} line of the pack's properties ({@code :464}),
+	 * which this engine reads nowhere: the stage stands on the programs alone. What either costs is
+	 * one oval more or less under a pack of which the corpus has none.
+	 */
+	public static boolean shadowMapServed() {
+		TerrainDraw self = PackChain.terrain();
+
+		return self != null && shadows() && self.shadowsServed();
+	}
+
+	/**
 	 * Takes the copy the pack reads as {@code shadowtex1}. The caller invokes it between the opaque
 	 * halves of the shadow map and the translucent one, which is the only moment the two names mean
 	 * different things, and outside any render pass: the renderer closes its own before returning.

--- a/docs/internals/entities.md
+++ b/docs/internals/entities.md
@@ -271,7 +271,10 @@ off by identity **before** the blend is looked at, so it is in neither half. And
 never goes through the sort at all: it goes into a phase of its own that the translucent execution
 runs first. It reaches the door regardless, its renderer inheriting the same `executeGroup`, and that
 was proved rather than assumed, since it is the one that could plausibly have had a group loop of its
-own the way the particles do.
+own the way the particles do. Where it is submitted at all, that is: while the pack draws a shadow
+map the oval is kept off the mob at the dispatcher, which is the reference's rule, so under a pack
+with a map no oval reaches any door, and under a pack without one the oval is the only shadow a mob
+has and keeps its row.
 
 From that one table three more are derived, row for row but one, and the reason is always
 the same: a row too many is a compiled module nobody selects, a row too few is geometry silently
@@ -346,12 +349,13 @@ Seen from the light the tables collapse to **one program** for the lot. The bloc
 the same pipelines and answers one key for every entity one, so there is no block row for anything
 this engine draws.
 
-The ground oval is left out because the reference leaves it out, and what a row would add is worth
-knowing and is not the obvious answer: that pipeline writes no depth at all, so it would lay no
-occluder under anything and would only paint into the map's colour. The eyes are in, and that is
-exactly what they reach. Neither eye pipeline writes depth, and the table keeps the write exactly, so
-an eye paints into the map's colour and lays nothing under itself: it is not an occluder and it
-darkens no shadow. What the row buys is a pack that reads the map's colour seeing the eyes where it
+The ground oval has no twin because nothing submits it while the map is drawn: the dispatcher keeps
+it off the mob for as long as the pack draws a map, and the light's walk submits through that same
+dispatcher, so a row would be a module nobody selects. The reference's shadow table has no key for
+it either. The eyes are in, and what they reach is worth knowing, because it is not the obvious
+answer. Neither eye pipeline writes depth, and the table keeps the write exactly, so an eye paints
+into the map's colour and lays nothing under itself: it is not an occluder and it darkens no
+shadow. What the row buys is a pack that reads the map's colour seeing the eyes where it
 used to see a dropped draw. They take the ordinary caster's row rather than the full light of their
 camera side, the reference's shadow key being declared with the light map where the two camera keys
 are declared full bright.

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -141,11 +141,11 @@ middle of the draw, so there is nothing to hand back to. What it costs is a cast
 shadow; the alternative costs worse, the pass open at that moment carrying the finished picture, so
 the caster would be painted across the frame the player is looking at.
 
-The ground oval under a mob is left out on purpose, as Iris leaves it out: neither engine has a
-shadow row for that pipeline. It is worth knowing what serving it would and would not do, because
-the answer is not the obvious one: that pipeline writes no depth, and the shadow table keeps the
-write exactly, so a row for it would put nothing at all into the depth a pack reads its shadows
-from. It would not lay a disc of occluder under every mob.
+The ground oval under a mob is not in the map and not under the mob either, for as long as the pack
+draws a map: the dispatcher never submits it then, which is Iris's rule. A pack with a map lights the
+ground under a mob with that map, and the game's oval on top of it would be a second shadow no pack
+author ever saw under their own pack. Under a pack without a map the oval is the only shadow a mob
+has, and it stays, drawn with the translucent entity program as Iris draws it.
 
 The two halves of that second walk are gathered at different moments, and it is not a tidiness.
 The entities are worked out before the light's own walk of the sections, since nothing that decides


### PR DESCRIPTION
## What changes

The game's flat entity shadow, the dark oval under every mob, is no longer submitted for as long as the loaded pack draws a shadow map. It used to reach the entity door and be drawn with `gbuffers_entities_translucent` on top of ground the pack was already shading with its map, a second shadow no pack author ever saw. Under a pack without a map the oval stays, drawn as before. The condition is a `@WrapWithCondition` on `submitShadow` in `EntityRenderDispatcherMixin`, keyed on a new `TerrainDraw.shadowMapServed()`: stage on and every shadow pass servable. The branch that logged the oval as "left out of the shadow map" in `EntityDraw.dropped` is removed, since nothing submits it during the light's walk any more.

## How it differs from the reference, and for what obstacle

It does not, at the line: Iris wraps the same call with the same condition (`mixin/MixinEntityRenderDispatcher.java:48-59`, `IrisRenderingPipeline.java:1101-1104`). Two edges of Iris's condition are read differently here and both are the shadow stage's, not this line's, written in the javadoc of `shadowMapServed`: Iris allocates shadow targets for a pack that merely samples `shadowtex` from a composite (`:767-768`) and takes the oval away under it, where this engine gives such a pack no stage and keeps the oval; and Iris reads a `shadow.enabled` properties line (`:464`) this engine reads nowhere. No pack of the corpus sits on either edge.

## What proves it

- `gradlew build` green on both loaders, after the rebase.
- In the game, on the NeoForge bench and the Fabric bench with Entity Shadows on, every pack of the corpus: no oval under a mob or under the player in third person, cast shadows intact. The "Fabric only" of the report was the NeoForge bench having `entityShadows:false` in its options; the defect was common.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
