### PR TITLE
ci(label): pose release on a request from release/ or dev

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,7 +16,7 @@
 #
 # `pull_request_target` and not `pull_request`, because a request opened from a fork is given a
 # token that may only read. Nothing of the request is checked out or run here: what is read is the
-# name of its branch, and all that is done with it is a match against nine words written below. A
+# name of its branch, and all that is done with it is a match against eleven words written below. A
 # name matching none of them reaches no command at all.
 
 name: label
@@ -51,10 +51,15 @@ jobs:
                 echo "::notice::Posing the label $type failed, so nothing is posed."
               fi
               ;;
-            release)
-              # A release request carries no type. What lands from such a branch is the version
-              # bump, and the request itself is the record of a fast-forward rather than a change.
-              echo "A release request carries no type label."
+            release|dev)
+              # A release request carries no type, and `release` instead. Two branches open one:
+              # `release/<version>`, which lands the bump in dev, and `dev` itself, which main
+              # takes by a fast-forward and no other branch opens a request from.
+              if gh pr edit "$NUMBER" --repo "$REPOSITORY" --add-label release; then
+                echo "Labelled release, which is what a request from $BRANCH is."
+              else
+                echo "::notice::Posing the label release failed, so nothing is posed."
+              fi
               ;;
             *)
               echo "::notice::$BRANCH opens with no type CONTRIBUTING knows, so nothing is posed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,8 +267,13 @@ way its name was settled.
 opened (`.github/workflows/label.yml`). A label derived rather than decided has no reason to be
 asked of anybody, and this one held only for as long as it was remembered: of the requests opened
 before the workflow existed, nine of the first eighty-eight carry it and none of the twenty-seven
-that followed do. Where it posts nothing, the branch either carries a release, which takes no type
-label, or opens on a word this convention does not know, and `commits.yml` is what says so.
+that followed do. Where it posts nothing, the branch opens on a word this convention does not know,
+and `commits.yml` is what says so.
+
+**A release request carries `release` and no type**, posed by that same workflow. Two requests carry
+it: `release/<version>` into `dev`, which lands the bump, and `dev` into `main`, which records the
+fast-forward. Neither is a change of the kind the nine words classify, the first carrying a number
+and the second nothing that did not enter `dev` under a label of its own.
 
 **An issue carries what it is about instead**, being a report rather than a change:
 


### PR DESCRIPTION
## What changes

A release request used to carry no label at all, `label.yml` saying so and stopping. It now carries `release`, a label created on the repository for it, posed by that same workflow on the two branches that open one: `release/<version>` into `dev` and `dev` into `main`. CONTRIBUTING's Labels section says the rule.

## How it differs from the reference, and for what obstacle

It does not: nothing here touches the engine.

## What proves it

- This request is labelled `ci` by the workflow it edits, from the branch name, which is the path the new case shares.
- The `release|dev` case itself only runs on the next release request; a failed pose stays a notice, as for the nine types.

## What it leaves owing

Nothing.
