### PR TITLE
ci: run the pull-request label job on every push

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -68,6 +68,10 @@ if [ -n "$second" ]; then
 	die "line 2 has to be blank, since it is what separates a subject from its body."
 fi
 
+if printf '%s\n' "$stored" | grep -qiE '^[[:space:]]*(Co-authored-by|Made-with|Generated-by):'; then
+	die "the message carries a trailer this history does not keep."
+fi
+
 # Absent under `git rebase` and anywhere else HEAD is detached, and there is nothing to check then.
 if [ "$#" -ge 2 ]; then
 	branch=$2

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -18,12 +18,16 @@
 # token that may only read. Nothing of the request is checked out or run here: what is read is the
 # name of its branch, and all that is done with it is a match against eleven words written below. A
 # name matching none of them reaches no command at all.
+#
+# `synchronize` as well as opened and reopened, because this job is a required check on origin/dev.
+# A request opened before the workflow existed, or whose check was skipped, stays blocked forever
+# if a later push does not run it again. Posing the label twice is the same pose.
 
 name: label
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## What changes

The label job runs on every push to a pull request, not only when the request is opened or reopened. It is a required check on origin/dev, so a request whose check never ran stayed blocked after later pushes. The commit-msg hook now refuses authorship and generator trailers.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

- The workflow lists synchronize beside opened and reopened.
- Harness: not this lot.
- In the game: not this lot.

## What it leaves owing

Pull requests already open still need one push (or a reopen) after this lands on origin/dev, so the check exists. After that, every push reruns it.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
