### PR TITLE
perf(sodium): skip the second ring rotate on the shadow walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ what the next one holds.
   picked while the loaded one goes on drawing, and Apply is the only thing that costs. A profile
   chosen before applying is the one that lands.
 
+- **The shadow walk no longer rotates Sodium's command ring a second time in the same frame.**
+  The lists still reset so the light does not append onto the camera's; the ring waits for the
+  next camera walk. Same shadows.
+
 ## 0.7.5-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/mixin/LevelRendererFrameMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/LevelRendererFrameMixin.java
@@ -1,6 +1,7 @@
 package dev.vitrail.mixin;
 
 import dev.vitrail.render.PassTimings;
+import dev.vitrail.render.RingTimings;
 
 import net.minecraft.client.renderer.LevelRenderer;
 import org.spongepowered.asm.mixin.Mixin;
@@ -21,5 +22,6 @@ public abstract class LevelRendererFrameMixin {
 	@Inject(method = "endFrame", at = @At("HEAD"), require = 1)
 	private void vitrail$endFrame(CallbackInfo ci) {
 		PassTimings.endFrame();
+		RingTimings.endFrame();
 	}
 }

--- a/common/src/main/java/dev/vitrail/mixin/MixinDefaultChunkRenderer.java
+++ b/common/src/main/java/dev/vitrail/mixin/MixinDefaultChunkRenderer.java
@@ -2,6 +2,7 @@ package dev.vitrail.mixin;
 
 import dev.vitrail.sodium.SodiumPasses;
 import dev.vitrail.pack.program.TerrainPass;
+import dev.vitrail.render.RingTimings;
 import dev.vitrail.render.TerrainDraw;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
@@ -18,6 +19,8 @@ import net.caffeinemc.mods.sodium.client.render.chunk.DefaultChunkRenderer;
 import net.caffeinemc.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -48,6 +51,18 @@ import java.util.function.Supplier;
  */
 @Mixin(value = DefaultChunkRenderer.class, remap = false)
 public abstract class MixinDefaultChunkRenderer {
+
+	// require, because a silently unapplied probe prints the same zeros as an empty rotate, and
+	// the whole point of the clock is telling those two apart.
+	@Inject(method = "rotate", at = @At("HEAD"), require = 1)
+	private void vitrail$rotateBegin(CallbackInfo ci) {
+		RingTimings.beginRotate();
+	}
+
+	@Inject(method = "rotate", at = @At("RETURN"), require = 1)
+	private void vitrail$rotateEnd(CallbackInfo ci) {
+		RingTimings.endRotate();
+	}
 
 	/**
 	 * Answers the target question with the game's own while the shadow map is being drawn.

--- a/common/src/main/java/dev/vitrail/mixin/RenderSectionManagerAccessor.java
+++ b/common/src/main/java/dev/vitrail/mixin/RenderSectionManagerAccessor.java
@@ -38,16 +38,4 @@ public interface RenderSectionManagerAccessor {
 
 	@Invoker("invalidateRenderLists")
 	void vitrail$invalidateRenderLists();
-
-	/**
-	 * The first two steps of {@code prepareRender}: bump the frame so the light's walk replaces
-	 * the camera's lists, and invalidate those lists if the camera moved. Does not rotate the
-	 * draw ring.
-	 */
-	default void vitrail$beginSecondWalk() {
-		vitrail$setFrame(vitrail$getFrame() + 1);
-		if (vitrail$cameraChanged()) {
-			vitrail$invalidateRenderLists();
-		}
-	}
 }

