### PR TITLE
docs(sodium): say the safe zone has no width on this engine

### DIFF
--- a/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
@@ -80,9 +80,22 @@ public final class ShadowCull implements Frustum {
 	 * It settles nothing while the safe zone is the shorter of the two, such a box being wholly
 	 * within the distance as well; it is what a pack asking for a voxel grid WIDER than its shadow
 	 * distance is owed, and {@code PackValues:332-333} works the two out apart without bounding
-	 * either by the other. Four packs of the corpus reach for this shape behind their voxelised
-	 * light, and one of them, Bliss, holds {@code voxelDistance} at 64 while offering a shadow
-	 * distance down to 32.
+	 * either by the other.
+	 * <p>
+	 * <strong>No pack of the corpus reaches it on this engine, and one flag is the whole
+	 * reason.</strong> Bliss, BSL, both Complementary and Reverie ask for this shape behind their
+	 * voxelised light, so the STATE is reached; what never arrives is its WIDTH. A pack declares
+	 * that as {@code voxelDistance}, and Bliss puts the declaration itself behind
+	 * {@code IRIS_FEATURE_CUSTOM_IMAGES} ({@code lib/settings.glsl}) where both Complementary reach
+	 * it through {@code COLORED_LIGHTING_INTERNAL}, a define the same flag alone turns on
+	 * ({@code lib/common.glsl}). {@link dev.vitrail.pack.option.EngineDefines} poses no
+	 * {@code IRIS_FEATURE_} for anything this engine does not serve, and
+	 * {@code ConstDirectives.read} keeps live lines only, so for those three the value never arrives
+	 * and the box is nought blocks wide. BSL declares one on a live line and it is SHORTER than the
+	 * smallest shadow distance it offers, which is the case just above that settles nothing. Reverie
+	 * requires the flag outright and is refused whole before a program is translated. So what stands
+	 * below is the reference's order held against the day custom images are served, and not a state
+	 * a player can put this engine in today.
 	 * <p>
 	 * <strong>{@link #testAab} does NOT carry that exception, and Iris does not carry it there
 	 * either</strong> ({@code SafeZoneCullingFrustum.java:54-56}, the distance cut first). The two
@@ -104,10 +117,10 @@ public final class ShadowCull implements Frustum {
 
 		// The safe zone outranks the distance on a box it holds whole, which is Iris's order and not
 		// a softening of the line above: its safe zone frustum answers INSIDE off that box alone the
-		// moment the distance is anything but OUTSIDE (SafeZoneCullingFrustum.java:74-78). It is
-		// reachable and not a corner: four packs of the corpus ask for this shape behind their
-		// voxelised light, and Bliss holds voxelDistance at 64 while offering a shadow distance down
-		// to 32, so a player who lowers one below the other would lose casters Iris draws.
+		// moment the distance is anything but OUTSIDE (SafeZoneCullingFrustum.java:74-78). No pack
+		// of the corpus can put a width behind it here, the javadoc above naming what stops each of
+		// them, so nothing below this line answers differently today; it is kept because it is what
+		// the reference does and what a served voxel grid would need.
 		return within(this.distance, minX, minY, minZ, maxX, maxY, maxZ)
 				|| (this.safeZone >= 0.0F
 						&& within(this.safeZone, minX, minY, minZ, maxX, maxY, maxZ))

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -178,6 +178,15 @@ default is the tightest of them rather than the loosest.
 
 A word this cannot read leaves the default standing, which is what the reference does with it.
 
+**The safe zone's box is nought blocks wide here, and that is worth knowing before you write against
+it.** The width comes from a `const float voxelDistance`, which only counts where it sits on a line
+that survives the pack's own preprocessor and where it is wider than the shadow distance. Neither
+holds for the packs asking for this state today: most put the declaration behind
+`IRIS_FEATURE_CUSTOM_IMAGES`, which this engine poses for nothing it does not serve, and where one
+declares it live it is shorter than the shortest shadow distance the same pack offers. The state is
+still chosen and the sweep still runs. It is the widening that does not happen, and it will start
+happening on its own the day custom images are served.
+
 **How far the walk reaches is a separate question from the shape.** Whichever shape is chosen, a box
 around the camera is cut out of it wherever a distance bounds the walk, and that distance is
 `shadowDistance` times the `const float shadowDistanceRenderMul` of the pack's own source, or the


### PR DESCRIPTION
## What changes

Nothing the engine does. Two comments in `ShadowCull` and one paragraph of `docs/pack-format.md`
had the safe zone of `shadow.culling=reversed` as a box a player can reach here, naming Bliss
holding `voxelDistance` at 64 against a shadow distance down to 32. That is Bliss under Iris. Here
the declaration sits behind `IRIS_FEATURE_CUSTOM_IMAGES`, this engine poses no `IRIS_FEATURE_` for
anything it does not serve, and `ConstDirectives` keeps live lines only, so the value never arrives
and the box is nought blocks wide. Both Complementary reach the same declaration through
`COLORED_LIGHTING_INTERNAL`, which that flag alone turns on; BSL declares one live at 32 against a
smallest offered shadow distance of 128, so its safe zone is always the shorter of the two; Reverie
requires the flag outright and is refused whole. The state is still chosen and the sweep still runs,
so the code is untouched.

## How it differs from the reference, and for what obstacle

It does not. The order `intersectAab` keeps is `SafeZoneCullingFrustum.java:74-78` unchanged. What
the comments now carry is that nothing can put a width behind that order until custom images are
served, which is a backlog item rather than a choice made here.

## What proves it

- `gradlew build` green.
- Read in the sources rather than in memory: each pack's own `shaders.properties` and `const float
  voxelDistance` line with the conditions around it, plus `EngineDefines`, `ConstDirectives.read`
  and `PackValues.shadowCullPlan`.
- Not in the game. Whether the exception is also invisible on screen is a measurement this branch
  does not make.

## What it leaves owing

The in-game half: the same viewpoint under Bliss with the jar of `dev` and a jar built without
`c8e78900`, which is what would turn "no pack can reach it" into a picture showing nothing moves.
The line the shadow stage prints already names the real value, so it needs no change.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. `docs/`, the
      javadoc and `README.md` were searched; the changelog entry that mentions `voxelDistance` is a
      record of what a past release did and is left standing.
