### PR TITLE
docs: move dev onto main for the README disclosure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -37,6 +37,18 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: gpu
+    attributes:
+      label: Graphics card and driver
+      description: >
+        The log names both, on its line "Using graphics backend Vulkan, using drivers". Everything
+        here is tried on one NVIDIA card, and a crash that comes with every pack is most often
+        something another card's driver refuses, so this is the line that tells.
+      placeholder: NVIDIA GeForce RTX 3060, driver 610.88
+    validations:
+      required: true
+
   - type: dropdown
     id: without
     attributes:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,7 +16,7 @@
 #
 # `pull_request_target` and not `pull_request`, because a request opened from a fork is given a
 # token that may only read. Nothing of the request is checked out or run here: what is read is the
-# name of its branch, and all that is done with it is a match against nine words written below. A
+# name of its branch, and all that is done with it is a match against eleven words written below. A
 # name matching none of them reaches no command at all.
 
 name: label
@@ -51,10 +51,15 @@ jobs:
                 echo "::notice::Posing the label $type failed, so nothing is posed."
               fi
               ;;
-            release)
-              # A release request carries no type. What lands from such a branch is the version
-              # bump, and the request itself is the record of a fast-forward rather than a change.
-              echo "A release request carries no type label."
+            release|dev)
+              # A release request carries no type, and `release` instead. Two branches open one:
+              # `release/<version>`, which lands the bump in dev, and `dev` itself, which main
+              # takes by a fast-forward and no other branch opens a request from.
+              if gh pr edit "$NUMBER" --repo "$REPOSITORY" --add-label release; then
+                echo "Labelled release, which is what a request from $BRANCH is."
+              else
+                echo "::notice::Posing the label release failed, so nothing is posed."
+              fi
               ;;
             *)
               echo "::notice::$BRANCH opens with no type CONTRIBUTING knows, so nothing is posed."

--- a/.github/workflows/main-from-dev.yml
+++ b/.github/workflows/main-from-dev.yml
@@ -1,0 +1,28 @@
+# main takes one branch and no other: dev, moved onto it by a fast-forward at a release. This job
+# fails every pull request opened against main from anywhere else, and the ruleset that requires
+# it on main turns that failure into a refusal, of the merge button and of a direct push alike: a
+# commit reaches main only once it has passed here on a request from dev. prefix.yml is the check
+# after the fact, this one is the check before.
+name: main-from-dev
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  main-from-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - name: The request comes from dev
+        env:
+          HEAD: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD" = "dev" ]; then
+            echo "The request comes from dev, which is the one branch main takes."
+            exit 0
+          fi
+          echo "::error::main takes dev and nothing else, and this request comes from $HEAD. Open it"
+          echo "::error::against dev; the release moves main onto dev by a fast-forward once it is in."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,8 +267,13 @@ way its name was settled.
 opened (`.github/workflows/label.yml`). A label derived rather than decided has no reason to be
 asked of anybody, and this one held only for as long as it was remembered: of the requests opened
 before the workflow existed, nine of the first eighty-eight carry it and none of the twenty-seven
-that followed do. Where it posts nothing, the branch either carries a release, which takes no type
-label, or opens on a word this convention does not know, and `commits.yml` is what says so.
+that followed do. Where it posts nothing, the branch opens on a word this convention does not know,
+and `commits.yml` is what says so.
+
+**A release request carries `release` and no type**, posed by that same workflow. Two requests carry
+it: `release/<version>` into `dev`, which lands the bump, and `dev` into `main`, which records the
+fast-forward. Neither is a change of the kind the nine words classify, the first carrying a number
+and the second nothing that did not enter `dev` under a label of its own.
 
 **An issue carries what it is about instead**, being a report rather than a change:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,15 @@ is the part worth knowing before changing either: a squash is linear, so the rul
 happily, and it is the button setting that rules it out. The same ruleset refuses the deletion of
 either branch.
 
+Two more rulesets require status checks, and they are what turns a check into a refusal. On `dev`:
+`build`, `commits` and `label`, so a request from a branch outside the naming form above, or one
+whose subjects fail, cannot merge, and a commit pushed straight onto `dev` without having passed
+them is refused. On `main`: `build` and `main-from-dev`, the second being a workflow that fails
+every request not opened from `dev`, so what the fast-forward moves onto `main` is exactly what a
+green request from `dev` carried, and a commit pushed onto `main` from anywhere else is refused.
+Repairing either branch by hand therefore means switching its ruleset off for the length of the
+push, which is a deliberate act rather than a slip.
+
 `.github/pull_request_template.md` is what a request opens with, and its four headings are the four
 questions this repository answers before anything lands. Three of them are ordinary. The one that
 is not is the second, "how it differs from the reference": packs are written against Iris, so a

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ It is a side project by one person, and it started as a question: whether packs
 written for OpenGL over more than a decade could run, untouched, on the renderer
 that now ships with the game. Well enough to play with, it turns out.
 
