### PR TITLE
fix(sodium): size the 0.9.2 arena at the pack's stride

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Fixed
+
+- **Sodium 0.9.2 no longer crashes when a pack extends the chunk mesh.** Its new arena allocator
+  was sized for Sodium's own twenty bytes and refused the wider mesh a pack needs. The allocator
+  now takes the same format the rest of the renderer already asked for. 0.9.1 is unchanged.
+
 ## 0.7.4-beta
 
 ### Changed

--- a/common/src/main/java/dev/vitrail/mixin/ArenaAggregatorMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/ArenaAggregatorMixin.java
@@ -1,0 +1,44 @@
+package dev.vitrail.mixin;
+
+import net.caffeinemc.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
+import net.caffeinemc.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * Sizes Sodium 0.9.2's shared geometry arena at the pack's stride, the same answer
+ * {@link ChunkMeshFormatsMixin} already gives everyone else.
+ * <p>
+ * 0.9.1 has no {@code ArenaAggregator}. 0.9.2 added one and baked
+ * {@code ChunkMeshFormats.COMPACT} into it at construction, twenty bytes, then refused any other
+ * width. The three readers that already asked {@code getCurrent()} still do: the chunk builder, the
+ * chunk renderer, and a region's device resources. Those three see the pack's mesh. The allocator
+ * did not, so the resources asked it for forty and it threw {@code Unsupported stride}.
+ * <p>
+ * The class is absent from the 0.9.1 this module compiles against, which is why the target is a
+ * name and why {@code @Pseudo} lets 0.9.1 skip the mixin rather than refuse to load. The redirect
+ * is required when the class is there: a silent miss would be the same crash the player already
+ * hit, arriving a world late.
+ * <p>
+ * Construction is after {@code TerrainMesh.settle}, at the head of {@code initRenderer}, so
+ * {@code getCurrent()} here is the format the builder is about to write. That is the same instant
+ * {@code MixinSodiumWorldRendererInit} already chose, not a second one.
+ */
+@Pseudo
+@Mixin(targets = "net.caffeinemc.mods.sodium.client.gpu.arena.ArenaAggregator", remap = false)
+public abstract class ArenaAggregatorMixin {
+
+	@Redirect(
+			method = "<init>",
+			at = @At(
+					value = "FIELD",
+					opcode = Opcodes.GETSTATIC,
+					target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/vertex/format/ChunkMeshFormats;COMPACT:Lnet/caffeinemc/mods/sodium/client/render/chunk/vertex/format/ChunkVertexType;"),
+			require = 1)
+	private static ChunkVertexType vitrail$geometryFormat() {
+		return ChunkMeshFormats.getCurrent();
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/ChunkMeshFormatsMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/ChunkMeshFormatsMixin.java
@@ -16,7 +16,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * One method and no state of its own: everything that needs to know the format asks here, the chunk
  * builder for the stride it writes at, the region for the size of its geometry arena, and the
  * renderer for the layout it binds. Iris does the same thing with two {@code ModifyArg}s on the two
- * calls, which only works while there are two.
+ * calls, which only works while there are two. Sodium 0.9.2 added a fourth site that does not ask
+ * here at all, {@link ArenaAggregatorMixin}, and that is a separate hole.
  * <p>
  * <strong>The answer may change while the game runs, and this is not where it changes.</strong> Two
  * of the three readers are the section manager's constructor and the third is a region's device

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -7,6 +7,7 @@
 		"defaultRequire": 0
 	},
 	"client": [
+		"ArenaAggregatorMixin",
 		"BiomesMixin",
 		"BlockEntityRenderDispatcherMixin",
 		"BlockEntityRenderStateAccessor",

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -40,6 +40,12 @@ notice. So the engine takes the answer at the single instant the chunk renderer 
 from nothing, and merely repeats it everywhere else. Turning the terrain switch on or off asks the
 game to rebuild the world, which is the same door F3+A uses; it does not ask for a restart.
 
+Sodium 0.9.2 added a shared geometry arena that does not call the accessor. It bakes the compact
+stride at construction and then refuses any other width, so a pack's mesh (thirty-two to forty bytes)
+dies with `Unsupported stride` on the first upload. A mixin on that constructor asks the accessor
+instead, at the same instant the section manager is built. 0.9.1 has no such class, and the mixin
+is skipped there.
+
 **One thing outlives that rebuild, and it is a pipeline.** The chunk renderer memoises its own
 pipeline in a map keyed by render pass, the map is static and the three passes are immortal, and a
 pipeline declares the vertex format of whichever renderer built it. Nothing ever empties it, so the


### PR DESCRIPTION
## What changes

Sodium 0.9.2's new geometry arena is sized from `ChunkMeshFormats.COMPACT` and then refuses any other width, so a pack's mesh (32 to 40 bytes) dies with `Unsupported stride` on the first upload. The constructor now asks `getCurrent()`, the same answer the builder, the renderer and the region's device resources already use. 0.9.1 has no such class; the mixin is skipped there. Issue 155, seen in #153.

## How it differs from the reference, and for what obstacle

It does not. Iris 26.1 has no `ArenaAggregator`. 0.9.1 already asked `getCurrent()` at the three older sites; 0.9.2 added a fourth that hardcodes the compact stride, which is what this puts back.

## What proves it

- [x] `gradlew build` green.
- [ ] The out-of-game harness: not run, the change is a constructor argument.
- [x] In the game: Complementary on Fabric with Sodium 0.9.2-alpha.4, world loads, no `Unsupported stride`. Same pack on NeoForge with Sodium 0.9.1, image unchanged.

## What it leaves owing

Nothing of the stride crash. Metal still refusing Complementary's `deferred1` at sampler 21 is #154, a different hole.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine prints at load.