### PR TITLE
fix(glsl): strip const from a non-constant initialiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack that marks a computed matrix as `const` loads instead of falling back to vanilla.**
+  Vulkan will not take `transpose` of a literal, or a uniform, as a constant initialiser, and one
+  such pass used to fail the compile and take the whole pack with it. The keyword comes off and
+  the value stays. Seen on Lux v1.2, a BSL derivative.
+
 - **Sodium 0.9.2 no longer crashes when a pack extends the chunk mesh.** Its new arena allocator
   was sized for Sodium's own twenty bytes and refused the wider mesh a pack needs. The allocator
   now takes the same format the rest of the renderer already asked for. 0.9.1 is unchanged.

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -566,6 +566,9 @@ public final class GlslTranslator {
 		flattenVolumes();
 		convertDepth();
 		dropPrecision();
+		// After precision, so a leftover highp does not sit between const and the type this pass
+		// matches on, and before outputs are rewritten, which do not use const.
+		demoteNonConstantInitialisers();
 		rewriteFragmentOutputs();
 		liftFragmentOutputs();
 		// Before the lifting and after the depth, and both halves matter: the declarator it takes out
@@ -1802,6 +1805,70 @@ public final class GlslTranslator {
 	private void takePassColour() {
 		record(this.blockMembers, PASS_COLOUR, "vec4 " + PASS_COLOUR);
 		this.injectedNames.add(PASS_COLOUR);
+	}
+
+	/**
+	 * {@code const} on a variable demands a compile-time constant under Vulkan, and OpenGL drivers
+	 * accepted a lot that is not one: {@code transpose} of a matrix literal, a constructor from a
+	 * uniform, {@code normalize} of a vector the pack treated as immutable. The keyword is the lie,
+	 * not the value, so it comes off and the declaration stays.
+	 * <p>
+	 * An array size still needs a real constant, so a declaration whose initialiser is only literals
+	 * and type constructors is left alone. Parameters keep {@code const}: that spelling means
+	 * immutable, not compile-time, and the language allows it.
+	 */
+	private void demoteNonConstantInitialisers() {
+		int parens = 0;
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.directive() != null) {
+				continue;
+			}
+
+			if (token.operator("(")) {
+				parens++;
+				continue;
+			}
+
+			if (token.operator(")")) {
+				parens--;
+				continue;
+			}
+
+			if (parens != 0 || !token.identifier("const")) {
+				continue;
+			}
+
+			int end = statementEnd(index);
+			if (end >= 0 && nonConstantInitialiser(index, end)) {
+				blank(index);
+			}
+		}
+	}
+
+	/**
+	 * Whether this {@code const} declaration assigns something Vulkan will not take as a constant
+	 * expression: any identifier that is not a type constructor.
+	 */
+	private boolean nonConstantInitialiser(int keyword, int end) {
+		boolean seenEquals = false;
+		for (int scan = keyword; scan <= end; scan++) {
+			Token token = this.tokens.get(scan);
+			if (token.operator("=")) {
+				seenEquals = true;
+				continue;
+			}
+
+			if (!seenEquals || token.kind() != Kind.IDENTIFIER) {
+				continue;
+			}
+
+			if (!LegacyGlsl.TYPE_NAMES.contains(token.text())) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -68,6 +68,11 @@ Iris draws Reverie. It refuses a required flag only when the name is unknown to 
 cannot serve it, and it has built every one of the ones Reverie asks for: some outright, some
 wherever the driver supports them.
 
+**A full-screen pass that fails to compile takes the whole pack with it**, and the log names the
+program. One shape of that was a `const` whose initialiser Vulkan will not take as a constant,
+which OpenGL drivers accepted as merely immutable; that spelling is now rewritten, see
+[Translation](translation.md). Other compile failures still refuse the pack.
+
 **A single pass can be refused without the pack being refused.** If a program's fragment stage
 genuinely *reads* an input its vertex stage does not provide, that one program fails to link and the
 engine falls back to the game's rendering for that surface. You get the game's version of that one

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -66,6 +66,12 @@ it correctly means finding the matching close parenthesis, which means tokenisin
 **Precision qualifiers are stripped.** They mean nothing on desktop, but two declarations of one
 function that disagree about them are a real conflict.
 
+**`const` on a variable whose initialiser is not a constant expression is stripped.** Vulkan
+refuses a global `const mat3` initialised from `transpose(...)`, or from a uniform, which OpenGL
+drivers took as merely immutable. The keyword comes off and the value stays. A declaration whose
+initialiser is only literals and type constructors is left alone, because an array size still
+needs a real constant. Parameters keep `const`: that spelling means immutable, not compile-time.
+
 **Names that collide with newer builtins are renamed.** A function a pack defines can collide with
 a builtin introduced after the version the pack targets, and the error does not name the collision:
 it complains about overload precision qualifiers. Renaming is triggered only on names the pack


### PR DESCRIPTION
## What changes

A pack that writes `const` on a value Vulkan will not take as a constant expression used to fail the compile of that pass and take the whole pack with it, so the world went vanilla. The keyword comes off when the initialiser is not a literal or a type constructor, and the value stays. Seen on Lux v1.2.

## How it differs from the reference, and for what obstacle

Iris leaves that `const` standing. OpenGL drivers take it as merely immutable; its CompatibilityTransformer only strips `const` from a local initialised from a const parameter (`CompatibilityTransformer.java:166-171`). The game's compiler here is glslang for Vulkan, which refuses a global const whose initialiser is a call such as `transpose` of a matrix literal. `GlslTranslator.demoteNonConstantInitialisers` is the rewrite. The image is the same once the pass compiles; without it the pack is not drawn.

## What proves it

- `gradlew build` green, after the rebase onto `origin/dev`.
- In the game: Lux v1.2 on the Fabric bench, Vulkan, NVIDIA 610.88. `world0/composite5` compiles and writes; the log no longer says the pack will not be drawn. Same pack, same error, before the change.

## What it leaves owing

Nothing for this spelling. A full-screen pass that fails to compile for any other reason still refuses the pack. Lux is not added to the measured table in `docs/compatibility.md`.

Closes #157

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine prints at load.