### PR TITLE
fix(glsl): put sampled textures first in the bind group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack that declares many textures and samples few of them can compile on Apple Silicon.**
+  Metal only has sixteen sampler slots, numbered by the layout rather than by how many the shader
+  actually reads, so a single used texture sitting behind unused declarations used to land on
+  slot 17 and the pipeline was refused. The names a program samples now take the first slots. A
+  program that samples more than sixteen textures still cannot run there.
+
 - **A pack that marks a computed matrix as `const` loads instead of falling back to vanilla.**
   Vulkan will not take `transpose` of a literal, or a uniform, as a constant initialiser, and one
   such pass used to fail the compile and take the whole pack with it. The keyword comes off and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ what the next one holds.
 ### Fixed
 
 - **A pack that declares many textures and samples few of them can compile on Apple Silicon.**
-  Metal only has sixteen sampler slots, numbered by the layout rather than by how many the shader
-  actually reads, so a single used texture sitting behind unused declarations used to land on
-  slot 17 and the pipeline was refused. The names a program samples now take the first slots. A
-  program that samples more than sixteen textures still cannot run there.
+  Metal only has sixteen sampler slots, numbered by the order the shader first names each texture
+  rather than by how many it actually reads, so a used texture sitting behind unused declarations
+  used to land on slot 17 and the pipeline was refused. The names a program samples are now
+  declared first. A program that samples more than sixteen textures still cannot run there.
 
 - **A pack that marks a computed matrix as `const` loads instead of falling back to vanilla.**
   Vulkan will not take `transpose` of a literal, or a uniform, as a constant initialiser, and one

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -626,6 +626,16 @@ public final class GlslTranslator {
 		}
 
 		/**
+		 * Sampler names this stage reads, not merely declares. A pack include can name twenty
+		 * textures of which the body samples one, and those unused declarations still occupy a slot
+		 * in the bind group if they are listed first: MoltenVK numbers a Metal sampler by that
+		 * slot, and only sixteen exist.
+		 */
+		public Set<String> sampled() {
+			return this.translator.sampledNames();
+		}
+
+		/**
 		 * Vertex inputs this stage declared that the mesh it is drawn from has not got, with the type
 		 * the pack gave them. Empty for anything not drawn from a mesh of the engine's own, and the
 		 * list of what the picture will be wrong about when it is not.
@@ -3966,6 +3976,46 @@ public final class GlslTranslator {
 		}
 
 		return names;
+	}
+
+	/**
+	 * Sampler names this stage reads outside their uniform declaration. An include can declare
+	 * twenty textures of which the body samples one: those unused names still occupy identifier
+	 * tokens at the declaration, and counting every identifier would treat them as used.
+	 */
+	private Set<String> sampledNames() {
+		boolean[] declared = new boolean[this.tokens.size()];
+		int[] lines = lineNumbers();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (!token.identifier("uniform") || token.directive() != null
+					|| !this.unit.isLive(lines[index])) {
+				continue;
+			}
+
+			FileScope scope = fileScopeDeclaration(index);
+			if (scope == null) {
+				continue;
+			}
+
+			for (int at = scope.start(); at <= scope.end() && at < declared.length; at++) {
+				declared[at] = true;
+			}
+		}
+
+		Set<String> sampled = new LinkedHashSet<>();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			if (declared[index]) {
+				continue;
+			}
+
+			Token token = this.tokens.get(index);
+			if (token.kind() == Kind.IDENTIFIER && this.samplers.containsKey(token.text())) {
+				sampled.add(token.text());
+			}
+		}
+
+		return sampled;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -627,9 +627,8 @@ public final class GlslTranslator {
 
 		/**
 		 * Sampler names this stage reads, not merely declares. A pack include can name twenty
-		 * textures of which the body samples one, and those unused declarations still occupy a slot
-		 * in the bind group if they are listed first: MoltenVK numbers a Metal sampler by that
-		 * slot, and only sixteen exist.
+		 * textures of which the body samples one; those unused names still occupy a Metal slot if
+		 * they are declared first, and only sixteen exist.
 		 */
 		public Set<String> sampled() {
 			return this.translator.sampledNames();
@@ -818,7 +817,7 @@ public final class GlslTranslator {
 	private TranslatedUnit render(List<TranslatedUnit.Uniform> block,
 			List<TranslatedUnit.Uniform> samplers, Set<String> varyings, Set<String> shadowed) {
 		return new TranslatedUnit(this.unit.entry(), this.stage,
-				header(block, varyings, shadowed) + body(shadowed) + "\n", notes(),
+				header(block, samplers, varyings, shadowed) + body(shadowed) + "\n", notes(),
 				List.copyOf(this.drawBuffers), List.copyOf(block), List.copyOf(samplers));
 	}
 
@@ -2812,9 +2811,9 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Moves every plain uniform into one block, because Vulkan takes no other kind. Samplers and
-	 * images stay where they are: they are opaque, they are allowed loose, and they are the one
-	 * thing here whose declaration the pack got right.
+	 * Moves every plain uniform into one block, because Vulkan takes no other kind. Samplers stay
+	 * opaque and loose, but their declarations leave the body the same way: the header writes them
+	 * in the order the program handed over, sampled names first, so MoltenVK numbers those first.
 	 * <p>
 	 * Brace depth is not consulted. A uniform is only legal at file scope, {@code uniform} is a
 	 * reserved word so it can be nothing else, and a pack that opens a brace in one branch of an
@@ -2889,8 +2888,8 @@ public final class GlslTranslator {
 
 		String type = this.tokens.get(parts.get(cursor)).text();
 
-		// An opaque uniform is read the same way but keeps its declaration where it stands. It is
-		// still recorded, because the engine has to name every sampler it binds.
+		// An opaque uniform is recorded the same way, then taken out of the body: the header
+		// writes every sampler in the order the program settled, which is what MoltenVK numbers.
 		boolean opaque = LegacyGlsl.isOpaqueType(type);
 
 		// The comparison is already out of the token stream by now, taken there by
@@ -2901,9 +2900,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		if (!opaque) {
-			blankRange(start, end);
-		}
+		blankRange(start, end);
 	}
 
 	/**
@@ -3573,8 +3570,8 @@ public final class GlslTranslator {
 	}
 
 
-	private String header(List<TranslatedUnit.Uniform> block, Set<String> varyings,
-			Set<String> shadowed) {
+	private String header(List<TranslatedUnit.Uniform> block, List<TranslatedUnit.Uniform> samplers,
+			Set<String> varyings, Set<String> shadowed) {
 		List<String> lines = new ArrayList<>();
 		lines.add(VERSION);
 
@@ -3606,11 +3603,11 @@ public final class GlslTranslator {
 			lines.addAll(LegacyGlsl.GAME_TRANSFORMS_BLOCK);
 		}
 
-		// The texel centerDepthSmooth was moved onto. Declared here and not left in the body, because
-		// the member was taken out of a statement that may still declare other names of the pack's
-		// own. Iris puts its own before the declarations for the same reason.
-		if (this.centerDepthTexel != null) {
-			lines.add("uniform " + SAMPLER_2D + " " + this.centerDepthTexel + ";");
+		// Written here, in the order the program handed over, rather than left in the body. The
+		// compiler numbers a sampler by the order it first meets the name, and MoltenVK turns that
+		// number into a Metal slot that only accepts 0 through 15. Sampled names come first.
+		for (TranslatedUnit.Uniform sampler : samplers) {
+			lines.add("uniform " + sampler.declaration() + ";");
 		}
 
 		// Attributes stay a matter for the stage that has them. Only a vertex shader has inputs
@@ -3756,10 +3753,6 @@ public final class GlslTranslator {
 				lines.add("flat " + (this.stage == ProgramStage.VERTEX ? "out" : "in") + " int "
 						+ identifier + ";");
 			}
-		}
-
-		if (this.makesOverlayColour) {
-			lines.add("uniform " + SAMPLER_2D + " " + OVERLAY + ";");
 		}
 
 		// From zero up with no gaps, because a location the game finds nothing declared at is not

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -60,7 +60,10 @@ public final class ProgramTranslator {
 	 * Every stage of one program, translated, with what the pipeline will have to declare.
 	 *
 	 * @param uniforms    the block every stage declares, in the order a std140 buffer is filled in
-	 * @param samplers    every opaque uniform any stage binds, which is what the pipeline declares
+	 * @param samplers    every opaque uniform any stage binds, which is what the pipeline declares.
+	 *                    Names a stage actually samples come first, so their bindings stay inside
+	 *                    Metal's sixteen sampler slots; unused declarations follow rather than
+	 *                    pushing a used name onto slot 17
 	 * @param synthesized vertex inputs the mesh has not got, answered with a constant, by name and
 	 *                    with the type the pack declared them under. Empty for every pass drawn over
 	 *                    a quad, which is every pass this engine drew before milestone six
@@ -243,7 +246,7 @@ public final class ProgramTranslator {
 		}
 
 		List<TranslatedUnit.Uniform> block = fixedFunctionFirst(uniforms);
-		List<TranslatedUnit.Uniform> bound = List.copyOf(samplers.values());
+		List<TranslatedUnit.Uniform> bound = sampledFirst(samplers, prepared);
 		Set<String> elements = clashingElements(prepared, inputs);
 
 		Map<ProgramStage, TranslatedUnit> translated = new LinkedHashMap<>();
@@ -421,5 +424,35 @@ public final class ProgramTranslator {
 		}
 
 		return List.copyOf(block);
+	}
+
+	/**
+	 * Names a stage samples first, unused declarations after, so the compiler assigns the used
+	 * ones the lowest bindings. Metal numbers a sampler by that binding and only accepts 0
+	 * through 15; a used name sitting behind sixteen unused ones is refused even when the
+	 * shader samples a single texture.
+	 */
+	private static List<TranslatedUnit.Uniform> sampledFirst(
+			Map<String, TranslatedUnit.Uniform> samplers,
+			Map<ProgramStage, GlslTranslator.Stage> prepared) {
+		Set<String> sampled = new LinkedHashSet<>();
+		for (GlslTranslator.Stage stage : prepared.values()) {
+			sampled.addAll(stage.sampled());
+		}
+
+		List<TranslatedUnit.Uniform> bound = new ArrayList<>();
+		for (TranslatedUnit.Uniform sampler : samplers.values()) {
+			if (sampled.contains(sampler.name())) {
+				bound.add(sampler);
+			}
+		}
+
+		for (TranslatedUnit.Uniform sampler : samplers.values()) {
+			if (!sampled.contains(sampler.name())) {
+				bound.add(sampler);
+			}
+		}
+
+		return List.copyOf(bound);
 	}
 }

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -427,10 +427,9 @@ public final class ProgramTranslator {
 	}
 
 	/**
-	 * Names a stage samples first, unused declarations after, so the compiler assigns the used
-	 * ones the lowest bindings. Metal numbers a sampler by that binding and only accepts 0
-	 * through 15; a used name sitting behind sixteen unused ones is refused even when the
-	 * shader samples a single texture.
+	 * Names a stage samples first, unused declarations after, so both the bind group and the
+	 * shader text meet the used names first. The compiler assigns bindings in the order it first
+	 * meets a name, and MoltenVK turns that into a Metal sampler that only accepts 0 through 15.
 	 */
 	private static List<TranslatedUnit.Uniform> sampledFirst(
 			Map<String, TranslatedUnit.Uniform> samplers,

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -179,6 +179,14 @@ Over-declaring is therefore free and under-declaring fails at compile time, whic
 direction is a generous layout. That is what makes it practical to serve a large uniform surface
 without declaring it pipeline by pipeline.
 
+**MoltenVK is the exception that makes the order of that layout load-bearing.** Metal numbers a
+sampler by the binding the compiler assigned, not by how many the shader actually samples, and it
+only accepts 0 through 15. A layout that lists twenty unused names ahead of the one texture the
+body reads still hands that texture binding 17, and the pipeline is refused. The translator
+therefore puts the names a program samples first and the unused declarations after. A program that
+samples more than sixteen textures is still refused there: that is Metal's own cap, the same one
+Iris documented for macOS.
+
 The asymmetry does not extend to the draw. A sampler that is declared and used, but not bound when
 the draw happens, throws, so the layout can be generous while the binding cannot be sloppy.
 

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -179,13 +179,13 @@ Over-declaring is therefore free and under-declaring fails at compile time, whic
 direction is a generous layout. That is what makes it practical to serve a large uniform surface
 without declaring it pipeline by pipeline.
 
-**MoltenVK is the exception that makes the order of that layout load-bearing.** Metal numbers a
-sampler by the binding the compiler assigned, not by how many the shader actually samples, and it
-only accepts 0 through 15. A layout that lists twenty unused names ahead of the one texture the
-body reads still hands that texture binding 17, and the pipeline is refused. The translator
-therefore puts the names a program samples first and the unused declarations after. A program that
-samples more than sixteen textures is still refused there: that is Metal's own cap, the same one
-Iris documented for macOS.
+**MoltenVK is the exception that makes the order of those declarations load-bearing.** Metal numbers
+a sampler by the binding the compiler assigned from the order it first met the name, not by how
+many the shader actually samples, and it only accepts 0 through 15. A shader that declares twenty
+unused names ahead of the one texture the body reads still hands that texture binding 17, and the
+pipeline is refused. The translator therefore writes the names a program samples first in the
+header, unused declarations after. A program that samples more than sixteen textures is still
+refused there: that is Metal's own cap, the same one Iris documented for macOS.
 
 The asymmetry does not extend to the draw. A sampler that is declared and used, but not bound when
 the draw happens, throws, so the layout can be generous while the binding cannot be sloppy.

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -116,6 +116,11 @@ mass overlapping-location errors. The game's compiler switches on the options th
 uniforms and auto-map locations, and that is exactly what makes emitting nothing work: they are not
 inert here, they are what assigns what the emitter deliberately leaves unassigned.
 
+Those assigned numbers follow the bind group layout order. Unused sampler declarations still consume
+a number if they sit in front of a used one, which on MoltenVK is a Metal sampler index above 15
+and a refused pipeline. Sampled names are therefore listed first; see
+[the graphics API](internals/game-graphics-api.md).
+
 The exception is fragment outputs, which keep their explicit location, because their **order** is
 the only thing that says which write lands on which attachment.
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -116,10 +116,10 @@ mass overlapping-location errors. The game's compiler switches on the options th
 uniforms and auto-map locations, and that is exactly what makes emitting nothing work: they are not
 inert here, they are what assigns what the emitter deliberately leaves unassigned.
 
-Those assigned numbers follow the bind group layout order. Unused sampler declarations still consume
-a number if they sit in front of a used one, which on MoltenVK is a Metal sampler index above 15
-and a refused pipeline. Sampled names are therefore listed first; see
-[the graphics API](internals/game-graphics-api.md).
+Those assigned numbers follow the order the compiler first meets each name in the shader. Unused
+sampler declarations still consume a number if they sit in front of a used one, which on MoltenVK
+is a Metal sampler index above 15 and a refused pipeline. Sampled names are therefore declared
+first in the header, unused after; see [the graphics API](internals/game-graphics-api.md).
 
 The exception is fragment outputs, which keep their explicit location, because their **order** is
 the only thing that says which write lands on which attachment.


### PR DESCRIPTION
## What changes

Closes #153.

A Complementary deferred pass was given Metal sampler 21 and refused on MoltenVK, because unused `colortex` names sat in front of the shadow map in the shader text. Sampled names are now declared first in the header; unused declarations follow. The bind-group list follows that same order.

## How it differs from the reference, and for what obstacle

It does not change the picture on a native Vulkan device. Iris already packed texture units the same way on macOS (`docs/changelogs/1.1.3/full.md`: a program may not sample more than sixteen). The cap remains; only the unused names in front of a used one are moved out of the way.

## What proves it

- [x] `gradlew build` green.
- [ ] The out-of-game harness: not run, the packing is order only.
- [ ] In the game: no Mac here. The reporter on #153 has a first jar that was not enough; a second jar with this header packing is the proof. Complementary with Real-Time Shadows on, or a new log.

## What it leaves owing

A program that truly samples more than sixteen textures still fails on Metal.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine prints at load.