### PR TITLE
docs(readme): disclose the AI assistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ It is a side project by one person, and it started as a question: whether packs
 written for OpenGL over more than a decade could run, untouched, on the renderer
 that now ships with the game. Well enough to play with, it turns out.
 
+Much of the code was written with Claude. The design, the testing
+against real packs, the decisions about where this renderer differs from OpenGL
+and the licensing are mine.
+
 ## Status
 
 The backend this runs on is marked experimental by the game itself, and Vitrail


### PR DESCRIPTION
## What changes

Adds a paragraph to the README saying that much of the code was written with an AI coding assistant, and what the author did. The same sentence goes on the store pages with their disclosure flag, so the repository and the listings say the same thing.

## How it differs from the reference, and for what obstacle

It does not; nothing in the engine changes.

## What proves it

Text only.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [ ] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.