--- a/common/src/main/java/dev/vitrail/mixin/RenderSectionManagerAccessor.java
+++ b/common/src/main/java/dev/vitrail/mixin/RenderSectionManagerAccessor.java
@@ -3,18 +3,51 @@ package dev.vitrail.mixin;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSectionManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
 
 /**
- * Puts the render list rebuild flag back up after the light's walk has consumed it.
+ * Reaches the walk state the shadow stage has to move without going through
+ * {@code prepareRender}.
  * <p>
- * {@code finalizeRenderLists} lowers the flag on its way out, whoever called it. The shadow stage
- * calls it at the end of a frame with the light's viewport, so without this the camera's own
- * finalize at the top of the next frame would find the flag down and keep the light's lists, and
- * the world would be drawn from the sun.
+ * {@code finalizeRenderLists} lowers the rebuild flag on its way out, whoever called it. The
+ * shadow stage calls it at the end of a frame with the light's viewport, so without putting the
+ * flag back the camera's own finalize at the top of the next frame would keep the light's lists,
+ * and the world would be drawn from the sun.
+ * <p>
+ * The second walk also has to bump the frame counter: the per-region lists only reset on the
+ * first walk of a number, and a second walk under the same one appends until they overflow.
+ * {@code prepareRender} does that bump and then rotates Sodium's indirect command ring. The
+ * rotation is the cost this accessor exists to skip. The camera already rotated at the top of
+ * the frame; doing it again fences a buffer the GPU is still reading and stalls the render
+ * thread on the busy frames.
  */
 @Mixin(value = RenderSectionManager.class, remap = false)
 public interface RenderSectionManagerAccessor {
 
 	@Accessor("needsRenderListUpdate")
 	void vitrail$setNeedsRenderListUpdate(boolean value);
+
+	@Accessor("frame")
+	int vitrail$getFrame();
+
+	@Accessor("frame")
+	void vitrail$setFrame(int frame);
+
+	@Accessor("cameraChanged")
+	boolean vitrail$cameraChanged();
+
+	@Invoker("invalidateRenderLists")
+	void vitrail$invalidateRenderLists();
+
+	/**
+	 * The first two steps of {@code prepareRender}: bump the frame so the light's walk replaces
+	 * the camera's lists, and invalidate those lists if the camera moved. Does not rotate the
+	 * draw ring.
+	 */
+	default void vitrail$beginSecondWalk() {
+		vitrail$setFrame(vitrail$getFrame() + 1);
+		if (vitrail$cameraChanged()) {
+			vitrail$invalidateRenderLists();
+		}
+	}
 }