+Much of the code was written with Claude. The design, the testing
+against real packs, the decisions about where this renderer differs from OpenGL
+and the licensing are mine.
+
 ## Status
 
 The backend this runs on is marked experimental by the game itself, and Vitrail

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
@@ -80,9 +80,22 @@ public final class ShadowCull implements Frustum {
 	 * It settles nothing while the safe zone is the shorter of the two, such a box being wholly
 	 * within the distance as well; it is what a pack asking for a voxel grid WIDER than its shadow
 	 * distance is owed, and {@code PackValues:332-333} works the two out apart without bounding
-	 * either by the other. Four packs of the corpus reach for this shape behind their voxelised
-	 * light, and one of them, Bliss, holds {@code voxelDistance} at 64 while offering a shadow
-	 * distance down to 32.
+	 * either by the other.
+	 * <p>
+	 * <strong>No pack of the corpus reaches it on this engine, and one flag is the whole
+	 * reason.</strong> Bliss, BSL, both Complementary and Reverie ask for this shape behind their
+	 * voxelised light, so the STATE is reached; what never arrives is its WIDTH. A pack declares
+	 * that as {@code voxelDistance}, and Bliss puts the declaration itself behind
+	 * {@code IRIS_FEATURE_CUSTOM_IMAGES} ({@code lib/settings.glsl}) where both Complementary reach
+	 * it through {@code COLORED_LIGHTING_INTERNAL}, a define the same flag alone turns on
+	 * ({@code lib/common.glsl}). {@link dev.vitrail.pack.option.EngineDefines} poses no
+	 * {@code IRIS_FEATURE_} for anything this engine does not serve, and
+	 * {@code ConstDirectives.read} keeps live lines only, so for those three the value never arrives
+	 * and the box is nought blocks wide. BSL declares one on a live line and it is SHORTER than the
+	 * smallest shadow distance it offers, which is the case just above that settles nothing. Reverie
+	 * requires the flag outright and is refused whole before a program is translated. So what stands
+	 * below is the reference's order held against the day custom images are served, and not a state
+	 * a player can put this engine in today.
 	 * <p>
 	 * <strong>{@link #testAab} does NOT carry that exception, and Iris does not carry it there
 	 * either</strong> ({@code SafeZoneCullingFrustum.java:54-56}, the distance cut first). The two
@@ -104,10 +117,10 @@ public final class ShadowCull implements Frustum {
 
 		// The safe zone outranks the distance on a box it holds whole, which is Iris's order and not
 		// a softening of the line above: its safe zone frustum answers INSIDE off that box alone the
-		// moment the distance is anything but OUTSIDE (SafeZoneCullingFrustum.java:74-78). It is
-		// reachable and not a corner: four packs of the corpus ask for this shape behind their
-		// voxelised light, and Bliss holds voxelDistance at 64 while offering a shadow distance down
-		// to 32, so a player who lowers one below the other would lose casters Iris draws.
+		// moment the distance is anything but OUTSIDE (SafeZoneCullingFrustum.java:74-78). No pack
+		// of the corpus can put a width behind it here, the javadoc above naming what stops each of
+		// them, so nothing below this line answers differently today; it is kept because it is what
+		// the reference does and what a served voxel grid would need.
 		return within(this.distance, minX, minY, minZ, maxX, maxY, maxZ)
 				|| (this.safeZone >= 0.0F
 						&& within(this.safeZone, minX, minY, minZ, maxX, maxY, maxZ))

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -178,6 +178,15 @@ default is the tightest of them rather than the loosest.
 
 A word this cannot read leaves the default standing, which is what the reference does with it.
 
+**The safe zone's box is nought blocks wide here, and that is worth knowing before you write against
+it.** The width comes from a `const float voxelDistance`, which only counts where it sits on a line
+that survives the pack's own preprocessor and where it is wider than the shadow distance. Neither
+holds for the packs asking for this state today: most put the declaration behind
+`IRIS_FEATURE_CUSTOM_IMAGES`, which this engine poses for nothing it does not serve, and where one
+declares it live it is shorter than the shortest shadow distance the same pack offers. The state is
+still chosen and the sweep still runs. It is the widening that does not happen, and it will start
+happening on its own the day custom images are served.
+
 **How far the walk reaches is a separate question from the shape.** Whichever shape is chosen, a box
 around the camera is cut out of it wherever a distance bounds the walk, and that distance is
 `shadowDistance` times the `const float shadowDistanceRenderMul` of the pack's own source, or the


### PR DESCRIPTION
## What this publishes

Nothing: no tag, no jar. This moves `main` onto `dev` so the repository front page carries the README paragraph that discloses how the code was written, the same day it was said on Reddit and on the store pages. Everything in the range is text and CI: the README paragraph, the Sodium page, the issue template, the label and main-from-dev workflows.

## The version

No version changes hands. `mod_version` stays at 0.7.4-beta and no tag is pushed.

## What the release carries that no changelog entry names

Nothing that a player sees; the range touches no Java and no shader.

## What proves it

`build` green on `dev` at 07ef1400; the rest is text.

---

- [x] `main` is an ancestor of `dev`, so this merges by fast-forward.
- [x] `gradlew build` green on the commit, on the pull request that brought it into `dev`.
- [x] No changelog section is involved: nothing is tagged.
- [ ] Merged by fast-forward from a terminal, and by no button.
- [x] No tag is pushed.