### PR TITLE
build: raise the version to 0.7.5-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.7.5-beta
 
 ### Added
 
@@ -37,6 +37,7 @@ what the next one holds.
 - **Sodium 0.9.2 no longer crashes when a pack extends the chunk mesh.** Its new arena allocator
   was sized for Sodium's own twenty bytes and refused the wider mesh a pack needs. The allocator
   now takes the same format the rest of the renderer already asked for. 0.9.1 is unchanged.
+
 ## 0.7.4-beta
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.7.4-beta
+mod_version=0.7.5-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
One number moved in two places: `mod_version` in `gradle.properties` and the heading of the changelog section above 0.7.4-beta, so that the tag the release pushes and the number inside the jar agree. Nothing else.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

- [x] `gradlew build` green.
- [ ] The out-of-game harness: not run, the version string is not in the corpus.
- [ ] In the game: the benches already ran this tree as 0.7.4-beta; the number in the jar is all that changes.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
