### PR TITLE
docs(comments): keep the trap in a comment, not its history

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,6 +311,12 @@ is where it is and what would break if it moved, and a figure says what was meas
 arrive at it. What is not wanted is the other kind, the comment that restates the line
 below it.
 
+Two more go with that one. A comment says what holds now and not how the code got there, so
+"this used to read", "for a while" and the story of the batch that changed it belong to the
+history, which keeps them better and keeps them out of the way. And a mechanism has one home
+in `docs/`, so a comment that explains one a second time is a copy that will drift out of
+step with the page: point at the page, and keep only the trap the page does not carry.
+
 ## Verifying a change
 
 Where a change lands decides how it can be checked, and the split is worth knowing before

--- a/common/src/main/java/dev/vitrail/dh/DhLods.java
+++ b/common/src/main/java/dev/vitrail/dh/DhLods.java
@@ -40,7 +40,7 @@ import java.util.List;
  * can be built against, and tying the repository to one jar on one machine is worse than a
  * reflective road that stays quiet on a DH which cannot answer it. Nothing here throws into a frame.
  * Every failure resolves once, says so once, and leaves DH drawing its own far terrain for the rest
- * of the session, which is the picture this engine had before this class existed.
+ * of the session, which is the picture this engine draws without this class.
  */
 public final class DhLods {
 
@@ -492,8 +492,8 @@ public final class DhLods {
 			Vitrail.logger().debug("Distant Horizons' own far terrain renderer cannot be put back", e);
 		}
 
-		// And its own frame order with it, so a DH handed back draws exactly as it did before this
-		// engine stood in the way. Iris clears the same switch when it stops overriding
+		// And its own frame order with it, so a DH handed back draws exactly as it does where this
+		// engine does not stand in the way. Iris clears the same switch when it stops overriding
 		// (compat/dh/LodRendererEvents.java:92 setting it from a live condition).
 		if (deferred) {
 			deferred = false;

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -952,7 +952,7 @@ public final class GlslTranslator {
 	 * between the two questions. Entry {@code n} of this list is where output {@code n} lands, so
 	 * an entry past the eighth belongs to an output that cannot exist; but the entries themselves
 	 * name colour targets and Reverie names {@code colortex19}, which a bound of sixteen on the
-	 * value used to drop, moving every attachment declared after it.
+	 * value would drop, moving every attachment declared after it.
 	 */
 	private void collectDrawBuffers() {
 		DrawBuffers.parse(this.unit).stream().limit(MAX_FRAGMENT_OUTPUTS).forEach(this.drawBuffers::add);

--- a/common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java
+++ b/common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java
@@ -230,7 +230,7 @@ public final class LegacyGlsl {
 	 * <strong>The glint is what made this necessary, because it is the first family whose depth test
 	 * is an EQUALITY.</strong> Its depth test is {@code EQUAL} and it writes no depth
 	 * ({@code RenderPipelines.java:434}), so a glint whose vertex lands a last bit away from the
-	 * armour under it does not z-fight, it VANISHES. Two things used to put it there and both are
+	 * armour under it does not z-fight, it VANISHES. Two things put a vertex there and both are
 	 * closed by reading this matrix on both sides. The nudge: its one pipeline carries two, since
 	 * {@code ARMOR_ENTITY_GLINT} sets {@code LayeringTransform.VIEW_OFFSET_Z_LAYERING} and the other
 	 * three set none ({@code rendertype/RenderTypes.java:252} against {@code :255,263,270}), so no

--- a/common/src/main/java/dev/vitrail/glsl/SodiumVertex.java
+++ b/common/src/main/java/dev/vitrail/glsl/SodiumVertex.java
@@ -31,8 +31,8 @@ import java.util.Set;
  * <strong>Every name a pack reads of this geometry is now in the mesh.</strong> The block id, the
  * middle of the sprite, the offset to the middle of the block and the tangent frame are four
  * elements of this engine's own; {@link #TINT_AND_AO} is a fifth, and the one that answers no name
- * of the pack's but the shape of a name it already reads. The facing that used to stand in for a
- * normal, in the spare bits of the material byte, is gone with the last thing that read it.
+ * of the pack's but the shape of a name it already reads. Nothing stands in for a normal in the
+ * spare bits of the material byte.
  * <p>
  * <strong>Which of the five a mesh really carries follows the pack</strong>, and the format is
  * therefore anything from twenty bytes to forty. {@link #reads} says what one vertex stage
@@ -173,7 +173,7 @@ public final class SodiumVertex {
 	 * Every texture unit above the light map. Declared whether the pack mentions them or not costs
 	 * nothing; not declaring one the pack does mention costs the program.
 	 * <p>
-	 * {@code of_Normal} used to be here and is not any more: the mesh carries a normal of its own.
+	 * {@code of_Normal} is not here: the mesh carries a normal of its own.
 	 */
 	private static final Map<String, String> FIXED = fixed();
 
@@ -339,11 +339,11 @@ public final class SodiumVertex {
 		lines.add("\tof_MultiTexCoord0 = vec4(vec2(a_TexCoord & 32767u) / 32768.0"
 				+ " + ofInward * of_TexShrink, 0.0, 1.0);");
 		// The light map RAW, as the mesh carries it, which is a pair of levels from nought to two
-		// hundred and forty. This used to divide by 256 here, and dividing here is the same mistake
-		// as answering gl_TextureMatrix[1] with the identity, seen from the other end: the scale
-		// belongs in that matrix, where the pack applies it itself and where the half texel that
-		// centres the sample on its level comes with it. Iris carries the raw pair too,
-		// SodiumTransformer.java:228, and every other family of this engine already did.
+		// hundred and forty. Dividing by 256 here is the same mistake as answering
+		// gl_TextureMatrix[1] with the identity, seen from the other end: the scale belongs in that
+		// matrix, where the pack applies it itself and where the half texel that centres the sample
+		// on its level comes with it. Iris carries the raw pair too, SodiumTransformer.java:228,
+		// and so does every other family of this engine.
 		lines.add("\tof_MultiTexCoord1 = vec4(vec2(a_LightAndData.xy), 0.0, 1.0);");
 		// Asked of the carried list and not of ANSWERED, this being the one name of the head that is
 		// no spelling of the pack's. A pack no chunk program of which reads gl_Normal leaves the

--- a/common/src/main/java/dev/vitrail/mixin/BlockRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/BlockRendererMixin.java
@@ -15,15 +15,15 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
  * Writes what a pack needs about each block a quad came from: the number
  * {@code block.properties} gave it, where it stands in its section, and what it emits.
  * <p>
- * <strong>All of it rides on the vertices, and it has to.</strong> The id used to travel in the bits
- * above the material byte, which is right for everything opaque and quietly wrong for everything
+ * <strong>All of it rides on the vertices, and it has to.</strong> Carrying the id in the bits
+ * above the material byte is right for everything opaque and quietly wrong for everything
  * translucent: the second branch below hands a translucent quad to the sorter and returns before the
  * push is reached, and the sorter writes it out later under a constant material. Anything left on
  * the material is gone by then, and nothing says so. {@link TerrainVertex} spells out why the
  * vertices are the one place that survives.
  * <p>
- * The quad's own facing used to ride on that material byte too, to stand in for a normal. It does
- * not any more, and nothing here writes it: the mesh carries a normal taken from the corners
+ * The quad's own facing does not ride on that material byte to stand in for a normal, and nothing
+ * here writes it: the mesh carries a normal taken from the corners
  * themselves, which is right for a plant, a sloped fluid and a custom model where an axis was not,
  * and which reaches a translucent quad like everything else here.
  * <p>

--- a/common/src/main/java/dev/vitrail/mixin/DefaultFluidRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/DefaultFluidRendererMixin.java
@@ -97,7 +97,7 @@ public abstract class DefaultFluidRendererMixin {
 		// contradicting itself inside one log.
 		int table = BlockStateIds.generation();
 		if (TerrainDraw.asked() && vitrail$said.getAndSet(table) != table) {
-			// The table is named, because this line is no longer the only one of the run: two loads
+			// The table is named, because this line is not the only one of the run: two loads
 			// of the same pack print it twice, word for word, and nothing else would say which
 			// reading belongs to which table.
 			Vitrail.logger().info("The first fluid meshed against block table {} is {} and it "

--- a/common/src/main/java/dev/vitrail/mixin/GameRendererBlurMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GameRendererBlurMixin.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
  * option, carried to the shader in the sixth argument of {@code GlobalSettingsUniform.update},
  * {@code menuBlurRadius}. A screen that fades the first half alone therefore fades nothing: the
  * widgets go in one frame, the blur stays at its full width for as long as the fade takes to fall
- * under one, and then goes out in a single frame. That is what the eye looked like before this.
+ * under one, and then goes out in a single frame. That is what the eye sees without this.
  * <p>
  * Iris does both halves and this is its second one, {@code MixinGameRenderer.iris$modifyBlur} at
  * line 67 of its own tree, on the same call and the same argument.

--- a/common/src/main/java/dev/vitrail/pack/menu/MenuValues.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/MenuValues.java
@@ -179,7 +179,7 @@ public final class MenuValues {
 	 * ({@code ProfileSet.scan}): the honest answer to "which profile is this" is the one the values
 	 * give. Storing the name instead makes a screen answer "none" the moment the file holding it is
 	 * deleted, while the values on screen are exactly the ones a profile names, which is what
-	 * pressing Reset used to look like.
+	 * pressing Reset looks like.
 	 * <p>
 	 * The most constrained profile wins, as it does there, because one profile is usually another
 	 * plus a setting or two and the looser of the pair would otherwise answer for both. Two profiles

--- a/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
@@ -66,7 +66,7 @@ public final class PackMenu {
 	 * them in, which is six of the eight in the corpus and BSL among them, BSL's five profiles all
 	 * naming eight settings. Sildur's declares none. Body Camera is the one pack that moves: its
 	 * three night vision profiles name twenty eight settings against the twenty five of the other
-	 * three, so the cycle reaches them first here and reached them last before this.
+	 * three, so the cycle reaches them first here and last in the order the pack declares them.
 	 * <p>
 	 * Iris's own {@code ProfileSet.java:17} calls the declared order "the order that profiles should
 	 * cycle through", and its code does not: only {@code forEach} reads that map.

--- a/common/src/main/java/dev/vitrail/pack/option/SettingSet.java
+++ b/common/src/main/java/dev/vitrail/pack/option/SettingSet.java
@@ -103,13 +103,13 @@ public final class SettingSet {
 	 * where the pack declares it and nowhere else, so a name the pack declares nowhere is applied
 	 * nowhere.
 	 * <p>
-	 * Such a name is dropped rather than written into the head of each unit, which is what this
-	 * engine used to do and what Iris has never done: {@code MutableOptionValues.addAll} walks the
-	 * options the PACK declares and looks each one up in the values it was handed
+	 * Such a name is dropped rather than written into the head of each unit, which is not what Iris
+	 * does either: {@code MutableOptionValues.addAll} walks the options the PACK declares and looks
+	 * each one up in the values it was handed
 	 * ({@code shaderpack/option/values/MutableOptionValues.java:49-97}), so a name no option carries
 	 * is never read at all.
 	 * <p>
-	 * Writing it was worse than useless, and this was measured rather than reasoned. A settings name
+	 * Writing it is worse than useless, and that was measured rather than reasoned. A settings name
 	 * is an identifier and a pack uses identifiers for its own things: a build that did not yet know
 	 * {@code hand} as a line of its own forced it as a setting of the pack, the header define landed
 	 * on the local {@code float hand} of BSL's composite stages, and the whole pack was refused at

--- a/common/src/main/java/dev/vitrail/pack/program/RenderStage.java
+++ b/common/src/main/java/dev/vitrail/pack/program/RenderStage.java
@@ -10,9 +10,9 @@ package dev.vitrail.pack.program;
  * every pack of the corpus takes. It is Iris's {@code pipeline/WorldRenderingPhase}, reproduced
  * as it stands and for the reason everything else of Iris's is: packs are written against it.
  * <p>
- * One table and not two. The names and the numbers used to be written out a second time in
- * {@code EngineDefines}, which is the shape of a failure nobody finds: two lists that agree today
- * and are edited on different days.
+ * One table and not two. Writing the names and the numbers out a second time in
+ * {@code EngineDefines} is the shape of a failure nobody finds: two lists that agree today and are
+ * edited on different days.
  * <p>
  * <strong>Rather more of these are unreachable than reachable</strong>, and the list of which is not
  * kept here: it is whatever the engine really poses, and a list written down would be one more pair

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -54,8 +54,8 @@ public final class ShaderProperties {
 	private static final Pattern SCREEN = Pattern.compile("^\\s*screen(\\.\\w+)?\\s*=\\s*(.*)$");
 	// Both are read before SCREEN, and in this order. "screen.columns=2" matches SCREEN as well,
 	// as a page named columns, which is how a page nobody can reach appears in the one pack that
-	// writes the line; and "screen.NAME.columns=1" matches neither, so it used to be counted as an
-	// unknown key. Packs indent these lines and put spaces around the equals sign, both of which
+	// writes the line; and "screen.NAME.columns=1" matches neither, so it would otherwise be counted
+	// as an unknown key. Packs indent these lines and put spaces around the equals sign, both of which
 	// are why the pattern has to be this loose.
 	private static final Pattern MAIN_COLUMNS = Pattern.compile("^\\s*screen\\.columns\\s*=\\s*(\\d+)\\s*$");
 	private static final Pattern PAGE_COLUMNS = Pattern.compile("^\\s*screen\\.(\\w+)\\.columns\\s*=\\s*(\\d+)\\s*$");
@@ -1215,10 +1215,10 @@ public final class ShaderProperties {
 				case "shadowPlayer" -> player = value;
 				case "shadowBlockEntities" -> blockEntities = value;
 				case "shadowLightBlockEntities" -> lightBlockEntities = value;
-				// Named one by one rather than letting the last word be the catch-all, which is what
-				// this switch used to do: a seventh alternative added to the pattern without its own
-				// arm would have been written into the sixth family in silence, and a caster read
-				// into the wrong family is a caster in a map the pack asked to keep it out of.
+				// Named one by one rather than letting the last word be the catch-all: a seventh
+				// alternative added to the pattern without its own arm would be written into the
+				// sixth family in silence, and a caster read into the wrong family is a caster in a
+				// map the pack asked to keep it out of.
 				default -> { }
 			}
 		}
@@ -1269,7 +1269,7 @@ public final class ShaderProperties {
 	 * {@code handleBooleanDirective} takes {@code true}, {@code 1}, {@code false} and {@code 0} and
 	 * warns at anything else without touching the field ({@code :636-648}).
 	 * <p>
-	 * That is the whole of the difference an earlier reading here would have made, and it takes a
+	 * That is the whole of the difference the other reading would make, and it takes a
 	 * pack writing the key twice to see it: on {@code separateAo=true} followed by
 	 * {@code separateAo=yes}, keeping the last line this can read answers true where the reference
 	 * leaves its default standing and answers false.
@@ -1319,8 +1319,8 @@ public final class ShaderProperties {
 	 * {@link #screens()} and {@link #screenTokens()} keep the shape and the role they had, because
 	 * the measurements this project compares itself against were taken with them, and they drop the
 	 * three hundred and eighteen tokens of the corpus that are not an option name. They lose one
-	 * thing: reading {@code screen.columns} now consumes that line, so it no longer leaves behind a
-	 * page named {@code columns} that nothing could reach. Bliss is the one pack that writes it, and
+	 * thing: reading {@code screen.columns} consumes that line, so it leaves behind no page named
+	 * {@code columns} that nothing could reach. Bliss is the one pack that writes it, and
 	 * it goes from sixty three pages to sixty two. This is the form a screen reads. Pages come in
 	 * the order the pack declares them, the one it opens on being "".
 	 */

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -413,7 +413,7 @@ public final class ChainPlan {
 	 *                  stage that writes no coverage mask, so off it takes the seed's own target with
 	 *                  it and hands the opaque particles back to the game, which is
 	 *                  {@code render/ParticleDraw.writes} refusing on the same answer. The entities
-	 *                  are no longer on that road: they write the mask and take their first draw
+	 *                  are not on that road: they write the mask and take their first draw
 	 *                  buffer in the pack's own targets, so this switch moves nothing for them
 	 */
 	public record Families(boolean terrain, boolean entities, boolean particles, boolean seed) {
@@ -481,10 +481,10 @@ public final class ChainPlan {
 		//
 		// One walk fills the three: the answers land in the shared table and each family keeps the
 		// keys it reaches. A program serving two families, which is the ordinary case for a pack
-		// whose sky falls back on gbuffers_basic, is therefore walked once where the two families
-		// used to memoise apart and walk it twice, saying anything it had to say twice with it. No
-		// pack of the corpus reaches that case, so nothing moved in the measurements; it is the
-		// shared table that now guarantees it rather than each family's own bookkeeping.
+		// whose sky falls back on gbuffers_basic, is therefore walked once, where memoising the two
+		// families apart would walk it twice and say anything it had to say twice with it. No pack
+		// of the corpus reaches that case, so nothing of it shows in the measurements; it is the
+		// shared table that guarantees it rather than each family's own bookkeeping.
 		Map<Key, Pass> attachments = new LinkedHashMap<>();
 		Map<TerrainPass, Key> terrainKeys = terrainKeysOf(plan, resolver, notes, attachments);
 		Map<NamedProgram, Key> namedKeys = namedKeysOf(plan, resolver, notes, attachments);
@@ -516,7 +516,7 @@ public final class ChainPlan {
 		// anywhere and the gate is what this depends on, not the name. Both branches of that pass
 		// are served now, the End's two methods as much as the other six, RenderPipelines.END_SKY
 		// being assigned gbuffers_skytextured as Iris assigns it (IrisPipelines.java:69), so what
-		// keeps the sky out of this count is that one gate and no longer two. The clouds are held
+		// keeps the sky out of this count is that one gate and not two. The clouds are held
 		// out by something else entirely: a pass of their own, opened on the cloud setting and on
 		// the alpha of the cloud colour (LevelRenderer:220-233) and in the overworld alone.
 		// The weather is drawn only where the level has weather,
@@ -758,7 +758,7 @@ public final class ChainPlan {
 	 * {@code attachmentsOf} - are down to two cases since the inference took the geometry in, and both
 	 * are honest: a program drawn from the light, whose draw buffers name shadow targets this plan
 	 * does not hold, and a file the expander could not read at all. A pack that simply declares no
-	 * directive no longer arrives here - it arrives with colortex0, as it does under Iris, and its
+	 * directive does not arrive here - it arrives with colortex0, as it does under Iris, and its
 	 * name is in the one line {@link #notes()} carries for the lot.
 	 */
 	private static Pass geometryOf(TargetPlan plan, String program, List<String> notes,
@@ -1010,7 +1010,7 @@ public final class ChainPlan {
 
 		if (undrawn.contains(half.target())) {
 			// What ends up here is the geometry no pass of this engine fills in EVERY place: the sky's
-			// three, held out by two gates and no longer by one, since a place whose skybox is none
+			// three, held out by two gates rather than one, since a place whose skybox is none
 			// opens no sky pass at all and the clouds hang off a pass of their own that the game
 			// opens in the overworld alone, the weather, which is drawn only where the level has
 			// weather, and every family whose line is off - the entity halves by default, and the
@@ -1018,10 +1018,10 @@ public final class ChainPlan {
 			// that is the question, and what holding each out was measured to cost, is where the
 			// verdicts are handed their map.
 			//
-			// The particles used to be here and no longer are. The sentence went on saying no geometry
-			// of ours reached the pack's targets while a particle program of the pack was writing them,
-			// which is a note that reads like a diagnosis and is a lie: Bliss's colortex9 carried it in
-			// all three of its places.
+			// The particles are NOT here, and putting them back would have the sentence say that no
+			// geometry of ours reaches the pack's targets while a particle program of the pack is
+			// writing them: a note that reads like a diagnosis and is a lie, Bliss's colortex9
+			// carrying it in all three of its places.
 			//
 			// The tail is flat, and it is flat because of where this branch now sits: nothing later in
 			// the frame writes this half, so the pack keeping the target between frames buys the
@@ -1137,7 +1137,7 @@ public final class ChainPlan {
 	 * before anything is added, and the line naming it belongs to {@code TargetPlan.notes()}, which
 	 * is a different list.
 	 * <p>
-	 * <strong>A pack that declares no draw buffer is not one of them and used to be</strong>: it is
+	 * <strong>A pack that declares no draw buffer is not one of them</strong>: it is
 	 * answered colortex0, as Iris answers it. Measured on the corpus in August 2026, no place answers
 	 * empty for any family at all.
 	 */
@@ -1227,11 +1227,11 @@ public final class ChainPlan {
 	 * pack and not faults of this engine, which is why they are handed back apart from
 	 * {@link #notes()}.
 	 * <p>
-	 * They used to be in that list, and the list is introduced to the reader as what the picture
-	 * will be wrong about. BSL's {@code colortex2} is the case that proved the cost: its line says
-	 * the target is not written until {@code composite7} and that {@code composite5} therefore reads
-	 * the frame before, which is exactly the temporal chain the pack is built on and exactly what
-	 * Iris gives it. Read among the faults it became a suspect, and stayed one for a fortnight.
+	 * Kept out of that list because the list is introduced to the reader as what the picture will be
+	 * wrong about, and these are not. BSL's {@code colortex2} is the case that shows the cost: its
+	 * line says the target is not written until {@code composite7} and that {@code composite5}
+	 * therefore reads the frame before, which is exactly the temporal chain the pack is built on and
+	 * exactly what Iris gives it. Read among the faults, it is a suspect until somebody checks.
 	 */
 	public List<String> history() {
 		return this.history;

--- a/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
@@ -19,7 +19,7 @@ import java.util.Set;
  * backend throws {@code Missing sampler} the moment a name in the layout is not bound. So a name
  * this engine has no answer for cannot be dropped; it has to come back as {@link Kind#UNSERVED}
  * and be given something harmless, and it has to be named in the log rather than quietly given
- * the scene, which is what made the first pass look as though it worked.
+ * the scene, which draws a program that looks as though it works.
  * <p>
  * The side of a colour target is answered here too, from the schedule and for this program, so
  * that no caller has to work out where the ping pong stands.

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -278,13 +278,13 @@ public final class TargetPlan {
 	 * attachment zero when a fragment declares none, and the packs are written against that, so a
 	 * program with no directive is sent to colortex0 and colortex0 is allocated for it.
 	 * <p>
-	 * <strong>Geometry is inferred too, and it used to be left out.</strong> The reason it was left
-	 * out expired: nothing of it was drawn, so the inference would have paid for a target on behalf of
-	 * a program that never ran. The terrain, the sky, the clouds, the weather, the particles and the
-	 * entities are drawn now, and what the exemption really bought was a program of the pack drawing
-	 * into the GAME'S target instead of the pack's, where nothing of the chain reports it back. Body
-	 * Camera is the measured case and it is total rather than cosmetic: it
-	 * has no clouds at all, at either setting of the pack, because its {@code gbuffers_clouds}
+	 * <strong>Geometry is inferred too, and leaving it out is the tempting exemption.</strong> It
+	 * would hold only while nothing of it is drawn, the inference otherwise paying for a target on
+	 * behalf of a program that never runs. The terrain, the sky, the clouds, the weather, the
+	 * particles and the entities are all drawn, so what that exemption buys is a program of the pack
+	 * drawing into the GAME'S target instead of the pack's, where nothing of the chain reports it
+	 * back. Body Camera is the measured case and it is total rather than cosmetic: it has no clouds
+	 * at all, at either setting of the pack, because its {@code gbuffers_clouds}
 	 * declares no draw buffer and its image goes somewhere nothing collects. Iris reads the same file
 	 * as {@code /* DRAWBUFFERS:0 *}{@code /}, {@code shaderpack/properties/ProgramDirectives.java:55}.
 	 * <p>

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -81,7 +81,7 @@ public final class EngineStages {
 	 * While the level's frame graph is being built, which is the one moment the model view and the
 	 * camera position of this frame are both to hand and neither has been pushed anywhere yet.
 	 * <p>
-	 * The frame graph no longer carries a pass of ours, only this reading: the shadow map is drawn
+	 * The frame graph carries no pass of ours, only this reading: the shadow map is drawn
 	 * at the end of the frame, for the next one, and this is what the stage needs from here.
 	 * <p>
 	 * It is also the top of the level frame, which is a second thing entirely and is why the first
@@ -111,9 +111,9 @@ public final class EngineStages {
 		// Opens the one window the entities are served in. It has to be a window, because the
 		// screen is drawn by the same feature renderers, with the same pipelines and into the same
 		// target, out of a submit storage GameRenderer hands them after the level: nothing about one
-		// of those draws says it is not an entity, and only the moment does. The hand used to be the
-		// other one this kept out and no longer is: HandDraw submits it inside the level with a mark
-		// of its own, so it is served rather than excluded.
+		// of those draws says it is not an entity, and only the moment does. The hand is not the
+		// other one this keeps out: HandDraw submits it inside the level with a mark of its own, so
+		// it is served rather than excluded.
 		EntityDraw.opaqueFeatures(true);
 	}
 
@@ -128,10 +128,10 @@ public final class EngineStages {
 	 * the prepares, the scene seed and the deferred stage. Then redirects the game's translucent
 	 * features into the layer that hands them to the pack's image.
 	 * <p>
-	 * Not a refinement of where it used to run. BSL's {@code gbuffers_water} reads {@code gaux1},
-	 * which its own {@code deferred} writes, and discards every fragment where it reads nought: with
-	 * the whole chain running after the world, that read found a clear colour and the water was
-	 * thrown away in its entirety.
+	 * The placement itself and not a refinement of it. BSL's {@code gbuffers_water} reads
+	 * {@code gaux1}, which its own {@code deferred} writes, and discards every fragment where it
+	 * reads nought: with the whole chain running after the world, that read finds a clear colour and
+	 * the water is thrown away in its entirety.
 	 */
 	public static void afterOpaqueFeatures() {
 		// First, and before anything of this engine draws: everything after this point is either the

--- a/common/src/main/java/dev/vitrail/render/BlockStateIds.java
+++ b/common/src/main/java/dev/vitrail/render/BlockStateIds.java
@@ -101,9 +101,9 @@ public final class BlockStateIds {
 				// Refused rather than truncated. A number that does not fit would come back out of
 				// the mesh as a different number, which lights the wrong blocks and says nothing.
 				// Weighed on the id and not on its packed form, which overflows an int long before
-				// it passes the mask: block.1073741924 used to be accepted here, the encoder cut it
-				// down, and the shader read the pack's own id 100. The file writes block. followed
-				// by digits, so there is no negative number to weigh.
+				// it passes the mask: weighed on its packed form, block.1073741924 is accepted, the
+				// encoder cuts it down, and the shader reads the pack's own id 100. The file writes
+				// block. followed by digits, so there is no negative number to weigh.
 				unknown.add("block." + entry.id() + ", too large for the mesh to carry");
 			} else if (entry.tag()) {
 				addTag(entry, built, unknown, widened);

--- a/common/src/main/java/dev/vitrail/render/CameraBob.java
+++ b/common/src/main/java/dev/vitrail/render/CameraBob.java
@@ -29,8 +29,8 @@ import org.joml.Vector3fc;
  * is the matrix the world was really drawn with, so the geometry lands in exactly the same pixels,
  * and a position rebuilt from {@code depthtex0} comes back to the same place it started.
  * <p>
- * Rebuilding the four from game state was considered by an earlier reading and rightly rejected,
- * {@code spinningEffectTime} and {@code spinningEffectSpeed} being private with no accessor. This is
+ * Rebuilding the four from game state is not open here, {@code spinningEffectTime} and
+ * {@code spinningEffectSpeed} being private with no accessor. This is
  * the third way: the multiplications themselves are intercepted, so nothing is reconstructed and
  * nothing is guessed.
  */

--- a/common/src/main/java/dev/vitrail/render/CloudDraw.java
+++ b/common/src/main/java/dev/vitrail/render/CloudDraw.java
@@ -49,8 +49,8 @@ import java.util.Optional;
  * and the pack's own colour target already holds the world, which is what a {@code gbuffers_clouds}
  * expects to blend onto. A pack that declares no draw buffer on the program is answered colortex0,
  * as Iris answers it, so the clouds land in a target of the pack's like any other piece; what leaves
- * them on the game's target, where the full screen layer brings them across flat exactly as it did
- * before this class existed, is the plan having no answer for the program at all, which
+ * them on the game's target, where the full screen layer brings them across flat exactly as it does
+ * without this class, is the plan having no answer for the program at all, which
  * {@link ChainPlan#geometry} lists the causes of.
  */
 public final class CloudDraw {
@@ -127,7 +127,7 @@ public final class CloudDraw {
 	 * {@link SkyDraw#sunPathRotation()} and like {@link SkyDraw#draws}. The word is a pack saying
 	 * "draw them this way, I have written for it", and with nothing of ours behind it
 	 * {@code clouds=off} would take the game's clouds away and put nothing in their place. That is
-	 * exactly what this engine refused to honour while no program here drew a cloud.
+	 * exactly what this engine refuses to honour while no program here draws a cloud.
 	 * <p>
 	 * It is read at the head of the game's own accessor, so it reaches the frame graph as well as the
 	 * renderer: a pack that switched them off has no cloud pass opened for it at all.

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -47,8 +47,8 @@ import java.util.Set;
  * with its.
  * <p>
  * <strong>This is the whole of what the far terrain was missing, and what it was missing was the
- * light.</strong> The colour used to be DH's, so the two halves of one landscape were lit by two
- * engines and met at a seam no pack could close. The geometry {@code dh/DhLods} takes over is drawn
+ * light.</strong> Left to itself the colour is DH's, so the two halves of one landscape are lit by
+ * two engines and meet at a seam no pack can close. The geometry {@code dh/DhLods} takes over is drawn
  * here instead, once per half of the frame, with {@code dh_terrain} and {@code dh_water} - the two
  * names every pack of the corpus ships, and two of the four Iris serves
  * ({@code compat/dh/DHCompatInternal.java:67-79}; the one still missing here is its
@@ -291,8 +291,8 @@ public final class DistantDraw {
 	 * Draws one half of the far terrain with the pack's own program.
 	 * <p>
 	 * The one door {@code dh/DhLods} comes through, and the answer decides what DH does next: false
-	 * hands the half back, and DH draws it with its own shader exactly as it did before this engine
-	 * stood in the way.
+	 * hands the half back, and DH draws it with its own shader exactly as it does where this engine
+	 * does not stand in the way.
 	 *
 	 * @param opaque   which half this is, taken from DH's own call rather than worked out here
 	 * @param sections every section of the far terrain, in the order DH sorted them
@@ -372,7 +372,7 @@ public final class DistantDraw {
 		} catch (RuntimeException e) {
 			// Latched on its own, and the picture keeps going: what stops here is the far terrain's
 			// entry into the map, so the LOD is lit by what the pack computes from its own depth,
-			// which is the whole of what it had before this half existed.
+			// which is the whole of what it has without this half.
 			draw.shadowBroken = true;
 			Vitrail.logger().error("Vitrail stopped drawing the far terrain into the shadow map after "
 					+ "an error, so nothing of it casts into the map for the rest of this pack", e);

--- a/common/src/main/java/dev/vitrail/render/DistantProgram.java
+++ b/common/src/main/java/dev/vitrail/render/DistantProgram.java
@@ -60,7 +60,7 @@ import java.util.Optional;
  * already kept off. The ways a sky loses the mask are structural and not Bliss's
  * ({@code GeometryProgram.covers} names four), so the observation is the corpus's and not a
  * rule. {@link SceneSeed} carries the cut, against this family's own depth image, so the far
- * terrain no longer depends on the sky in front of it having claimed the mask.
+ * terrain does not depend on the sky in front of it having claimed the mask.
  * <p>
  * <strong>Its namespace is ours and has no {@code sodium} in it</strong>, for the reason
  * {@link SkyProgram} gives: the word is what makes Sodium's mixin push twenty bytes of region offset

--- a/common/src/main/java/dev/vitrail/render/EngineOptions.java
+++ b/common/src/main/java/dev/vitrail/render/EngineOptions.java
@@ -146,7 +146,7 @@ final class EngineOptions {
 	 * names it at each load.
 	 * <p>
 	 * Iris routes the same geometry with nothing to switch,
-	 * {@code shaderpack/loading/ProgramId.java:40-41}, so this line is no longer a divergence from it
+	 * {@code shaderpack/loading/ProgramId.java:40-41}, so this line is not a divergence from it
 	 * at the default; it stays a line because turning a family off in one word is what tells a wrong
 	 * picture from a wrong family, without a rebuild.
 	 */
@@ -156,18 +156,15 @@ final class EngineOptions {
 	 * Takes the player's own hand out of the game's late call and draws it inside the level, with the
 	 * pack's own {@code gbuffers_hand} and {@code gbuffers_hand_water}. On, with the entities.
 	 * <p>
-	 * It was off for the entities' reason and for one of its own. The entities' reason is above and
-	 * has shrunk with it: the hand comes in by the same door and through the same vertex format, so
+	 * The hand comes in by the same door and through the same vertex format as the entities, so
 	 * what a pack reads as a constant here is what it reads as a constant there, and
-	 * {@code currentRenderedItemId}, the one that names what is being held, is no longer among them.
-	 * Its own was that the half that blends served the
-	 * ARM alone, and that one is spent: the entities' blending rows landed, every row of that table
-	 * has a hand twin ({@link EntityDraw}), so a translucent block held in hand goes through the water
-	 * pass with the arm and both are the pack's. What still goes back to the game there goes back
-	 * everywhere else too, the rows naming the item entity target under the game's improved
-	 * transparency.
+	 * {@code currentRenderedItemId}, the one that names what is being held, is not among them.
+	 * Every row of that table has a hand twin ({@link EntityDraw}), so a translucent block held in
+	 * hand goes through the water pass with the arm and both are the pack's. What still goes back to
+	 * the game there goes back everywhere else too, the rows naming the item entity target under the
+	 * game's improved transparency.
 	 * <p>
-	 * <strong>It carries the position as well as the shading, and that is what changed.</strong> The
+	 * <strong>It carries the position as well as the shading.</strong> The
 	 * solid half is drawn where the reference draws it, after the game's own opaque features and
 	 * before the deferred stage, with the depth taken past it first; the blending half goes in ahead
 	 * of the chain rather than after it, so what it draws is in the picture the composites read. Off,
@@ -180,7 +177,7 @@ final class EngineOptions {
 	/**
 	 * Draws the game's clouds with the pack's own program. On, like most of these.
 	 * <p>
-	 * <strong>It was off for one evening and that was one evening too long.</strong> A line of this
+	 * <strong>On rather than off, and the default is the decision.</strong> A line of this
 	 * file is a thing somebody wrote and knows about; a default is what everyone else gets. Off, the
 	 * picture a reader sees on cloning is not the picture this engine was judged on, and every
 	 * report about it is about a configuration nobody shipped.

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -113,7 +113,7 @@ import java.util.stream.Stream;
  * none of them is a row here. The shadow map is a family of its own and is NOT in either window, a
  * pass of its own that neither bracket reaches.
  * <p>
- * <strong>The eyes were among them and are not any more</strong>: they alone of the four bind
+ * <strong>The eyes are not among them</strong>: they alone of the four bind
  * {@code DefaultVertexFormat.ENTITY}, so they come in by this door with a table of their own,
  * {@link #FIXED}, which says why it is not the mob table.
  * <p>
@@ -151,10 +151,10 @@ public final class EntityDraw {
 	 * finished. Every one of them reaches this class with the same pipelines and the same main
 	 * target, so nothing about a draw says which of the three it belongs to; only the moment does.
 	 * <p>
-	 * <strong>The hand is no longer among what this window has to keep out, and the window is kept
-	 * all the same.</strong> {@link HandDraw} takes it off that late call and submits it inside the
-	 * level with a dispatcher of its own, so it now arrives with a mark of its own and is served
-	 * rather than excluded. What is left after the level is the screen, which has none and would
+	 * <strong>The hand is not among what this window has to keep out, and the window is kept all
+	 * the same.</strong> {@link HandDraw} takes it off that late call and submits it inside the
+	 * level with a dispatcher of its own, so it arrives with a mark of its own and is served rather
+	 * than excluded. What is left after the level is the screen, which has none and would
 	 * otherwise be drawn as a mob, so nothing about this window may be relaxed.
 	 * <p>
 	 * Measured rather than reasoned about, and it cost a session: with this open all the time, every
@@ -304,7 +304,7 @@ public final class EntityDraw {
 		 * its texture coordinates off whatever the format really carries, without a word being said.
 		 * {@link #decodable} is where the claim is checked against the pipeline in hand.
 		 * <p>
-		 * The entity one is {@link EntityMesh}'s and no longer the game's own: this is what a pipeline
+		 * The entity one is {@link EntityMesh}'s rather than the game's own: this is what a pipeline
 		 * of this engine's is built to bind, and it is what the game's own entity pipelines report
 		 * while the mesh carries. The rows are only ever read while it does, {@link #served} refusing
 		 * the whole family otherwise, so the two answers cannot be taken under different ones. The
@@ -352,8 +352,8 @@ public final class EntityDraw {
 		 * Which side of the deferred stage this piece's PASS is drawn on, which is not always what
 		 * its own pipeline blends.
 		 * <p>
-		 * <strong>One question, three answers, and asked HERE because it used to be written out
-		 * twice and the two copies disagreed.</strong> An entity row is asked of its pipeline, the
+		 * <strong>One question, three answers, and asked HERE and nowhere else, two copies of it
+		 * being two answers that drift apart.</strong> An entity row is asked of its pipeline, the
 		 * game sorting its own submissions that way. A hand row is asked of its row, a hand pass
 		 * being drawn wholly on one side whatever its rows blend, which is what {@link
 		 * #afterDeferred} carries and what the javadoc of that field says. A shadow row is neither:
@@ -416,8 +416,7 @@ public final class EntityDraw {
 		 * of it</strong>, and a held banner's pattern is the one that is reachable ({@code
 		 * BANNER_PATTERN}, {@code RenderPipelines.java:319}). The mask takes the hand's own squeezed
 		 * depth and the attachment keeps what stands behind the hand, which is farther, so the cut
-		 * finds nothing in front and leaves the pixel alone. That is the piece the seed used to throw
-		 * away outright.
+		 * finds nothing in front and leaves the pixel alone.
 		 * <p>
 		 * A piece drawn after the stage owes no mask, the seed having run long before, and a shadow
 		 * row is in neither position: it is drawn into the map, which no seed ever paints.
@@ -548,7 +547,7 @@ public final class EntityDraw {
 	 * <p>
 	 * <strong>Read as a list here and not as a blend, and the swirl is why.</strong> It is the one row
 	 * of the table that blends and still asks for the writing half's name; asking the blend first,
-	 * which is what {@link #blockTwin} used to do, would give it {@code gbuffers_block_translucent}
+	 * which is what {@link #blockTwin} must not do, would give it {@code gbuffers_block_translucent}
 	 * where Iris keeps {@code gbuffers_entities}.
 	 * <p>
 	 * <strong>The hand does not read this list, and that is a divergence this engine already
@@ -796,7 +795,7 @@ public final class EntityDraw {
 	 * row again. Both are the pack's in the water pass.
 	 * <p>
 	 * That row is {@code ENTITY_TRANSLUCENT} and not {@code ENTITY_SOLID}, which is worth saying
-	 * because this file used to say the other and the demotion of draw buffer nought turns on it:
+	 * because the demotion of draw buffer nought turns on it:
 	 * {@code AvatarRenderer.renderHand} submits the arm with {@code RenderTypes.entityTranslucent}
 	 * ({@code AvatarRenderer.java:288}), and that pipeline blends.
 	 */
@@ -1033,7 +1032,7 @@ public final class EntityDraw {
 	 * one, and {@code EntityProgram.intoMap} keeps the write exactly. So an eye paints into
 	 * {@code shadowcolor} and lays nothing under itself: it is not an occluder and it darkens no
 	 * shadow, which is the same reading this file gives the ground oval. What the row buys is a pack
-	 * that reads the map's colour seeing the eyes where it used to see a dropped draw.
+	 * that reads the map's colour seeing the eyes rather than a dropped draw.
 	 * <p>
 	 * <strong>Nor at full light, and that side of it is the camera's alone.</strong> The shadow key is
 	 * declared {@code LightingModel.LIGHTMAP} ({@code pipeline/programs/ShaderKey.java:79}) where the
@@ -1395,7 +1394,7 @@ public final class EntityDraw {
 		// submitted by this engine itself, twice, and both of those moments fall outside the
 		// windows. Each family is guarded by its own switch and neither borrows the other's.
 		//
-		// Asked of the ROW and no longer of the moment, which is what carrying a fixed table costs:
+		// Asked of the ROW rather than of the moment, which is what carrying a fixed table costs:
 		// an eyes row is the answer even inside a hand pass, and it is not a hand row, so it may not
 		// take the hand's switch. What it does take is its own window, and inside a hand pass that
 		// window is shut, so the game keeps that draw. Iris would serve it, gbuffers_spidereyes being
@@ -1669,7 +1668,7 @@ public final class EntityDraw {
 	/**
 	 * Hands one draw back to the game and says why, once per reason and per load.
 	 * <p>
-	 * <strong>Every one of these used to be silent, and that is what made the defect they cause
+	 * <strong>None of these is silent, silence being what makes the defect they cause
 	 * undiagnosable.</strong> A draw handed back is drawn by the game's own shader, so an entity is
 	 * lit by the game where everything around it is lit by the pack, with nothing anywhere to say
 	 * which reason it was. That is the exact shape of failure this engine exists to refuse, and it
@@ -2055,11 +2054,11 @@ public final class EntityDraw {
 	 * Where the outputs of one file that serves a half belong, in draw buffer order and each on the
 	 * side the schedule gives it, or null when this place cannot answer for it.
 	 * <p>
-	 * <strong>Empty is not a refusal, and it no longer means what it used to.</strong> It makes the
+	 * <strong>Empty is not a refusal, and it is not one thing either.</strong> It makes the
 	 * piece write ONE output, to the game's target, and it covers three quite different things. A key
 	 * the plan never walked, which is a name missing from its {@code NAMED_PROGRAMS}. A program the
-	 * plan holds no draw buffers for at all, which since the inference means a program drawn from the
-	 * light or a file the expander could not read ({@code ChainPlan.geometryOf}). And a
+	 * plan holds no draw buffers for at all, which, the plan inferring geometry, means a program
+	 * drawn from the light or a file the expander could not read ({@code ChainPlan.geometryOf}). And a
 	 * walk the plan REFUSED, which is five cases of its own: more than eight draw buffers, the same
 	 * target named twice, no schedule step, a target nothing allocates, or two sizes in one pass -
 	 * the one list {@code ChainPlan.attachmentsOf} carries.
@@ -2067,7 +2066,7 @@ public final class EntityDraw {
 	 * The last of those three is the one worth naming, because it is a fault dressed as a default: a
 	 * pack whose entity program the plan refused is served with one output and loses its normals and
 	 * its specular map without this file saying anything, the plan having put its reason in the notes
-	 * rather than here. <strong>What is NOT in that list any more is the ordinary pack.</strong> A
+	 * rather than here. <strong>What is NOT in that list is the ordinary pack.</strong> A
 	 * pack that simply declares no directive arrives with colortex0, as it does under Iris, so it
 	 * never reaches this branch at all: Body Camera's {@code world1} and {@code world-1} are that
 	 * case, their entities falling back on a {@code gbuffers_textured} that declares nothing, and

--- a/common/src/main/java/dev/vitrail/render/EntityProgram.java
+++ b/common/src/main/java/dev/vitrail/render/EntityProgram.java
@@ -49,11 +49,11 @@ import java.util.Set;
  * takes the buffer by writing the coverage mask, which carries the depth its fragment left and is
  * what the seed is cut against; {@link EntityDraw.Element#covers} is where that is decided and why.
  * <p>
- * <strong>That is what the trip through the game's target used to cost, and it is Bliss's
- * albedo.</strong> The writing half was in the position the opaque chunk passes were in before the
- * mask existed: its colour went to the game's target and reached the pack through the seed, eight
- * bits a channel. A pack packing two values into each channel of a sixteen bit target loses the
- * first of them there, and reads the second back as the albedo. What it always kept is every other
+ * <strong>That is what a trip through the game's target costs, and it is Bliss's albedo.</strong>
+ * A writing half with no mask stands where an opaque chunk pass with none stands: its colour goes
+ * to the game's target and reaches the pack through the seed, eight bits a channel. A pack packing
+ * two values into each channel of a sixteen bit target loses the first of them there, and reads the
+ * second back as the albedo. What it keeps either way is every other
  * draw buffer, which is where a pack keeps the normal, the specular map and the material it lights
  * an entity by, and which is the whole of what {@code the entities still come from the game} meant.
  * <p>
@@ -280,7 +280,7 @@ final class EntityProgram implements DumpedProgram {
 	 *
 	 * @param modelView  the matrix this pass is drawn under, which is the frame's camera for every
 	 *                   piece but the hand's and null for those. It is what the derived uniforms are
-	 *                   built from and no longer what places the geometry: {@code EntityDraw.Element}
+	 *                   built from and not what places the geometry: {@code EntityDraw.Element}
 	 *                   says why the depth nudge of a render type is not in it
 	 * @param bob        the bob that placed this piece, or null for the frame's. Only the hand passes
 	 *                   one, and it must: the projection above is built with the walk bob and the

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -309,10 +309,10 @@ public final class FrameState implements WorldState {
 			// A different world, so nothing carried over from the previous frame means anything:
 			// the camera has jumped a dimension's worth of coordinates and the shift, the history
 			// and every motion vector built from them would be one frame of nonsense. The clock is
-			// part of that and used to be the half left out, which only shows on a dimension the
+			// part of that and the half easiest to leave out, which only shows on a dimension the
 			// pack serves out of the directory it was already loaded from: nothing is read again
-			// there, so the first frame on the far side published a frameTime measuring the whole
-			// change, seconds of it, into every value a pack integrates over one.
+			// there, so the first frame on the far side would publish a frameTime measuring the
+			// whole change, seconds of it, into every value a pack integrates over one.
 			this.lastLevel = level;
 			reset();
 		}
@@ -453,8 +453,8 @@ public final class FrameState implements WorldState {
 		// And the volume itself, which is the row rather than the pair of planes the planes were
 		// worked out from: a row put back together out of two planes would be the same arithmetic
 		// done twice and rounded twice. Handed a zero offset where there is no row to be had, and
-		// then the volume published is the frame's own, which is what a pack read before this engine
-		// drew a far terrain at all.
+		// then the volume published is the frame's own, which is what a pack reads where this engine
+		// draws no far terrain at all.
 		boolean row = DhDepth.zRow(this.distantPlanes);
 		this.view.advanceDistantVolume(row ? this.distantPlanes.x : 0.0F,
 				row ? this.distantPlanes.y : 0.0F);

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -91,7 +91,7 @@ final class GeometryProgram {
 
 	/**
 	 * Everything one family of geometry answers differently, so that the rest of this class can be
-	 * written once. Each of these is read below exactly where the enum of a family used to be.
+	 * written once.
 	 *
 	 * @param family       what the log calls this geometry, {@code chunk} for a chunk pass. One word,
 	 *                     and it lands in the middle of a sentence
@@ -133,10 +133,9 @@ final class GeometryProgram {
 	 *                     cone would have closed: the lower half of the stars, the sunrise fan, a
 	 *                     rising or setting sun or moon. Or the disc's own mask is turned down,
 	 *                     which is {@code covers} below, and then nothing of the sky marks anything
-	 *                     and the seed repaints the whole of it. Both were already true before this
-	 *                     field existed, the blend alone having granted the same pixels: a defect it
-	 *                     records rather than one it introduces, and what the field buys is that it
-	 *                     is written down somewhere
+	 *                     and the seed repaints the whole of it. The blend alone grants those pixels
+	 *                     either way, so this is a defect the field records rather than one it
+	 *                     introduces, and what the field buys is that it is written down somewhere
 	 * @param afterDeferred whether the pass is drawn after the deferred stage, which is what decides
 	 *                     that a depth sampler can be answered with the opaque world's image
 	 * @param topology     how the mesh is assembled, which is the game's answer and not a choice:

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -245,9 +245,9 @@ final class GeometryProgram {
 	 * pair the pass open resolved for it.
 	 * <p>
 	 * Walked in order rather than looked up by name, and that is the whole point of it: what a name
-	 * is answered with used to be worked out again for every name at every draw, and each of those
-	 * answers is a search through {@link PbrMap} by string, a second one through the plan's map, a
-	 * cascade of equals and a switch. Only two of the questions can move between two draws of one
+	 * is answered with, worked out again for every name at every draw, is a search through
+	 * {@link PbrMap} by string, a second one through the plan's map, a cascade of equals and a
+	 * switch, each time. Only two of the questions can move between two draws of one
 	 * pass, and both are the same question: which image this draw brought.
 	 */
 	private static final class Sampled {
@@ -347,7 +347,7 @@ final class GeometryProgram {
 	 * that says what it costs the BLEND rather than what it costs the colour. Kept as a field
 	 * because it is answered where {@code owns} is in scope and said where it is not.
 	 * <p>
-	 * <strong>It no longer has a cause of its own, and that is worth saying rather than leaving a
+	 * <strong>It has no cause of its own, and that is worth saying rather than leaving a
 	 * reader to work out.</strong> Every blending pass drawn before the seed either writes the mask
 	 * or has an opaque sibling of its own family marking those pixels, so what is left here is a
 	 * pass that asked for a mask and could not be given one, which the constructor has already
@@ -432,8 +432,8 @@ final class GeometryProgram {
 		// drawn and then thrown away: the final overwrites that target with the image the chain
 		// composed out of a colortex the water never reached.
 		//
-		// Every opaque half used to keep it on the game's target and reach the pack's colortex
-		// through the seed, which was one conversion too many. What a gbuffers program puts in draw
+		// Keeping every opaque half on the game's target and reaching the pack's colortex through
+		// the seed is one conversion too many. What a gbuffers program puts in draw
 		// buffer nought is not a colour but whatever the pack packed there, and the game's target is
 		// eight bits a channel: Bliss packs two values into each channel of a sixteen bit colortex1,
 		// and the trip through the game's target quantised its albedo away entirely, leaving the
@@ -521,7 +521,7 @@ final class GeometryProgram {
 		// no output at all - its whole body is one discard test, so the count is nought - and a pass
 		// with no colour attachment is one the encoder accepts on the strength of its depth while
 		// the pipeline substitutes a state of its own, which is the mismatch this file refuses by
-		// name elsewhere. It draws into the map and into nought, exactly as before this rule.
+		// name elsewhere. It draws into the map and into nought, exactly as it would without this rule.
 		//
 		// And never more than a pipeline holds states for. The builder writes them into an array of
 		// that length, so one rank past it is an index out of bounds where the program is built
@@ -1680,8 +1680,8 @@ final class GeometryProgram {
 		// is continuous in the same way, carrying the light that came through glass and water
 		// across a penumbra, and both OptiFine and Iris filter it linearly.
 		//
-		// The shadow DEPTH is LINEAR too, and the reason that used to be given here for keeping it
-		// NEAREST was wrong: where the compare mode is on, a sampler averages the RESULTS of the
+		// The shadow DEPTH is LINEAR too, and the reason a reader reaches for to keep it NEAREST
+		// does not hold: where the compare mode is on, a sampler averages the RESULTS of the
 		// four tests and never the depths, so nothing is ever compared against a surface that exists
 		// nowhere. Iris filters this LINEAR whatever the pack asks, its SamplingSettings starting at
 		// nearest=false, and adds GL_COMPARE_REF_TO_TEXTURE on top only where the pack writes

--- a/common/src/main/java/dev/vitrail/render/HorizonCone.java
+++ b/common/src/main/java/dev/vitrail/render/HorizonCone.java
@@ -61,12 +61,12 @@ import net.minecraft.client.Minecraft;
  * on the boundary between the two at the tail of the first one, and the plan never puts the world
  * past that boundary: the rank counts the begins and the prepares, and {@code deferredEnd()} counts
  * those and the deferred stage after them. A place shipping no deferred at all has the two equal,
- * and it is that equality the walk used to lose: on a half open interval alone the seed missed the
- * first half and led the second, at {@code AfterLevel}, by which time the clouds, the weather and
- * the particles are in the game's target and the mask would have taken them. Measured on the corpus
- * before it was fixed: one place in twenty five, Body Camera's overworld. The same state is
- * reachable on any pack through {@code passes=}, which removes passes from the running list exactly
- * as {@code terrain=off} removes the terrain, and it is no longer a state that costs anything.
+ * and it is that equality a half open interval loses: the seed would miss the first half and lead
+ * the second, at {@code AfterLevel}, by which time the clouds, the weather and the particles are in
+ * the game's target and the mask would have taken them. Measured on the corpus: one place in twenty
+ * five, Body Camera's overworld. The same state is reachable on any pack through {@code passes=},
+ * which removes passes from the running list exactly as {@code terrain=off} removes the terrain,
+ * and it costs nothing here.
  * <p>
  * <strong>The one thing that would be lost is the world itself</strong>, and only where the world
  * reaches the pack's colour target through that same seed rather than writing it. There the cone
@@ -142,7 +142,7 @@ final class HorizonCone {
 	 * comment gives in full. An answer nobody has given yet counts as no, and costs the first frame
 	 * of a world its cone: the geometry is read where the chunk renderer picks its shader, which is
 	 * after the sky in the frame, so the first sky of a world is drawn before the world has said
-	 * anything. That frame then looks exactly as it looked before this class existed, which is the
+	 * anything. That frame then looks exactly as it does without this class, which is the
 	 * one wrong answer that cannot make a picture worse.
 	 *
 	 * @param program what is drawing it, for the one line that says it happened

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -64,16 +64,14 @@ import java.util.concurrent.atomic.AtomicInteger;
  * this class: two answers to "which half does this pass write" produce no error at all, only a
  * picture that is plausible and wrong.
  * <p>
- * What it cannot do yet has to be said rather than covered up, and this paragraph said something
- * else for a while: it claimed no geometry program runs at all, which {@link TerrainDraw},
- * {@link GeometryProgram} and {@link SkyDraw} have all contradicted since. What is true is narrower.
- * The families that still come from the game reach the pack's first target through
- * {@link SceneSeed}, carrying the game's finished frame, and every other buffer starts from its
- * clear colour underneath them. A pass reading normals or a material id off one of those pixels
- * reads nothing of the sort. Which families those are is {@link #announceSeed}'s to say and not
- * this comment's, a list written twice being a list that drifts; and that line does not always
- * appear, since a place with no seed in its plan and a run with the seed switched off both leave
- * the target on its clear colour instead, and both say so in their own words.
+ * What it cannot do yet has to be said rather than covered up. The families that still come from
+ * the game reach the pack's first target through {@link SceneSeed}, carrying the game's finished
+ * frame, and every other buffer starts from its clear colour underneath them: a pass reading
+ * normals or a material id off one of those pixels reads nothing of the sort. Which families those
+ * are is {@link #announceSeed}'s to say and not this comment's, a list written twice being a list
+ * that drifts, and it is not always said at all, a place with no seed in its plan and a run with
+ * the seed switched off both leaving the target on its clear colour instead. What the seed costs
+ * the image is in {@code docs/frame.md}.
  * <p>
  * Two lifecycle traps are paid for here rather than rediscovered. The device caches a compiled
  * module under an identifier, a stage and a set of defines, never under the source, so every load
@@ -132,12 +130,12 @@ public final class PackChain {
 	 * Whether {@code pack.txt} named a pack this folder does not hold, which is the one way of
 	 * drawing nothing that is not a way of asking for nothing.
 	 * <p>
-	 * <strong>Held apart from {@link #packOff} because the two ended in the same place and mean
-	 * opposite things.</strong> A file saying {@code none} asked for the game's own image and got it,
-	 * so nothing is wrong and nothing is said. A file naming a pack that was renamed, deleted or
-	 * mistyped asked for a picture and got the game's, and it used to raise {@link #packOff} as well:
-	 * the screen then read "No shader pack: the game draws its own image", which says the player got
-	 * what they asked for at the moment they did not.
+	 * <strong>Held apart from {@link #packOff}, near enough to be folded into it and meaning the
+	 * opposite.</strong> A file saying {@code none} asked for the game's own image and got it, so
+	 * nothing is wrong and nothing is said. A file naming a pack that was renamed, deleted or
+	 * mistyped asked for a picture and got the game's, and answering that one with {@code packOff}
+	 * puts "No shader pack: the game draws its own image" on the screen, which tells the player they
+	 * got what they asked for at the moment they did not.
 	 */
 	private static volatile boolean packMissing;
 
@@ -163,11 +161,10 @@ public final class PackChain {
 	/**
 	 * Whether this frame's values have been moved on yet.
 	 * <p>
-	 * The frame used to begin where the chain draws, which is after the world. A terrain program runs
-	 * during the world and reads the same block, so whichever of the two comes first opens the frame
-	 * and {@link #draw} closes it. Two advances in one frame would shift the previous frame's
-	 * matrices twice and make every {@code smooth()} in the pack fade at twice the speed, with
-	 * nothing on screen to say so.
+	 * A terrain program runs during the world and reads the same block the chain reads after it, so
+	 * whichever of the two comes first opens the frame and {@link #draw} closes it. Two advances in
+	 * one frame would shift the previous frame's matrices twice and make every {@code smooth()} in
+	 * the pack fade at twice the speed, with nothing on screen to say so.
 	 * <p>
 	 * The chain's own and not the class's, because the store it guards is the chain's own. A reload
 	 * runs at the top of {@link #draw}, in the middle of a frame the terrain has already opened, and
@@ -267,12 +264,11 @@ public final class PackChain {
 	 * Whether {@link #openFeatures()} really posed the game's overrides, which is the one thing
 	 * {@link #closeFeatures()} may take back down and compose on.
 	 * <p>
-	 * Held here rather than read back off {@code RenderSystem.outputColorTextureOverride}, which is
-	 * where it used to be read from. That field is the game's own and the game sets it for its own
-	 * always-on-top features, and openFeatures now has a reason of its own to refuse: the two
-	 * questions were the same only while it never did. Read off the wrong one, a refused frame
-	 * composes a layer nothing drew into, the frame before's, the clear living in the open that
-	 * refusal skipped.
+	 * Held here rather than read back off {@code RenderSystem.outputColorTextureOverride}. That field
+	 * is the game's own and the game sets it for its own always-on-top features, and
+	 * {@link #openFeatures()} has a reason of its own to refuse, so the two questions are not one.
+	 * Read off the game's, a refused frame composes a layer nothing drew into, the frame before's,
+	 * the clear living in the open that refusal skipped.
 	 */
 	private boolean redirected;
 

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -488,7 +488,7 @@ public final class PackChain {
 		// all leaves the screen naming nothing rather than whatever the load before it asked for.
 		askedFor = PackFile.EMPTY;
 		try {
-			// Read here and no longer inside choose(), which the empty folder road below returns ahead
+			// Read here rather than inside choose(), which the empty folder road below returns ahead
 			// of. That road is the one a player takes who has just renamed or deleted their only pack,
 			// and without the name this far up it is the one road that cannot say which of the two
 			// happened: the folder is empty, which is true, and is not what they did.
@@ -556,9 +556,8 @@ public final class PackChain {
 			// through here, on the render thread, and neither has anything new to report.
 			//
 			// Never fatal either, and that is the whole reason for the catch. It is a report and not
-			// the drawing: it used to swallow its own failures and the pack was prepared anyway, and
-			// letting one reach the catch below would turn a diagnosis that could not be taken into
-			// a pack that is not drawn.
+			// the drawing, so its own failures stop here: letting one reach the catch below would
+			// turn a diagnosis that could not be taken into a pack that is not drawn.
 			if (!pack.equals(reported)) {
 				try {
 					PackReport.log(PackLoader.load(pack));
@@ -621,10 +620,10 @@ public final class PackChain {
 			// than an incomplete one.
 			//
 			// **Here and not one line earlier**, and TerrainDraw.wanted above is the reason. It settles
-			// what the chunk mesh carries, and returning before it left that answer at its
-			// default, so a refused pack decided the mesh for whichever pack was picked after it.
-			// That used to last the whole run; the mesh follows the pack now, so what it costs is a
-			// rebuilt world rather than a session. The session is published by then as well, so the
+			// what the chunk mesh carries, and returning ahead of it would leave that answer at its
+			// default, so a refused pack would decide the mesh for whichever pack was picked after
+			// it. The mesh follows the pack, so what that costs is a rebuilt world rather than a
+			// session. The session is published by then as well, so the
 			// settings screen shows the pack it is refusing rather than an empty list, which is
 			// where the two other refusals of this method stand.
 			//
@@ -1377,8 +1376,8 @@ public final class PackChain {
 	/**
 	 * Called when the client leaves a world, on the render thread and between two frames.
 	 * <p>
-	 * Nothing of this engine used to hear about it, and the whole of what a pack costs stayed
-	 * allocated for as long as the player sat in the menu: the colour targets, the shadow map, the two
+	 * Nothing of this engine hearing about it leaves the whole of what a pack costs allocated for as
+	 * long as the player sits in the menu: the colour targets, the shadow map, the two
 	 * depth images, the feature layer and every ring buffer, which is about a hundred megabytes of
 	 * video memory on BSL at 1080p, held for a screen that draws a panorama. What is freed here is
 	 * exactly what a reload frees, and everything of it is made again by the first frame of the next
@@ -1560,7 +1559,7 @@ public final class PackChain {
 	 * The OptiFine frame runs shadow, prepare, opaque geometry, deferred, translucent geometry,
 	 * composite, final, and packs are written against exactly that: BSL's {@code gbuffers_water}
 	 * reads {@code gaux1}, which its own {@code deferred} writes, and discards every fragment where
-	 * it reads nought. Run after the world, as the whole chain used to be, that read finds a clear
+	 * it reads nought. Run after the world, that read finds a clear
 	 * colour and the water is thrown away in its entirety.
 	 * <p>
 	 * Called once a frame, from {@code AfterOpaqueFeatures}, which is the moment the game has
@@ -1613,7 +1612,7 @@ public final class PackChain {
 		// this is the one point of the frame reached exactly when DH's far terrain matters to a
 		// pack. What it costs is that a takeover lands on the NEXT frame, DH having drawn its LODs
 		// long before this line; nothing of the picture turns on that, the frame before it being
-		// the picture this engine drew before this door existed.
+		// what this engine draws with the door shut.
 		DhLods.install();
 
 		GpuTextureView served = chain.distant.served();
@@ -2327,11 +2326,9 @@ public final class PackChain {
 	private void announceSeed(boolean seeding) {
 		Optional<ChainPlan.Seed> where = this.chain.chain().seed();
 		if (seeding && where.isPresent()) {
-			// What the seed still carries is not a constant any more, and this line is where docs/
-			// sends a reader for it. Composed from the switches rather than written out, or it goes
-			// stale the day the next family lands, in the one place that must not. It DID go stale
-			// exactly that way once, naming the weather after the weather had landed and never
-			// naming the particles at all, which is why the list is now built rather than branched.
+			// What the seed still carries is not a constant, and this line is where docs/ sends a
+			// reader for it. Composed from the switches rather than written out, or it goes stale
+			// the day the next family lands, in the one place that must not.
 			//
 			// The switch and NOT what the pack turned out to serve, which is a real limit and not a
 			// shortcut: this runs when the chain is built and the entity programs are read at the

--- a/common/src/main/java/dev/vitrail/render/PackDefines.java
+++ b/common/src/main/java/dev/vitrail/render/PackDefines.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * filled the same way ({@code mixin/MixinBiomes.java:14-22}) and whose defines are written from it
  * ({@code shaderpack/IrisDefines.java:28}).
  * <p>
- * The world-join reload stays even though the biome symbols no longer need it, because the
+ * The world-join reload stays even though the biome symbols do not need it, because the
  * symbols were never the only thing riding it: {@code block.properties} may name block TAGS, and
  * {@code BlockStateIds} can only resolve those once the world's own registries exist
  * ({@code BlockStateIds.java:86-88}, resolving through {@code BuiltInRegistries.BLOCK.getTags()}

--- a/common/src/main/java/dev/vitrail/render/PackDepth.java
+++ b/common/src/main/java/dev/vitrail/render/PackDepth.java
@@ -44,7 +44,7 @@ import java.util.Optional;
  * reason: {@link ShadowTargets} writes the forward window so that a {@code shadowtex} lookup never
  * has to be wrapped. This is that rule applied to the world's depth as well.
  * <p>
- * Nothing is lost against what the shader used to compute. The operation is the same one, in the
+ * Nothing is lost against a shader computing it itself. The operation is the same one, in the
  * same place in the order, applied before any filtering: {@code |readA|} is one, the image is bound
  * NEAREST, and a {@code textureGather} or a {@code texelFetch} therefore comes back bit for bit
  * what it came back before. What is spent is memory, a full screen image of one float per moment
@@ -486,7 +486,7 @@ final class PackDepth {
 		}
 
 		// Said out loud rather than left to be discovered: this is two full screen images of a float
-		// each where there used to be one copy of the game's depth, about eight more mebibytes at
+		// each in place of one copy of the game's depth, about eight more mebibytes at
 		// 1080p and thirty-two at 4K.
 		Vitrail.logger().info("The world's depth is converted into the pack's window in two images at "
 				+ "{}x{}, {} MiB", width, height,

--- a/common/src/main/java/dev/vitrail/render/PackDump.java
+++ b/common/src/main/java/dev/vitrail/render/PackDump.java
@@ -131,11 +131,11 @@ final class PackDump {
 				return;
 			}
 
-			// Said once and the line left armed, which is not what this did: it used to turn the
-			// dump off outright, and that was right only while everything a place draws with was read
-			// on its first frame. Three families are read at the moment the world first draws one, so
-			// naming a piece of the sky or an entity was refused before the thing existed and stayed
-			// refused for the rest of the session. What is listed is therefore what has been read SO
+			// Said once and the line left armed, rather than turning the dump off outright: that
+			// would be right only while everything a place draws with is read on its first frame.
+			// Three families are read at the moment the world first draws one, so naming a piece of
+			// the sky or an entity would be refused before the thing existed and stay refused for
+			// the rest of the session. What is listed is therefore what has been read SO
 			// FAR and the line says as much, since another family reading later still answers.
 			said = true;
 			Vitrail.logger().warn("{}={} names nothing read so far, so nothing is dumped yet. Read so "

--- a/common/src/main/java/dev/vitrail/render/PackImages.java
+++ b/common/src/main/java/dev/vitrail/render/PackImages.java
@@ -144,7 +144,7 @@ final class PackImages {
 
 	/**
 	 * One texture, decoded. Null when it cannot be, with the reason in the notes: a name nothing
-	 * could be read for reads black rather than reading whatever that name used to mean.
+	 * could be read for reads black rather than whatever that name meant before the pack took it over.
 	 */
 	private static Image decode(PackTexture texture, VolumeAtlas atlas, ShaderPackSource source,
 			List<String> notes) {

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -60,7 +60,7 @@ import java.util.stream.Collectors;
  * them may repeat. The device caches a compiled module under the identifier, the stage and the
  * defines, and never under the source, so two programs given one identifier are one program: the
  * second is not compiled at all, the first one's SPIR-V is drawn with the second one's targets
- * and samplers, and nothing says so. A chain is ten programs where a final alone used to be one,
+ * and samplers, and nothing says so. A chain is ten programs where a final alone is one,
  * and it is reloaded every time a setting is forced, so the constructor refuses a name it has
  * already handed out rather than trusting the rule to hold.
  * <p>
@@ -498,7 +498,7 @@ final class PackPass {
 				// White where no image is there, and white is the far plane rather than a
 				// placeholder: what a depth lookup reads is now an image already in the pack's own
 				// window, where one is the far plane, and the whole world would otherwise be drawn
-				// against the camera. It follows the image and no longer the convention of the
+				// against the camera. It follows the image rather than the convention of the
 				// target, which is what makes it the same answer as the shadow map's.
 				case DEPTH -> depth(binding.sampler(), targets, depthView);
 				// White where the map is not there, and white is the far plane rather than a
@@ -527,7 +527,7 @@ final class PackPass {
 				// layout carries it either way and the draw throws on the first name it misses.
 				//
 				// A pack texture reaches this line only when the pack took the name over and
-				// nothing could be read for it, which no longer covers a file the pack simply does
+				// nothing could be read for it, which does not cover a file the pack simply does
 				// not ship: that case hands the name back and the colour target keeps its ordinary
 				// binding, as it does under Iris. What is left here is a declaration that named
 				// something real and could not be turned into an image, and black is the honest
@@ -545,17 +545,18 @@ final class PackPass {
 			// that came through stained glass and water, which a pack blurs across a penumbra; read
 			// NEAREST it steps in blocks the size of a shadow texel.
 			//
-			// The shadow DEPTH is LINEAR for a reason of its own, and the reason it used to be
-			// NEAREST was wrong. An averaged depth would indeed be a comparison against a surface
-			// standing nowhere, but that is true of an ordinary sampler and not of a comparison one,
-			// where the hardware compares first and averages the RESULTS; and the comparison this
-			// engine makes for itself takes its four texels with textureGather, which no bound
-			// filter reaches either way. What the filter really decides is the other read, the one
-			// every pack of the corpus makes: a PCF loop that samples shadowtex as a plain
-			// sampler2D and expects each of its taps to be smoothed over a texel. Iris filters both
-			// depth images LINEAR unless the pack asks otherwise, since SamplingSettings.nearest
-			// starts false (ShadowRenderer.configureDepthSampler), so read NEAREST every edge of
-			// such a loop walks in texels of the map however many taps it pays for.
+			// The shadow DEPTH is LINEAR for a reason of its own, and the reason a reader reaches
+			// for to keep it NEAREST does not hold. An averaged depth would indeed be a comparison
+			// against a surface standing nowhere, but that is true of an ordinary sampler and not
+			// of a comparison one, where the hardware compares first and averages the RESULTS; and
+			// the comparison this engine makes for itself takes its four texels with textureGather,
+			// which no bound filter reaches either way. What the filter really decides is the other
+			// read, the one every pack of the corpus makes: a PCF loop that samples shadowtex as a
+			// plain sampler2D and expects each of its taps to be smoothed over a texel. Iris
+			// filters both depth images LINEAR unless the pack asks otherwise, since
+			// SamplingSettings.nearest starts false (ShadowRenderer.configureDepthSampler), so read
+			// NEAREST every edge of such a loop walks in texels of the map however many taps it
+			// pays for.
 			//
 			// The three names that would ask for NEAREST back - shadowtexNearest, shadowtexNNearest
 			// and shadowNMinMagNearest - are not read: no pack of the corpus writes one.

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -397,7 +397,7 @@ public final class PackValues {
 	 * it.</strong> Seven of the eight packs tested declare {@code shadowDistanceRenderMul}, six of
 	 * them at one, so they take the first branch and are bounded at their own half plane whatever
 	 * the slider says. That is the pack getting the distance it asked for and was tuned against; it
-	 * is parity, and it is a walk that stops earlier than this engine used to stop it.
+	 * is parity, and it is a walk that stops earlier than the slider on its own would.
 	 *
 	 * @param userChunks           what the player asked for, in chunks
 	 * @param renderDistanceChunks the game's effective render distance, in chunks, which is as far

--- a/common/src/main/java/dev/vitrail/render/ParticleDraw.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleDraw.java
@@ -518,7 +518,7 @@ public final class ParticleDraw {
 	 * Where the outputs of one half belong, in draw buffer order and each on the half of the schedule
 	 * its side of the deferred stage gives it, or null when this place cannot answer for it.
 	 * <p>
-	 * Empty is not a refusal, and it is no longer the pack's silence: a program that declares no draw
+	 * Empty is not a refusal, and it is not the pack's silence: a program that declares no draw
 	 * buffer is answered colortex0, as Iris answers it. What is left is the plan having no answer at
 	 * all for the file that serves this half, and what puts a file there is the one list
 	 * {@link ChainPlan#geometry} carries. No place of the corpus is in that case.

--- a/common/src/main/java/dev/vitrail/render/PbrAtlas.java
+++ b/common/src/main/java/dev/vitrail/render/PbrAtlas.java
@@ -206,7 +206,7 @@ final class PbrAtlas implements AutoCloseable {
 					.orElseGet(() -> new FrameSize(read.getWidth(), read.getHeight()));
 		} catch (IOException | RuntimeException e) {
 			// The whole read in one try, the close of the stream included: a failure between the
-			// decode and the metadata used to leave the image allocated with nothing holding it, and
+			// decode and the metadata leaves the image allocated with nothing holding it, and
 			// native memory nothing points at is not memory anything gets back.
 			if (image != null) {
 				image.close();

--- a/common/src/main/java/dev/vitrail/render/SceneSeed.java
+++ b/common/src/main/java/dev/vitrail/render/SceneSeed.java
@@ -57,7 +57,7 @@ import java.util.Optional;
  * every real depth is in front of, so those pixels take the game's picture through the same
  * comparison and owe no test of their own. That is the whole of why the mask is a depth: the two
  * questions a flag needed - did the pack write here, and has anything moved closer since - are one
- * number and one test, and the depth the pack's geometry left no longer has to be copied into an
+ * number and one test, and the depth the pack's geometry left does not have to be copied into an
  * image of its own before the game's features overwrite it.
  * <p>
  * This is not a fallback and should not be read as one. The first draw buffer of the terrain pass
@@ -67,12 +67,12 @@ import java.util.Optional;
  * through {@code gbuffers_textured}, whose draw buffers start at colortex4. The whole class goes
  * away the day the gbuffers run, and the mask with it.
  * <p>
- * <strong>The other draw buffers of that program are emptied wherever the scene lands on top of
- * it, or the pixel carries half a gbuffer.</strong> A gbuffers program fills all of its targets in
- * one draw, so a pixel it touched carries a set of targets that agree with one another. The seed
- * used to write the first of them alone, and where the mask is set and the game drew in front - a
- * mob standing against a wall - the colour became the mob's while the normal, the specular and the
- * lightmap stayed the wall's, and the deferred stage lit the one with the other. Those are the only
+ * <strong>The other draw buffers of that program are emptied wherever the scene lands on top of it,
+ * or the pixel carries half a gbuffer.</strong> A gbuffers program fills all of its targets in one
+ * draw, so a pixel it touched carries a set of targets that agree with one another. A seed writing
+ * the first of them alone would leave the colour the mob's while the normal, the specular and the
+ * lightmap stay the wall's, wherever the mask is set and the game draws in front - a mob standing
+ * against a wall - and the deferred stage would light the one with the other. Those are the only
  * pixels emptied, and the reason for the narrowness is the same one: everywhere else the pack's own
  * geometry wrote nothing at all into those targets, and whatever is there is a prepare's or the
  * clear's and none of the seed's business.

--- a/common/src/main/java/dev/vitrail/render/SkyDraw.java
+++ b/common/src/main/java/dev/vitrail/render/SkyDraw.java
@@ -429,13 +429,13 @@ public final class SkyDraw {
 	 * Reads the pack for all eight pieces at once, at the first of them the game draws, and settles
 	 * where every one of them is drawn.
 	 * <p>
-	 * All eight and not the one being asked for, which is what this used to do. The game reaches four
+	 * All eight and not the one being asked for. The game reaches four
 	 * of these pieces at moments of its own choosing: the band is skipped until its alpha passes a
 	 * thousandth, the stars until their brightness leaves nought, the void plane until the eye goes
 	 * under the world's horizon, and the End's flash until its own clock brings one round, which it
 	 * does once every six hundred ticks for a stretch drawn at random. Read one at a time, the pack
-	 * was opened, expanded and translated inside the frame the sun first neared the horizon, on the
-	 * render thread and in the middle of the world. The compiling is not moved with it and still
+	 * would be opened, expanded and translated inside the frame the sun first neared the horizon, on
+	 * the render thread and in the middle of the world. The compiling is not moved with it and still
 	 * falls where the piece is first drawn, one module a piece.
 	 * <p>
 	 * The two branches of the game's sky pass are read together and neither waits for the other, which
@@ -561,7 +561,7 @@ public final class SkyDraw {
 	 * <p>
 	 * A piece is one of these for either of two reasons, and they weigh the same: the pack serves no
 	 * program for it, so the game's own shader draws it, or it serves one the plan has no answer for.
-	 * The second is no longer the pack's silence, a program that declares no draw buffer being
+	 * The second is not the pack's silence, a program that declares no draw buffer being
 	 * answered colortex0 as Iris answers it: what puts a file there is the one list
 	 * {@link ChainPlan#geometry} carries, plus the targets the pack asked to be scaled, which
 	 * {@link #writes} turns down above. Both leave that piece reaching the pack's colour target

--- a/common/src/main/java/dev/vitrail/render/SkyProgram.java
+++ b/common/src/main/java/dev/vitrail/render/SkyProgram.java
@@ -95,15 +95,9 @@ final class SkyProgram implements DumpedProgram {
 				// discard at exactly those pixels, on the mask their own siblings wrote: no stars, no
 				// sun, no moon and no flash.
 				//
-				// WHAT IT DOES NOT COVER, and the repository already knew: the game draws the dark
-				// disc only while the eye is under the world's horizon height and not underwater,
-				// and the top disc stops at atan(16/512) over the horizontal, so nothing of the
-				// game's marks the band that the lower half of the stars, the sunrise fan and a
-				// rising or setting sun stand in. What marks it is ours, HorizonCone, which shares
-				// the disc's pass and its mask - and which is drawn only for a pack whose world
-				// writes the colour target rather than reaching it through the seed. There, and
-				// over the whole sky wherever the disc's own mask is turned down, the overworld's
-				// four are repainted, exactly as they were before this field existed.
+				// The band the game's own discs leave open is marked by ours, HorizonCone, which
+				// shares the disc's pass and its mask. What that still does not cover is written
+				// where the field is declared, GeometryProgram.Pass#claimed.
 				element.covers(), true, false, element.topology(),
 				// Five pipelines under the eight passes, the disc sharing one with the dark plane and
 				// the End's flash sharing another with the sun and the moon, and not one of the five

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -214,7 +214,7 @@ public final class TerrainDraw {
 	 * <p>
 	 * A reading that throws takes the terrain down rather than the pack: the sky and the entities are
 	 * read from the same archive and have their own answer about it, and a world drawn by the game
-	 * under a pack's sky is what this used to leave behind.
+	 * under a pack's sky is what this would otherwise leave behind.
 	 */
 	void read() {
 		if (!wanted) {
@@ -247,9 +247,9 @@ public final class TerrainDraw {
 	 * renderer again and where {@code TerrainMesh.settle} takes this answer.
 	 * <p>
 	 * <strong>Two packs that both draw the terrain are the case this exists for.</strong> The flag
-	 * above does not move between them, and the ids moving is what used to rebuild the world;
-	 * two packs reading different names of the mesh with the same {@code block.properties} would have
-	 * left the sections at a stride nothing was writing.
+	 * above does not move between them, and a rebuild that hung on the ids moving would not fire:
+	 * two packs reading different names of the mesh with the same {@code block.properties} would
+	 * leave the sections at a stride nothing writes.
 	 * <p>
 	 * Silent before a world is joined, where nothing has been meshed and the first reading answers
 	 * itself.
@@ -554,12 +554,12 @@ public final class TerrainDraw {
 	 * stage is declared open.
 	 * <p>
 	 * {@link #shadowsServed} is a promise the first compilation can still break, because
-	 * {@code broken} is raised by that compilation and it used to happen inside the pass the renderer
-	 * had already opened. A refusal there is safe for a camera pass and is the opposite here: with
-	 * nothing of ours handed back, Sodium opens its own pass on the target {@code vitrail$target}
-	 * gave it, the game's own, and the shadow half repaints the whole opaque world over the finished
-	 * image, coplanar and under the same reversed Z so nothing stops it. Asked here, the same
-	 * refusal only closes the stage.
+	 * {@code broken} is raised by that compilation, and raising it inside the pass the renderer has
+	 * already opened is what this avoids. A refusal there is safe for a camera pass and is the
+	 * opposite here: with nothing of ours handed back, Sodium opens its own pass on the target
+	 * {@code vitrail$target} gave it, the game's own, and the shadow half repaints the whole opaque
+	 * world over the finished image, coplanar and under the same reversed Z so nothing stops it.
+	 * Asked here, the same refusal only closes the stage.
 	 * <p>
 	 * Everything it does is done again by the real prepare a few lines of the renderer later, and
 	 * every bit of it is idempotent: {@code precompilePipeline} is a computeIfAbsent, the three

--- a/common/src/main/java/dev/vitrail/render/TerrainProgram.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainProgram.java
@@ -38,15 +38,15 @@ import java.util.Optional;
  * The work of drawing one is {@link GeometryProgram}'s and is not done here twice: this class is
  * what makes that work Sodium's. It reads the three programs out of the pack, answers
  * {@link GeometryProgram.Pass} out of {@link TerrainPass}, and checks that the mesh is still the one
- * the prologue decodes. Everything else it is asked for it hands straight on, and the surface it
- * keeps is the one {@link TerrainDraw} and {@link PackDump} were already written against.
+ * the prologue decodes. Everything else it is asked for it hands straight on, keeping the surface
+ * {@link TerrainDraw} and {@link PackDump} call.
  * <p>
- * Nothing of the mesh is changed: the attributes it carries are decoded and the names it does not
- * carry are given constants, which {@link SodiumVertex} spells out. What separates the three is not
- * the geometry but the pass, and {@link TerrainPass} holds all of it: which program the pack serves
- * it with, what alpha the fragment stage discards at, and whether the result is blended. The first
- * two are settled at translation and reach here already written into the text; only the blend is a
- * property of the pipeline, and it is one of the answers passed on below.
+ * The mesh is left as it stands, as it is for every family, and which names Sodium's really carries
+ * is {@link SodiumVertex}'s to spell out. What separates the three is not the geometry but the
+ * pass, and {@link TerrainPass} holds all of it: which program the pack serves it with, what alpha
+ * the fragment stage discards at, and whether the result is blended. The first two are settled at
+ * translation and reach here already written into the text; only the blend is a property of the
+ * pipeline, and it is one of the answers passed on below.
  * <p>
  * <strong>The pipeline is named in a namespace containing {@code sodium}, and that is not a
  * cosmetic.</strong> blaze3d never declares a push constant range; Sodium adds one by a mixin on

--- a/common/src/main/java/dev/vitrail/render/WeatherDraw.java
+++ b/common/src/main/java/dev/vitrail/render/WeatherDraw.java
@@ -458,7 +458,7 @@ public final class WeatherDraw {
 	 * Where the outputs of the file that serves the weather belong, in draw buffer order and each on
 	 * the half the schedule gives it, or null when this place cannot answer at all.
 	 * <p>
-	 * Empty is not a refusal, and it is no longer the pack's silence: a program that declares no draw
+	 * Empty is not a refusal, and it is not the pack's silence: a program that declares no draw
 	 * buffer is answered colortex0, as Iris answers it, and the curtain then lands in the pack's own
 	 * target rather than on the game's. What is left is the plan having no answer at all for the file
 	 * that serves the weather, and what puts a file there is the one list

--- a/common/src/main/java/dev/vitrail/screen/SettingsKey.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsKey.java
@@ -95,11 +95,10 @@ public final class SettingsKey {
 	 * that same question. Iris says both lines too, {@code Iris.java:184} and {@code Iris.java:191},
 	 * off a catch rather than off a question because throwing is what its own reload does.
 	 * <p>
-	 * <b>A reading that read nothing because the named pack is gone answers as a failure</b>, which it
-	 * did not always: a {@code pack.txt} naming a pack the folder no longer holds used to be warned
-	 * about and then treated as no pack having been asked for, so this line said "Shaders Reloaded!"
-	 * over a reading that had opened nothing, and the screen's own bottom line went further and said
-	 * the game was drawing its own image on purpose. Asking for no pack at all is still no failure and
+	 * <b>A reading that read nothing because the named pack is gone answers as a failure.</b> Warned
+	 * about and then treated as no pack having been asked for, it would put "Shaders Reloaded!" over
+	 * a reading that opened nothing, and the screen's own bottom line would go further and say the
+	 * game was drawing its own image on purpose. Asking for no pack at all is still no failure and
 	 * still says the first line, which is the whole distinction: {@code PackChain.packMissing} holds
 	 * it.
 	 */

--- a/common/src/main/java/dev/vitrail/settings/SettingsFile.java
+++ b/common/src/main/java/dev/vitrail/settings/SettingsFile.java
@@ -32,8 +32,8 @@ import java.util.Map;
  * holding it.
  * <p>
  * Read and written in ISO-8859-1, which is what OptiFine specifies for these files and what Iris
- * does on both sides. Strict UTF-8 threw on any byte past 0x7F, and the file is no longer ours
- * alone to keep in ASCII. The one exception is the file {@link #migrate} carries over, read as the
+ * does on both sides. Strict UTF-8 throws on any byte past 0x7F, and the file is not ours alone to
+ * keep in ASCII. The one exception is the file {@link #migrate} carries over, read as the
  * UTF-8 this engine wrote it in.
  * <p>
  * A name the pack no longer declares is kept and reported once. Dropping it, which is what Iris
@@ -232,7 +232,7 @@ public final class SettingsFile {
 	 * lets a file written by Iris, whose first line is the date it wrote it, be read as is.
 	 * <p>
 	 * {@link #PROFILE_KEY} is dropped, and only {@link #migrate} ever does anything else with it.
-	 * Nothing writes it any more, and kept it would stop being the name of a set of values and
+	 * Nothing writes it, and kept it would stop being the name of a set of values and
 	 * become one: it would go down with the settings, and a pack declaring an option literally
 	 * called {@code profile} would have that declaration rewritten to the profile's name. What
 	 * dropping it costs is the same pack, whose {@code profile} setting can then not be chosen from

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
@@ -107,9 +107,8 @@ import org.joml.Vector4f;
  * {@code -109.125}, giving {@code -21.83 + 77.16 = 55.33 >= 0}. Kept, as it must be, being in plain
  * sight.</li>
  * <li>Behind the camera, centre {@code (0, -40, 100)}: the left plane {@code (-0.7071, 0, -0.7071,
- * 0)} gives {@code 6.45 - 64.25 = -57.80 < 0}. Dropped. Under the box the light was culled with
- * before this class existed it was kept, and that one section is the whole of what this change
- * buys.</li>
+ * 0)} gives {@code 6.45 - 64.25 = -57.80 < 0}. Dropped. Under the light's own box alone it would be
+ * kept, and that one section is the whole of what this class buys.</li>
  * <li>Above the camera and out of its view, centre {@code (0, 80, -20)}: the camera's own top plane
  * {@code (0, -0.7071, -0.7071, 0)} gives {@code -50.12 + 20.59 = -29.53 < 0}, so the camera cannot
  * see it, while the bottom plane gives {@code 63.02 + 20.59 = 83.61 >= 0} and every other kept plane

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -170,9 +170,9 @@ public final class ShadowTerrain {
 		ShadowCasters casters = TerrainDraw.shadowCasters();
 		ShadowGeometry.gather(light, camera, casters);
 
-		// The frame counter first, and it is the piece the three failed designs before this one
-		// were missing: the per region lists only reset themselves for the first walk of a frame,
-		// so a second walk under the same number appends to the camera's lists until it overflows
+		// The frame counter first, and it is the piece easiest to miss: the per region lists only
+		// reset themselves for the first walk of a frame, so a second walk under the same number
+		// appends to the camera's lists until it overflows
 		// them. The walk itself is the synchronous fallback, which is the one path that neither
 		// consults the asynchronous occlusion tree, empty for a viewport it has never seen, nor
 		// waits for it.

--- a/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
+++ b/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
@@ -244,9 +244,10 @@ public final class TerrainMesh implements ChunkVertexType {
 
 		said = carried;
 		if (carried.isEmpty()) {
-			// Said out loud, and it used to be the silent branch. Without naming a cause, because
-			// there are three and this cannot tell them apart: a terrain= line, no pack chosen yet,
-			// which is every first launch of a fresh instance, and a terrain program that threw.
+			// Said out loud, this being the branch that would otherwise be silent. Without naming a
+			// cause, because there are three and this cannot tell them apart: a terrain= line, no
+			// pack chosen yet, which is every first launch of a fresh instance, and a terrain
+			// program that threw.
 			Vitrail.logger().info("The pack's own terrain program is not wanted, so the mesh keeps the "
 					+ "format Sodium gave it and carries none of {}",
 					Arrays.stream(Extra.values()).map(Extra::attribute).toList());
@@ -283,9 +284,9 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * a whole number of words, which is what makes the id four bytes wide where two would do.
 	 * <p>
 	 * Ours are laid out one word after another in the order they are handed in, which is also where
-	 * the encoder writes them: both read {@code offsets}, and the two used to be a walk over the
-	 * sizes here and a literal offset for each there, agreeing because every element happens to
-	 * be one word and for no other reason.
+	 * the encoder writes them: both read {@code offsets}, rather than a walk over the sizes here and
+	 * a literal offset for each there, which would agree because every element happens to be one
+	 * word and for no other reason.
 	 *
 	 * @param extras the ones of {@link Extra} this pack asked for, in {@link Extra}'s own order.
 	 *               An element left out closes the gap rather than leaving a hole: the shader
@@ -402,7 +403,7 @@ public final class TerrainMesh implements ChunkVertexType {
 	}
 
 	/**
-	 * @param materialBits Sodium's own, untouched. Nothing of this engine rides there any more:
+	 * @param materialBits Sodium's own, untouched. Nothing of this engine rides there:
 	 *                     everything it adds is on the vertices, because a translucent quad reaches
 	 *                     this encoder from the sorter, under a material Sodium chose itself
 	 */
@@ -484,8 +485,8 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * <p>
 	 * The tangent is the direction the texture's own U axis points in, taken from the two edges and
 	 * their texture coordinates, and then squared up against the normal by {@link #orthogonalise}. It
-	 * is what every normal map on the terrain is read through, and this engine used to hand back a
-	 * constant, which tilts every one of them the same wrong way. Its handedness says which way the
+	 * is what every normal map on the terrain is read through, and handing back a constant instead
+	 * tilts every one of them the same wrong way. Its handedness says which way the
 	 * third axis of that frame goes and is the difference between a bump and a dent.
 	 * <p>
 	 * A quad whose texture coordinates are degenerate, the two edges mapping to the same direction,
@@ -559,10 +560,10 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * normalising here does is give that cross product a length of one as well, and the handedness
 	 * bit goes on meaning what {@link #handedness} says it means.
 	 * <p>
-	 * <strong>Nothing of that difference is left in the quantisation any more.</strong> This used to
-	 * store the vector itself as three rounded bytes, so the dot product with the normal came back at
-	 * a few thousandths rather than at nought and the work below was undone by the rounding.
-	 * {@link Extra#TANGENT_FRAME} now stores the angle in the plane, which is what Iris stores, so
+	 * <strong>Nothing of that difference is left in the quantisation.</strong> Storing the vector
+	 * itself as three rounded bytes brings the dot product with the normal back at a few thousandths
+	 * rather than at nought, and the work below is then undone by the rounding.
+	 * {@link Extra#TANGENT_FRAME} stores the angle in the plane, which is what Iris stores, so
 	 * what a pack reads is perpendicular to the last bit on both engines and this projection is what
 	 * decides the angle rather than a step on the way to it.
 	 */

--- a/common/src/main/java/dev/vitrail/uniform/UniformGaps.java
+++ b/common/src/main/java/dev/vitrail/uniform/UniformGaps.java
@@ -16,21 +16,21 @@ import java.util.Map;
  * reader through Iris for a source that was never written.
  * <p>
  * Nothing here is guessed, and nothing here is in the table merely because it is a constant.
- * {@code renderStage} was in that sentence and has left it: the passes that draw the world and the
- * sky each say what they are, and a full screen pass says the phase Iris calls NONE because that is
+ * {@code renderStage} is not one of them: the passes that draw the world and the sky each say what
+ * they are, and a full screen pass says the phase Iris calls NONE because that is
  * what it is. A name is listed because the accessor that answers it says in its own javadoc why it
  * cannot do better, and the sentence is carried across so that the two do not drift apart. A name
  * that stops being a stand-in has to be taken out, and that is the point: a list somebody has to
  * maintain is a list somebody reads.
  * <p>
- * <strong>The stand-ins used to be two lists and are one, which is what a list like this looks
- * like when it works.</strong> The second held the names that were a right answer under a full
- * screen pass and a stand-in under the entity mesh, so that listing them everywhere would not put a
- * false alarm on every composite: {@code entityColor} first, then the three identifiers. Both are
- * now made where the mesh carries them, out of an element apiece, so neither is a stand-in anywhere
- * and the question the second list answered has no instance left. It is not kept warm for the day
- * one turns up: an empty list is a distinction nobody can check, and the reason it existed is
- * written here rather than in code nothing reaches.
+ * <strong>The stand-ins are one list and not two, which is what a list like this looks like when it
+ * works.</strong> A second list would hold the names that are a right answer under a full screen
+ * pass and a stand-in under the entity mesh, so that listing them everywhere would not put a false
+ * alarm on every composite: {@code entityColor} and the three identifiers. Neither is a stand-in
+ * anywhere, both being made where the mesh carries them out of an element apiece, so that list has
+ * no instance left to hold. It is not kept warm for the day one turns up: an empty list is a
+ * distinction nobody can check, and the reason it would exist is written here rather than in code
+ * nothing reaches.
  */
 public final class UniformGaps {
 

--- a/common/src/main/java/dev/vitrail/uniform/WorldState.java
+++ b/common/src/main/java/dev/vitrail/uniform/WorldState.java
@@ -276,9 +276,9 @@ public interface WorldState extends ViewSource {
 	 * {@code wetnessHalflife} and the {@code drynessHalflife} directives fail to reach, so no pack
 	 * can change it, and packs are written against that.
 	 * <p>
-	 * Never return the pack's own directive here. Measured on the corpus rather than guessed at, and
-	 * an earlier version of this line guessed: the three packs that declare one disagree with the
-	 * constant in BOTH directions, BSL at 5 and both Complementary at 300. Honouring the declaration
+	 * Never return the pack's own directive here, and the reason is measured rather than guessed at:
+	 * the three packs that declare one disagree with the constant in BOTH directions, BSL at 5 and
+	 * both Complementary at 300. Honouring the declaration
 	 * would make the fall forty times faster on one and half again slower on the other two, so there
 	 * is no single wrong direction to argue about - only three packs tuned against what they get.
 	 */

--- a/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
@@ -160,7 +160,7 @@ public final class GeometryValues {
 		// the game puts the sun where it is by pushing a rotation onto its own stack, and a pack reads
 		// that rotation here while reading the camera under gbufferModelView, using both at once.
 		//
-		// The families the entity door records from the camera no longer read this name at all: their
+		// The families the entity door records from the camera do not read this name at all: their
 		// gl_ModelViewMatrix goes to the game's own per draw block, LegacyGlsl.readsDrawModelView
 		// saying which and why. What they still take from here is the inverse and the normal matrix
 		// below, which Iris also leaves on its own per pass answer.

--- a/common/src/main/java/dev/vitrail/uniform/values/ShadowGeometryValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/ShadowGeometryValues.java
@@ -43,7 +43,7 @@ public final class ShadowGeometryValues {
 				out.set(new Matrix4f(world.drawnShadowProjection())
 						.mul(world.drawnShadowModelView())));
 
-		// The shadow model view carries the grid snap as a translation, so this is no longer the
+		// The shadow model view carries the grid snap as a translation, so this is not the
 		// transpose of a pure rotation and computing it is the only way to get it right.
 		builder.add("of_NormalMatrix", UniformShape.MAT3, (world, out) ->
 				out.set(new Matrix3f().set(world.drawnShadowModelView()).invert().transpose()));

--- a/fabric/src/main/java/dev/vitrail/fabric/mixin/FrameGraphMixin.java
+++ b/fabric/src/main/java/dev/vitrail/fabric/mixin/FrameGraphMixin.java
@@ -21,7 +21,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * At the head of the method rather than in the middle of the graph being built, which is a few
  * statements earlier than the event and reads the same two values: both are parameters of this
  * method and nothing between the two points writes to either. What the position of the event buys
- * there is the targets it also carries, and this engine no longer puts a pass of its own in the
+ * there is the targets it also carries, and this engine puts no pass of its own in the
  * graph, so nothing here needs them.
  */
 @Mixin(LevelRenderer.class)


### PR DESCRIPTION
## What changes

Comments only, in two commits. `CONTRIBUTING.md` carries the bar the rest of the branch is measured
against: a comment says what holds now rather than how the code got there, and a mechanism that has
a page in `docs/` is pointed at instead of explained a second time. The first commit applies it to
five class headers that had grown to telling the story of their own class, the second to the method
javadoc and the body comments across the tree. Every trap they carried is kept and turned around,
from "this used to do X" to what X would cost. No executable line is touched.

## How it differs from the reference, and for what obstacle

It does not. Nothing here reaches the engine.

## What proves it

- `gradlew build` green, with `:common:compileJava` and `:checkText` really executed rather than
  restored from the cache, so the javadoc lint ran over every edited file.
- `git diff` outside comments and javadoc is empty across all 53 files. The only prose on a
  non-comment line is `CONTRIBUTING.md`'s own.

## What it leaves owing

The sweep is grep-driven, over `used to`, `no longer`, `any more`, `before this` and `since then`,
so a sentence that dates a change without reaching for one of those words survives it. Two were
found by reading the neighbourhood rather than by the grep. What the sweep deliberately leaves
standing is the other kind of hit, which is most of them: the fixed function pipeline that once held
the alpha test, a setting the pack no longer declares, a target gone mid-resize, the order inside
the frame, and the log lines that say so to the player.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
