### PR TITLE
docs(issues): ask for the graphics card in a bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -37,6 +37,18 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: gpu
+    attributes:
+      label: Graphics card and driver
+      description: >
+        The log names both, on its line "Using graphics backend Vulkan, using drivers". Everything
+        here is tried on one NVIDIA card, and a crash that comes with every pack is most often
+        something another card's driver refuses, so this is the line that tells.
+      placeholder: NVIDIA GeForce RTX 3060, driver 610.88
+    validations:
+      required: true
+
   - type: dropdown
     id: without
     attributes:


### PR DESCRIPTION
## What changes

The bug report form gets a required field for the graphics card and driver, pointing at the log line that names both. Three reports of a crash on every world load, with any pack, arrived this week from people whose hardware we do not know; everything here has only ever run on one NVIDIA card, and that is the first thing a crash like that turns on.

## How it differs from the reference, and for what obstacle

It does not. Nothing in the engine changes.

## What proves it

Nothing to build: a form file only.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it. Not run: no code is touched.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.