--- a/common/src/main/java/dev/vitrail/render/RingTimings.java
+++ b/common/src/main/java/dev/vitrail/render/RingTimings.java
@@ -1,0 +1,171 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+
+import net.caffeinemc.mods.sodium.client.gpu.device.backend.DrawBackend;
+import net.minecraft.client.Minecraft;
+
+import java.nio.file.Files;
+import java.util.Locale;
+
+/**
+ * How long Sodium's command-ring {@code rotate} takes on the render thread, and how many times a
+ * frame it runs.
+ * <p>
+ * {@code prepareRender} rotates once for the camera. The shadow walk used to call it again, which
+ * on the Vulkan indirect path fences a mapped buffer the GPU may still be reading. Issue 115 is
+ * that wait. This clock sits around {@code DefaultChunkRenderer.rotate}, which is the call that
+ * does the fence, the swap and the remap, so the number in the log is the stall itself rather than
+ * a guess from the frame counter.
+ * <p>
+ * Off unless {@code -Dvitrail.ringTimings=N} asks for a report every N seconds, the same shape the
+ * per-pass profile takes: a clock nobody armed must not write a line into a player's log. A second
+ * flag, {@code -Dvitrail.keepShadowRotate=true}, puts the old second rotate back, so both paths are
+ * timed on ONE jar rather than on two builds whose difference is anybody's guess. A
+ * {@code vitrail/keep-shadow-rotate} file in the game directory says the same thing as that flag,
+ * because the launcher's arguments are a place a session cannot reach while a file next to the
+ * pack is one it can. The file is asked once and the answer kept: it arms a launch, not a frame.
+ */
+public final class RingTimings {
+
+	private static final int REPORT_SECONDS = Integer.getInteger("vitrail.ringTimings", 0);
+
+	private static final boolean ENABLED = REPORT_SECONDS > 0;
+
+	private static final boolean KEEP = Boolean.getBoolean("vitrail.keepShadowRotate");
+
+	private static final long NANOS_PER_SECOND = 1_000_000_000L;
+
+	private static int rotatesThisFrame;
+
+	private static long begin;
+
+	private static long frames;
+
+	private static long firstNanos;
+
+	private static long firstCount;
+
+	private static long firstMax;
+
+	private static long secondNanos;
+
+	private static long secondCount;
+
+	private static long secondMax;
+
+	private static long lastReport;
+
+	private static boolean loggedBackend;
+
+	/** The marker file's answer, held after the first ask: a stat per frame is not a probe cost. */
+	private static Boolean keepFromFile;
+
+	private RingTimings() {
+	}
+
+	/**
+	 * The old shadow walk, the one that goes through {@code prepareRender} and rotates again, asked
+	 * for by the JVM flag or by the marker file. The file is read once, on the first frame that can
+	 * resolve the game directory.
+	 */
+	public static boolean keepSecondRotate() {
+		if (KEEP) {
+			return true;
+		}
+
+		if (keepFromFile == null) {
+			Minecraft minecraft = Minecraft.getInstance();
+			if (minecraft == null || minecraft.gameDirectory == null) {
+				return false;
+			}
+
+			keepFromFile = Files.isRegularFile(minecraft.gameDirectory.toPath()
+					.resolve("vitrail").resolve("keep-shadow-rotate"));
+		}
+
+		return keepFromFile;
+	}
+
+	public static void beginRotate() {
+		if (!ENABLED) {
+			return;
+		}
+
+		begin = System.nanoTime();
+	}
+
+	public static void endRotate() {
+		if (!ENABLED) {
+			return;
+		}
+
+		long dt = System.nanoTime() - begin;
+		rotatesThisFrame++;
+		if (rotatesThisFrame == 1) {
+			firstNanos += dt;
+			firstCount++;
+			if (dt > firstMax) {
+				firstMax = dt;
+			}
+		} else if (rotatesThisFrame == 2) {
+			secondNanos += dt;
+			secondCount++;
+			if (dt > secondMax) {
+				secondMax = dt;
+			}
+		}
+
+		if (!loggedBackend) {
+			loggedBackend = true;
+			Vitrail.logger().info("Ring timings: backend {}, keepShadowRotate {}",
+					DrawBackend.BACKEND, keepSecondRotate());
+		}
+	}
+
+	public static void endFrame() {
+		if (!ENABLED) {
+			return;
+		}
+
+		long now = System.nanoTime();
+		if (lastReport == 0) {
+			lastReport = now;
+		}
+
+		frames++;
+		rotatesThisFrame = 0;
+		if (now - lastReport >= REPORT_SECONDS * NANOS_PER_SECOND) {
+			report(now);
+		}
+	}
+
+	private static void report(long now) {
+		double seconds = (now - lastReport) / (double) NANOS_PER_SECOND;
+		Vitrail.logger().info(
+				"Ring timings over {} s, {} frames, backend {}, keepShadowRotate {}",
+				String.format(Locale.ROOT, "%.1f", seconds), frames, DrawBackend.BACKEND,
+				keepSecondRotate());
+		Vitrail.logger().info("  first rotate:  {} ms avg, {} ms max, {} times",
+				millis(firstNanos, firstCount), millis(firstMax, 1), firstCount);
+		Vitrail.logger().info("  second rotate: {} ms avg, {} ms max, {} times",
+				millis(secondNanos, secondCount), millis(secondMax, 1), secondCount);
+
+		frames = 0;
+		firstNanos = 0;
+		firstCount = 0;
+		firstMax = 0;
+		secondNanos = 0;
+		secondCount = 0;
+		secondMax = 0;
+		lastReport = now;
+	}
+
+	private static String millis(long nanos, long count) {
+		if (count == 0) {
+			return "  0.000";
+		}
+
+		return String.format(Locale.ROOT, "%7.3f", nanos / 1_000_000.0 / count);
+	}
+}

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -176,7 +176,10 @@ public final class ShadowTerrain {
 		// them. The walk itself is the synchronous fallback, which is the one path that neither
 		// consults the asynchronous occlusion tree, empty for a viewport it has never seen, nor
 		// waits for it.
-		manager.prepareRender();
+		//
+		// prepareRender would then rotate the indirect command ring. The camera already did that
+		// at the top of the frame; a second rotate in the same frame is the stall #115 names.
+		((RenderSectionManagerAccessor) manager).vitrail$beginSecondWalk();
 		try {
 			FogParameters fog = ((MixinSodiumWorldRenderer) renderer).vitrail$lastFogParameters();
 			// The shape the pack asked for, and a box around the camera cut out of it wherever a

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -5,6 +5,7 @@ import dev.vitrail.mixin.RenderSectionManagerAccessor;
 import dev.vitrail.pack.source.ShadowCasters;
 import dev.vitrail.render.BlockStateIds;
 import dev.vitrail.render.DistantDraw;
+import dev.vitrail.render.RingTimings;
 import dev.vitrail.render.ShadowCullPlan;
 import dev.vitrail.render.ShadowGeometry;
 import dev.vitrail.render.TerrainDraw;
@@ -182,10 +183,15 @@ public final class ShadowTerrain {
 		// The steps live here rather than as a default on the accessor: Mixin treats an interface
 		// mixin with a default method as targeting an interface, and RenderSectionManager is a
 		// class, so the config fails to prepare. The check is Mixin's own, seen on the Fabric boot.
-		RenderSectionManagerAccessor access = (RenderSectionManagerAccessor) manager;
-		access.vitrail$setFrame(access.vitrail$getFrame() + 1);
-		if (access.vitrail$cameraChanged()) {
-			access.vitrail$invalidateRenderLists();
+		// keepShadowRotate puts the old call back so the two paths can be timed on the same jar.
+		if (RingTimings.keepSecondRotate()) {
+			manager.prepareRender();
+		} else {
+			RenderSectionManagerAccessor access = (RenderSectionManagerAccessor) manager;
+			access.vitrail$setFrame(access.vitrail$getFrame() + 1);
+			if (access.vitrail$cameraChanged()) {
+				access.vitrail$invalidateRenderLists();
+			}
 		}
 		try {
 			FogParameters fog = ((MixinSodiumWorldRenderer) renderer).vitrail$lastFogParameters();

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -179,7 +179,14 @@ public final class ShadowTerrain {
 		//
 		// prepareRender would then rotate the indirect command ring. The camera already did that
 		// at the top of the frame; a second rotate in the same frame is the stall #115 names.
-		((RenderSectionManagerAccessor) manager).vitrail$beginSecondWalk();
+		// The steps live here rather than as a default on the accessor: Mixin treats an interface
+		// mixin with a default method as targeting an interface, and RenderSectionManager is a
+		// class, so the config fails to prepare. The check is Mixin's own, seen on the Fabric boot.
+		RenderSectionManagerAccessor access = (RenderSectionManagerAccessor) manager;
+		access.vitrail$setFrame(access.vitrail$getFrame() + 1);
+		if (access.vitrail$cameraChanged()) {
+			access.vitrail$invalidateRenderLists();
+		}
 		try {
 			FogParameters fog = ((MixinSodiumWorldRenderer) renderer).vitrail$lastFogParameters();
 			// The shape the pack asked for, and a box around the camera cut out of it wherever a


### PR DESCRIPTION
## What changes

The shadow walk no longer calls Sodium `prepareRender`. That call bumps the frame counter, then rotates the command ring. The camera already rotated at the top of the frame. The light's walk still bumps the frame and invalidates the lists when the camera moved, so the lists reset instead of appending onto the camera's. Same shadows. Closes #115.

## How it differs from the reference, and for what obstacle

It does not, for the picture. Iris has no second ring rotate to skip: the Sodium its 26.1 branch rides has no rotate in `prepareRender` at all, and its shadow mixin cancels the occlusion-tree walk rather than this bump. The rotate that costs is Sodium 0.9.1's Vulkan indirect backend, whose ring waits on a fence in `MappableRingBuffer.currentBuffer` when it comes back around too fast; the same Sodium's multidraw rotate is empty. This skip is that cost, not a pack workaround.

## What proves it

- `gradlew build` green, after the rebase onto `dev`.
- Harness: not this lot.
- In the game, NeoForge bench, Vulkan, BSL then Complementary, world `shader test`: same shadows, FPS unchanged. The backend here is multidraw.
- Growing the ring mid-walk is safe by construction: `recreateRingBuffer` copies the old contents forward and the old buffer's close is `queueForDestroy`, deferred until the GPU is done with it. That is the path the skip makes more likely on the indirect backend, and it is the path vanilla Sodium already takes whenever a walk outgrows the ring.

## What it leaves owing

- The indirect backend is still untimed, and the earlier "both timed at zero" reading is not trusted: the probe hooks carried no `require`, so a silently unapplied hook prints the same zeros. They are `require = 1` now, and the clock owes a re-run.
- The Fabric boot has not been re-run since the accessor lost its default method, and the failure it fixes was seen on Fabric.
- Changelog does not claim a player-visible FPS gain.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine prints at load.
