### PR TITLE
ci: refuse a request to main that does not come from dev

### DIFF
--- a/.github/workflows/main-from-dev.yml
+++ b/.github/workflows/main-from-dev.yml
@@ -1,0 +1,28 @@
+# main takes one branch and no other: dev, moved onto it by a fast-forward at a release. This job
+# fails every pull request opened against main from anywhere else, and the ruleset that requires
+# it on main turns that failure into a refusal, of the merge button and of a direct push alike: a
+# commit reaches main only once it has passed here on a request from dev. prefix.yml is the check
+# after the fact, this one is the check before.
+name: main-from-dev
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  main-from-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - name: The request comes from dev
+        env:
+          HEAD: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD" = "dev" ]; then
+            echo "The request comes from dev, which is the one branch main takes."
+            exit 0
+          fi
+          echo "::error::main takes dev and nothing else, and this request comes from $HEAD. Open it"
+          echo "::error::against dev; the release moves main onto dev by a fast-forward once it is in."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,15 @@ is the part worth knowing before changing either: a squash is linear, so the rul
 happily, and it is the button setting that rules it out. The same ruleset refuses the deletion of
 either branch.
 
+Two more rulesets require status checks, and they are what turns a check into a refusal. On `dev`:
+`build`, `commits` and `label`, so a request from a branch outside the naming form above, or one
+whose subjects fail, cannot merge, and a commit pushed straight onto `dev` without having passed
+them is refused. On `main`: `build` and `main-from-dev`, the second being a workflow that fails
+every request not opened from `dev`, so what the fast-forward moves onto `main` is exactly what a
+green request from `dev` carried, and a commit pushed onto `main` from anywhere else is refused.
+Repairing either branch by hand therefore means switching its ruleset off for the length of the
+push, which is a deliberate act rather than a slip.
+
 `.github/pull_request_template.md` is what a request opens with, and its four headings are the four
 questions this repository answers before anything lands. Three of them are ordinary. The one that
 is not is the second, "how it differs from the reference": packs are written against Iris, so a


### PR DESCRIPTION
A ten line workflow, main-from-dev, that fails every pull request opened against main from a branch other than dev, and the paragraph of CONTRIBUTING that says which checks the two new rulesets require on main (build, main-from-dev) and on dev (build, commits, label). The rulesets themselves are repository settings and are already in place; this is the check they name and the sentence that explains them.