### PR TITLE
feat(render): serve a pack's custom images, storage buffers and compute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ what the next one holds.
 
 ### Added
 
+- **A pack's coloured lighting runs.** The storage images, storage buffers and shadow compute
+  pass behind it are served, and `IRIS_FEATURE_CUSTOM_IMAGES` is announced, so the voxel
+  lighting of Complementary's top profiles, Euphoria Patches' Colored Lighting among them,
+  draws instead of switching itself off behind a red overlay: lamps and torches colour the
+  world around them. A pack that requires custom images loads instead of being refused.
+
 - **A crash during startup no longer takes the graphics backend with it.** The game resets the
   preferred graphics API, and the fullscreen mode, whenever the previous startup did not finish,
   and it does that for any crash rather than for a backend that failed. Since nothing of this mod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ what the next one holds.
   draws instead of switching itself off behind a red overlay: lamps and torches colour the
   world around them. A pack that requires custom images loads instead of being refused.
 
+  That light no longer blinks as you move. The glow of ores and lava used to flicker each time
+  you crossed from one block to the next, and worst of all going up: a ring of dark around you
+  on every jump, a constant shimmer flying upwards, and nothing at all coming back down. A
+  torch you place never showed it, because the ordinary block light under it covers it over.
+
 - **A crash during startup no longer takes the graphics backend with it.** The game resets the
   preferred graphics API, and the fullscreen mode, whenever the previous startup did not finish,
   and it does that for any crash rather than for a backend that failed. Since nothing of this mod

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -10,6 +10,8 @@ import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
 import dev.vitrail.pack.target.DrawBuffers;
 import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.SamplerTypes;
+import dev.vitrail.pack.texture.CustomImages;
+import dev.vitrail.pack.texture.CustomStorage;
 import dev.vitrail.pack.texture.VolumeAtlas;
 
 import java.util.ArrayList;
@@ -22,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -2858,6 +2861,27 @@ public final class GlslTranslator {
 		}
 	}
 
+	/**
+	 * Vulkan GLSL requires a format on a storage image. Iris's GL bind supplies it at bind time,
+	 * so Complementary writes {@code writeonly uniform uimage3D voxel_img} with none. The format
+	 * comes off the {@code image.} directive and is written here, in the header: the body
+	 * declaration has already been lifted, so a layout qualifier inserted into the token stream
+	 * would qualify a statement that is no longer in the shader.
+	 */
+	private static String declareOpaque(TranslatedUnit.Uniform sampler) {
+		if (!isImageType(sampler.type())) {
+			return "uniform " + sampler.declaration() + ";";
+		}
+
+		return CustomImages.layoutFormat(sampler.name())
+				.map(format -> "layout(" + format + ") uniform " + sampler.declaration() + ";")
+				.orElse("uniform " + sampler.declaration() + ";");
+	}
+
+	private static boolean isImageType(String type) {
+		return type.startsWith("image") || type.startsWith("iimage") || type.startsWith("uimage");
+	}
+
 	private void liftOne(int keyword) {
 		int end = statementEnd(keyword);
 		if (end < 0) {
@@ -3422,13 +3446,13 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Records every storage block the unit declares, which nothing here can make bindable.
+	 * Records every storage block the unit declares, so a {@code bufferObject} can be bound to it.
 	 * <p>
 	 * Named rather than rewritten because the game never looks for one.
 	 * {@code IntermediaryShaderModule.createFromSpirv} lists the module's uniform buffers and its
-	 * sampled images and nothing else, so a storage block never enters a bind group, its binding is
-	 * never rewritten with the rest, and the descriptor stays on whatever number the pack wrote.
-	 * Reverie writes two at set 0, bindings 0 and 1, where the layout already puts the uniform block.
+	 * sampled images and nothing else, so a storage block is appended afterwards and remapped with
+	 * the rest. Complementary Ultra writes {@code blockDataBuffer} at binding 0 for world-space
+	 * reflections; without that name the shadow program is refused and voxel lighting never writes.
 	 * <p>
 	 * Read on the shape and not on the word alone: {@code buffer} followed by a name and an opening
 	 * brace is an interface block and can be nothing else, so no brace depth has to be counted, which
@@ -3451,10 +3475,67 @@ public final class GlslTranslator {
 			}
 
 			int brace = significantAfter(name);
-			if (brace >= 0 && this.tokens.get(brace).operator("{")) {
-				this.storageBlocks.add(this.tokens.get(name).text());
+			if (brace < 0 || !this.tokens.get(brace).operator("{")) {
+				continue;
+			}
+
+			String block = this.tokens.get(name).text();
+			int binding = layoutBinding(index);
+			if (!this.storageBlocks.contains(block)) {
+				this.storageBlocks.add(block);
+			}
+
+			CustomStorage.declare(block, binding);
+			int close = matchingBracket(brace);
+			int instance = close < 0 ? -1 : significantAfter(close);
+			if (instance >= 0 && this.tokens.get(instance).kind() == Kind.IDENTIFIER) {
+				String instanceName = this.tokens.get(instance).text();
+				if (!this.storageBlocks.contains(instanceName)) {
+					this.storageBlocks.add(instanceName);
+				}
+
+				CustomStorage.declare(instanceName, binding);
 			}
 		}
+	}
+
+	/**
+	 * The {@code binding = N} in the layout qualifier that precedes this {@code buffer} token, or
+	 * {@code -1} when the pack wrote none. Complementary always writes one; a nameless
+	 * {@code bufferObject.N} is matched against it.
+	 */
+	private int layoutBinding(int bufferIndex) {
+		int start = 0;
+		for (int scan = bufferIndex - 1; scan >= 0; scan--) {
+			if (this.tokens.get(scan).operator(";")) {
+				start = scan + 1;
+				break;
+			}
+		}
+
+		for (int scan = start; scan < bufferIndex; scan++) {
+			if (!this.tokens.get(scan).identifier("binding")) {
+				continue;
+			}
+
+			int equals = significantAfter(scan);
+			if (equals < 0 || !this.tokens.get(equals).operator("=")) {
+				continue;
+			}
+
+			int number = significantAfter(equals);
+			if (number < 0 || this.tokens.get(number).kind() != Kind.NUMBER) {
+				continue;
+			}
+
+			try {
+				return Integer.parseInt(this.tokens.get(number).text());
+			} catch (NumberFormatException ignored) {
+				return -1;
+			}
+		}
+
+		return -1;
 	}
 
 	/**
@@ -3607,7 +3688,7 @@ public final class GlslTranslator {
 		// compiler numbers a sampler by the order it first meets the name, and MoltenVK turns that
 		// number into a Metal slot that only accepts 0 through 15. Sampled names come first.
 		for (TranslatedUnit.Uniform sampler : samplers) {
-			lines.add("uniform " + sampler.declaration() + ";");
+			lines.add(declareOpaque(sampler));
 		}
 
 		// Attributes stay a matter for the stage that has them. Only a vertex shader has inputs

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -20,6 +20,8 @@ import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.SamplerTypes;
 import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.target.TargetSchedule;
+import dev.vitrail.pack.texture.CustomImages;
+import dev.vitrail.pack.texture.CustomStorage;
 import dev.vitrail.pack.texture.PackTextures;
 import dev.vitrail.pack.texture.TextureStage;
 import dev.vitrail.pack.texture.VolumeAtlas;
@@ -34,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -102,17 +106,19 @@ public final class PackProgram {
 		public List<TranslatedUnit.Uniform> unbindable() {
 			return this.program.samplers().stream()
 					.filter(sampler -> SamplerTypes.refused(sampler.type()))
+					.filter(sampler -> !CustomImages.named(sampler.name()))
 					.toList();
 		}
 
 		/**
-		 * The storage blocks this program declares, which nothing in this game binds. Empty is the
-		 * norm, and the one pack of the corpus that is not says so in every ordinary program.
+		 * The storage blocks this program declares. Empty is the norm. Complementary Ultra writes
+		 * {@code blockDataBuffer} when world-space reflections are on; those names are bound when
+		 * {@link CustomStorage#named} answers, and refused when it does not.
 		 * <p>
 		 * Worth asking separately from {@link #unbindable}: a sampler the backend refuses stops the
 		 * pipeline from being built, which every caller already notices, and a storage block does
-		 * not. It compiles, it is left out of the bind group, and the descriptor keeps the binding
-		 * the pack wrote.
+		 * not. It compiles, and without a bind-group entry its descriptor keeps the binding the
+		 * pack wrote.
 		 */
 		public List<String> storageBlocks() {
 			return this.program.stages().values().stream()
@@ -208,10 +214,9 @@ public final class PackProgram {
 	 *                   Nothing is missing there but the compute pass that would fill it, and this
 	 *                   engine runs none; every one of them in the corpus sits under a setting that
 	 *                   is off by default
-	 * @param storage    storage blocks. {@code IntermediaryShaderModule.createFromSpirv} lists a
-	 *                   module's uniform buffers and its sampled images and nothing else, so one of
-	 *                   these never enters a bind group, its binding is never rewritten, and the
-	 *                   descriptor stays on the number the pack wrote
+	 * @param storage    storage blocks this engine has no {@code bufferObject} for. A served one
+	 *                   is left out of this list and enters the bind group as a uniform name the
+	 *                   mixins turn into a storage buffer
 	 */
 	public record Refusal(List<TranslatedUnit.Uniform> unbindable,
 			List<TranslatedUnit.Uniform> volumes, List<String> storage) {
@@ -370,6 +375,76 @@ public final class PackProgram {
 			return Optional.of(bind(source.packName(), path, program, targets, AlphaTest.OFF,
 					textures));
 		}
+	}
+
+	/**
+	 * A compute-only program, translated, with the work group count Iris reads off
+	 * {@code const ivec3 workGroups}.
+	 */
+	public record Compute(Loaded loaded, int groupsX, int groupsY, int groupsZ) {
+	}
+
+	private static final Pattern WORK_GROUPS = Pattern.compile(
+			"const\\s+ivec3\\s+workGroups\\s*=\\s*ivec3\\s*\\(\\s*(-?\\d+)\\s*,\\s*(-?\\d+)\\s*,\\s*(-?\\d+)\\s*\\)");
+
+	/**
+	 * One {@code .csh} entry point, translated on its own. Empty when the pack does not ship it.
+	 */
+	public static Optional<Compute> loadCompute(Path packPath, String path,
+			Map<String, OptionValue> chosen, String profile) throws IOException {
+		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
+			OptionIndex options = OptionIndex.build(source);
+			ShaderProperties properties = ShaderProperties.parse(source);
+			Map<String, OptionValue> fromProfile = profile.isEmpty()
+					? Map.of()
+					: properties.expandProfile(profile);
+			SettingSet settings = SettingSet.resolve(fromProfile, chosen,
+					profile.isEmpty() ? "chosen" : profile);
+			IncludeExpander expander = new IncludeExpander(source, settings);
+			Optional<Path> file = source.file(path + "." + ProgramStage.COMPUTE.extension());
+			if (file.isEmpty()) {
+				return Optional.empty();
+			}
+
+			ExpandedUnit unit = expander.expand(file.get());
+			TargetPlan targets = TargetPlan.build(source, options, settings, properties,
+					dimensionOf(path));
+			PackTextures textures = textures(source, properties, options, settings);
+			Map<ProgramStage, ExpandedUnit> units = new LinkedHashMap<>();
+			units.put(ProgramStage.COMPUTE, unit);
+			ProgramTranslator.TranslatedProgram program = ProgramTranslator.translate(units,
+					VertexInputs.FULLSCREEN, VertexInputs.FULLSCREEN.elements(), AlphaTest.OFF, false,
+					programOf(path), textures.volumes());
+			int[] groups = workGroupsOf(unit);
+			return Optional.of(new Compute(
+					bind(source.packName(), path, program, targets, AlphaTest.OFF, textures),
+					groups[0], groups[1], groups[2]));
+		}
+	}
+
+	/**
+	 * Iris reads {@code const ivec3 workGroups} off the live preprocessor branch. Complementary
+	 * lists every volume size, dead branches kept in the text, so the first match in the file
+	 * is the 128 one even on Ultra.
+	 */
+	private static int[] workGroupsOf(ExpandedUnit unit) {
+		List<String> lines = unit.lines();
+		for (int i = 0; i < lines.size(); i++) {
+			if (!unit.isLive(i)) {
+				continue;
+			}
+
+			Matcher matcher = WORK_GROUPS.matcher(lines.get(i));
+			if (matcher.find()) {
+				return new int[] {
+						Math.max(1, Integer.parseInt(matcher.group(1))),
+						Math.max(1, Integer.parseInt(matcher.group(2))),
+						Math.max(1, Integer.parseInt(matcher.group(3)))
+				};
+			}
+		}
+
+		return new int[] { 1, 1, 1 };
 	}
 
 	/**
@@ -1090,14 +1165,18 @@ public final class PackProgram {
 						.forEach(sampler -> found.putIfAbsent(sampler.name(), sampler));
 				stage.notes().storageBlocks().stream()
 						.filter(block -> !storage.contains(block))
+						.filter(block -> !CustomStorage.named(block))
 						.forEach(storage::add);
 			});
 
-			List<TranslatedUnit.Uniform> volumes = found.values().stream()
-					.filter(sampler -> filled.contains(sampler.name()))
-					.toList();
+			List<TranslatedUnit.Uniform> volumes = CustomImages.served()
+					? List.of()
+					: found.values().stream()
+							.filter(sampler -> filled.contains(sampler.name()))
+							.toList();
 			List<TranslatedUnit.Uniform> plain = found.values().stream()
-					.filter(sampler -> !filled.contains(sampler.name()))
+					.filter(sampler -> !filled.contains(sampler.name())
+							&& !CustomImages.named(sampler.name()))
 					.toList();
 
 			Refusal refusal = new Refusal(plain, volumes, storage);
@@ -1175,6 +1254,8 @@ public final class PackProgram {
 	 */
 	private static PackTextures textures(ShaderPackSource source, ShaderProperties properties,
 			OptionIndex options, SettingSet settings) throws IOException {
+		CustomImages.install(properties.imageDirectives(settings.globalDefines(options)));
+		CustomStorage.install(properties.bufferObjects(settings.globalDefines(options)));
 		return PackTextures.read(properties, settings.globalDefines(options), source);
 	}
 

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedUnit.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedUnit.java
@@ -95,9 +95,9 @@ public record TranslatedUnit(String entry, ProgramStage stage, String text, Note
 	 * @param comparedSamplers   the samplers the pack asked the hardware to compare and that are
 	 *                           declared here as ordinary ones. Read off the declarations rather
 	 *                           than off {@code samplers}, whose types have already been rewritten
-	 * @param storageBlocks      the storage blocks this unit declares at file scope, which nothing
-	 *                           binds and no rewrite can help: they are what refuses the program
-	 *                           that carries one
+	 * @param storageBlocks      the storage blocks this unit declares at file scope. A
+	 *                           {@code bufferObject} that matches one is bound; the rest refuse
+	 *                           the program that carries them
 	 * @param volumeLookups      lookups on a volume the pack ships, moved onto the flat atlas it was
 	 *                           laid out in
 	 * @param volumesLeftAlone   volumes this unit reaches some way the rewrite does not cover, and

--- a/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
@@ -1,0 +1,27 @@
+package dev.vitrail.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+
+/**
+ * Lets a sampled or stored 3D image through the bind-group walk.
+ * <p>
+ * {@code addToBindGroup} refuses anything whose SPIR-V dimension is not 2D or Cube. SpvDim3D is 2.
+ * Pretending it is 2D is enough for the check; the view that is actually bound is the 3D one
+ * {@code StorageImages} allocated.
+ */
+@Mixin(GlslCompiler.class)
+public abstract class GlslCompilerMixin {
+
+	@WrapOperation(method = "addToBindGroup", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lcom/mojang/blaze3d/vulkan/glsl/SpvSampler;dimensions()I"))
+	private static int vitrail$allow3d(@Coerce Object sampler, Operation<Integer> original) {
+		int dimension = original.call(sampler);
+		return dimension == 2 ? 1 : dimension;
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/IntermediaryShaderModuleAccessor.java
+++ b/common/src/main/java/dev/vitrail/mixin/IntermediaryShaderModuleAccessor.java
@@ -1,0 +1,24 @@
+package dev.vitrail.mixin;
+
+import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+/**
+ * The sampler and uniform-buffer lists on a reflected module, without naming the package-private
+ * record types those lists hold.
+ */
+@Mixin(IntermediaryShaderModule.class)
+@SuppressWarnings("rawtypes")
+public interface IntermediaryShaderModuleAccessor {
+
+	@Accessor("samplers")
+	@SuppressWarnings("rawtypes")
+	List vitrail$samplers();
+
+	@Accessor("uniformBuffers")
+	@SuppressWarnings("rawtypes")
+	List vitrail$uniformBuffers();
+}

--- a/common/src/main/java/dev/vitrail/mixin/IntermediaryShaderModuleMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/IntermediaryShaderModuleMixin.java
@@ -1,0 +1,41 @@
+package dev.vitrail.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
+import dev.vitrail.render.ComputeShader;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Lists SPIR-V storage images and storage buffers beside the resources the game asks SPIRV-Cross
+ * for, and lets a 3D image through {@code rebind}.
+ * <p>
+ * Type 6 is a storage image. Type 5 is a storage buffer. Type 7 is a sampled image.
+ * {@code createFromSpirv} walks 1 and 7 and leaves 5 and 6 on the bindings shaderc assigned.
+ * Complementary's {@code uimage3D voxel_img} and {@code blockDataBuffer} are those resources.
+ * Construction of the package-private records is {@link ComputeShader}, by reflection.
+ */
+@Mixin(IntermediaryShaderModule.class)
+public abstract class IntermediaryShaderModuleMixin {
+
+	@Inject(method = "createFromSpirv", at = @At("RETURN"), require = 1)
+	private static void vitrail$storageImages(String filename, ByteBuffer spirv,
+			CallbackInfoReturnable<IntermediaryShaderModule> callback) {
+		ComputeShader.appendStorageImages(callback.getReturnValue());
+		ComputeShader.appendStorageBuffers(callback.getReturnValue());
+	}
+
+	@WrapOperation(method = "rebind", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lcom/mojang/blaze3d/vulkan/glsl/SpvSampler;dimensions()I"))
+	private int vitrail$allow3d(@Coerce Object sampler, Operation<Integer> original) {
+		int dimension = original.call(sampler);
+		return dimension == 2 ? 1 : dimension;
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
@@ -1,0 +1,102 @@
+package dev.vitrail.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.vulkan.VulkanBackend;
+import com.mojang.blaze3d.vulkan.VulkanPhysicalDevice;
+import com.mojang.blaze3d.vulkan.init.VulkanFeature;
+import dev.vitrail.Vitrail;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.VK12;
+import org.lwjgl.vulkan.VkDevice;
+import org.lwjgl.vulkan.VkPhysicalDeviceFeatures;
+import org.lwjgl.vulkan.VkPhysicalDeviceFeatures2;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Turns on the storage-image features Complementary's voxel lighting needs, which the game never
+ * asks for.
+ * <p>
+ * Complementary writes {@code voxel_img} from the shadow vertex shader
+ * ({@code UpdateVoxelMap} under {@code SHADOW && VERTEX_SHADER}). Vulkan ignores those stores
+ * unless {@code vertexPipelineStoresAndAtomics} is enabled, and {@code r16ui} / {@code rgba16f}
+ * are not core storage formats unless {@code shaderStorageImageExtendedFormats} is on. The game's
+ * {@code VulkanBackend} enables neither: its required set is draw-indirect, anisotropy and
+ * dynamic rendering. Without this, floodfill runs on a volume that stays empty and the pack's
+ * coloured lamps never light.
+ */
+@Mixin(VulkanBackend.class)
+public abstract class VulkanBackendMixin {
+
+	@Unique
+	private static final VulkanFeature VERTEX_STORES = new VulkanFeature(
+			VulkanBackend.VK10_FEATURES_STRUCT, "vertexPipelineStoresAndAtomics",
+			VkPhysicalDeviceFeatures.VERTEXPIPELINESTORESANDATOMICS);
+
+	@Unique
+	private static final VulkanFeature FRAGMENT_STORES = new VulkanFeature(
+			VulkanBackend.VK10_FEATURES_STRUCT, "fragmentStoresAndAtomics",
+			VkPhysicalDeviceFeatures.FRAGMENTSTORESANDATOMICS);
+
+	@Unique
+	private static final VulkanFeature EXTENDED_FORMATS = new VulkanFeature(
+			VulkanBackend.VK10_FEATURES_STRUCT, "shaderStorageImageExtendedFormats",
+			VkPhysicalDeviceFeatures.SHADERSTORAGEIMAGEEXTENDEDFORMATS);
+
+	@Unique
+	private static final VulkanFeature WRITE_WITHOUT_FORMAT = new VulkanFeature(
+			VulkanBackend.VK10_FEATURES_STRUCT, "shaderStorageImageWriteWithoutFormat",
+			VkPhysicalDeviceFeatures.SHADERSTORAGEIMAGEWRITEWITHOUTFORMAT);
+
+	@WrapOperation(method = "createDevice(JLcom/mojang/blaze3d/shaders/ShaderSource;"
+			+ "Lcom/mojang/blaze3d/shaders/GpuDebugOptions;Ljava/lang/Runnable;)"
+			+ "Lcom/mojang/blaze3d/systems/GpuDevice;", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lcom/mojang/blaze3d/vulkan/VulkanBackend;createDevice("
+							+ "Ljava/util/Collection;Lcom/mojang/blaze3d/vulkan/VulkanPhysicalDevice;"
+							+ "Ljava/util/Set;)Lorg/lwjgl/vulkan/VkDevice;"))
+	private VkDevice vitrail$storageFeatures(Collection<String> extensions,
+			VulkanPhysicalDevice physical, Set<VulkanFeature> features,
+			Operation<VkDevice> original) {
+		List<String> enabled = new ArrayList<>();
+		enable(physical, features, VERTEX_STORES, enabled);
+		enable(physical, features, FRAGMENT_STORES, enabled);
+		enable(physical, features, EXTENDED_FORMATS, enabled);
+		enable(physical, features, WRITE_WITHOUT_FORMAT, enabled);
+		if (!enabled.isEmpty()) {
+			Vitrail.logger().info("Vulkan storage features: {}", String.join(", ", enabled));
+		}
+
+		return original.call(extensions, physical, features);
+	}
+
+	@Unique
+	private static void enable(VulkanPhysicalDevice physical, Set<VulkanFeature> features,
+			VulkanFeature feature, List<String> enabled) {
+		if (!supported(physical, feature)) {
+			Vitrail.logger().warn("Vulkan device does not support {}, voxel lighting will not write",
+					feature.name());
+			return;
+		}
+
+		features.add(feature);
+		enabled.add(feature.name());
+	}
+
+	@Unique
+	private static boolean supported(VulkanPhysicalDevice physical, VulkanFeature feature) {
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			VkPhysicalDeviceFeatures2 queried = VkPhysicalDeviceFeatures2.calloc(stack).sType$Default();
+			feature.struct().findOrCreateStructInPNextChain(queried, stack);
+			VK12.vkGetPhysicalDeviceFeatures2(physical.vkPhysicalDevice(), queried);
+			return feature.get(queried);
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBindGroupLayoutMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBindGroupLayoutMixin.java
@@ -1,0 +1,60 @@
+package dev.vitrail.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
+import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout.Entry;
+import dev.vitrail.pack.texture.CustomImages;
+import dev.vitrail.render.StorageBuffers;
+import dev.vitrail.render.StorageImages;
+import org.lwjgl.vulkan.VkDescriptorSetLayoutBinding;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.List;
+
+/**
+ * Emits {@code VK_DESCRIPTOR_TYPE_STORAGE_IMAGE} for an {@code image.NAME} uniform, and
+ * {@code VK_DESCRIPTOR_TYPE_STORAGE_BUFFER} for a {@code bufferObject} block.
+ * <p>
+ * The Java enum has no storage-image or storage-buffer arm, so the layout would otherwise write
+ * a combined image sampler (type 1) for {@code voxel_img} and a uniform buffer (type 6) for
+ * {@code blockDataBuffer}. Complementary writes both with {@code imageStore} / SSBO stores.
+ */
+@Mixin(VulkanBindGroupLayout.class)
+public abstract class VulkanBindGroupLayoutMixin {
+
+	@Unique
+	private static final ThreadLocal<Entry> CURRENT = new ThreadLocal<>();
+
+	@WrapOperation(method = "create", require = 1,
+			at = @At(value = "INVOKE", target = "Ljava/util/List;get(I)Ljava/lang/Object;"))
+	private static Object vitrail$entry(List<?> entries, int index, Operation<Object> original) {
+		Object entry = original.call(entries, index);
+		if (entry instanceof Entry named) {
+			CURRENT.set(named);
+		}
+
+		return entry;
+	}
+
+	@WrapOperation(method = "create", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/VkDescriptorSetLayoutBinding;descriptorType(I)"
+							+ "Lorg/lwjgl/vulkan/VkDescriptorSetLayoutBinding;"))
+	private static VkDescriptorSetLayoutBinding vitrail$storageType(
+			VkDescriptorSetLayoutBinding binding, int type, Operation<VkDescriptorSetLayoutBinding> original) {
+		Entry entry = CURRENT.get();
+		if (type == 1 && entry != null && (StorageImages.storageBinding(entry.name())
+				|| CustomImages.storage(entry.name()))) {
+			type = 3;
+		}
+
+		if (type == 6 && entry != null && StorageBuffers.named(entry.name())) {
+			type = 7;
+		}
+
+		return original.call(binding, type);
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderAccessor.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderAccessor.java
@@ -1,0 +1,23 @@
+package dev.vitrail.mixin;
+
+import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
+import com.mojang.blaze3d.vulkan.VulkanRenderPass;
+import org.lwjgl.vulkan.VkCommandBuffer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+/**
+ * The command buffer the encoder is recording into this frame, which is where storage-image
+ * clears and compute dispatches have to go: a buffer of our own would race the pass the shadow
+ * geometry just closed.
+ */
+@Mixin(VulkanCommandEncoder.class)
+public interface VulkanCommandEncoderAccessor {
+
+	@Invoker("commandBuffer")
+	VkCommandBuffer vitrail$commandBuffer();
+
+	@Accessor("currentRenderPass")
+	VulkanRenderPass vitrail$currentRenderPass();
+}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
@@ -73,12 +73,15 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 	 * that first attaches it rather than being a clear of its own, so a pass and the clear meant to
 	 * precede it are two writes to one image with no dependency between them.
 	 * <p>
-	 * <strong>What the masks deliberately leave out, and the day that stops being safe.</strong>
-	 * A pass of ours writes colour and depth attachments and nothing else, so the source names
-	 * those two. Nothing downstream is a compute dispatch, an image store or a shader storage
-	 * buffer, so the destination names no compute stage and no storage access. The day a pack's
-	 * compute programs are dispatched, both ends stop covering what the frame does, and the
-	 * dependency has to be widened here rather than worked around where it shows.
+	 * <strong>Both ends also name what a pack's compute programs move.</strong>
+	 * A pass of ours no longer writes attachments and nothing else: a pack's geometry stores into
+	 * its own volumes from the fragment stage, so a storage write is one of the things a closing
+	 * pass leaves behind. And what reads next is no longer graphics alone, which is the half that
+	 * the barrier standing beside the dispatch cannot cover: that one carries storage writes as
+	 * its source, so it orders the stores of the shadow geometry against the floodfill, and
+	 * nothing in it names the ATTACHMENT writes of the same pass. The pack's compute samples the
+	 * shadow map through the same views the graphics passes bind, and shadowtex0 is a depth
+	 * attachment we wrote.
 	 */
 	@Redirect(method = "submitRenderPass", at = @At(value = "INVOKE",
 			target = "Lcom/mojang/blaze3d/vulkan/VulkanCommandEncoder;memoryBarrier("
@@ -105,10 +108,15 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 	private static void vitrail$framebufferBarrier(VkCommandBuffer commands, MemoryStack stack) {
 		VkMemoryBarrier2.Buffer barrier = VkMemoryBarrier2.calloc(1, stack)
 				.sType$Default()
+				// The shader stages are here for the image stores of a pack's own geometry, which
+				// land in the volumes its compute reads and its gbuffers sample.
 				.srcStageMask(KHRSynchronization2.VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR
-						| KHRSynchronization2.VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR)
+						| KHRSynchronization2.VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR
+						| KHRSynchronization2.VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR
+						| KHRSynchronization2.VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR)
 				.srcAccessMask(KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR
-						| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT_KHR)
+						| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT_KHR)
 				// The vertex stage samples too, and leaving it out is not theoretical: a sampler
 				// declared in a pack's vertex unit is kept and bound like any other
 				// (ProgramTranslator collects the samplers of every stage), so a program whose
@@ -117,6 +125,7 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR
+						| KHRSynchronization2.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR)
 				// The writes sit here beside the reads, and each of the three is reached every frame:
 				// a colour target the next pass writes, or that the emptying writes through its
@@ -126,6 +135,8 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 				// write-after-write with nothing between them, which a driver is free to run in
 				// either order.
 				.dstAccessMask(KHRSynchronization2.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_SHADER_STORAGE_READ_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT_KHR
 						| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT_KHR
 						| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR
 						| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT_KHR

--- a/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
@@ -1,0 +1,129 @@
+package dev.vitrail.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
+import com.mojang.blaze3d.vulkan.VulkanRenderPass;
+import dev.vitrail.render.StorageBuffers;
+import dev.vitrail.render.StorageImages;
+import org.lwjgl.vulkan.VkDescriptorBufferInfo;
+import org.lwjgl.vulkan.VkDescriptorImageInfo;
+import org.lwjgl.vulkan.VkWriteDescriptorSet;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.List;
+
+/**
+ * Pushes a storage-image descriptor, a 3D sampled view, and a storage-buffer descriptor for
+ * names {@link StorageImages} and {@link StorageBuffers} hold.
+ * <p>
+ * The game always writes a combined image sampler from a 2D {@code GpuTextureView}, and a
+ * uniform buffer from a {@code GpuBufferSlice}. Complementary needs type 3 and a 3D view on
+ * {@code voxel_img}, a 3D sampled view on {@code voxel_sampler}, and type 7 plus the VMA handle
+ * on {@code blockDataBuffer}.
+ */
+@Mixin(VulkanRenderPass.class)
+public abstract class VulkanRenderPassMixin {
+
+	@Unique
+	private static final ThreadLocal<VulkanBindGroupLayout.Entry> CURRENT = new ThreadLocal<>();
+
+	@WrapOperation(method = "pushDescriptors", require = 1,
+			at = @At(value = "INVOKE", target = "Ljava/util/List;get(I)Ljava/lang/Object;", ordinal = 0))
+	private Object vitrail$entry(List<?> entries, int index, Operation<Object> original) {
+		Object entry = original.call(entries, index);
+		if (entry instanceof VulkanBindGroupLayout.Entry named) {
+			CURRENT.set(named);
+		}
+
+		return entry;
+	}
+
+	@WrapOperation(method = "pushDescriptors", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/VkDescriptorImageInfo$Buffer;imageView(J)"
+							+ "Lorg/lwjgl/vulkan/VkDescriptorImageInfo$Buffer;"))
+	private VkDescriptorImageInfo.Buffer vitrail$view(VkDescriptorImageInfo.Buffer info, long view,
+			Operation<VkDescriptorImageInfo.Buffer> original) {
+		StorageImages.Bound bound = currentBound();
+		if (bound != null) {
+			view = bound.view();
+		}
+
+		return original.call(info, view);
+	}
+
+	@WrapOperation(method = "pushDescriptors", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/VkDescriptorImageInfo$Buffer;sampler(J)"
+							+ "Lorg/lwjgl/vulkan/VkDescriptorImageInfo$Buffer;"))
+	private VkDescriptorImageInfo.Buffer vitrail$sampler(VkDescriptorImageInfo.Buffer info,
+			long sampler, Operation<VkDescriptorImageInfo.Buffer> original) {
+		StorageImages.Bound bound = currentBound();
+		if (bound != null && bound.storage()) {
+			sampler = 0L;
+		}
+
+		return original.call(info, sampler);
+	}
+
+	@WrapOperation(method = "pushDescriptors", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/VkDescriptorBufferInfo$Buffer;buffer(J)"
+							+ "Lorg/lwjgl/vulkan/VkDescriptorBufferInfo$Buffer;"))
+	private VkDescriptorBufferInfo.Buffer vitrail$buffer(VkDescriptorBufferInfo.Buffer info,
+			long buffer, Operation<VkDescriptorBufferInfo.Buffer> original) {
+		StorageBuffers.Bound bound = currentBuffer();
+		if (bound != null) {
+			buffer = bound.buffer();
+		}
+
+		return original.call(info, buffer);
+	}
+
+	@WrapOperation(method = "pushDescriptors", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/VkDescriptorBufferInfo$Buffer;range(J)"
+							+ "Lorg/lwjgl/vulkan/VkDescriptorBufferInfo$Buffer;"))
+	private VkDescriptorBufferInfo.Buffer vitrail$range(VkDescriptorBufferInfo.Buffer info,
+			long range, Operation<VkDescriptorBufferInfo.Buffer> original) {
+		StorageBuffers.Bound bound = currentBuffer();
+		if (bound != null) {
+			range = bound.range();
+		}
+
+		return original.call(info, range);
+	}
+
+	@WrapOperation(method = "pushDescriptors", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/VkWriteDescriptorSet;descriptorType(I)"
+							+ "Lorg/lwjgl/vulkan/VkWriteDescriptorSet;"))
+	private VkWriteDescriptorSet vitrail$type(VkWriteDescriptorSet set, int type,
+			Operation<VkWriteDescriptorSet> original) {
+		StorageImages.Bound image = currentBound();
+		if (type == 1 && image != null && image.storage()) {
+			type = 3;
+		}
+
+		if (type == 6 && currentBuffer() != null) {
+			type = 7;
+		}
+
+		return original.call(set, type);
+	}
+
+	@Unique
+	private static StorageImages.Bound currentBound() {
+		VulkanBindGroupLayout.Entry entry = CURRENT.get();
+		return entry == null ? null : StorageImages.bound(entry.name());
+	}
+
+	@Unique
+	private static StorageBuffers.Bound currentBuffer() {
+		VulkanBindGroupLayout.Entry entry = CURRENT.get();
+		return entry == null ? null : StorageBuffers.bound(entry.name());
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -1,6 +1,7 @@
 package dev.vitrail.pack.option;
 
 import dev.vitrail.pack.program.RenderStage;
+import dev.vitrail.pack.texture.CustomImages;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -131,11 +132,14 @@ public final class EngineDefines {
 		// it is also a promise, and every one of those has to work before it can stay.
 		defines.put("IS_IRIS", "");
 
-		// And no IRIS_FEATURE_ beside it, deliberately. Iris poses one per flag it can serve, in two
-		// places and not one: among the defines that read shaders.properties, for every flag it
-		// holds usable, and among the GLSL ones for the names of the optional line alone. A pack
-		// reads them to pick a path, so claiming one here would send the five packs of the corpus
-		// that name one down a road this engine has not built. See
+		// Posed only for a flag this engine serves. Custom images are the voxel volumes
+		// Complementary writes from shadow geometry and floods in shadowcomp; claiming the
+		// symbol without that pipe sends the pack down a road that refuses gbuffers.
+		if (CustomImages.served()) {
+			defines.put("IRIS_FEATURE_CUSTOM_IMAGES", "");
+		}
+
+		// The rest of IRIS_FEATURE_ stays unposted until each capability is served. See
 		// ShaderProperties.optionalFeatures for the other half of the answer, and PackChain for
 		// what a pack requiring one is told.
 

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -321,10 +321,10 @@ public final class ShaderProperties {
 
 		// Replaced and not added to: a second line of the same name is the one that counts, which is
 		// how Iris reads both of them, and not how the sliders below are read, where the tokens of a
-		// second line join the first. Read even though this engine serves no feature at all, because that is
-		// exactly what makes the refusal say something: a pack that names what it cannot do without
-		// is answered with the names, instead of falling over later on whichever sampler its
-		// storage buffers happened to sit behind.
+		// second line join the first. Read so the refusal can say something: a pack that names
+		// what it cannot do without is answered with the names this engine has not built, instead
+		// of falling over later on whichever sampler its storage buffers happened to sit behind.
+		// What is served is settled at the chain, not here: this only carries the names.
 		Matcher features = IRIS_FEATURES.matcher(line);
 		if (features.matches()) {
 			List<String> named = new ArrayList<>();
@@ -1627,8 +1627,9 @@ public final class ShaderProperties {
 
 	/**
 	 * What the pack would use if it were there, and takes another path without. It is the list Iris
-	 * turns into {@code IRIS_FEATURE_} defines for the GLSL; this engine defines none, which is what
-	 * tells a pack to take the other path.
+	 * turns into {@code IRIS_FEATURE_} defines for the GLSL. This engine poses
+	 * {@code IRIS_FEATURE_CUSTOM_IMAGES} when the storage-image pipe is served, and none of the
+	 * others, which is what tells a pack to take the other path for those.
 	 * <p>
 	 * Nothing in the engine reads this list, and that is deliberate rather than an oversight: there
 	 * is nothing here to decide from it. What taking the line out of the ignored keys buys is

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -4,7 +4,13 @@ import dev.vitrail.pack.option.OptionIndex;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.option.PackOption;
 import dev.vitrail.pack.program.AlphaTest;
+import dev.vitrail.pack.target.TargetFormat;
 import dev.vitrail.pack.target.TargetSize;
+import dev.vitrail.pack.texture.BufferObject;
+import dev.vitrail.pack.texture.ImageInformation;
+import dev.vitrail.pack.texture.PackTexture;
+import dev.vitrail.pack.texture.PixelFormat;
+import dev.vitrail.pack.texture.PixelType;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -128,7 +134,9 @@ public final class ShaderProperties {
 			Pattern.compile("^\\s*shadow\\.enabled\\s*=\\s*(.*)$");
 	private static final Pattern CUSTOM_TEXTURE =
 			Pattern.compile("^\\s*((?:texture|customTexture)\\.[^=\\s]+)\\s*=\\s*(.*)$");
-	private static final Pattern IMAGE = Pattern.compile("^\\s*image\\.[^=\\s.]+\\s*=\\s*(.*)$");
+	private static final Pattern IMAGE = Pattern.compile("^\\s*image\\.([^=\\s.]+)\\s*=\\s*(.*)$");
+	private static final Pattern BUFFER_OBJECT =
+			Pattern.compile("^\\s*bufferObject\\.(\\d+)\\s*=\\s*(.*)$");
 	private static final Pattern FLIP = Pattern.compile("^\\s*flip\\.([^=\\s.]+)\\.([^=\\s.]+)\\s*=\\s*(.*)$");
 	private static final Pattern OTHER_KEY = Pattern.compile("^\\s*([A-Za-z_][\\w]*)[.=].*$");
 
@@ -484,6 +492,18 @@ public final class ShaderProperties {
 		// conditionals. Falling through here would leave those lines among the keys nothing reads
 		// and make that count say the engine ignores what it now honours.
 		if (CUSTOM_TEXTURE.matcher(line).matches()) {
+			return;
+		}
+
+		// Same reason as the texture family: the live lines are walked later, with the
+		// conditionals, and falling through would count {@code image} as a prefix nobody reads.
+		if (IMAGE.matcher(line).matches()) {
+			return;
+		}
+
+		// Same reason as the image family: the live lines are walked later, and falling through
+		// would count {@code bufferObject} as a prefix nobody reads.
+		if (BUFFER_OBJECT.matcher(line).matches()) {
 			return;
 		}
 
@@ -1063,6 +1083,25 @@ public final class ShaderProperties {
 	 */
 	public Set<String> imageSamplers(Map<String, String> defines) {
 		Set<String> samplers = new LinkedHashSet<>();
+		for (ImageInformation image : imageDirectives(defines).images()) {
+			image.sampler().ifPresent(samplers::add);
+		}
+
+		return samplers;
+	}
+
+	/**
+	 * The storage images the pack declares, live lines only, in the order it wrote them.
+	 * <p>
+	 * Iris reads the same grammar after its preprocessor has already substituted the pack's
+	 * settings ({@code ShaderProperties} around the {@code image.} handler). Here the
+	 * conditionals are evaluated against {@code defines} and a size written as a setting name
+	 * is looked up in that table, which is what lets Complementary size a volume with
+	 * {@code COLORED_LIGHTING} itself. A seventeenth image is dropped, which is Iris's ceiling.
+	 */
+	public ImageInformation.Reading imageDirectives(Map<String, String> defines) {
+		List<ImageInformation> images = new ArrayList<>();
+		List<String> dropped = new ArrayList<>();
 		ConditionStack conditions = new ConditionStack();
 
 		for (String line : this.lines) {
@@ -1073,15 +1112,233 @@ public final class ShaderProperties {
 			}
 
 			Matcher image = IMAGE.matcher(line);
-			if (conditions.active() && image.matches()) {
-				String[] words = image.group(1).trim().split(" ", -1);
-				if (!words[0].isEmpty() && !words[0].equalsIgnoreCase("none")) {
-					samplers.add(words[0]);
-				}
+			if (!conditions.active() || !image.matches()) {
+				continue;
+			}
+
+			String name = image.group(1);
+			String value = image.group(2).trim();
+			if (images.size() >= ImageInformation.LIMIT) {
+				dropped.add("image." + name + ": only " + ImageInformation.LIMIT
+						+ " storage images are allowed");
+				continue;
+			}
+
+			String reason = readImage(name, value, defines, images);
+			if (reason != null) {
+				dropped.add("image." + name + " = " + value + ": " + reason);
 			}
 		}
 
-		return samplers;
+		return new ImageInformation.Reading(images, dropped);
+	}
+
+	/**
+	 * The storage buffers the pack declares, live lines only, in the order it wrote them.
+	 * <p>
+	 * Iris reads the same grammar after its preprocessor has already substituted the pack's
+	 * settings ({@code ShaderProperties} around the {@code bufferObject.} handler). Here the
+	 * conditionals are evaluated against {@code defines}. An index past twelve is dropped, which
+	 * is Iris's ceiling, and a size below one disables the line, which is Iris's way of turning
+	 * one off.
+	 */
+	public BufferObject.Reading bufferObjects(Map<String, String> defines) {
+		Map<Integer, BufferObject> buffers = new LinkedHashMap<>();
+		List<String> dropped = new ArrayList<>();
+		ConditionStack conditions = new ConditionStack();
+
+		for (String line : this.lines) {
+			Matcher directive = DIRECTIVE.matcher(line);
+			if (directive.matches()) {
+				applyDirective(directive.group(1), line, conditions, defines);
+				continue;
+			}
+
+			Matcher buffer = BUFFER_OBJECT.matcher(line);
+			if (!conditions.active() || !buffer.matches()) {
+				continue;
+			}
+
+			String reason = readBufferObject(buffer.group(1), buffer.group(2).trim(), buffers);
+			if (reason != null) {
+				dropped.add("bufferObject." + buffer.group(1) + " = " + buffer.group(2).trim()
+						+ ": " + reason);
+			}
+		}
+
+		return new BufferObject.Reading(List.copyOf(buffers.values()), dropped);
+	}
+
+	/**
+	 * One {@code bufferObject.N} value, Iris's word counts, or a reason this line cannot be kept.
+	 * <p>
+	 * Returns null when the buffer was added. Two words or fewer are an absolute size and an
+	 * optional name; four or more are the relative form.
+	 */
+	private static String readBufferObject(String indexText, String value,
+			Map<Integer, BufferObject> buffers) {
+		int index;
+		try {
+			index = Integer.parseInt(indexText);
+		} catch (NumberFormatException e) {
+			return "index is not a number";
+		}
+
+		if (index > BufferObject.LIMIT) {
+			return "only indices 0 to " + BufferObject.LIMIT + " are allowed";
+		}
+
+		String[] parts = value.split(" ", -1);
+		if (parts.length == 0 || parts[0].isEmpty()) {
+			return "expected a size";
+		}
+
+		long size;
+		try {
+			size = Long.parseLong(parts[0]);
+		} catch (NumberFormatException e) {
+			return "size is not a number";
+		}
+
+		if (size < 1L) {
+			return "size below one disables the buffer";
+		}
+
+		if (parts.length <= 2) {
+			Optional<String> name = parts.length > 1 && !parts[1].isEmpty()
+					? Optional.of(parts[1])
+					: Optional.empty();
+			buffers.put(index, new BufferObject(index, size, false, 0.0F, 0.0F, name));
+			return null;
+		}
+
+		if (parts.length < 4) {
+			return "a relative buffer takes four words";
+		}
+
+		boolean relative = Boolean.parseBoolean(parts[1]);
+		float scaleX;
+		float scaleY;
+		try {
+			scaleX = Float.parseFloat(parts[2]);
+			scaleY = Float.parseFloat(parts[3]);
+		} catch (NumberFormatException e) {
+			return "relative scale is not a number";
+		}
+
+		buffers.put(index, new BufferObject(index, size, relative, scaleX, scaleY, Optional.empty()));
+		return null;
+	}
+
+	/**
+	 * One {@code image.NAME} value, Iris's word counts, or a reason this line cannot be kept.
+	 * <p>
+	 * Returns null when the image was added. A size that is not a number is looked up in
+	 * {@code defines}, which is the substitute for Iris running the preprocessor over the file
+	 * before this parser sees a token.
+	 */
+	private static String readImage(String name, String value, Map<String, String> defines,
+			List<ImageInformation> images) {
+		String[] parts = value.split(" ", -1);
+		if (parts.length < 6) {
+			return "expected at least six words";
+		}
+
+		Optional<String> sampler = parts[0].isEmpty() || parts[0].equalsIgnoreCase("none")
+				? Optional.empty()
+				: Optional.of(parts[0]);
+		Optional<PixelFormat> format = PixelFormat.parse(parts[1]);
+		TargetFormat.Resolution internal = TargetFormat.resolve(parts[2]);
+		Optional<PixelType> pixelType = PixelType.parse(parts[3]);
+		if (format.isEmpty() || pixelType.isEmpty()
+				|| internal.reason() == TargetFormat.Reason.UNKNOWN) {
+			return "format " + parts[1] + " internal " + parts[2] + " pixel type " + parts[3];
+		}
+
+		boolean clear = Boolean.parseBoolean(parts[4]);
+		boolean relative = Boolean.parseBoolean(parts[5]);
+		PackTexture.Shape shape;
+		int width;
+		int height;
+		int depth;
+		float relativeWidth = 0;
+		float relativeHeight = 0;
+		if (relative) {
+			if (parts.length != 8) {
+				return "a relative image takes two size words";
+			}
+
+			try {
+				relativeWidth = Float.parseFloat(parts[6]);
+				relativeHeight = Float.parseFloat(parts[7]);
+			} catch (NumberFormatException e) {
+				return "relative size is not a number";
+			}
+
+			shape = PackTexture.Shape.TEXTURE_2D;
+			width = 0;
+			height = 0;
+			depth = 0;
+		} else if (parts.length == 7) {
+			OptionalInt size = dimension(parts[6], defines);
+			if (size.isEmpty()) {
+				return "size is not a number";
+			}
+
+			shape = PackTexture.Shape.TEXTURE_1D;
+			width = size.getAsInt();
+			height = 0;
+			depth = 0;
+		} else if (parts.length == 8) {
+			OptionalInt sizeX = dimension(parts[6], defines);
+			OptionalInt sizeY = dimension(parts[7], defines);
+			if (sizeX.isEmpty() || sizeY.isEmpty()) {
+				return "size is not a number";
+			}
+
+			shape = PackTexture.Shape.TEXTURE_2D;
+			width = sizeX.getAsInt();
+			height = sizeY.getAsInt();
+			depth = 0;
+		} else if (parts.length == 9) {
+			OptionalInt sizeX = dimension(parts[6], defines);
+			OptionalInt sizeY = dimension(parts[7], defines);
+			OptionalInt sizeZ = dimension(parts[8], defines);
+			if (sizeX.isEmpty() || sizeY.isEmpty() || sizeZ.isEmpty()) {
+				return "size is not a number";
+			}
+
+			shape = PackTexture.Shape.TEXTURE_3D;
+			width = sizeX.getAsInt();
+			height = sizeY.getAsInt();
+			depth = sizeZ.getAsInt();
+		} else {
+			return "unknown image type";
+		}
+
+		images.add(new ImageInformation(name, sampler, shape, format.get(), internal,
+				pixelType.get(), width, height, depth, clear, relative, relativeWidth,
+				relativeHeight));
+
+		return null;
+	}
+
+	/** A size token, or the same name looked up in the pack's settings when it is not a number. */
+	private static OptionalInt dimension(String token, Map<String, String> defines) {
+		try {
+			return OptionalInt.of(Integer.parseInt(token));
+		} catch (NumberFormatException e) {
+			String value = defines.get(token);
+			if (value == null) {
+				return OptionalInt.empty();
+			}
+
+			try {
+				return OptionalInt.of(Integer.parseInt(value.trim()));
+			} catch (NumberFormatException ignored) {
+				return OptionalInt.empty();
+			}
+		}
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
@@ -1,6 +1,7 @@
 package dev.vitrail.pack.target;
 
 import dev.vitrail.pack.program.ProgramNames;
+import dev.vitrail.pack.texture.CustomImages;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -101,7 +102,7 @@ public final class SamplerPlan {
 	 */
 	public enum Kind {
 		COLORTEX, DEPTH, SHADOW_DEPTH, SHADOW_COLOUR, NOISE, PACK_TEXTURE, CENTER_DEPTH,
-		DISTANT_DEPTH, UNSERVED, UNBINDABLE
+		DISTANT_DEPTH, CUSTOM_IMAGE, UNSERVED, UNBINDABLE
 	}
 
 	/**
@@ -136,6 +137,10 @@ public final class SamplerPlan {
 	 *                 narrowed to it
 	 */
 	public static Kind classify(String name, String type, Set<String> supplied) {
+		if (CustomImages.named(name)) {
+			return Kind.CUSTOM_IMAGE;
+		}
+
 		if (type != null && SamplerTypes.refused(type)) {
 			return Kind.UNBINDABLE;
 		}

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -107,6 +107,7 @@ public final class TargetPlan {
 	private final Set<String> inferred;
 	private final Map<String, Set<Integer>> samples;
 	private final int geometryAt;
+	private final List<String> computes;
 	private final List<String> unreadable;
 	private final List<String> notes;
 	private final int programsRead;
@@ -125,6 +126,7 @@ public final class TargetPlan {
 		this.inferred = Collections.unmodifiableSet(new TreeSet<>(draft.inferred));
 		this.samples = Collections.unmodifiableMap(new LinkedHashMap<>(draft.samples));
 		this.geometryAt = draft.geometryAt;
+		this.computes = List.copyOf(draft.computes);
 		this.written = Collections.unmodifiableSet(new TreeSet<>(draft.written));
 		this.sampled = Collections.unmodifiableSet(new TreeSet<>(draft.sampled));
 
@@ -504,6 +506,14 @@ public final class TargetPlan {
 	}
 
 	/**
+	 * Compute entry points this place ships, by bare name. Shadowcomp is dispatched after the
+	 * shadow map; the rest are named in {@link #notes()} until a stage exists for them.
+	 */
+	public List<String> computes() {
+		return this.computes;
+	}
+
+	/**
 	 * Full screen programs this place ships and does not run, by bare name, with the reason. The
 	 * reason is the pack's own expression when the pack switched it off, {@code MOTION_BLUR} or
 	 * {@code false}, and {@link #LEFT_OUT} when {@code passes=} did, so a log can tell the two
@@ -635,7 +645,19 @@ public final class TargetPlan {
 		}
 
 		if (!draft.computes.isEmpty()) {
-			notes.add("compute programs skipped, no stage exists for them yet: " + draft.computes);
+			List<String> shadow = draft.computes.stream()
+					.filter(name -> ProgramNames.shadowComposite(ProgramNames.familyOf(name)))
+					.toList();
+			List<String> other = draft.computes.stream()
+					.filter(name -> !ProgramNames.shadowComposite(ProgramNames.familyOf(name)))
+					.toList();
+			if (!shadow.isEmpty()) {
+				notes.add("shadow compute after the shadow map: " + shadow);
+			}
+
+			if (!other.isEmpty()) {
+				notes.add("compute programs skipped, no stage exists for them yet: " + other);
+			}
 		}
 
 		if (!draft.shadowComposites.isEmpty()) {

--- a/common/src/main/java/dev/vitrail/pack/texture/BufferObject.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/BufferObject.java
@@ -1,0 +1,68 @@
+package dev.vitrail.pack.texture;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * One {@code bufferObject.N} directive, as Iris reads it and before anything is allocated.
+ * <p>
+ * The grammar is Iris's, {@code ShaderProperties} around the {@code bufferObject.} handler: an
+ * index, a size in bytes, an optional block name, or the four-word relative form. Twelve is the
+ * ceiling Iris enforces. Nothing here touches a device.
+ *
+ * @see <a href="https://github.com/IrisShaders/Iris">Iris ShaderStorageInfo, LGPL-3.0</a>
+ */
+public record BufferObject(int index, long size, boolean relative, float scaleX, float scaleY,
+		Optional<String> name) {
+
+	/** Iris refuses an index past twelve; those slots are reserved. */
+	public static final int LIMIT = 12;
+
+	/**
+	 * What {@link dev.vitrail.pack.source.ShaderProperties#bufferObjects} answered, including the
+	 * lines that were live and could not be read.
+	 */
+	public record Reading(List<BufferObject> buffers, List<String> dropped) {
+
+		public Reading {
+			buffers = List.copyOf(buffers);
+			dropped = List.copyOf(dropped);
+		}
+
+		public static Reading empty() {
+			return new Reading(List.of(), List.of());
+		}
+
+		boolean hasIndex(int index) {
+			for (BufferObject buffer : this.buffers) {
+				if (buffer.index() == index) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		boolean hasName(String name) {
+			for (BufferObject buffer : this.buffers) {
+				if (buffer.name().filter(name::equals).isPresent()) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+	}
+
+	/** One clause for the log, saying the index, the optional name and the size. */
+	public String describe() {
+		String size = this.relative
+				? this.size + " bytes per pixel at " + this.scaleX + "x" + this.scaleY
+						+ " of the screen"
+				: this.size + " bytes";
+
+		return this.index
+				+ this.name.map(name -> " as " + name).orElse("")
+				+ " " + size;
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/texture/CustomImages.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/CustomImages.java
@@ -1,0 +1,122 @@
+package dev.vitrail.pack.texture;
+
+import dev.vitrail.pack.target.TargetFormat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The storage images the loaded pack declared, and whether this engine serves the pipe they need.
+ * <p>
+ * Complementary gates voxel lighting on {@code IRIS_FEATURE_CUSTOM_IMAGES}. That define is posed
+ * only while {@link #served()} is true, which is this engine having the allocation, the 3D bind
+ * and the shadow compute dispatch, not a promise of a pass still to be built.
+ */
+public final class CustomImages {
+
+	private static volatile Map<String, ImageInformation> byName = Map.of();
+	private static volatile Set<String> names = Set.of();
+
+	private CustomImages() {
+	}
+
+	/**
+	 * Whether geometry {@code imageStore} and the shadow compute pass are wired. False would send
+	 * Complementary down its fallback and show the Iris banner; true without a bind would refuse
+	 * the programs that declare {@code usampler3D}.
+	 */
+	public static boolean served() {
+		return true;
+	}
+
+	/** Records the live {@code image.NAME} lines of the pack about to be translated. */
+	public static void install(ImageInformation.Reading reading) {
+		Map<String, ImageInformation> images = new LinkedHashMap<>();
+		for (ImageInformation image : reading.images()) {
+			images.put(image.name(), image);
+			image.sampler().ifPresent(sampler -> images.putIfAbsent(sampler, image));
+		}
+
+		byName = Map.copyOf(images);
+		names = Set.copyOf(images.keySet());
+	}
+
+	public static void clear() {
+		byName = Map.of();
+		names = Set.of();
+	}
+
+	/** Image name or sampler name hanging off an {@code image.} directive. */
+	public static boolean named(String name) {
+		return names.contains(name);
+	}
+
+	/** The image uniform itself, as opposed to the sampler that reads the same volume. */
+	public static boolean storage(String name) {
+		ImageInformation image = byName.get(name);
+		return image != null && image.name().equals(name);
+	}
+
+	/**
+	 * The GLSL layout format a storage image declaration needs on Vulkan, where Iris's GL bind
+	 * supplies the format at bind time and the pack often writes none.
+	 */
+	public static Optional<String> layoutFormat(String name) {
+		ImageInformation image = byName.get(name);
+		if (image == null || !image.name().equals(name)) {
+			return Optional.empty();
+		}
+
+		return Optional.of(glslLayout(image.internalFormat().used()));
+	}
+
+	public static Optional<ImageInformation> image(String name) {
+		return Optional.ofNullable(byName.get(name));
+	}
+
+	static String glslLayout(TargetFormat format) {
+		return switch (format) {
+			case R8_UNORM -> "r8";
+			case R8_SNORM -> "r8_snorm";
+			case RG8_UNORM -> "rg8";
+			case RG8_SNORM -> "rg8_snorm";
+			case RGBA8_UNORM -> "rgba8";
+			case RGBA8_SNORM -> "rgba8_snorm";
+			case R16_UNORM -> "r16";
+			case R16_SNORM -> "r16_snorm";
+			case RG16_UNORM -> "rg16";
+			case RG16_SNORM -> "rg16_snorm";
+			case RGBA16_UNORM -> "rgba16";
+			case RGBA16_SNORM -> "rgba16_snorm";
+			case R8_UINT -> "r8ui";
+			case R8_SINT -> "r8i";
+			case RG8_UINT -> "rg8ui";
+			case RG8_SINT -> "rg8i";
+			case RGBA8_UINT -> "rgba8ui";
+			case RGBA8_SINT -> "rgba8i";
+			case R16_UINT -> "r16ui";
+			case R16_SINT -> "r16i";
+			case RG16_UINT -> "rg16ui";
+			case RG16_SINT -> "rg16i";
+			case RGBA16_UINT -> "rgba16ui";
+			case RGBA16_SINT -> "rgba16i";
+			case R32_UINT -> "r32ui";
+			case R32_SINT -> "r32i";
+			case RG32_UINT -> "rg32ui";
+			case RG32_SINT -> "rg32i";
+			case RGBA32_UINT -> "rgba32ui";
+			case RGBA32_SINT -> "rgba32i";
+			case R16_FLOAT -> "r16f";
+			case RG16_FLOAT -> "rg16f";
+			case RGBA16_FLOAT -> "rgba16f";
+			case R32_FLOAT -> "r32f";
+			case RG32_FLOAT -> "rg32f";
+			case RGBA32_FLOAT -> "rgba32f";
+			case RGB10A2_UNORM -> "rgb10_a2";
+			case RGB10A2_UINT -> "rgb10_a2ui";
+			case RG11B10_FLOAT -> "r11f_g11f_b10f";
+		};
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/texture/CustomStorage.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/CustomStorage.java
@@ -1,0 +1,74 @@
+package dev.vitrail.pack.texture;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The storage buffers the loaded pack declared, keyed by the GLSL block name a program writes.
+ * <p>
+ * Complementary Ultra plus world-space reflections sizes {@code bufferObject.0} at hundreds of
+ * megabytes and writes {@code layout(std430, binding = 0) buffer blockDataBuffer}. The Java bind
+ * group has no storage-buffer arm, so the name is recorded here and the Vulkan mixins swap the
+ * descriptor type once {@link dev.vitrail.render.StorageBuffers} has allocated the bytes.
+ *
+ * @see <a href="https://github.com/IrisShaders/Iris">Iris ShaderStorageBuffer, LGPL-3.0</a>
+ */
+public final class CustomStorage {
+
+	private static volatile BufferObject.Reading declared = BufferObject.Reading.empty();
+	private static final Map<String, Integer> bindings = new ConcurrentHashMap<>();
+
+	private CustomStorage() {
+	}
+
+	/** Records the live {@code bufferObject.N} lines of the pack about to be translated. */
+	public static void install(BufferObject.Reading reading) {
+		declared = reading;
+	}
+
+	public static void clear() {
+		declared = BufferObject.Reading.empty();
+		bindings.clear();
+	}
+
+	/**
+	 * Records a storage block the translator just saw, with the {@code layout(..., binding = N)}
+	 * it carried, or {@code -1} when the pack wrote none.
+	 */
+	public static void declare(String name, int binding) {
+		if (name == null || name.isEmpty()) {
+			return;
+		}
+
+		bindings.put(name, binding);
+	}
+
+	/**
+	 * Whether this engine has a {@code bufferObject} for the name a program declared. True is what
+	 * keeps the program in the chain instead of refusing it for a block nothing would bind.
+	 */
+	public static boolean named(String name) {
+		if (declared.hasName(name)) {
+			return true;
+		}
+
+		Integer index = bindings.get(name);
+		return index != null && index >= 0 && declared.hasIndex(index);
+	}
+
+	public static BufferObject.Reading reading() {
+		return declared;
+	}
+
+	/** The {@code bufferObject} index this GLSL name maps to, or {@code -1}. */
+	public static int indexOf(String name) {
+		for (BufferObject buffer : declared.buffers()) {
+			if (buffer.name().filter(name::equals).isPresent()) {
+				return buffer.index();
+			}
+		}
+
+		Integer index = bindings.get(name);
+		return index == null ? -1 : index;
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/texture/ImageInformation.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/ImageInformation.java
@@ -1,0 +1,59 @@
+package dev.vitrail.pack.texture;
+
+import dev.vitrail.pack.target.TargetFormat;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * One {@code image.NAME} directive, as Iris reads it and before anything is allocated.
+ * <p>
+ * The grammar is Iris's, {@code ShaderProperties.java} around the {@code image.} handler: a
+ * sampler name or {@code none}, a pixel format, an internal format, a pixel type, whether to
+ * clear, whether the size is a fraction of the screen, then the dimensions. Sixteen is the
+ * ceiling Iris enforces. Nothing here touches a device.
+ *
+ * @param sampler empty when the pack wrote {@code none}, so the image is stored and never sampled
+ * @see <a href="https://github.com/IrisShaders/Iris">Iris, LGPL-3.0</a>
+ */
+public record ImageInformation(String name, Optional<String> sampler, PackTexture.Shape shape,
+		PixelFormat pixelFormat, TargetFormat.Resolution internalFormat, PixelType pixelType,
+		int width, int height, int depth, boolean clear, boolean relative, float relativeWidth,
+		float relativeHeight) {
+
+	/** Iris refuses a seventeenth. Complementary Ultra sits well under it. */
+	public static final int LIMIT = 16;
+
+	/**
+	 * What {@link dev.vitrail.pack.source.ShaderProperties#imageDirectives} answered, including
+	 * the lines that were live and could not be read.
+	 */
+	public record Reading(List<ImageInformation> images, List<String> dropped) {
+
+		public Reading {
+			images = List.copyOf(images);
+			dropped = List.copyOf(dropped);
+		}
+
+		public static Reading empty() {
+			return new Reading(List.of(), List.of());
+		}
+	}
+
+	/** One clause for the log, saying the name, the sampler, the shape and the size. */
+	public String describe() {
+		String size = this.relative
+				? this.relativeWidth + "x" + this.relativeHeight + " of the screen"
+				: switch (this.shape) {
+					case TEXTURE_1D -> Integer.toString(this.width);
+					case TEXTURE_2D -> this.width + "x" + this.height;
+					case TEXTURE_3D -> this.width + "x" + this.height + "x" + this.depth;
+					case TEXTURE_RECTANGLE -> this.width + "x" + this.height;
+				};
+
+		return this.name
+				+ this.sampler.map(sampler -> " as " + sampler).orElse("")
+				+ " " + this.shape.name() + " " + this.internalFormat.declared() + " " + size
+				+ (this.clear ? ", cleared each frame" : "");
+	}
+}

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -102,6 +102,16 @@ public final class EngineStages {
 		}
 
 		ShadowTerrain.capture(modelView, cameraPosition);
+
+		// The pack's shadow compute, HERE at the head of the frame and not beside the shadow map
+		// that feeds it, and the placement is the parity contract. Complementary's floodfill
+		// ping-pongs on frameCounter % 2, writing one half and having this frame's gbuffers read
+		// the other. Dispatched at the end of the frame it runs under the WRITER's parity, and
+		// every reader is a frame late forever after: the coloured light smears and snaps as the
+		// player walks. Run here it shares the frame, and so the parity, of its readers, which is
+		// the moment Iris gives it inside its own shadow render. The volumes it propagates are the
+		// previous frame's shadow-geometry writes, one frame late like the shadow map itself.
+		PackChain.dispatchShadowCompute();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -9,6 +9,8 @@ import dev.vitrail.pack.target.TargetName;
 import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.target.TargetSchedule;
 import dev.vitrail.pack.target.TargetSize;
+import dev.vitrail.pack.texture.CustomStorage;
+import dev.vitrail.pack.texture.ImageInformation;
 import dev.vitrail.pack.texture.TextureStage;
 import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.NoiseTexture;
@@ -157,6 +159,10 @@ final class ColorTargets {
 	/** The textures the pack ships as files, already decoded, waiting for a device to exist. */
 	private final PackImages packImages;
 
+	/** Storage images the pack declared. Allocated on the device; not bound yet. */
+	private final StorageImages storageImages;
+	private final StorageBuffers storageBuffers;
+
 	/** One surface per texture the pack ships, allocated and uploaded with the constants. */
 	private final Map<PackImages.Image, TargetSurface> packSurfaces = new LinkedHashMap<>();
 
@@ -267,10 +273,12 @@ final class ColorTargets {
 	 * disagrees with itself, and that shows as a plausible picture rather than as an error.
 	 */
 	ColorTargets(TargetPlan plan, int noiseResolution, NoiseTexture.Image noiseImage,
-			PackImages packImages, int shadowResolution,
+			PackImages packImages, ImageInformation.Reading storageImages, int shadowResolution,
 			List<PackDirectives.ShadowColour> shadowColours) {
 		this.plan = plan;
 		this.packImages = packImages;
+		this.storageImages = new StorageImages(storageImages);
+		this.storageBuffers = new StorageBuffers(CustomStorage.reading());
 		// The pack asks for it by directive and 256 is the default. Held rather than looked up at
 		// allocation: this class knows nothing of a frame, and the resolution never moves while a
 		// pack is loaded.
@@ -354,6 +362,8 @@ final class ColorTargets {
 			// and again at the top of the stage that fills it, because its content has to cross the
 			// frame boundary.
 			this.shadowMap.ensure();
+			this.storageImages.ensure(screenWidth, screenHeight);
+			this.storageBuffers.ensure(screenWidth, screenHeight);
 			for (int index : this.plan.ordered()) {
 				// Each target has its own size, so one of them can be half the screen and be the
 				// only one reallocated when the window changes.
@@ -773,6 +783,14 @@ final class ColorTargets {
 		return List.copyOf(this.notes);
 	}
 
+	/**
+	 * Empties the storage images the pack marked {@code clear = true}, at the top of the shadow
+	 * stage, before geometry writes them. Complementary's voxel volume is one of those.
+	 */
+	void clearStorage(CommandEncoder encoder) {
+		this.storageImages.clearMarked(encoder);
+	}
+
 	void release() {
 		this.mainSide.values().forEach(TargetSurface::close);
 		this.altSide.values().forEach(TargetSurface::close);
@@ -781,6 +799,8 @@ final class ColorTargets {
 
 		this.packSurfaces.values().forEach(TargetSurface::close);
 		this.packSurfaces.clear();
+		this.storageImages.close();
+		this.storageBuffers.close();
 
 		this.black = release(this.black);
 		this.white = release(this.white);

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -791,6 +791,11 @@ final class ColorTargets {
 		this.storageImages.clearMarked(encoder);
 	}
 
+	/** Moves what may be moved onto this frame's anchor. {@link StorageImages#reanchor} says why. */
+	void reanchorStorage(CommandEncoder encoder, int dx, int dy, int dz) {
+		this.storageImages.reanchor(encoder, dx, dy, dz);
+	}
+
 	void release() {
 		this.mainSide.values().forEach(TargetSurface::close);
 		this.altSide.values().forEach(TargetSurface::close);

--- a/common/src/main/java/dev/vitrail/render/ComputeShader.java
+++ b/common/src/main/java/dev/vitrail/render/ComputeShader.java
@@ -1,0 +1,290 @@
+package dev.vitrail.render;
+
+import dev.vitrail.mixin.IntermediaryShaderModuleAccessor;
+
+import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.util.spvc.Spvc;
+import org.lwjgl.util.spvc.SpvcReflectedResource;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Compiles a compute SPIR-V module and remaps its bindings the way the game remaps a render one.
+ * <p>
+ * The sampler and uniform-buffer records are package-private in the game. They are built by
+ * reflection rather than a class in {@code com.mojang.blaze3d.vulkan.glsl}: NeoForge treats that
+ * package as Minecraft's, and a second export of it refuses to boot. A mixin factory cannot
+ * return {@code Object} either; Mixin demands the exact record type, which we cannot name.
+ */
+public final class ComputeShader {
+
+	/** {@code SPVC_RESOURCE_TYPE_STORAGE_IMAGE}. */
+	private static final int STORAGE_IMAGE = 6;
+
+	/** {@code SPVC_RESOURCE_TYPE_STORAGE_BUFFER}. */
+	private static final int STORAGE_BUFFER = 5;
+
+	private static final Constructor<?> SAMPLER;
+	private static final Constructor<?> UNIFORM;
+	private static final Method SAMPLER_NAME;
+	private static final Method UNIFORM_NAME;
+
+	static {
+		try {
+			Class<?> sampler = Class.forName("com.mojang.blaze3d.vulkan.glsl.SpvSampler");
+			SAMPLER = sampler.getDeclaredConstructor(String.class, int.class, int.class);
+			SAMPLER.setAccessible(true);
+			SAMPLER_NAME = sampler.getDeclaredMethod("name");
+			SAMPLER_NAME.setAccessible(true);
+			Class<?> uniform = Class.forName("com.mojang.blaze3d.vulkan.glsl.SpvUniformBuffer");
+			UNIFORM = uniform.getDeclaredConstructor(String.class, int.class);
+			UNIFORM.setAccessible(true);
+			UNIFORM_NAME = uniform.getDeclaredMethod("name");
+			UNIFORM_NAME.setAccessible(true);
+		} catch (ReflectiveOperationException e) {
+			throw new ExceptionInInitializerError(e);
+		}
+	}
+
+	private ComputeShader() {
+	}
+
+	public record Compiled(long module, List<VulkanBindGroupLayout.Entry> entries) {
+	}
+
+	/**
+	 * SPIRV-Cross type 6, which the game never asks for. Complementary's {@code uimage3D voxel_img}
+	 * is that resource; without it the binding shaderc assigned is never remapped.
+	 */
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public static void appendStorageImages(IntermediaryShaderModule module) {
+		if (module == null || module.spirv() == null) {
+			return;
+		}
+
+		List extra = listStorage(module.spirv());
+		if (!extra.isEmpty()) {
+			List samplers = ((IntermediaryShaderModuleAccessor) (Object) module).vitrail$samplers();
+			samplers.addAll(extra);
+		}
+	}
+
+	/**
+	 * SPIRV-Cross type 5, which the game never asks for. Complementary's {@code blockDataBuffer}
+	 * is that resource; without it the binding shaderc assigned is never remapped.
+	 */
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public static void appendStorageBuffers(IntermediaryShaderModule module) {
+		if (module == null || module.spirv() == null) {
+			return;
+		}
+
+		List extra = listStorageBuffers(module.spirv());
+		if (!extra.isEmpty()) {
+			List buffers = ((IntermediaryShaderModuleAccessor) (Object) module)
+					.vitrail$uniformBuffers();
+			buffers.addAll(extra);
+		}
+	}
+
+	public static Compiled compile(VulkanDevice vulkan, String name, ByteBuffer spirv) {
+		try (IntermediaryShaderModule module = IntermediaryShaderModule.createFromSpirv(name, spirv)) {
+			IntermediaryShaderModuleAccessor access =
+					(IntermediaryShaderModuleAccessor) (Object) module;
+			List<VulkanBindGroupLayout.Entry> entries = new ArrayList<>();
+			for (Object buffer : access.vitrail$uniformBuffers()) {
+				entries.add(new VulkanBindGroupLayout.Entry(
+						VulkanBindGroupLayout.VulkanBindGroupEntryType.UNIFORM_BUFFER,
+						nameOf(buffer, UNIFORM_NAME), null));
+			}
+
+			for (Object sampler : access.vitrail$samplers()) {
+				entries.add(new VulkanBindGroupLayout.Entry(
+						VulkanBindGroupLayout.VulkanBindGroupEntryType.SAMPLED_IMAGE,
+						nameOf(sampler, SAMPLER_NAME), null));
+			}
+
+			List<VulkanBindGroupLayout.Entry> frozen = List.copyOf(entries);
+			module.rebind(List.of(), frozen);
+			return new Compiled(module.createVulkanShaderModule(vulkan), frozen);
+		} catch (RuntimeException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	private static List listStorage(ByteBuffer spirv) {
+		List found = new ArrayList();
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			PointerBuffer pointer = stack.callocPointer(1);
+			IntBuffer offset = stack.callocInt(1);
+			if (Spvc.spvc_context_create(pointer) != 0) {
+				return found;
+			}
+
+			long context = pointer.get(0);
+			try {
+				if (Spvc.spvc_context_parse_spirv(context, spirv.asIntBuffer(), spirv.remaining() / 4,
+						pointer) != 0) {
+					return found;
+				}
+
+				long ir = pointer.get(0);
+				if (Spvc.spvc_context_create_compiler(context, 0, ir, 1, pointer) != 0) {
+					return found;
+				}
+
+				long compiler = pointer.get(0);
+				if (Spvc.spvc_compiler_create_shader_resources(compiler, pointer) != 0) {
+					return found;
+				}
+
+				long resources = pointer.get(0);
+				PointerBuffer countPointer = stack.callocPointer(1);
+				if (Spvc.spvc_resources_get_resource_list_for_type(resources, STORAGE_IMAGE, pointer,
+						countPointer) != 0) {
+					return found;
+				}
+
+				long list = pointer.get(0);
+				int count = (int) countPointer.get(0);
+				SpvcReflectedResource.Buffer reflected = SpvcReflectedResource.create(list, count);
+				for (int i = 0; i < count; i++) {
+					SpvcReflectedResource resource = reflected.get(i);
+					if (!Spvc.spvc_compiler_get_binary_offset_for_decoration(compiler, resource.id(),
+							33, offset)) {
+						continue;
+					}
+
+					String name = resourceName(compiler, resource);
+					if (name.isEmpty()) {
+						continue;
+					}
+
+					long type = Spvc.spvc_compiler_get_type_handle(compiler, resource.type_id());
+					int dimension = Spvc.spvc_type_get_image_dimension(type);
+					found.add(newSampler(name, offset.get(0), dimension));
+				}
+			} finally {
+				Spvc.spvc_context_destroy(context);
+			}
+		}
+
+		return found;
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	private static List listStorageBuffers(ByteBuffer spirv) {
+		List found = new ArrayList();
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			PointerBuffer pointer = stack.callocPointer(1);
+			IntBuffer offset = stack.callocInt(1);
+			if (Spvc.spvc_context_create(pointer) != 0) {
+				return found;
+			}
+
+			long context = pointer.get(0);
+			try {
+				if (Spvc.spvc_context_parse_spirv(context, spirv.asIntBuffer(), spirv.remaining() / 4,
+						pointer) != 0) {
+					return found;
+				}
+
+				long ir = pointer.get(0);
+				if (Spvc.spvc_context_create_compiler(context, 0, ir, 1, pointer) != 0) {
+					return found;
+				}
+
+				long compiler = pointer.get(0);
+				if (Spvc.spvc_compiler_create_shader_resources(compiler, pointer) != 0) {
+					return found;
+				}
+
+				long resources = pointer.get(0);
+				PointerBuffer countPointer = stack.callocPointer(1);
+				if (Spvc.spvc_resources_get_resource_list_for_type(resources, STORAGE_BUFFER, pointer,
+						countPointer) != 0) {
+					return found;
+				}
+
+				long list = pointer.get(0);
+				int count = (int) countPointer.get(0);
+				SpvcReflectedResource.Buffer reflected = SpvcReflectedResource.create(list, count);
+				for (int i = 0; i < count; i++) {
+					SpvcReflectedResource resource = reflected.get(i);
+					if (!Spvc.spvc_compiler_get_binary_offset_for_decoration(compiler, resource.id(),
+							33, offset)) {
+						continue;
+					}
+
+					String name = resourceName(compiler, resource);
+					if (name.isEmpty()) {
+						continue;
+					}
+
+					found.add(newUniform(name, offset.get(0)));
+				}
+			} finally {
+				Spvc.spvc_context_destroy(context);
+			}
+		}
+
+		return found;
+	}
+
+	/**
+	 * SPIRV-Cross {@code nameString()} is empty when the OpName sits on the block type rather
+	 * than the instance. Complementary's {@code buffer blockDataBuffer { } blockDataSSBO} is
+	 * that shape. {@code rebind} matches Java layout entries by this string, so an empty name
+	 * would throw {@code Shader expects uniform buffers which are not being provided}.
+	 */
+	private static String resourceName(long compiler, SpvcReflectedResource resource) {
+		String name = resource.nameString();
+		if (name != null && !name.isEmpty()) {
+			return name;
+		}
+
+		String fromId = Spvc.spvc_compiler_get_name(compiler, resource.id());
+		if (fromId != null && !fromId.isEmpty()) {
+			return fromId;
+		}
+
+		String fromType = Spvc.spvc_compiler_get_name(compiler, resource.type_id());
+		return fromType == null ? "" : fromType;
+	}
+
+	private static Object newSampler(String name, int bindingOffset, int dimension) {
+		try {
+			return SAMPLER.newInstance(name, bindingOffset, dimension);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private static Object newUniform(String name, int bindingOffset) {
+		try {
+			return UNIFORM.newInstance(name, bindingOffset);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private static String nameOf(Object record, Method accessor) {
+		try {
+			return (String) accessor.invoke(record);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -11,6 +11,7 @@ import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.DrawBuffers;
 import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.TargetName;
+import dev.vitrail.pack.texture.CustomImages;
 import dev.vitrail.pack.texture.TextureStage;
 import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.TextSink;
@@ -361,6 +362,7 @@ final class GeometryProgram {
 	private final PackValues values;
 	private final PackUniforms uniforms;
 	private final List<String> samplers;
+	private final List<String> storage;
 
 	/**
 	 * The same names in the same order, each carrying what the load settled about it and what the
@@ -583,6 +585,10 @@ final class GeometryProgram {
 		this.uniforms = new PackUniforms(loaded.program().uniforms(),
 				pass.shadow() ? values.shadowGeometryCatalog() : values.geometryCatalog());
 		this.samplers = loaded.program().samplers().stream().map(TranslatedUnit.Uniform::name).toList();
+		this.storage = loaded.storageBlocks().stream()
+				.distinct()
+				.filter(StorageBuffers::named)
+				.toList();
 		// Which map a name asks for, and whether it is the albedo, are questions about the NAME and
 		// about the plan the load built, so they are asked here once for the life of the program.
 		this.bound = this.samplers.stream()
@@ -619,6 +625,7 @@ final class GeometryProgram {
 		}
 
 		this.samplers.forEach(bindings::withSampler);
+		this.storage.forEach(name -> bindings.withUniform(name, UniformType.UNIFORM_BUFFER));
 
 		// Everything but the shaders, the bind group, the attachments and the two lines below is
 		// Sodium's own, taken from ShaderChunkRenderer.createShader: the pass this is bound into was
@@ -688,12 +695,16 @@ final class GeometryProgram {
 
 		this.pipeline = builder.build();
 
-		// A storage block is the one refusal that does not announce itself. An unbindable sampler
-		// stops the pipeline from being built and this class already falls back on that; a storage
-		// block compiles, never enters a bind group, and leaves the descriptor on the binding the
-		// pack wrote, which is a draw against nothing. The chain refuses one by name and so does
-		// this, so that the world keeps the game's own shader instead.
-		List<String> storage = loaded.storageBlocks();
+		// A storage block this engine has no bufferObject for is the one refusal that does not
+		// announce itself. An unbindable sampler stops the pipeline from being built and this class
+		// already falls back on that; a storage block compiles, never enters a bind group, and
+		// leaves the descriptor on the binding the pack wrote, which is a draw against nothing.
+		// The chain refuses one by name and so does this, so that the world keeps the game's own
+		// shader instead. Complementary's blockDataBuffer is served, and stays off this list.
+		List<String> storage = loaded.storageBlocks().stream()
+				.distinct()
+				.filter(name -> !StorageBuffers.named(name))
+				.toList();
 		if (!storage.isEmpty()) {
 			this.broken = true;
 			Vitrail.logger().error("{} declares the storage block {}, which nothing binds, so the "
@@ -902,6 +913,7 @@ final class GeometryProgram {
 		}
 
 		pass.setUniform(UNIFORM_BLOCK, blockSlice());
+		StorageBuffers.bind(pass, this.storage);
 
 		for (Sampled one : this.bound) {
 			if (one.followsTheImage()) {
@@ -1768,6 +1780,7 @@ final class GeometryProgram {
 
 		return ATLAS.contains(sampler) || LIGHTMAP.equals(sampler) || OVERLAY.equals(sampler)
 				|| kind == SamplerPlan.Kind.COLORTEX
+				|| kind == SamplerPlan.Kind.CUSTOM_IMAGE
 				|| kind == SamplerPlan.Kind.NOISE
 				|| (kind == SamplerPlan.Kind.DEPTH && (this.pass.afterDeferred()
 						|| (SamplerPlan.preHandCopy(sampler)
@@ -1812,8 +1825,15 @@ final class GeometryProgram {
 		// since every tap of such a loop rides on this filter. It has to match PackPass, which binds
 		// the same name for the full screen passes: the two halves of one frame reading one map
 		// through two filters is a difference nothing would ever explain.
+		// A custom image follows its format, which is Iris's rule (GlImage filters a non-integer
+		// image LINEAR): the floodfill volumes are rgba16f and the light they carry is continuous,
+		// so NEAREST turns every voxel into a lit brick with a hard edge. An integer volume keeps
+		// NEAREST, since ids do not average.
 		return switch (binding.kind()) {
 			case NOISE, SHADOW_COLOUR, SHADOW_DEPTH -> FilterMode.LINEAR;
+			case CUSTOM_IMAGE -> CustomImages.image(sampler)
+					.map(image -> image.internalFormat().used().integer())
+					.orElse(true) ? FilterMode.NEAREST : FilterMode.LINEAR;
 			default -> FilterMode.NEAREST;
 		};
 	}

--- a/common/src/main/java/dev/vitrail/render/GpuRecording.java
+++ b/common/src/main/java/dev/vitrail/render/GpuRecording.java
@@ -55,9 +55,12 @@ final class GpuRecording {
 	}
 
 	/**
-	 * Makes what shaders and transfers did to an image before this point visible to a
-	 * {@code vkCmdClearColorImage} about to rewrite it. Without it the clear races the previous
-	 * frame's sampled reads and the previous dispatch's stores on the same volume.
+	 * Makes what shaders and transfers did to an image before this point visible to a transfer
+	 * about to rewrite it or read it. Without it the clear races the previous frame's sampled reads
+	 * and the previous dispatch's stores on the same volume.
+	 * <p>
+	 * The read half is not spare. A volume moved onto this frame's anchor is COPIED OUT of first,
+	 * and what it is copied out of is exactly the previous frame's shadow geometry stores.
 	 */
 	static void beforeTransfer(VkCommandBuffer commands, MemoryStack stack) {
 		VkMemoryBarrier2.Buffer barrier = VkMemoryBarrier2.calloc(1, stack).sType$Default();
@@ -69,7 +72,8 @@ final class GpuRecording {
 				| VK13.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT
 				| VK13.VK_ACCESS_2_TRANSFER_WRITE_BIT);
 		barrier.dstStageMask(VK13.VK_PIPELINE_STAGE_2_TRANSFER_BIT);
-		barrier.dstAccessMask(VK13.VK_ACCESS_2_TRANSFER_WRITE_BIT);
+		barrier.dstAccessMask(VK13.VK_ACCESS_2_TRANSFER_WRITE_BIT
+				| VK13.VK_ACCESS_2_TRANSFER_READ_BIT);
 		VkDependencyInfo dependency = VkDependencyInfo.calloc(stack).sType$Default();
 		dependency.pMemoryBarriers(barrier);
 		KHRSynchronization2.vkCmdPipelineBarrier2KHR(commands, dependency);
@@ -89,6 +93,23 @@ final class GpuRecording {
 		barrier.dstAccessMask(VK13.VK_ACCESS_2_SHADER_STORAGE_READ_BIT
 				| VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT
 				| VK13.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT);
+		VkDependencyInfo dependency = VkDependencyInfo.calloc(stack).sType$Default();
+		dependency.pMemoryBarriers(barrier);
+		KHRSynchronization2.vkCmdPipelineBarrier2KHR(commands, dependency);
+	}
+
+	/**
+	 * Orders one copy against the next, which neither of the two above does: they carry a transfer
+	 * on one side only, and a volume copied out and back reads on the transfer side what the
+	 * transfer side has just written.
+	 */
+	static void betweenTransfers(VkCommandBuffer commands, MemoryStack stack) {
+		VkMemoryBarrier2.Buffer barrier = VkMemoryBarrier2.calloc(1, stack).sType$Default();
+		barrier.srcStageMask(VK13.VK_PIPELINE_STAGE_2_TRANSFER_BIT);
+		barrier.srcAccessMask(VK13.VK_ACCESS_2_TRANSFER_WRITE_BIT);
+		barrier.dstStageMask(VK13.VK_PIPELINE_STAGE_2_TRANSFER_BIT);
+		barrier.dstAccessMask(VK13.VK_ACCESS_2_TRANSFER_READ_BIT
+				| VK13.VK_ACCESS_2_TRANSFER_WRITE_BIT);
 		VkDependencyInfo dependency = VkDependencyInfo.calloc(stack).sType$Default();
 		dependency.pMemoryBarriers(barrier);
 		KHRSynchronization2.vkCmdPipelineBarrier2KHR(commands, dependency);

--- a/common/src/main/java/dev/vitrail/render/GpuRecording.java
+++ b/common/src/main/java/dev/vitrail/render/GpuRecording.java
@@ -1,0 +1,96 @@
+package dev.vitrail.render;
+
+import dev.vitrail.mixin.CommandEncoderAccessor;
+import dev.vitrail.mixin.VulkanCommandEncoderAccessor;
+
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.CommandEncoderBackend;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.KHRSynchronization2;
+import org.lwjgl.vulkan.VK12;
+import org.lwjgl.vulkan.VK13;
+import org.lwjgl.vulkan.VkCommandBuffer;
+import org.lwjgl.vulkan.VkDependencyInfo;
+import org.lwjgl.vulkan.VkMemoryBarrier2;
+
+/**
+ * Recording helpers for storage work that cannot legally sit inside a dynamic render pass.
+ */
+final class GpuRecording {
+
+	private GpuRecording() {
+	}
+
+	/** Ends the encoder's open pass, if any, so a clear, fill or dispatch can be recorded. */
+	static void endPass(CommandEncoder encoder) {
+		CommandEncoderBackend backend = ((CommandEncoderAccessor) encoder).vitrail$backend();
+		if (!(backend instanceof VulkanCommandEncoder vulkan)) {
+			return;
+		}
+
+		if (((VulkanCommandEncoderAccessor) vulkan).vitrail$currentRenderPass() != null) {
+			vulkan.submitRenderPass();
+		}
+	}
+
+	/**
+	 * Runs a destruction only once the GPU is done with the frames that may still reference the
+	 * resource, through the game's own two-deep queue. Destroying inline is the shape this
+	 * backend cannot forgive: it records continuously, up to two submissions are in flight, and
+	 * a handle freed under one of them is a device loss with a stack that names nobody. When no
+	 * Vulkan encoder is there to queue on, the device is gone and took every handle with it, so
+	 * the destruction is dropped rather than run against a device that no longer exists.
+	 */
+	static void destroyLater(Runnable destruction) {
+		GpuDevice device = RenderSystem.tryGetDevice();
+		CommandEncoderBackend backend = device == null
+				? null
+				: ((CommandEncoderAccessor) device.createCommandEncoder()).vitrail$backend();
+		if (backend instanceof VulkanCommandEncoder vulkan) {
+			vulkan.queueForDestroy(destruction::run);
+		}
+	}
+
+	/**
+	 * Makes what shaders and transfers did to an image before this point visible to a
+	 * {@code vkCmdClearColorImage} about to rewrite it. Without it the clear races the previous
+	 * frame's sampled reads and the previous dispatch's stores on the same volume.
+	 */
+	static void beforeTransfer(VkCommandBuffer commands, MemoryStack stack) {
+		VkMemoryBarrier2.Buffer barrier = VkMemoryBarrier2.calloc(1, stack).sType$Default();
+		barrier.srcStageMask(VK13.VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT
+				| VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT
+				| VK13.VK_PIPELINE_STAGE_2_TRANSFER_BIT);
+		barrier.srcAccessMask(VK13.VK_ACCESS_2_SHADER_STORAGE_READ_BIT
+				| VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT
+				| VK13.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT
+				| VK13.VK_ACCESS_2_TRANSFER_WRITE_BIT);
+		barrier.dstStageMask(VK13.VK_PIPELINE_STAGE_2_TRANSFER_BIT);
+		barrier.dstAccessMask(VK13.VK_ACCESS_2_TRANSFER_WRITE_BIT);
+		VkDependencyInfo dependency = VkDependencyInfo.calloc(stack).sType$Default();
+		dependency.pMemoryBarriers(barrier);
+		KHRSynchronization2.vkCmdPipelineBarrier2KHR(commands, dependency);
+	}
+
+	/**
+	 * Makes a {@code vkCmdClearColorImage} / {@code vkCmdFillBuffer} visible to shaders. The
+	 * game's compute-to-compute barrier does not wait for transfer writes; leaving it as the
+	 * only fence after a 3D clear is how the GPU died two seconds later (Windows TDR).
+	 */
+	static void afterTransfer(VkCommandBuffer commands, MemoryStack stack) {
+		VkMemoryBarrier2.Buffer barrier = VkMemoryBarrier2.calloc(1, stack).sType$Default();
+		barrier.srcStageMask(VK13.VK_PIPELINE_STAGE_2_TRANSFER_BIT);
+		barrier.srcAccessMask(VK13.VK_ACCESS_2_TRANSFER_WRITE_BIT);
+		barrier.dstStageMask(VK13.VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT
+				| VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT);
+		barrier.dstAccessMask(VK13.VK_ACCESS_2_SHADER_STORAGE_READ_BIT
+				| VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT
+				| VK13.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT);
+		VkDependencyInfo dependency = VkDependencyInfo.calloc(stack).sType$Default();
+		dependency.pMemoryBarriers(barrier);
+		KHRSynchronization2.vkCmdPipelineBarrier2KHR(commands, dependency);
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -13,6 +13,7 @@ import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.TargetDirectives;
 import dev.vitrail.pack.target.TargetName;
 import dev.vitrail.pack.target.TargetPlan;
+import dev.vitrail.pack.texture.CustomImages;
 import dev.vitrail.settings.PackFile;
 import dev.vitrail.settings.PackSession;
 import dev.vitrail.settings.SettingsFile;
@@ -253,6 +254,9 @@ public final class PackChain {
 	/** Distant Horizons' far terrain, drawn with the pack's own programs where DH is there at all. */
 	private final DistantDraw distant;
 
+	/** Shadow compute, dispatched after the shadow map, Complementary's floodfill among them. */
+	private final PackCompute compute;
+
 	private List<PackPass> programs;
 	private PackPass last;
 
@@ -292,8 +296,8 @@ public final class PackChain {
 		// None of this touches the device: the textures are allocated by the first frame and this
 		// runs while the client is still starting up, off the render thread.
 		this.targets = new ColorTargets(chain.targets(), values.noiseResolution(),
-				values.noiseImage(), values.packImages(), values.shadowResolution(),
-				values.shadowColours());
+				values.noiseImage(), values.packImages(), values.storageImages(),
+				values.shadowResolution(), values.shadowColours());
 		this.seed = chain.chain().seed()
 				.filter(where -> this.targets.has(where.target()))
 				.map(where -> new SceneSeed(where, this.targets.format(where.target()),
@@ -356,6 +360,8 @@ public final class PackChain {
 		// on the frames DH really draws a far terrain.
 		this.distant = new DistantDraw(this, packPath, chain.place(), chosen, profile, values,
 				this.load, chain.chain(), chain.targets(), chainWanted, this.targets);
+		this.compute = PackCompute.load(packPath, chain.place(), chosen, profile,
+				chain.targets().computes(), this.load, values.shadowGeometryCatalog());
 	}
 
 	/**
@@ -1370,6 +1376,44 @@ public final class PackChain {
 		PackChain chain = active;
 
 		return disabled || chain == null ? null : chain.terrain;
+	}
+
+	/**
+	 * Empties the pack's cleared storage images at the top of the shadow stage, matching Iris
+	 * clearing custom images before the shadow map is drawn.
+	 */
+	public static void clearCustomImages() {
+		PackChain chain = active;
+		if (disabled || chain == null) {
+			return;
+		}
+
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (device == null) {
+			return;
+		}
+
+		chain.targets.clearStorage(device.createCommandEncoder());
+	}
+
+	/**
+	 * Dispatches {@code shadowcomp} after the shadow geometry, as Iris does at
+	 * {@code ShadowRenderer.java:631}.
+	 */
+	public static void dispatchShadowCompute() {
+		PackChain chain = active;
+		if (disabled || chain == null) {
+			return;
+		}
+
+		// The frame opens HERE, not at the first draw, and the compute's correctness hangs on it.
+		// The values only move at beginFrame, so without this the dispatch reads the PREVIOUS
+		// frame's numbers: the floodfill then runs under the old frameCounter parity and writes
+		// the half this frame's gbuffers do not read, and every voxel light flickers as the
+		// player moves. Idempotent for the rest of the frame, which sees the same numbers it
+		// always did, only settled a moment earlier.
+		chain.beginFrame();
+		chain.compute.dispatch(chain.values, chain.targets);
 	}
 
 	/** The same, for the sky. */
@@ -2718,6 +2762,8 @@ public final class PackChain {
 		named(byKind, SamplerPlan.Kind.DISTANT_DEPTH,
 				"read the far terrain's own depth, kept beside the world's as Iris keeps it, on the "
 						+ "frames this pack draws the far terrain, and the far plane on the rest");
+		named(byKind, SamplerPlan.Kind.CUSTOM_IMAGE,
+				"read a storage image the pack declared with image.NAME");
 		named(byKind, SamplerPlan.Kind.UNBINDABLE,
 				"are declared under a type this backend cannot bind, and should have gone with "
 						+ "their pass");
@@ -2769,6 +2815,8 @@ public final class PackChain {
 	}
 
 	private void release() {
+		CustomImages.clear();
+		this.compute.close();
 		this.targets.release();
 		if (this.features != null) {
 			this.features.release();

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -41,6 +41,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.util.Mth;
 import net.minecraft.util.Util;
 
+import org.joml.Vector3dc;
+import org.joml.Vector3i;
 import org.joml.Vector4f;
 
 import java.io.IOException;
@@ -186,6 +188,30 @@ public final class PackChain {
 	 * opened", for the values and for the targets.
 	 */
 	private boolean opened;
+
+	/**
+	 * The block the camera stood in when the shadow stage last refilled the pack's cleared volumes,
+	 * which is the origin the identities in them are measured from.
+	 * <p>
+	 * Not a per frame flag, and that is why it is not reset with the four below: it belongs to the
+	 * volume rather than to a frame, and the frame that reads it is never the one that wrote it.
+	 */
+	private final Vector3i voxelAnchor = new Vector3i();
+
+	/** Whether {@link #voxelAnchor} names a real fill rather than the zero it starts at. */
+	private boolean voxelAnchored;
+
+	/**
+	 * Whether this chain has ever opened a frame, which is a different question from
+	 * {@link #advanced} and is asked by exactly one caller.
+	 * <p>
+	 * A chain replacing another does so at the head of {@link #draw}, so it is BUILT in the middle
+	 * of a frame whose shadow stage is still to come, and while it warms its pipelines it compiles
+	 * one a frame and draws nothing at all, so its value store never moves. The camera it would
+	 * report through those frames is the zero a fresh store starts at, and an anchor taken there
+	 * names the origin of the world rather than where the player stands.
+	 */
+	private boolean everAdvanced;
 
 	/** Whether the half of the chain that belongs before the world's translucents has run. */
 	private boolean early;
@@ -1398,6 +1424,20 @@ public final class PackChain {
 		}
 
 		chain.targets.clearStorage(device.createCommandEncoder());
+
+		// Taken with the clear rather than after the geometry, because the clear is the line that
+		// says the volume from here on holds THIS frame's writes and nothing older. A pack anchors
+		// what it stores on the block the camera stands in, so that block is what says which cell
+		// each identity lands in, and the frame reading it is not this one.
+		//
+		// Not taken at all from a chain that has never opened a frame: see everAdvanced. The value
+		// store would answer the origin of the world, and the next frame would read a move of the
+		// player's whole coordinates, which reanchor answers by emptying the volume.
+		if (chain.everAdvanced) {
+			Vector3dc camera = chain.values.world().cameraPositionUnshifted();
+			chain.voxelAnchor.set(block(camera.x()), block(camera.y()), block(camera.z()));
+			chain.voxelAnchored = true;
+		}
 	}
 
 	/**
@@ -1417,7 +1457,48 @@ public final class PackChain {
 		// player moves. Idempotent for the rest of the frame, which sees the same numbers it
 		// always did, only settled a moment earlier.
 		chain.beginFrame();
+		chain.reanchorCustomImages();
 		chain.compute.dispatch(chain.values, chain.targets);
+	}
+
+	/**
+	 * Moves the identity volume onto the anchor of the frame about to read it, before the compute
+	 * and before any gbuffer samples it. {@link StorageImages#reanchor} carries the whole of why,
+	 * against what Iris does. This half only works out how far.
+	 */
+	private void reanchorCustomImages() {
+		if (!this.voxelAnchored) {
+			return;
+		}
+
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (device == null) {
+			return;
+		}
+
+		Vector3dc camera = this.values.world().cameraPositionUnshifted();
+		int x = block(camera.x());
+		int y = block(camera.y());
+		int z = block(camera.z());
+		this.targets.reanchorStorage(device.createCommandEncoder(), x - this.voxelAnchor.x,
+				y - this.voxelAnchor.y, z - this.voxelAnchor.z);
+
+		// Where the volume stands now, and it stays there until the shadow stage refills it.
+		// Written rather than a flag lowered, and the difference is a frame that draws no shadow
+		// map at all: the identities in the volume are still the last ones written, they still have
+		// to follow the camera, and a second call of the same frame moves them by nothing.
+		this.voxelAnchor.set(x, y, z);
+	}
+
+	/**
+	 * The block a coordinate stands in, which is the origin a pack measures its voxel grid from: it
+	 * writes {@code scenePos + cameraPositionBestFract}, and this is the whole part that pair leaves
+	 * out. Read off the UNSHIFTED position, because {@code cameraPositionFract} is unshifted too,
+	 * and that is the name {@code cameraPositionBestFract} resolves to on anything this engine
+	 * answers as.
+	 */
+	private static int block(double coordinate) {
+		return (int) Math.floor(coordinate);
 	}
 
 	/** The same, for the sky. */
@@ -1469,6 +1550,7 @@ public final class PackChain {
 	void beginFrame() {
 		if (!this.advanced) {
 			this.advanced = true;
+			this.everAdvanced = true;
 			PassTimings.armCensus();
 			this.values.advance();
 			PackDump.take(this.chain.place(), this.load,
@@ -1645,6 +1727,12 @@ public final class PackChain {
 
 			chain.release();
 			chain.values.leaveWorld();
+
+			// The volumes went back with the targets and the camera went back to nought, so what
+			// the anchor names no longer exists. Lowered rather than left standing: this chain is
+			// NOT replaced on the way out, so nothing else would ever reset it, and a world joined
+			// again would be measured against where the player stood in the one they left.
+			chain.voxelAnchored = false;
 		} catch (RuntimeException e) {
 			disabled = true;
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -633,12 +633,10 @@ public final class PackChain {
 			PackDump.configure(engine.dump(),
 					gameDirectory.resolve(Vitrail.MOD_ID).resolve("dump.txt"));
 
-			// Refused by name, and before a single program is TRANSLATED. This engine serves no
-			// feature flag at all and defines no IRIS_FEATURE_, which is the honest answer and the
-			// one that keeps a pack on its fallback path; a pack that says it REQUIRES one is asking
-			// for something that is not here. Left unread, the refusal came much later and named
-			// whichever sampler the missing feature stood behind, which is a wrong diagnosis rather
-			// than an incomplete one.
+			// Refused by name, and before a single program is TRANSLATED. Required flags this
+			// engine does not serve keep the pack on its fallback; optional CUSTOM_IMAGES is
+			// posed from EngineDefines when the storage-image pipe is served, and is not a
+			// required flag in the corpus.
 			//
 			// **Here and not one line earlier**, and TerrainDraw.wanted above is the reason. It settles
 			// what the chunk mesh carries, and returning ahead of it would leave that answer at its
@@ -658,14 +656,20 @@ public final class PackChain {
 			//
 			// Read from the one file rather than from the report above, because a refusal has to
 			// hold at every load and the report is taken once.
-			List<String> required = PackLoader.properties(pack).requiredFeatures();
+			List<String> required = new ArrayList<>(PackLoader.properties(pack).requiredFeatures());
+			// Only the names this engine has not built refuse the pack: custom images are served
+			// now, so a pack that cannot draw without them is simply right about what it needs.
+			if (CustomImages.served()) {
+				required.remove("CUSTOM_IMAGES");
+			}
+
 			if (!required.isEmpty()) {
 				disabled = true;
 				String names = String.join(", ", required);
 				String named = ShaderPackSource.nameOf(pack);
 				lastError = named + " requires " + names
-						+ ", and this engine serves no feature flag";
-				Vitrail.logger().error("{} requires {}, and this engine serves none of them, so "
+						+ ", which this engine does not serve";
+				Vitrail.logger().error("{} requires {}, which this engine does not serve, so "
 						+ "nothing is drawn", named, names);
 				return;
 			}

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -1,0 +1,583 @@
+package dev.vitrail.render;
+
+import dev.vitrail.glsl.PackProgram;
+import dev.vitrail.glsl.TranslatedUnit;
+import dev.vitrail.mixin.CommandEncoderAccessor;
+import dev.vitrail.mixin.GpuDeviceAccessor;
+import dev.vitrail.mixin.VulkanCommandEncoderAccessor;
+import dev.vitrail.pack.option.OptionValue;
+import dev.vitrail.pack.program.ProgramNames;
+import dev.vitrail.pack.program.ProgramStage;
+import dev.vitrail.pack.program.RenderStage;
+import dev.vitrail.pack.texture.CustomImages;
+import dev.vitrail.uniform.ClipSpace;
+import dev.vitrail.uniform.UniformCatalog;
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.buffers.Std140Builder;
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.GpuDeviceBackend;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
+import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.VulkanGpuBuffer;
+import com.mojang.blaze3d.vulkan.VulkanGpuSampler;
+import com.mojang.blaze3d.vulkan.VulkanGpuTextureView;
+import com.mojang.blaze3d.vulkan.VulkanUtils;
+import net.minecraft.client.renderer.MappableRingBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.util.shaderc.Shaderc;
+import org.lwjgl.vulkan.KHRPushDescriptor;
+import org.lwjgl.vulkan.KHRSynchronization2;
+import org.lwjgl.vulkan.VK12;
+import org.lwjgl.vulkan.VK13;
+import org.lwjgl.vulkan.VkCommandBuffer;
+import org.lwjgl.vulkan.VkComputePipelineCreateInfo;
+import org.lwjgl.vulkan.VkDependencyInfo;
+import org.lwjgl.vulkan.VkDescriptorBufferInfo;
+import org.lwjgl.vulkan.VkDescriptorImageInfo;
+import org.lwjgl.vulkan.VkDescriptorSetLayoutBinding;
+import org.lwjgl.vulkan.VkDescriptorSetLayoutCreateInfo;
+import org.lwjgl.vulkan.VkMemoryBarrier2;
+import org.lwjgl.vulkan.VkPipelineLayoutCreateInfo;
+import org.lwjgl.vulkan.VkPipelineShaderStageCreateInfo;
+import org.lwjgl.vulkan.VkWriteDescriptorSet;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.LongBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The pack's shadow compute passes, dispatched at the head of the frame, in the parity of the
+ * gbuffers that read what they propagate; the volumes they read are the previous frame's
+ * shadow-geometry writes, one frame late like the shadow map itself.
+ * <p>
+ * Complementary's floodfill lives in {@code shadowcomp.csh}. The Java facade has no compute, so
+ * the pipeline is built the way the storage probe was: shaderc kind 2, a VMA storage image,
+ * push descriptors. Iris runs it inside its shadow render ({@code ShadowRenderer.java:631},
+ * {@code compositeRenderer.renderAll()}), before its gbuffers in the SAME frame; under this
+ * engine's deferred shadow stage, the head of the frame is that moment's translation.
+ *
+ * @see <a href="https://github.com/IrisShaders/Iris">Iris ComputeProgram, LGPL-3.0</a>
+ */
+final class PackCompute implements AutoCloseable {
+
+	private static final int SHADERC_VULKAN_1_2 = 4202496;
+	private static final int SHADERC_COMPUTE = 2;
+
+	private final List<Pass> passes;
+	private boolean announced;
+
+	private PackCompute(List<Pass> passes) {
+		this.passes = List.copyOf(passes);
+	}
+
+	static PackCompute none() {
+		return new PackCompute(List.of());
+	}
+
+	static PackCompute load(Path packPath, String place, Map<String, OptionValue> chosen,
+			String profile, List<String> computes, int load, UniformCatalog catalog) {
+		List<Pass> passes = new ArrayList<>();
+		for (String name : computes) {
+			if (!ProgramNames.shadowComposite(ProgramNames.familyOf(name))) {
+				continue;
+			}
+
+			String path = place.isEmpty() ? name : place + "/" + name;
+			try {
+				Optional<PackProgram.Compute> compute = PackProgram.loadCompute(packPath, path, chosen,
+						profile);
+				if (compute.isEmpty()) {
+					continue;
+				}
+
+				passes.add(new Pass(compute.get(), catalog, load, path));
+				Vitrail.logger().info("Loaded shadow compute {} ({}x{}x{} groups)", path,
+						compute.get().groupsX(), compute.get().groupsY(), compute.get().groupsZ());
+			} catch (IOException | RuntimeException e) {
+				Vitrail.logger().warn("shadow compute {} could not be translated: {}", path,
+						e.toString());
+			}
+		}
+
+		return new PackCompute(passes);
+	}
+
+	void dispatch(PackValues values, ColorTargets targets) {
+		if (this.passes.isEmpty()) {
+			return;
+		}
+
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (device == null) {
+			return;
+		}
+
+		CommandEncoder encoder = device.createCommandEncoder();
+		// The hold first, and through its own door: it keeps a RenderPass OBJECT open across
+		// draws, so ending the pass underneath it would leave that object to close a pass the
+		// encoder no longer has, which is a crash at the next flush and not here.
+		GeometryHold.flush(() -> "the shadow compute dispatch");
+		GpuRecording.endPass(encoder);
+		VkCommandBuffer commands = commands(encoder);
+		VulkanDevice vulkan = vulkan(device);
+		if (commands == null || vulkan == null) {
+			return;
+		}
+
+		values.convention(ClipSpace.FORWARD);
+		values.modelView(null, null);
+		values.projection(null);
+		values.passColour(null);
+		values.renderStage(RenderStage.NONE);
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			afterShadowGeometry(commands, stack);
+		}
+
+		for (Pass pass : this.passes) {
+			try {
+				pass.dispatch(vulkan, commands, values, targets);
+			} catch (RuntimeException e) {
+				if (pass.failed.add(e.toString())) {
+					Vitrail.logger().warn("shadow compute {} failed: {}", pass.path, e.toString());
+				}
+			}
+		}
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			afterCompute(commands, stack);
+		}
+
+		if (!this.announced) {
+			this.announced = true;
+			Vitrail.logger().info("Dispatched {} shadow compute pass(es) at the head of the frame",
+					this.passes.size());
+		}
+	}
+
+	@Override
+	public void close() {
+		this.passes.forEach(Pass::close);
+	}
+
+	private static VkCommandBuffer commands(CommandEncoder encoder) {
+		return ((CommandEncoderAccessor) encoder).vitrail$backend() instanceof VulkanCommandEncoder vulkan
+				? ((VulkanCommandEncoderAccessor) vulkan).vitrail$commandBuffer()
+				: null;
+	}
+
+	private static VulkanDevice vulkan(GpuDevice device) {
+		GpuDeviceBackend backend = ((GpuDeviceAccessor) device).vitrail$backend();
+		return backend instanceof VulkanDevice found ? found : null;
+	}
+
+	/**
+	 * The views the engine serves a pack program under these names, for a compute that samples
+	 * them. White where a map is not there, for the same reason the passes answer white: it is
+	 * the far plane in the pack's window, so a lookup that finds nothing reads "nothing between
+	 * here and the light" rather than a world in its own shadow.
+	 */
+	private static GpuTextureView engineView(ColorTargets targets, String name) {
+		ShadowTargets shadow = targets.shadow();
+		return switch (name) {
+			case "noisetex" -> targets.noise();
+			case "shadowtex0" -> orWhite(targets, shadow == null ? null : shadow.depth());
+			case "shadowtex1" ->
+					orWhite(targets, shadow == null ? null : shadow.depthWithoutTranslucents());
+			case "shadowcolor0" -> orWhite(targets, shadow == null ? null : shadow.colour(0));
+			case "shadowcolor1" -> orWhite(targets, shadow == null ? null : shadow.colour(1));
+			default -> null;
+		};
+	}
+
+	private static GpuTextureView orWhite(ColorTargets targets, GpuTextureView view) {
+		return view == null ? targets.white() : view;
+	}
+
+	/**
+	 * The same sampler state the graphics passes bind for the name. The noise field repeats and
+	 * is filtered, Iris's choice: a pack indexes it in texels well past one, and clamped it reads
+	 * the same edge row for the whole volume. The shadow set is filtered the way Iris filters its
+	 * shadow samplers. A pack's own image stays NEAREST and clamped, on the pack's own indexing.
+	 */
+	private static long samplerFor(String name) {
+		boolean noise = "noisetex".equals(name);
+		boolean shadow = name.startsWith("shadowtex") || name.startsWith("shadowcolor");
+		return ((VulkanGpuSampler) PackPass.sampler(noise,
+				noise || shadow ? FilterMode.LINEAR : FilterMode.NEAREST, false)).vkSampler();
+	}
+
+	/**
+	 * Makes the shadow fragment {@code imageStore} into voxel volumes visible to
+	 * {@code shadowcomp}'s {@code texelFetch} of the same images. The game's barrier is
+	 * compute-to-compute storage only, which does not cover a sampled read of a volume the
+	 * geometry just wrote.
+	 */
+	private static void afterShadowGeometry(VkCommandBuffer commands, MemoryStack stack) {
+		shaderBarrier(commands, stack,
+				VK13.VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT
+						| VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+				VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT
+						| VK13.VK_ACCESS_2_SHADER_STORAGE_READ_BIT,
+				VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+				VK13.VK_ACCESS_2_SHADER_STORAGE_READ_BIT
+						| VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT
+						| VK13.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT);
+	}
+
+	/**
+	 * Makes the floodfill {@code imageStore} visible to the next frame's gbuffers, which sample
+	 * those volumes as {@code sampler3D}.
+	 */
+	private static void afterCompute(VkCommandBuffer commands, MemoryStack stack) {
+		shaderBarrier(commands, stack, VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+				VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT,
+				VK13.VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT
+						| VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+				VK13.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT
+						| VK13.VK_ACCESS_2_SHADER_STORAGE_READ_BIT
+						| VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT);
+	}
+
+	private static void shaderBarrier(VkCommandBuffer commands, MemoryStack stack, long srcStage,
+			long srcAccess, long dstStage, long dstAccess) {
+		VkMemoryBarrier2.Buffer barrier = VkMemoryBarrier2.calloc(1, stack).sType$Default();
+		barrier.srcStageMask(srcStage);
+		barrier.srcAccessMask(srcAccess);
+		barrier.dstStageMask(dstStage);
+		barrier.dstAccessMask(dstAccess);
+		VkDependencyInfo dependency = VkDependencyInfo.calloc(stack).sType$Default();
+		dependency.pMemoryBarriers(barrier);
+		KHRSynchronization2.vkCmdPipelineBarrier2KHR(commands, dependency);
+	}
+
+	private static final class Pass {
+
+		private final PackProgram.Compute compute;
+		private final PackUniforms uniforms;
+		private final String path;
+		private final String label;
+		private final Set<String> failed = new LinkedHashSet<>();
+		private MappableRingBuffer block;
+		private long shaderModule;
+		private long setLayout;
+		private long pipelineLayout;
+		private long pipeline;
+		private List<VulkanBindGroupLayout.Entry> entries = List.of();
+		private boolean compiled;
+
+		private Pass(PackProgram.Compute compute, UniformCatalog catalog, int load, String path) {
+			this.compute = compute;
+			this.path = path;
+			this.label = "pack/" + load + "/" + path + "/compute";
+			this.uniforms = new PackUniforms(compute.loaded().program().uniforms(), catalog);
+		}
+
+		private void dispatch(VulkanDevice vulkan, VkCommandBuffer commands, PackValues values,
+				ColorTargets targets) {
+			if (!this.compiled) {
+				compile(vulkan);
+			}
+
+			if (this.pipeline == 0L) {
+				return;
+			}
+
+			writeBlock(values);
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				VulkanCommandEncoder.memoryBarrier(commands, stack);
+				VK12.vkCmdBindPipeline(commands, VK12.VK_PIPELINE_BIND_POINT_COMPUTE, this.pipeline);
+				pushDescriptors(commands, stack, targets);
+				VK12.vkCmdDispatch(commands, this.compute.groupsX(), this.compute.groupsY(),
+						this.compute.groupsZ());
+			}
+
+			if (this.block != null) {
+				this.block.rotate();
+			}
+		}
+
+		private void compile(VulkanDevice vulkan) {
+			this.compiled = true;
+			TranslatedUnit unit = this.compute.loaded().program().stages().get(ProgramStage.COMPUTE);
+			if (unit == null) {
+				return;
+			}
+
+			ByteBuffer spirv = compileSpirv(unit.text());
+			if (spirv == null) {
+				return;
+			}
+
+			try {
+				ComputeShader.Compiled compiled = ComputeShader.compile(vulkan, this.label, spirv);
+				this.shaderModule = compiled.module();
+				this.entries = compiled.entries();
+			} catch (Exception e) {
+				Vitrail.logger().warn("shadow compute {} SPIR-V failed: {}", this.path, e.toString());
+				return;
+			}
+
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				createLayout(vulkan, stack);
+				createPipeline(vulkan, stack);
+			} catch (RuntimeException e) {
+				destroy(vulkan);
+				Vitrail.logger().warn("shadow compute {} pipeline failed: {}", this.path, e.toString());
+			}
+
+			if (this.pipeline != 0L) {
+				Vitrail.logger().info("Compiled shadow compute {} ({}x{}x{} groups)", this.path,
+						this.compute.groupsX(), this.compute.groupsY(), this.compute.groupsZ());
+			}
+		}
+
+		private static ByteBuffer compileSpirv(String source) {
+			long compiler = Shaderc.shaderc_compiler_initialize();
+			long options = Shaderc.shaderc_compile_options_initialize();
+			ByteBuffer sourceBuffer = MemoryUtil.memUTF8(source, false);
+			ByteBuffer filename = MemoryUtil.memUTF8("shadowcomp.csh");
+			ByteBuffer entry = MemoryUtil.memUTF8("main");
+			long result = 0L;
+			try {
+				Shaderc.shaderc_compile_options_set_target_env(options, 0, SHADERC_VULKAN_1_2);
+				Shaderc.shaderc_compile_options_set_auto_bind_uniforms(options, true);
+				Shaderc.shaderc_compile_options_set_auto_map_locations(options, true);
+				Shaderc.shaderc_compile_options_set_generate_debug_info(options);
+				// Performance, and for the LAYOUT before speed: the pack's common include
+				// declares samplers a compute never reads, an unoptimised module keeps them,
+				// and reflection then demands a binding for every one. Optimised, the dead
+				// declarations fall out and the entries are the names the shader touches.
+				Shaderc.shaderc_compile_options_set_optimization_level(options, 2);
+				result = Shaderc.shaderc_compile_into_spv(compiler, sourceBuffer, SHADERC_COMPUTE,
+						filename, entry, options);
+				int status = Shaderc.shaderc_result_get_compilation_status(result);
+				if (status != 0) {
+					Vitrail.logger().warn("shadow compute shaderc: {}",
+							Shaderc.shaderc_result_get_error_message(result));
+					return null;
+				}
+
+				ByteBuffer spirv = Shaderc.shaderc_result_get_bytes(result);
+				ByteBuffer copy = MemoryUtil.memCalloc(spirv.remaining());
+				MemoryUtil.memCopy(spirv, copy);
+				return copy;
+			} finally {
+				if (result != 0L) {
+					Shaderc.shaderc_result_release(result);
+				}
+
+				MemoryUtil.memFree(entry);
+				MemoryUtil.memFree(filename);
+				MemoryUtil.memFree(sourceBuffer);
+				Shaderc.shaderc_compile_options_release(options);
+				Shaderc.shaderc_compiler_release(compiler);
+			}
+		}
+
+		private void createLayout(VulkanDevice vulkan, MemoryStack stack) {
+			int count = Math.max(1, this.entries.size());
+			VkDescriptorSetLayoutBinding.Buffer bindings =
+					VkDescriptorSetLayoutBinding.calloc(this.entries.isEmpty() ? 0 : count, stack);
+			for (int i = 0; i < this.entries.size(); i++) {
+				VulkanBindGroupLayout.Entry entry = this.entries.get(i);
+				boolean storage = CustomImages.storage(entry.name())
+						|| StorageImages.storageBinding(entry.name());
+				int type;
+				if (entry.type() == VulkanBindGroupLayout.VulkanBindGroupEntryType.UNIFORM_BUFFER) {
+					type = StorageBuffers.named(entry.name())
+							? VK12.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+							: VK12.VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+				} else {
+					type = storage
+							? VK12.VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
+							: VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+				}
+				bindings.get(i).binding(i).descriptorType(type).descriptorCount(1)
+						.stageFlags(VK12.VK_SHADER_STAGE_COMPUTE_BIT);
+			}
+
+			VkDescriptorSetLayoutCreateInfo layoutInfo = VkDescriptorSetLayoutCreateInfo.calloc(stack)
+					.sType$Default()
+					.flags(1)
+					.pBindings(bindings);
+			LongBuffer layoutPtr = stack.callocLong(1);
+			VulkanUtils.crashIfFailure(vulkan,
+					VK12.vkCreateDescriptorSetLayout(vulkan.vkDevice(), layoutInfo, null, layoutPtr),
+					"shadow compute set layout");
+			this.setLayout = layoutPtr.get(0);
+			LongBuffer setLayouts = stack.callocLong(1).put(0, this.setLayout);
+			VkPipelineLayoutCreateInfo pipelineLayoutInfo = VkPipelineLayoutCreateInfo.calloc(stack)
+					.sType$Default()
+					.pSetLayouts(setLayouts);
+			LongBuffer pipelineLayoutPtr = stack.callocLong(1);
+			VulkanUtils.crashIfFailure(vulkan,
+					VK12.vkCreatePipelineLayout(vulkan.vkDevice(), pipelineLayoutInfo, null,
+							pipelineLayoutPtr),
+					"shadow compute pipeline layout");
+			this.pipelineLayout = pipelineLayoutPtr.get(0);
+		}
+
+		private void createPipeline(VulkanDevice vulkan, MemoryStack stack) {
+			VkPipelineShaderStageCreateInfo stage = VkPipelineShaderStageCreateInfo.calloc(stack)
+					.sType$Default();
+			stage.stage(VK12.VK_SHADER_STAGE_COMPUTE_BIT);
+			stage.module(this.shaderModule);
+			stage.pName(stack.UTF8("main"));
+			VkComputePipelineCreateInfo pipelineInfo = VkComputePipelineCreateInfo.calloc(stack)
+					.sType$Default();
+			pipelineInfo.stage(stage);
+			pipelineInfo.layout(this.pipelineLayout);
+			VkComputePipelineCreateInfo.Buffer infos = VkComputePipelineCreateInfo.calloc(1, stack);
+			infos.put(0, pipelineInfo);
+			LongBuffer pipelinePtr = stack.callocLong(1);
+			VulkanUtils.crashIfFailure(vulkan,
+					VK12.vkCreateComputePipelines(vulkan.vkDevice(), 0L, infos, null, pipelinePtr),
+					"shadow compute pipeline");
+			this.pipeline = pipelinePtr.get(0);
+		}
+
+		private void writeBlock(PackValues values) {
+			int bytes = Math.max(16, this.uniforms.size());
+			if (this.block == null) {
+				this.block = new MappableRingBuffer(() -> "vitrail shadowcomp " + this.path,
+						GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, bytes);
+			}
+
+			try (GpuBufferSlice.MappedView view = this.block.currentBuffer().map(false, true)) {
+				ByteBuffer data = view.data();
+				data.position(0);
+				this.uniforms.write(Std140Builder.intoBuffer(data), values.world());
+			}
+		}
+
+		private void pushDescriptors(VkCommandBuffer commands, MemoryStack stack,
+				ColorTargets targets) {
+			if (this.entries.isEmpty()) {
+				return;
+			}
+
+			VkWriteDescriptorSet.Buffer writes = VkWriteDescriptorSet.calloc(this.entries.size(), stack);
+			for (int i = 0; i < this.entries.size(); i++) {
+				VulkanBindGroupLayout.Entry entry = this.entries.get(i);
+				VkWriteDescriptorSet write = writes.get(i).sType$Default();
+				write.dstBinding(i);
+				write.dstArrayElement(0);
+				write.descriptorCount(1);
+				if (entry.type() == VulkanBindGroupLayout.VulkanBindGroupEntryType.UNIFORM_BUFFER) {
+					if (StorageBuffers.named(entry.name())) {
+						StorageBuffers.Bound bound = StorageBuffers.bound(entry.name());
+						if (bound == null) {
+							throw new IllegalStateException("Missing storage buffer " + entry.name());
+						}
+
+						VkDescriptorBufferInfo.Buffer bufferInfo = VkDescriptorBufferInfo.calloc(1, stack);
+						bufferInfo.buffer(bound.buffer());
+						bufferInfo.offset(0L);
+						bufferInfo.range(bound.range());
+						write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+						write.pBufferInfo(bufferInfo);
+						continue;
+					}
+
+					int bytes = Math.max(16, this.uniforms.size());
+					GpuBufferSlice slice = this.block.currentBuffer().slice(0, bytes);
+					VkDescriptorBufferInfo.Buffer bufferInfo = VkDescriptorBufferInfo.calloc(1, stack);
+					bufferInfo.buffer(((VulkanGpuBuffer) slice.buffer()).vkBuffer());
+					bufferInfo.offset(slice.offset());
+					bufferInfo.range(slice.length());
+					write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+					write.pBufferInfo(bufferInfo);
+					continue;
+				}
+
+				StorageImages.Bound bound = StorageImages.bound(entry.name());
+				VkDescriptorImageInfo.Buffer imageInfo = VkDescriptorImageInfo.calloc(1, stack);
+				if (bound == null) {
+					// The samplers the engine serves every pack program, noisetex and the shadow
+					// set among them: shadowcomp reads them the way a composite does, and only a
+					// name neither the pack's images nor this set carries is a real miss.
+					if (engineView(targets, entry.name()) instanceof VulkanGpuTextureView served) {
+						imageInfo.sampler(samplerFor(entry.name()));
+						imageInfo.imageView(served.vkImageView());
+						imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+						write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+						write.pImageInfo(imageInfo);
+						continue;
+					}
+
+					throw new IllegalStateException("Missing storage image " + entry.name());
+				}
+
+				boolean storage = bound.storage();
+				imageInfo.sampler(storage ? 0L : samplerFor(entry.name()));
+				imageInfo.imageView(bound.view());
+				imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+				write.descriptorType(storage
+						? VK12.VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
+						: VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+				write.pImageInfo(imageInfo);
+			}
+
+			KHRPushDescriptor.vkCmdPushDescriptorSetKHR(commands,
+					VK12.VK_PIPELINE_BIND_POINT_COMPUTE, this.pipelineLayout, 0, writes);
+		}
+
+		private void close() {
+			GpuDevice device = RenderSystem.tryGetDevice();
+			VulkanDevice vulkan = device == null ? null : vulkan(device);
+			if (vulkan != null) {
+				destroy(vulkan);
+			}
+
+			if (this.block != null) {
+				this.block.close();
+				this.block = null;
+			}
+		}
+
+		/** Deferred like every destruction of this engine's: two frames are still in flight. */
+		private void destroy(VulkanDevice vulkan) {
+			long pipeline = this.pipeline;
+			long pipelineLayout = this.pipelineLayout;
+			long setLayout = this.setLayout;
+			long shaderModule = this.shaderModule;
+			this.pipeline = 0L;
+			this.pipelineLayout = 0L;
+			this.setLayout = 0L;
+			this.shaderModule = 0L;
+			GpuRecording.destroyLater(() -> {
+				if (pipeline != 0L) {
+					VK12.vkDestroyPipeline(vulkan.vkDevice(), pipeline, null);
+				}
+
+				if (pipelineLayout != 0L) {
+					VK12.vkDestroyPipelineLayout(vulkan.vkDevice(), pipelineLayout, null);
+				}
+
+				if (setLayout != 0L) {
+					VK12.vkDestroyDescriptorSetLayout(vulkan.vkDevice(), setLayout, null);
+				}
+
+				if (shaderModule != 0L) {
+					VK12.vkDestroyShaderModule(vulkan.vkDevice(), shaderModule, null);
+				}
+			});
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -113,6 +113,7 @@ final class PackPass {
 	private final PackValues values;
 	private final PackUniforms uniforms;
 	private final List<String> samplers;
+	private final List<String> storage;
 	private final List<LodRead> lodReads;
 
 	/** The targets of {@link #lodReads}, for the binding to answer one name at a time. */
@@ -157,6 +158,10 @@ final class PackPass {
 		this.values = values;
 		this.uniforms = new PackUniforms(loaded.program().uniforms(), values.catalog());
 		this.samplers = loaded.program().samplers().stream().map(TranslatedUnit.Uniform::name).toList();
+		this.storage = loaded.storageBlocks().stream()
+				.distinct()
+				.filter(StorageBuffers::named)
+				.toList();
 		this.lodReads = lodReadsOf(program, loaded, targets);
 		this.lodTargets = this.lodReads.stream().map(LodRead::target).collect(Collectors.toSet());
 
@@ -188,6 +193,7 @@ final class PackPass {
 		BindGroupLayout.Builder bindings = BindGroupLayout.builder()
 				.withUniform(UNIFORM_BLOCK, UniformType.UNIFORM_BUFFER);
 		this.samplers.forEach(bindings::withSampler);
+		this.storage.forEach(name -> bindings.withUniform(name, UniformType.UNIFORM_BUFFER));
 
 		RenderPipeline.Builder builder = RenderPipeline.builder()
 				.withLocation(Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pipeline/" + stem))
@@ -474,6 +480,7 @@ final class PackPass {
 		pass.setPipeline(this.pipeline);
 		RenderSystem.bindDefaultUniforms(pass);
 		pass.setUniform(UNIFORM_BLOCK, uniforms);
+		StorageBuffers.bind(pass, this.storage);
 		pass.setVertexBuffer(0, quad.slice());
 		bindSamplers(pass, targets, depthView, distantView);
 		pass.draw(VERTICES, 1, 0, 0);
@@ -543,7 +550,7 @@ final class PackPass {
 				// something real and could not be turned into an image, and black is the honest
 				// answer for it: falling back to the colour target of the same name would have the
 				// pass read the scene as whatever the pack meant to sample and look convincing.
-				case UNSERVED, UNBINDABLE, PACK_TEXTURE -> targets.black();
+				case UNSERVED, UNBINDABLE, PACK_TEXTURE, CUSTOM_IMAGE -> targets.black();
 			};
 
 			// The noise image is LINEAR for the same reason the terrain reads it LINEAR: it is a

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -11,6 +11,9 @@ import dev.vitrail.pack.source.ShaderProperties;
 import dev.vitrail.pack.source.ShadowCasters;
 import dev.vitrail.pack.source.ShadowCullState;
 import dev.vitrail.pack.target.PackDirectives;
+import dev.vitrail.pack.texture.BufferObject;
+import dev.vitrail.pack.texture.CustomStorage;
+import dev.vitrail.pack.texture.ImageInformation;
 import dev.vitrail.uniform.expr.CustomUniforms;
 import dev.vitrail.uniform.NoiseTexture;
 import dev.vitrail.uniform.UniformCatalog;
@@ -93,6 +96,8 @@ public final class PackValues {
 	private Optional<String> particleOrdering = Optional.empty();
 	private NoiseTexture.Image noiseImage;
 	private PackImages packImages = PackImages.none();
+	private ImageInformation.Reading storageImages = ImageInformation.Reading.empty();
+	private BufferObject.Reading bufferObjects = BufferObject.Reading.empty();
 	private UniformCatalog catalog = UniformCatalog.engine();
 	private UniformCatalog geometry = UniformCatalog.geometry();
 	private UniformCatalog shadowGeometry = UniformCatalog.shadowGeometry();
@@ -140,6 +145,9 @@ public final class PackValues {
 			values.readNoise(properties, source, settings.globalDefines(options));
 			values.packImages =
 					PackImages.read(properties, settings.globalDefines(options), source);
+			values.storageImages = properties.imageDirectives(settings.globalDefines(options));
+			values.bufferObjects = properties.bufferObjects(settings.globalDefines(options));
+			CustomStorage.install(values.bufferObjects);
 
 			// Read against the same settings as everything above, which is not a formality: BSL wraps
 			// all its declarations in one conditional and keeps a fifth of them under the #else, so a
@@ -165,6 +173,15 @@ public final class PackValues {
 	/** The textures the pack ships as files of its own, decoded and waiting to be uploaded. */
 	PackImages packImages() {
 		return this.packImages;
+	}
+
+	/**
+	 * The storage images the pack declared, not yet allocated. Empty until custom images are
+	 * served; the notes still name them so a missing volume is a missing pass rather than a
+	 * missing file.
+	 */
+	ImageInformation.Reading storageImages() {
+		return this.storageImages;
 	}
 
 	/** The engine's table with the pack's own uniforms layered over it. */
@@ -605,6 +622,10 @@ public final class PackValues {
 		}
 
 		this.problems.forEach(problem -> notes.add("Dropped the pack's own " + problem));
+		this.storageImages.images().forEach(image -> notes.add("storage image " + image.describe()));
+		this.storageImages.dropped().forEach(dropped -> notes.add("Dropped " + dropped));
+		this.bufferObjects.buffers().forEach(buffer -> notes.add("storage buffer " + buffer.describe()));
+		this.bufferObjects.dropped().forEach(dropped -> notes.add("Dropped " + dropped));
 		notes.addAll(this.packImages.notes());
 
 		return notes;

--- a/common/src/main/java/dev/vitrail/render/StorageBuffers.java
+++ b/common/src/main/java/dev/vitrail/render/StorageBuffers.java
@@ -1,0 +1,320 @@
+package dev.vitrail.render;
+
+import dev.vitrail.mixin.CommandEncoderAccessor;
+import dev.vitrail.mixin.GpuDeviceAccessor;
+import dev.vitrail.mixin.VulkanCommandEncoderAccessor;
+import dev.vitrail.pack.texture.BufferObject;
+import dev.vitrail.pack.texture.CustomStorage;
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.GpuDeviceBackend;
+import com.mojang.blaze3d.systems.RenderPass;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.VulkanUtils;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.util.vma.Vma;
+import org.lwjgl.util.vma.VmaAllocationCreateInfo;
+import org.lwjgl.vulkan.VK12;
+import org.lwjgl.vulkan.VkBufferCreateInfo;
+import org.lwjgl.vulkan.VkCommandBuffer;
+
+import java.nio.LongBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The shader storage buffers a pack declared with {@code bufferObject.N}, allocated on the Vulkan
+ * device.
+ * <p>
+ * The Java buffer facade has no storage bit, so these go through VMA the way the custom images do:
+ * a dummy {@code USAGE_UNIFORM} slice satisfies {@code setUniform}, and mixins swap the real
+ * {@code VkBuffer} and {@code VK_DESCRIPTOR_TYPE_STORAGE_BUFFER} while pushing descriptors.
+ *
+ * @see <a href="https://github.com/IrisShaders/Iris">Iris ShaderStorageBuffer, LGPL-3.0</a>
+ */
+public final class StorageBuffers implements AutoCloseable {
+
+	private static volatile StorageBuffers current = none();
+
+	private final BufferObject.Reading declared;
+	private final List<Allocated> allocated = new ArrayList<>();
+	private GpuBuffer dummy;
+	private int lastWidth;
+	private int lastHeight;
+
+	StorageBuffers(BufferObject.Reading declared) {
+		this.declared = declared;
+	}
+
+	static StorageBuffers none() {
+		return new StorageBuffers(BufferObject.Reading.empty());
+	}
+
+	/** Whether this name is a storage buffer this engine serves, allocated or about to be. */
+	public static boolean named(String name) {
+		return CustomStorage.named(name);
+	}
+
+	/**
+	 * The VMA buffer currently allocated for this GLSL name. Mixins look it up while pushing
+	 * descriptors.
+	 */
+	public static Bound bound(String name) {
+		return current.lookup(name);
+	}
+
+	private Bound lookup(String name) {
+		int index = CustomStorage.indexOf(name);
+		if (index < 0) {
+			return null;
+		}
+
+		for (Allocated buffer : this.allocated) {
+			if (buffer.declared.index() == index) {
+				return new Bound(buffer.buffer, buffer.bytes);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * One bound buffer. {@code range} is the whole allocation: Complementary indexes
+	 * {@code blockDataSSBO.data[face]} across hundreds of megabytes, and a 16-byte dummy would OOB.
+	 */
+	public record Bound(long buffer, long range) {
+	}
+
+	void install() {
+		current = this;
+	}
+
+	/**
+	 * Allocates every absolute buffer once, and rebuilds the relative ones when the screen moves.
+	 * A failure is thrown rather than skipped: a tiny stand-in would let the pack compile and then
+	 * hang the GPU on the first out-of-range write.
+	 */
+	void ensure(int screenWidth, int screenHeight) {
+		install();
+		if (this.declared.buffers().isEmpty()) {
+			return;
+		}
+
+		boolean first = this.allocated.isEmpty();
+		boolean resized = screenWidth != this.lastWidth || screenHeight != this.lastHeight;
+		if (!first && !resized) {
+			return;
+		}
+
+		VulkanDevice vulkan = vulkan();
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (vulkan == null || device == null) {
+			return;
+		}
+
+		ensurePlaceholder(device);
+		if (first) {
+			for (BufferObject buffer : this.declared.buffers()) {
+				if (buffer.relative()) {
+					continue;
+				}
+
+				this.allocated.add(Allocated.create(vulkan, buffer, aligned(buffer.size())));
+				Vitrail.logger().info("storage buffer {}", buffer.describe());
+			}
+		}
+
+		if (first || resized) {
+			List<Allocated> kept = new ArrayList<>();
+			for (Allocated buffer : this.allocated) {
+				if (buffer.relative) {
+					buffer.destroy(vulkan);
+				} else {
+					kept.add(buffer);
+				}
+			}
+
+			this.allocated.clear();
+			this.allocated.addAll(kept);
+			for (BufferObject buffer : this.declared.buffers()) {
+				if (!buffer.relative()) {
+					continue;
+				}
+
+				long bytes = aligned((long) (screenWidth * buffer.scaleX())
+						* (long) (screenHeight * buffer.scaleY())
+						* buffer.size());
+				this.allocated.add(Allocated.create(vulkan, buffer, Math.max(bytes, 4L)));
+				Vitrail.logger().info("storage buffer {} at {} bytes", buffer.describe(), bytes);
+			}
+		}
+
+		this.lastWidth = screenWidth;
+		this.lastHeight = screenHeight;
+		zero(device);
+	}
+
+	private void ensurePlaceholder(GpuDevice device) {
+		if (this.dummy == null) {
+			this.dummy = device.createBuffer(() -> "vitrail ssbo placeholder",
+					GpuBuffer.USAGE_UNIFORM, 16);
+		}
+	}
+
+	/**
+	 * Binds a dummy uniform slice for every storage-buffer name this program's layout carries.
+	 * Mixins replace the {@code VkBuffer} and the range while the descriptors are pushed.
+	 */
+	public static void bind(RenderPass pass, List<String> names) {
+		GpuBufferSlice slice = current.placeholder();
+		if (slice == null) {
+			return;
+		}
+
+		for (String name : names) {
+			pass.setUniform(name, slice);
+		}
+	}
+
+	private GpuBufferSlice placeholder() {
+		return this.dummy == null ? null : this.dummy.slice(0, 16);
+	}
+
+	/**
+	 * Zeros storage buffers small enough to fill on this command buffer. Complementary Ultra's
+	 * {@code bufferObject.0} is hundreds of megabytes; {@code vkCmdFillBuffer} of that size on
+	 * the frame that also draws the world trips Windows TDR ({@code VK_ERROR_DEVICE_LOST} two
+	 * seconds later). The pack writes the cells it uses.
+	 */
+	private void zero(GpuDevice device) {
+		CommandEncoder encoder = device.createCommandEncoder();
+		GpuRecording.endPass(encoder);
+		VkCommandBuffer commands = commands(encoder);
+		if (commands == null) {
+			return;
+		}
+
+		boolean filled = false;
+		for (Allocated buffer : this.allocated) {
+			if (buffer.zeroed) {
+				continue;
+			}
+
+			if (buffer.bytes > 4L * 1024 * 1024) {
+				buffer.zeroed = true;
+				continue;
+			}
+
+			VK12.vkCmdFillBuffer(commands, buffer.buffer, 0L, buffer.bytes, 0);
+			buffer.zeroed = true;
+			filled = true;
+		}
+
+		if (filled) {
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				GpuRecording.afterTransfer(commands, stack);
+			}
+		}
+	}
+
+	private static long aligned(long size) {
+		return Math.max(4L, (size + 3L) & ~3L);
+	}
+
+	private static VkCommandBuffer commands(CommandEncoder encoder) {
+		return ((CommandEncoderAccessor) encoder).vitrail$backend() instanceof VulkanCommandEncoder vulkan
+				? ((VulkanCommandEncoderAccessor) vulkan).vitrail$commandBuffer()
+				: null;
+	}
+
+	@Override
+	public void close() {
+		if (current == this) {
+			current = none();
+		}
+
+		VulkanDevice vulkan = vulkan();
+		if (vulkan != null) {
+			this.allocated.forEach(buffer -> buffer.destroy(vulkan));
+		}
+
+		this.allocated.clear();
+		if (this.dummy != null) {
+			this.dummy.close();
+			this.dummy = null;
+		}
+
+		this.lastWidth = 0;
+		this.lastHeight = 0;
+	}
+
+	private static VulkanDevice vulkan() {
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (device == null) {
+			return null;
+		}
+
+		GpuDeviceBackend backend = ((GpuDeviceAccessor) device).vitrail$backend();
+		return backend instanceof VulkanDevice vulkan ? vulkan : null;
+	}
+
+	private static final class Allocated {
+
+		private final BufferObject declared;
+		private final boolean relative;
+		private final long bytes;
+		private long buffer;
+		private long allocation;
+		private boolean zeroed;
+
+		private Allocated(BufferObject declared, boolean relative, long bytes, long buffer,
+				long allocation) {
+			this.declared = declared;
+			this.relative = relative;
+			this.bytes = bytes;
+			this.buffer = buffer;
+			this.allocation = allocation;
+		}
+
+		private static Allocated create(VulkanDevice vulkan, BufferObject declared, long bytes) {
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				VkBufferCreateInfo bufferInfo = VkBufferCreateInfo.calloc(stack).sType$Default();
+				bufferInfo.size(bytes);
+				bufferInfo.usage(VK12.VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
+						| VK12.VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+				bufferInfo.sharingMode(VK12.VK_SHARING_MODE_EXCLUSIVE);
+				VmaAllocationCreateInfo allocationInfo = VmaAllocationCreateInfo.calloc(stack);
+				allocationInfo.usage(8);
+				LongBuffer bufferPtr = stack.callocLong(1);
+				PointerBuffer allocationPtr = stack.callocPointer(1);
+				VulkanUtils.crashIfFailure(vulkan,
+						Vma.vmaCreateBuffer(vulkan.vma(), bufferInfo, allocationInfo, bufferPtr,
+								allocationPtr, null),
+						"storage buffer " + declared.index());
+				return new Allocated(declared, declared.relative(), bytes, bufferPtr.get(0),
+						allocationPtr.get(0));
+			}
+		}
+
+		/**
+		 * Deferred like the images: two frames may still hold descriptors naming this buffer, and
+		 * freeing under them is the settings-change device loss.
+		 */
+		private void destroy(VulkanDevice vulkan) {
+			long buffer = this.buffer;
+			long allocation = this.allocation;
+			this.buffer = 0L;
+			this.allocation = 0L;
+			if (buffer != 0L) {
+				GpuRecording.destroyLater(() -> Vma.vmaDestroyBuffer(vulkan.vma(), buffer, allocation));
+			}
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/StorageImages.java
+++ b/common/src/main/java/dev/vitrail/render/StorageImages.java
@@ -1,0 +1,470 @@
+package dev.vitrail.render;
+
+import dev.vitrail.mixin.CommandEncoderAccessor;
+import dev.vitrail.mixin.GpuDeviceAccessor;
+import dev.vitrail.mixin.VulkanCommandEncoderAccessor;
+import dev.vitrail.pack.target.TargetFormat;
+import dev.vitrail.pack.texture.ImageInformation;
+import dev.vitrail.pack.texture.PackTexture;
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.GpuDeviceBackend;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.VulkanUtils;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.util.vma.Vma;
+import org.lwjgl.util.vma.VmaAllocationCreateInfo;
+import org.lwjgl.vulkan.VK12;
+import org.lwjgl.vulkan.VkClearColorValue;
+import org.lwjgl.vulkan.VkCommandBuffer;
+import org.lwjgl.vulkan.VkImageCreateInfo;
+import org.lwjgl.vulkan.VkImageMemoryBarrier;
+import org.lwjgl.vulkan.VkImageSubresourceRange;
+import org.lwjgl.vulkan.VkImageViewCreateInfo;
+
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The storage images a pack declared with {@code image.NAME}, allocated on the Vulkan device.
+ * <p>
+ * The Java texture facade has no storage bit and no three-dimensional texture, so these go through
+ * VMA the way the compute probe did: {@code VulkanConst.textureUsageToVk} never sets
+ * {@code VK_IMAGE_USAGE_STORAGE_BIT}. Mixins on the game's bind-group walk swap the 3D view in
+ * for both {@code imageStore} names and the sampler hanging off the same directive.
+ *
+ * @see <a href="https://github.com/IrisShaders/Iris">Iris GlImage, LGPL-3.0</a>
+ */
+public final class StorageImages implements AutoCloseable {
+
+	private static volatile StorageImages current = none();
+
+	private final ImageInformation.Reading declared;
+	private final List<Allocated> allocated = new ArrayList<>();
+	private int lastWidth;
+	private int lastHeight;
+	private boolean laidOut;
+
+	StorageImages(ImageInformation.Reading declared) {
+		this.declared = declared;
+	}
+
+	static StorageImages none() {
+		return new StorageImages(ImageInformation.Reading.empty());
+	}
+
+	/**
+	 * The image currently allocated for this name, whether the pack wrote it as the image uniform
+	 * or as the sampler on the same {@code image.} line. Mixins look it up while pushing
+	 * descriptors.
+	 */
+	public static Bound bound(String name) {
+		return current.lookup(name);
+	}
+
+	public static boolean storageBinding(String name) {
+		Bound bound = bound(name);
+		return bound != null && bound.storage();
+	}
+
+	void install() {
+		current = this;
+	}
+
+	private Bound lookup(String name) {
+		for (Allocated image : this.allocated) {
+			if (image.declared.name().equals(name)) {
+				return new Bound(image.view, true, image.declared.internalFormat().used().integer());
+			}
+
+			if (image.declared.sampler().filter(name::equals).isPresent()) {
+				return new Bound(image.view, false, image.declared.internalFormat().used().integer());
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * One bound view. {@code storage} is the image uniform ({@code voxel_img}); a sampler name
+	 * hanging off the same directive is sampled, not stored.
+	 */
+	public record Bound(long view, boolean storage, boolean integer) {
+	}
+
+	/**
+	 * Allocates every absolute image once, and rebuilds the relative ones when the screen moves.
+	 * Failures are named and skipped: one volume is not worth taking the pack down.
+	 */
+	void ensure(int screenWidth, int screenHeight) {
+		install();
+		if (this.declared.images().isEmpty()) {
+			return;
+		}
+
+		boolean first = this.allocated.isEmpty();
+		boolean resized = screenWidth != this.lastWidth || screenHeight != this.lastHeight;
+		if (!first && !resized) {
+			return;
+		}
+
+		VulkanDevice vulkan = vulkan();
+		if (vulkan == null) {
+			return;
+		}
+
+		if (first) {
+			for (ImageInformation image : this.declared.images()) {
+				if (image.relative()) {
+					continue;
+				}
+
+				try {
+					this.allocated.add(Allocated.create(vulkan, image, image.width(), image.height(),
+							Math.max(image.depth(), 1)));
+					Vitrail.logger().info("storage image {}", image.describe());
+				} catch (RuntimeException e) {
+					Vitrail.logger().warn("storage image {} could not be allocated: {}",
+							image.describe(), e.toString());
+				}
+			}
+		}
+
+		if (first || resized) {
+			List<Allocated> kept = new ArrayList<>();
+			for (Allocated image : this.allocated) {
+				if (image.relative) {
+					image.destroy(vulkan);
+					this.laidOut = false;
+				} else {
+					kept.add(image);
+				}
+			}
+
+			this.allocated.clear();
+			this.allocated.addAll(kept);
+			for (ImageInformation image : this.declared.images()) {
+				if (!image.relative()) {
+					continue;
+				}
+
+				int width = Math.max(1, (int) (screenWidth * image.relativeWidth()));
+				int height = Math.max(1, (int) (screenHeight * image.relativeHeight()));
+				try {
+					this.allocated.add(Allocated.create(vulkan, image, width, height, 1));
+					Vitrail.logger().info("storage image {} at {}x{}", image.describe(), width,
+							height);
+				} catch (RuntimeException e) {
+					Vitrail.logger().warn("storage image {} could not be allocated: {}",
+							image.describe(), e.toString());
+				}
+			}
+		}
+
+		this.lastWidth = screenWidth;
+		this.lastHeight = screenHeight;
+		layoutIfNeeded();
+	}
+
+	/**
+	 * Empties every image the pack asked to clear, which Complementary's voxel volume is. Called
+	 * at the top of the shadow stage, before geometry writes, matching Iris clearing custom images
+	 * before the shadow map is drawn.
+	 */
+	void clearMarked(CommandEncoder encoder) {
+		GpuRecording.endPass(encoder);
+		VkCommandBuffer commands = commands(encoder);
+		if (commands == null) {
+			return;
+		}
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			// The volume being emptied was sampled by the previous frame's gbuffers and stored by
+			// the previous dispatch, and nothing else orders those against a transfer write.
+			GpuRecording.beforeTransfer(commands, stack);
+			for (Allocated image : this.allocated) {
+				if (!image.declared.clear()) {
+					continue;
+				}
+
+				clearImage(commands, stack, image);
+			}
+
+			GpuRecording.afterTransfer(commands, stack);
+		}
+	}
+
+	private void layoutIfNeeded() {
+		if (this.laidOut || this.allocated.isEmpty()) {
+			return;
+		}
+
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (device == null) {
+			return;
+		}
+
+		CommandEncoder encoder = device.createCommandEncoder();
+		GpuRecording.endPass(encoder);
+		VkCommandBuffer commands = commands(encoder);
+		if (commands == null) {
+			return;
+		}
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			for (Allocated image : this.allocated) {
+				// Only the images created since the last pass here. An UNDEFINED transition
+				// DISCARDS contents, so re-running it over a surviving absolute volume on a
+				// window resize would throw away the floodfill the frames carry forward.
+				if (image.laidOut) {
+					continue;
+				}
+
+				image.laidOut = true;
+				VkImageMemoryBarrier.Buffer barriers = VkImageMemoryBarrier.calloc(1, stack)
+						.sType$Default();
+				VkImageMemoryBarrier barrier = barriers.get(0);
+				barrier.oldLayout(VK12.VK_IMAGE_LAYOUT_UNDEFINED);
+				barrier.newLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+				barrier.srcAccessMask(0);
+				barrier.dstAccessMask(VK12.VK_ACCESS_SHADER_READ_BIT
+						| VK12.VK_ACCESS_SHADER_WRITE_BIT
+						| VK12.VK_ACCESS_TRANSFER_WRITE_BIT);
+				barrier.srcQueueFamilyIndex(VK12.VK_QUEUE_FAMILY_IGNORED);
+				barrier.dstQueueFamilyIndex(VK12.VK_QUEUE_FAMILY_IGNORED);
+				barrier.image(image.image);
+				barrier.subresourceRange().set(VK12.VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1);
+				VK12.vkCmdPipelineBarrier(commands, VK12.VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+						VK12.VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, null, null, barriers);
+			}
+
+			// Only the images the pack marked clear. Complementary's two floodfill volumes are
+			// 500 MiB each at Ultra: zeroing them here with the 773 MiB SSBO fill on the same
+			// command buffer is what killed the device two seconds later (Windows TDR). Voxel
+			// is clear=true and is emptied each shadow frame by clearMarked. Floodfill is
+			// written by shadowcomp on this same first dispatch.
+		}
+
+		this.laidOut = true;
+	}
+
+	private static void clearImage(VkCommandBuffer commands, MemoryStack stack, Allocated image) {
+		VkClearColorValue colour = VkClearColorValue.calloc(stack);
+		if (image.declared.internalFormat().used().integer()) {
+			IntBuffer ints = colour.int32();
+			ints.put(0, 0).put(1, 0).put(2, 0).put(3, 0);
+		} else {
+			colour.float32().put(0, 0.0F).put(1, 0.0F).put(2, 0.0F).put(3, 0.0F);
+		}
+
+		VkImageSubresourceRange range = VkImageSubresourceRange.calloc(stack);
+		range.set(VK12.VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1);
+		VK12.vkCmdClearColorImage(commands, image.image, VK12.VK_IMAGE_LAYOUT_GENERAL, colour, range);
+	}
+
+	private static VkCommandBuffer commands(CommandEncoder encoder) {
+		return ((CommandEncoderAccessor) encoder).vitrail$backend() instanceof VulkanCommandEncoder vulkan
+				? ((VulkanCommandEncoderAccessor) vulkan).vitrail$commandBuffer()
+				: null;
+	}
+
+	int count() {
+		return this.allocated.size();
+	}
+
+	@Override
+	public void close() {
+		if (current == this) {
+			current = none();
+		}
+
+		VulkanDevice vulkan = vulkan();
+		if (vulkan != null) {
+			this.allocated.forEach(image -> image.destroy(vulkan));
+		}
+
+		this.allocated.clear();
+		this.lastWidth = 0;
+		this.lastHeight = 0;
+		this.laidOut = false;
+	}
+
+	private static VulkanDevice vulkan() {
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (device == null) {
+			return null;
+		}
+
+		GpuDeviceBackend backend = ((GpuDeviceAccessor) device).vitrail$backend();
+		return backend instanceof VulkanDevice vulkan ? vulkan : null;
+	}
+
+	/**
+	 * One VMA image. The view is what a storage binding and a sampler will both name, once those
+	 * roads exist.
+	 */
+	private static final class Allocated {
+
+		private final ImageInformation declared;
+		private final boolean relative;
+		private long image;
+		private long allocation;
+		private long view;
+
+		/** Whether the one UNDEFINED-to-GENERAL transition of this image's life has been recorded. */
+		private boolean laidOut;
+
+		private Allocated(ImageInformation declared, boolean relative, long image, long allocation,
+				long view) {
+			this.declared = declared;
+			this.relative = relative;
+			this.image = image;
+			this.allocation = allocation;
+			this.view = view;
+		}
+
+		private static Allocated create(VulkanDevice vulkan, ImageInformation declared, int width,
+				int height, int depth) {
+			int vkFormat = vkFormat(declared.internalFormat().used());
+			int type = imageType(declared.shape());
+			int viewType = viewType(declared.shape());
+			int extentHeight = Math.max(height, 1);
+			int extentDepth = Math.max(depth, 1);
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				VkImageCreateInfo imageInfo = VkImageCreateInfo.calloc(stack).sType$Default();
+				imageInfo.imageType(type);
+				imageInfo.extent().set(Math.max(width, 1), extentHeight, extentDepth);
+				imageInfo.mipLevels(1);
+				imageInfo.arrayLayers(1);
+				imageInfo.format(vkFormat);
+				imageInfo.tiling(VK12.VK_IMAGE_TILING_OPTIMAL);
+				imageInfo.initialLayout(VK12.VK_IMAGE_LAYOUT_UNDEFINED);
+				imageInfo.usage(VK12.VK_IMAGE_USAGE_STORAGE_BIT
+						| VK12.VK_IMAGE_USAGE_SAMPLED_BIT
+						| VK12.VK_IMAGE_USAGE_TRANSFER_SRC_BIT
+						| VK12.VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+				imageInfo.sharingMode(VK12.VK_SHARING_MODE_EXCLUSIVE);
+				imageInfo.samples(VK12.VK_SAMPLE_COUNT_1_BIT);
+				VmaAllocationCreateInfo allocationInfo = VmaAllocationCreateInfo.calloc(stack);
+				allocationInfo.usage(8);
+				LongBuffer imagePtr = stack.callocLong(1);
+				PointerBuffer allocationPtr = stack.callocPointer(1);
+				VulkanUtils.crashIfFailure(vulkan,
+						Vma.vmaCreateImage(vulkan.vma(), imageInfo, allocationInfo, imagePtr,
+								allocationPtr, null),
+						"storage image " + declared.name());
+				long image = imagePtr.get(0);
+				long allocation = allocationPtr.get(0);
+
+				VkImageViewCreateInfo viewInfo = VkImageViewCreateInfo.calloc(stack).sType$Default();
+				viewInfo.image(image);
+				viewInfo.viewType(viewType);
+				viewInfo.format(vkFormat);
+				viewInfo.subresourceRange().set(VK12.VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1);
+				LongBuffer viewPtr = stack.callocLong(1);
+				try {
+					VulkanUtils.crashIfFailure(vulkan,
+							VK12.vkCreateImageView(vulkan.vkDevice(), viewInfo, null, viewPtr),
+							"storage image view " + declared.name());
+				} catch (RuntimeException e) {
+					Vma.vmaDestroyImage(vulkan.vma(), image, allocation);
+					throw e;
+				}
+
+				return new Allocated(declared, declared.relative(), image, allocation, viewPtr.get(0));
+			}
+		}
+
+		/**
+		 * Frees the handles through the game's deferred queue, never inline: up to two frames are
+		 * still in flight with descriptors naming this view, and freeing under them is the device
+		 * loss a settings change to a bigger volume turned from latent into certain. Same rule as
+		 * {@code StalePipelines}: destruction has no safe instant in a running session, only a
+		 * deferred one.
+		 */
+		private void destroy(VulkanDevice vulkan) {
+			long view = this.view;
+			long image = this.image;
+			long allocation = this.allocation;
+			this.view = 0L;
+			this.image = 0L;
+			this.allocation = 0L;
+			GpuRecording.destroyLater(() -> {
+				if (view != 0L) {
+					VK12.vkDestroyImageView(vulkan.vkDevice(), view, null);
+				}
+
+				if (image != 0L) {
+					Vma.vmaDestroyImage(vulkan.vma(), image, allocation);
+				}
+			});
+		}
+	}
+
+	private static int imageType(PackTexture.Shape shape) {
+		return switch (shape) {
+			case TEXTURE_1D -> VK12.VK_IMAGE_TYPE_1D;
+			case TEXTURE_3D -> VK12.VK_IMAGE_TYPE_3D;
+			case TEXTURE_2D, TEXTURE_RECTANGLE -> VK12.VK_IMAGE_TYPE_2D;
+		};
+	}
+
+	private static int viewType(PackTexture.Shape shape) {
+		return switch (shape) {
+			case TEXTURE_1D -> VK12.VK_IMAGE_VIEW_TYPE_1D;
+			case TEXTURE_3D -> VK12.VK_IMAGE_VIEW_TYPE_3D;
+			case TEXTURE_2D, TEXTURE_RECTANGLE -> VK12.VK_IMAGE_VIEW_TYPE_2D;
+		};
+	}
+
+	private static int vkFormat(TargetFormat format) {
+		return switch (format) {
+			case R8_UNORM -> VK12.VK_FORMAT_R8_UNORM;
+			case R8_SNORM -> VK12.VK_FORMAT_R8_SNORM;
+			case RG8_UNORM -> VK12.VK_FORMAT_R8G8_UNORM;
+			case RG8_SNORM -> VK12.VK_FORMAT_R8G8_SNORM;
+			case RGBA8_UNORM -> VK12.VK_FORMAT_R8G8B8A8_UNORM;
+			case RGBA8_SNORM -> VK12.VK_FORMAT_R8G8B8A8_SNORM;
+			case R16_UNORM -> VK12.VK_FORMAT_R16_UNORM;
+			case R16_SNORM -> VK12.VK_FORMAT_R16_SNORM;
+			case RG16_UNORM -> VK12.VK_FORMAT_R16G16_UNORM;
+			case RG16_SNORM -> VK12.VK_FORMAT_R16G16_SNORM;
+			case RGBA16_UNORM -> VK12.VK_FORMAT_R16G16B16A16_UNORM;
+			case RGBA16_SNORM -> VK12.VK_FORMAT_R16G16B16A16_SNORM;
+			case R8_UINT -> VK12.VK_FORMAT_R8_UINT;
+			case R8_SINT -> VK12.VK_FORMAT_R8_SINT;
+			case RG8_UINT -> VK12.VK_FORMAT_R8G8_UINT;
+			case RG8_SINT -> VK12.VK_FORMAT_R8G8_SINT;
+			case RGBA8_UINT -> VK12.VK_FORMAT_R8G8B8A8_UINT;
+			case RGBA8_SINT -> VK12.VK_FORMAT_R8G8B8A8_SINT;
+			case R16_UINT -> VK12.VK_FORMAT_R16_UINT;
+			case R16_SINT -> VK12.VK_FORMAT_R16_SINT;
+			case RG16_UINT -> VK12.VK_FORMAT_R16G16_UINT;
+			case RG16_SINT -> VK12.VK_FORMAT_R16G16_SINT;
+			case RGBA16_UINT -> VK12.VK_FORMAT_R16G16B16A16_UINT;
+			case RGBA16_SINT -> VK12.VK_FORMAT_R16G16B16A16_SINT;
+			case R32_UINT -> VK12.VK_FORMAT_R32_UINT;
+			case R32_SINT -> VK12.VK_FORMAT_R32_SINT;
+			case RG32_UINT -> VK12.VK_FORMAT_R32G32_UINT;
+			case RG32_SINT -> VK12.VK_FORMAT_R32G32_SINT;
+			case RGBA32_UINT -> VK12.VK_FORMAT_R32G32B32A32_UINT;
+			case RGBA32_SINT -> VK12.VK_FORMAT_R32G32B32A32_SINT;
+			case R16_FLOAT -> VK12.VK_FORMAT_R16_SFLOAT;
+			case RG16_FLOAT -> VK12.VK_FORMAT_R16G16_SFLOAT;
+			case RGBA16_FLOAT -> VK12.VK_FORMAT_R16G16B16A16_SFLOAT;
+			case R32_FLOAT -> VK12.VK_FORMAT_R32_SFLOAT;
+			case RG32_FLOAT -> VK12.VK_FORMAT_R32G32_SFLOAT;
+			case RGBA32_FLOAT -> VK12.VK_FORMAT_R32G32B32A32_SFLOAT;
+			case RGB10A2_UNORM -> VK12.VK_FORMAT_A2B10G10R10_UNORM_PACK32;
+			case RGB10A2_UINT -> VK12.VK_FORMAT_A2B10G10R10_UINT_PACK32;
+			case RG11B10_FLOAT -> VK12.VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+		};
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/StorageImages.java
+++ b/common/src/main/java/dev/vitrail/render/StorageImages.java
@@ -22,6 +22,7 @@ import org.lwjgl.util.vma.VmaAllocationCreateInfo;
 import org.lwjgl.vulkan.VK12;
 import org.lwjgl.vulkan.VkClearColorValue;
 import org.lwjgl.vulkan.VkCommandBuffer;
+import org.lwjgl.vulkan.VkImageCopy;
 import org.lwjgl.vulkan.VkImageCreateInfo;
 import org.lwjgl.vulkan.VkImageMemoryBarrier;
 import org.lwjgl.vulkan.VkImageSubresourceRange;
@@ -126,10 +127,20 @@ public final class StorageImages implements AutoCloseable {
 					continue;
 				}
 
+				boolean movable = movable(image);
 				try {
 					this.allocated.add(Allocated.create(vulkan, image, image.width(), image.height(),
-							Math.max(image.depth(), 1)));
-					Vitrail.logger().info("storage image {}", image.describe());
+							Math.max(image.depth(), 1), movable));
+					// Which volumes follow the camera and which do not, said once per pack rather
+					// than left to be guessed from the picture: a volume left behind keeps a frame
+					// of lag at every block crossed, and a volume that follows costs a second
+					// image of its own size. Neither shows as itself on screen.
+					Vitrail.logger().info("storage image {}{}", image.describe(), movable
+							? ", moved onto each frame's camera block for " + scratchCost(image)
+									+ " more"
+							: image.clear() && image.depth() > 1
+									? ", left on the frame that filled it"
+									: "");
 				} catch (RuntimeException e) {
 					Vitrail.logger().warn("storage image {} could not be allocated: {}",
 							image.describe(), e.toString());
@@ -158,7 +169,9 @@ public final class StorageImages implements AutoCloseable {
 				int width = Math.max(1, (int) (screenWidth * image.relativeWidth()));
 				int height = Math.max(1, (int) (screenHeight * image.relativeHeight()));
 				try {
-					this.allocated.add(Allocated.create(vulkan, image, width, height, 1));
+					// Never movable: a relative image is a screen and not a volume, and it goes
+					// back and is built again on every resize.
+					this.allocated.add(Allocated.create(vulkan, image, width, height, 1, false));
 					Vitrail.logger().info("storage image {} at {}x{}", image.describe(), width,
 							height);
 				} catch (RuntimeException e) {
@@ -201,6 +214,166 @@ public final class StorageImages implements AutoCloseable {
 		}
 	}
 
+	/**
+	 * What a second image of this one's shape costs, for the line that says a volume follows. In
+	 * mebibytes where there is a whole one and in kibibytes below that: the smallest volume the
+	 * corpus declares is half a mebibyte, and a line reading "0 MiB more" says the move is free.
+	 */
+	private static String scratchCost(ImageInformation image) {
+		long texels = (long) Math.max(image.width(), 1) * Math.max(image.height(), 1)
+				* Math.max(image.depth(), 1);
+		long bytes = texels * image.internalFormat().used().bytesPerPixel();
+
+		return bytes >= 1024L * 1024L
+				? bytes / (1024L * 1024L) + " MiB"
+				: bytes / 1024L + " KiB";
+	}
+
+	/**
+	 * Whether a volume may be moved by a count of BLOCKS, which is the one thing this class has to
+	 * settle before {@link #reanchor} may touch anything: a custom image is a grid whose scale the
+	 * pack keeps to itself, and the engine sees only three extents.
+	 * <p>
+	 * The rule is a volume the pack CLEARS whose three extents match a volume it does NOT clear.
+	 * What that buys: an uncleared volume survives frames, so it is the pack that carries it
+	 * forward, and it does so by the blocks the camera crossed and nothing else,
+	 * {@code pos - (floor(previousCameraPosition) - floor(cameraPosition))} in Complementary's
+	 * {@code program/shadowcomp.glsl}. One texel a block, and a cleared volume declared at that same
+	 * extent is the identity half of the same grid. Three packs of the corpus are built that way,
+	 * each with its identity volume beside the light volumes it feeds: Complementary, BSL and Bliss,
+	 * and all three anchor on the fractional part of the camera position plus half the volume, which
+	 * only the first of them writes under the {@code cameraPositionBestFract} name.
+	 * <p>
+	 * <strong>Anything else is left where it is, and the counter-example is in the same pack.</strong>
+	 * Complementary's coarse reflection volume is stored at a QUARTER of the voxel position
+	 * ({@code lib/voxelization/reflectionVoxelization.glsl}), one cell per four blocks, and it is
+	 * cleared each stage exactly like the identity volume. Moved by a block count it would land four
+	 * cells out in the direction of travel, which is worse than the frame of lag it carries today,
+	 * and nothing in an {@code image.} directive tells the two apart. It has no uncleared twin, so
+	 * the rule excludes it.
+	 * <p>
+	 * <strong>The rule is sufficient and not necessary, and the log says so.</strong> The same
+	 * pack's full-scale reflection volume IS one texel a block, and it is left behind at every
+	 * setting but the smallest, being the only one where its height happens to equal the floodfill's.
+	 * Widening the rule to catch it means guessing from two extents out of three, which is the guess
+	 * that would have caught the quarter-scale volume as well.
+	 */
+	private boolean movable(ImageInformation image) {
+		if (!image.clear() || image.relative() || image.depth() <= 1) {
+			return false;
+		}
+
+		for (ImageInformation other : this.declared.images()) {
+			if (!other.clear() && !other.relative() && other.width() == image.width()
+					&& other.height() == image.height() && other.depth() == image.depth()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Moves every volume {@link #movable} accepts onto the anchor of the frame about to read it, by
+	 * the whole blocks the camera has crossed since it was filled.
+	 * <p>
+	 * <strong>What Iris does.</strong> It empties the custom images at the head of the level render
+	 * ({@code pipeline/IrisRenderingPipeline.java:892}), draws the shadow geometry that stores block
+	 * identities into them, and dispatches {@code shadowcomp} at the foot of that stage
+	 * ({@code shadows/ShadowRenderer.java:632}). Three points of ONE frame, so writer and reader
+	 * share a {@code cameraPosition}, and the volume Complementary indexes as
+	 * {@code scenePos + cameraPositionBestFract + half} is anchored on the same block for both.
+	 * <p>
+	 * <strong>What prevents it here.</strong> This engine draws the shadow stage at the END of a
+	 * frame for the next one ({@link dev.vitrail.sodium.ShadowTerrain}, and that placement is not a
+	 * preference: Sodium's per region lists reset on the FIRST walk of a frame, so the light's walk
+	 * has to follow the camera's rather than precede it). The identities are therefore written under
+	 * the previous frame's anchor, and {@code shadowcomp} runs at the head of this one, where it has
+	 * to run or the floodfill ping-pong lands on the half this frame's gbuffers do not read.
+	 * <p>
+	 * <strong>What it costs the image without this.</strong> The compute reads the floodfill at
+	 * {@code pos - (floor(previousCameraPosition) - floor(cameraPosition))}, so the light it carries
+	 * forward IS reprojected; the identities at {@code pos} are not. One frame per block crossed,
+	 * every block is read as its neighbour, and the cost is not symmetric: crossing UPWARDS the
+	 * reader takes each block for the one below it, so the layer of air just over the floor reads as
+	 * {@code voxel == 1u}, which the pack answers with {@code light = 0}. The coloured light around
+	 * the player collapses for that frame (a halo on a jump, continuous while climbing). Crossing
+	 * DOWNWARDS the same error makes a solid block read as air, which merely lights a cell buried in
+	 * the floor and shows nothing. That asymmetry is the signature the defect was reported under.
+	 * <p>
+	 * The {@code |d|} planes at the leading face keep what they held rather than being emptied. They
+	 * sit at the far edge of the volume, they are rewritten by the shadow stage at the end of this
+	 * same frame, and a stale identity there blocks light where an emptied one would leak it.
+	 */
+	void reanchor(CommandEncoder encoder, int dx, int dy, int dz) {
+		if (dx == 0 && dy == 0 && dz == 0) {
+			return;
+		}
+
+		GpuRecording.endPass(encoder);
+		VkCommandBuffer commands = commands(encoder);
+		if (commands == null) {
+			return;
+		}
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			GpuRecording.beforeTransfer(commands, stack);
+			for (Allocated image : this.allocated) {
+				if (image.scratch == 0L) {
+					continue;
+				}
+
+				// Past the extent nothing of the volume survives the move, which is a teleport
+				// rather than a step. Emptied and not moved: the pack's own floodfill reprojection
+				// is just as lost there, and identities from the world the player has left would
+				// block light all over the one they arrived in.
+				if (Math.abs(dx) >= image.width || Math.abs(dy) >= image.height
+						|| Math.abs(dz) >= image.depth) {
+					clearImage(commands, stack, image);
+					continue;
+				}
+
+				move(commands, stack, image, dx, dy, dz);
+			}
+
+			GpuRecording.afterTransfer(commands, stack);
+		}
+	}
+
+	/**
+	 * The move itself, in two copies through the image's own scratch because Vulkan leaves a copy
+	 * whose source and destination regions overlap undefined, and a shift of one plane overlaps
+	 * everywhere.
+	 */
+	private static void move(VkCommandBuffer commands, MemoryStack stack, Allocated image,
+			int dx, int dy, int dz) {
+		VkImageCopy.Buffer whole = VkImageCopy.calloc(1, stack);
+		layers(whole.get(0));
+		whole.get(0).extent().set(image.width, image.height, image.depth);
+		VK12.vkCmdCopyImage(commands, image.image, VK12.VK_IMAGE_LAYOUT_GENERAL,
+				image.scratch, VK12.VK_IMAGE_LAYOUT_GENERAL, whole);
+
+		GpuRecording.betweenTransfers(commands, stack);
+
+		// The reader wants index p to hold what index p + d holds, d being the blocks the camera
+		// has crossed since the write: so the source starts d planes in where the camera moved
+		// forward, and the destination does where it moved back.
+		VkImageCopy.Buffer shifted = VkImageCopy.calloc(1, stack);
+		VkImageCopy region = shifted.get(0);
+		layers(region);
+		region.srcOffset().set(Math.max(dx, 0), Math.max(dy, 0), Math.max(dz, 0));
+		region.dstOffset().set(Math.max(-dx, 0), Math.max(-dy, 0), Math.max(-dz, 0));
+		region.extent().set(image.width - Math.abs(dx), image.height - Math.abs(dy),
+				image.depth - Math.abs(dz));
+		VK12.vkCmdCopyImage(commands, image.scratch, VK12.VK_IMAGE_LAYOUT_GENERAL,
+				image.image, VK12.VK_IMAGE_LAYOUT_GENERAL, shifted);
+	}
+
+	private static void layers(VkImageCopy region) {
+		region.srcSubresource().set(VK12.VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1);
+		region.dstSubresource().set(VK12.VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1);
+	}
+
 	private void layoutIfNeeded() {
 		if (this.laidOut || this.allocated.isEmpty()) {
 			return;
@@ -228,19 +401,28 @@ public final class StorageImages implements AutoCloseable {
 				}
 
 				image.laidOut = true;
-				VkImageMemoryBarrier.Buffer barriers = VkImageMemoryBarrier.calloc(1, stack)
+				// The scratch beside its image and in the same breath: it is a transfer end of the
+				// same volume, so it has to leave UNDEFINED before the first copy names it, and a
+				// copy is the only thing that ever will.
+				int count = image.scratch == 0L ? 1 : 2;
+				VkImageMemoryBarrier.Buffer barriers = VkImageMemoryBarrier.calloc(count, stack)
 						.sType$Default();
-				VkImageMemoryBarrier barrier = barriers.get(0);
-				barrier.oldLayout(VK12.VK_IMAGE_LAYOUT_UNDEFINED);
-				barrier.newLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
-				barrier.srcAccessMask(0);
-				barrier.dstAccessMask(VK12.VK_ACCESS_SHADER_READ_BIT
-						| VK12.VK_ACCESS_SHADER_WRITE_BIT
-						| VK12.VK_ACCESS_TRANSFER_WRITE_BIT);
-				barrier.srcQueueFamilyIndex(VK12.VK_QUEUE_FAMILY_IGNORED);
-				barrier.dstQueueFamilyIndex(VK12.VK_QUEUE_FAMILY_IGNORED);
-				barrier.image(image.image);
-				barrier.subresourceRange().set(VK12.VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1);
+				for (int at = 0; at < count; at++) {
+					VkImageMemoryBarrier barrier = barriers.get(at);
+					barrier.sType$Default();
+					barrier.oldLayout(VK12.VK_IMAGE_LAYOUT_UNDEFINED);
+					barrier.newLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+					barrier.srcAccessMask(0);
+					barrier.dstAccessMask(VK12.VK_ACCESS_SHADER_READ_BIT
+							| VK12.VK_ACCESS_SHADER_WRITE_BIT
+							| VK12.VK_ACCESS_TRANSFER_WRITE_BIT
+							| VK12.VK_ACCESS_TRANSFER_READ_BIT);
+					barrier.srcQueueFamilyIndex(VK12.VK_QUEUE_FAMILY_IGNORED);
+					barrier.dstQueueFamilyIndex(VK12.VK_QUEUE_FAMILY_IGNORED);
+					barrier.image(at == 0 ? image.image : image.scratch);
+					barrier.subresourceRange().set(VK12.VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1);
+				}
+
 				VK12.vkCmdPipelineBarrier(commands, VK12.VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 						VK12.VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, null, null, barriers);
 			}
@@ -314,33 +496,48 @@ public final class StorageImages implements AutoCloseable {
 
 		private final ImageInformation declared;
 		private final boolean relative;
+		private final int width;
+		private final int height;
+		private final int depth;
 		private long image;
 		private long allocation;
 		private long view;
 
+		/**
+		 * A second image of the same shape, for the volumes {@link #reanchor} moves, and nought for
+		 * every other. It carries no view: nothing samples it and nothing stores into it, it is one
+		 * end of a copy and no more.
+		 */
+		private long scratch;
+		private long scratchAllocation;
+
 		/** Whether the one UNDEFINED-to-GENERAL transition of this image's life has been recorded. */
 		private boolean laidOut;
 
-		private Allocated(ImageInformation declared, boolean relative, long image, long allocation,
-				long view) {
+		private Allocated(ImageInformation declared, boolean relative, int width, int height,
+				int depth, long image, long allocation, long view) {
 			this.declared = declared;
 			this.relative = relative;
+			this.width = width;
+			this.height = height;
+			this.depth = depth;
 			this.image = image;
 			this.allocation = allocation;
 			this.view = view;
 		}
 
 		private static Allocated create(VulkanDevice vulkan, ImageInformation declared, int width,
-				int height, int depth) {
+				int height, int depth, boolean movable) {
 			int vkFormat = vkFormat(declared.internalFormat().used());
 			int type = imageType(declared.shape());
 			int viewType = viewType(declared.shape());
+			int extentWidth = Math.max(width, 1);
 			int extentHeight = Math.max(height, 1);
 			int extentDepth = Math.max(depth, 1);
 			try (MemoryStack stack = MemoryStack.stackPush()) {
 				VkImageCreateInfo imageInfo = VkImageCreateInfo.calloc(stack).sType$Default();
 				imageInfo.imageType(type);
-				imageInfo.extent().set(Math.max(width, 1), extentHeight, extentDepth);
+				imageInfo.extent().set(extentWidth, extentHeight, extentDepth);
 				imageInfo.mipLevels(1);
 				imageInfo.arrayLayers(1);
 				imageInfo.format(vkFormat);
@@ -378,7 +575,32 @@ public final class StorageImages implements AutoCloseable {
 					throw e;
 				}
 
-				return new Allocated(declared, declared.relative(), image, allocation, viewPtr.get(0));
+				Allocated allocated = new Allocated(declared, declared.relative(), extentWidth,
+						extentHeight, extentDepth, image, allocation, viewPtr.get(0));
+
+				// The scratch only where the volume may be moved at all, which movable settles. It
+				// is a second image of the same shape, so it is not owed to a volume nothing will
+				// ever copy.
+				//
+				// A failure here is not the image's failure, and that is why it is caught rather
+				// than raised. The volume itself is allocated and bound; with no scratch it simply
+				// keeps the frame of lag it carried before, which is a worse picture. Raising here
+				// would drop the volume outright and take the pack's coloured light with it.
+				if (movable) {
+					try {
+						VulkanUtils.crashIfFailure(vulkan,
+								Vma.vmaCreateImage(vulkan.vma(), imageInfo, allocationInfo, imagePtr,
+										allocationPtr, null),
+								"storage image scratch " + declared.name());
+						allocated.scratch = imagePtr.get(0);
+						allocated.scratchAllocation = allocationPtr.get(0);
+					} catch (RuntimeException e) {
+						Vitrail.logger().warn("storage image {} keeps a frame of lag, its scratch "
+								+ "could not be allocated: {}", declared.name(), e.toString());
+					}
+				}
+
+				return allocated;
 			}
 		}
 
@@ -393,9 +615,13 @@ public final class StorageImages implements AutoCloseable {
 			long view = this.view;
 			long image = this.image;
 			long allocation = this.allocation;
+			long scratch = this.scratch;
+			long scratchAllocation = this.scratchAllocation;
 			this.view = 0L;
 			this.image = 0L;
 			this.allocation = 0L;
+			this.scratch = 0L;
+			this.scratchAllocation = 0L;
 			GpuRecording.destroyLater(() -> {
 				if (view != 0L) {
 					VK12.vkDestroyImageView(vulkan.vkDevice(), view, null);
@@ -403,6 +629,10 @@ public final class StorageImages implements AutoCloseable {
 
 				if (image != 0L) {
 					Vma.vmaDestroyImage(vulkan.vma(), image, allocation);
+				}
+
+				if (scratch != 0L) {
+					Vma.vmaDestroyImage(vulkan.vma(), scratch, scratchAllocation);
 				}
 			});
 		}

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
@@ -78,30 +78,33 @@ public final class ShadowCull implements Frustum {
 	 * whole answers {@code INSIDE} at Iris the moment the distance is anything but {@code OUTSIDE}
 	 * ({@code shadows/frustum/advanced/SafeZoneCullingFrustum.java:74-78}), and that order is kept.
 	 * It settles nothing while the safe zone is the shorter of the two, such a box being wholly
-	 * within the distance as well; it is what a pack asking for a voxel grid WIDER than its shadow
-	 * distance is owed, and {@code PackValues:332-333} works the two out apart without bounding
+	 * within the distance as well. It is what a pack asking for a voxel grid WIDER than its shadow
+	 * distance is owed, and {@code PackValues:347-351} works the two out apart without bounding
 	 * either by the other.
 	 * <p>
-	 * <strong>No pack of the corpus reaches it on this engine, and one flag is the whole
-	 * reason.</strong> Bliss, BSL, both Complementary and Reverie ask for this shape behind their
-	 * voxelised light, so the STATE is reached; what never arrives is its WIDTH. A pack declares
-	 * that as {@code voxelDistance}, and Bliss puts the declaration itself behind
-	 * {@code IRIS_FEATURE_CUSTOM_IMAGES} ({@code lib/settings.glsl}) where both Complementary reach
-	 * it through {@code COLORED_LIGHTING_INTERNAL}, a define the same flag alone turns on
-	 * ({@code lib/common.glsl}). {@link dev.vitrail.pack.option.EngineDefines} poses no
-	 * {@code IRIS_FEATURE_} for anything this engine does not serve, and
-	 * {@code ConstDirectives.read} keeps live lines only, so for those three the value never arrives
-	 * and the box is nought blocks wide. BSL declares one on a live line and it is SHORTER than the
-	 * smallest shadow distance it offers, which is the case just above that settles nothing. Reverie
-	 * requires the flag outright and is refused whole before a program is translated. So what stands
-	 * below is the reference's order held against the day custom images are served, and not a state
-	 * a player can put this engine in today.
+	 * <strong>Three packs of the corpus could not reach it until the storage images were served, and
+	 * one always could.</strong> The width is a {@code const float voxelDistance}. Both Complementary
+	 * write it behind their coloured lighting, which {@code lib/common.glsl} gates on
+	 * {@code IRIS_FEATURE_CUSTOM_IMAGES} among other conditions and which
+	 * {@code program/gbuffers_terrain} then declares the width behind, and Bliss writes it behind
+	 * that flag directly, inside its own light volume switch ({@code lib/settings.glsl}). With no
+	 * {@code IRIS_FEATURE_} posed at all those lines were dead, {@code ConstDirectives.read} keeping
+	 * live lines only, and the box came out nought blocks wide while the STATE was still reached: the
+	 * shape said safe zone and behaved as the plain sweep. The flag being posed, a pack that also
+	 * turns its own switch on brings a width and the box has a side.
 	 * <p>
-	 * <strong>{@link #testAab} does NOT carry that exception, and Iris does not carry it there
-	 * either</strong> ({@code SafeZoneCullingFrustum.java:54-56}, the distance cut first). The two
-	 * tests are therefore asymmetric on one box: wholly in the safe zone and wholly past the
-	 * distance. Nothing reaches it, that box being {@code OUTSIDE} by the distance in both methods
-	 * before either exception is looked at.
+	 * BSL is the fourth and it never depended on any of that: it declares the width on a line held
+	 * by nothing but the stage it is in ({@code program/final.glsl}), so the value has always
+	 * arrived, and its safe zone hangs off a setting of its own rather than off a feature flag. It
+	 * is also the case the paragraph above says settles nothing, its box being shorter than the
+	 * smallest shadow distance it offers.
+	 * <p>
+	 * <strong>{@link #testAab} carries the exception too, one layer down.</strong> Iris takes a box
+	 * reaching into the safe zone AT ALL for visible there, without asking its planes
+	 * ({@code SafeZoneCullingFrustum.java:58-60}, after the distance cut at :54-56), and
+	 * {@link ShadowCullFrustum#testAab} answers exactly that, so the composition below is the same
+	 * pair of questions in the same order. What is left to this method is the distance, which Iris
+	 * asks first as well.
 	 */
 	@Override
 	public int intersectAab(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
@@ -117,10 +120,7 @@ public final class ShadowCull implements Frustum {
 
 		// The safe zone outranks the distance on a box it holds whole, which is Iris's order and not
 		// a softening of the line above: its safe zone frustum answers INSIDE off that box alone the
-		// moment the distance is anything but OUTSIDE (SafeZoneCullingFrustum.java:74-78). No pack
-		// of the corpus can put a width behind it here, the javadoc above naming what stops each of
-		// them, so nothing below this line answers differently today; it is kept because it is what
-		// the reference does and what a served voxel grid would need.
+		// moment the distance is anything but OUTSIDE (SafeZoneCullingFrustum.java:74-78).
 		return within(this.distance, minX, minY, minZ, maxX, maxY, maxZ)
 				|| (this.safeZone >= 0.0F
 						&& within(this.safeZone, minX, minY, minZ, maxX, maxY, maxZ))

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -8,6 +8,7 @@ import dev.vitrail.render.DistantDraw;
 import dev.vitrail.render.RingTimings;
 import dev.vitrail.render.ShadowCullPlan;
 import dev.vitrail.render.ShadowGeometry;
+import dev.vitrail.render.PackChain;
 import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.Vitrail;
 
@@ -140,6 +141,11 @@ public final class ShadowTerrain {
 		// below hands them to the light, and from that point on the camera has to be given them
 		// back whatever else happens.
 		if (!TerrainDraw.openShadowStage()) {
+			// Complementary Ultra still samples floodfill and WSR from gbuffers. The shadow
+			// programs may be refused so the stage never opens, but the clear still has to run
+			// or the voxel volume keeps stale writes; the compute itself runs at the head of
+			// the frame, from the frame graph setup, whatever this stage does.
+			PackChain.clearCustomImages();
 			return;
 		}
 
@@ -255,6 +261,10 @@ public final class ShadowTerrain {
 		GpuSampler sampler = RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR, true);
 
 		ShadowCasters casters = TerrainDraw.shadowCasters();
+
+		// Before geometry writes, matching Iris clearing custom images at the head of the
+		// shadow stage. Complementary's voxel volume is marked clear; the floodfill is not.
+		PackChain.clearCustomImages();
 
 		// Refused by the pack rather than skipped for cheapness.
 		if (casters.terrain()) {

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -24,6 +24,7 @@
 		"CustomSubmitMixin",
 		"DebugScreenEntriesMixin",
 		"DebugScreenEntryListMixin",
+		"GlslCompilerMixin",
 		"MinecraftStartupGuardMixin",
 		"MixinDefaultChunkRenderer",
 		"DefaultFluidRendererMixin",
@@ -63,10 +64,12 @@
 		"TextureManagerAccessor",
 		"VKDrawContextMixin",
 		"VulkanBackendMixin",
+		"VulkanBindGroupLayoutMixin",
 		"VulkanCommandEncoderAccessor",
 		"VulkanCommandEncoderMixin",
 		"VulkanDeviceMixin",
 		"VulkanQueueSubmitMixin",
+		"VulkanRenderPassMixin",
 		"WeatherEffectRendererMixin"
 	]
 }

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -25,6 +25,8 @@
 		"DebugScreenEntriesMixin",
 		"DebugScreenEntryListMixin",
 		"GlslCompilerMixin",
+		"IntermediaryShaderModuleAccessor",
+		"IntermediaryShaderModuleMixin",
 		"MinecraftStartupGuardMixin",
 		"MixinDefaultChunkRenderer",
 		"DefaultFluidRendererMixin",

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -62,6 +62,7 @@
 		"StagedVertexBufferDrawMixin",
 		"TextureManagerAccessor",
 		"VKDrawContextMixin",
+		"VulkanBackendMixin",
 		"VulkanCommandEncoderMixin",
 		"VulkanDeviceMixin",
 		"VulkanQueueSubmitMixin",

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -63,6 +63,7 @@
 		"TextureManagerAccessor",
 		"VKDrawContextMixin",
 		"VulkanBackendMixin",
+		"VulkanCommandEncoderAccessor",
 		"VulkanCommandEncoderMixin",
 		"VulkanDeviceMixin",
 		"VulkanQueueSubmitMixin",

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -61,10 +61,11 @@ before any of its programs is translated, so the refusal names what the pack ask
 get (the log lists them) rather than the symptom that would have come later: a storage block,
 which compiles but never enters a bind group, so the draw would go against nothing.
 
-**Any such declaration is refused, whatever it names**, and that is wider than the paragraph above:
-this engine serves no feature flag at all, so it has nothing to check a name against. It also
-defines no `IRIS_FEATURE_`, which is what a pack reads to find out whether it should take the path
-it wrote for a renderer that has none: the declaration a pack marks optional rather than required.
+**Any name this engine has not built refuses the declaration.** One name is built and served
+today, `CUSTOM_IMAGES`, so a pack that requires it alone loads; every other name still refuses
+the pack, with the list in the log. The served flag is also the one `IRIS_FEATURE_` define a
+pack finds, `IRIS_FEATURE_CUSTOM_IMAGES`: a capability define is a promise, so each appears the
+day its feature is served and not before, and the optional declarations keep reading the truth.
 
 Iris draws Reverie. It refuses a required flag only when the name is unknown to it or the hardware
 cannot serve it, and it has built every one of the ones Reverie asks for: some outright, some
@@ -98,19 +99,19 @@ and asks you to switch to Iris. This is not the engine refusing anything: the pa
 message is one of its passes, and it is drawn because a capability test in its code came out false.
 
 The test reads capability defines. This engine announces itself the way Iris does, but a
-capability define is a promise, so it defines only what the backend actually serves, and it
-serves no `IRIS_FEATURE_` at all; the section above says why the features behind those names are
-closed. A pack that finds the announcement without the capability concludes it is running on
-OptiFine, the only renderer in that position when the pack was written, and words its message for
-it. Read "OptiFine" as "not Iris" and the message is accurate.
+capability define is a promise, so it defines only what the backend actually serves, which today
+is `IRIS_FEATURE_CUSTOM_IMAGES` and nothing else; the section above says why the features behind
+the other names are closed. A pack that finds the announcement without the capability it wants
+concludes it is running on OptiFine, the only renderer in that position when the pack was
+written, and words its message for it. Read "OptiFine" as "not Iris" and the message is accurate.
 
-Complementary is the pack of the test set that does this. Its colored lighting, which its two top
-profiles Very High and Ultra turn on, is voxel lighting: storage images filled by the geometry
-passes and a compute pass that spreads the light, all behind `IRIS_FEATURE_CUSTOM_IMAGES`. Finding
-that define absent, the pack switches its colored lighting off, draws the message over the frame,
-and leaves every other setting of the profile applied, so the image behind the overlay is the
-pack's own and correct. Any profile from High down draws without the message, and so do the two
-top ones once their Colored Lighting setting is turned back off.
+Complementary was the pack of the test set that did this, and it is why the define exists. Its
+colored lighting, which its two top profiles Very High and Ultra turn on, is voxel lighting:
+storage images filled by the geometry passes and a compute pass that spreads the light, all
+behind `IRIS_FEATURE_CUSTOM_IMAGES`. That pipe is served now and the define with it, so those
+profiles draw with their colored lighting instead of switching it off behind the message. A pack
+testing for a name still unserved keeps drawing its own overlay, and the paragraph above keeps
+being how to read it.
 
 ## The effect never ran
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -20,7 +20,7 @@ quietly stale.
 | Sildur's Vibrant Extreme v2.01 | Drawn, except for its water, which is an open case here. It is the pack that exercises the paths least travelled: it keeps the overworld's programs at the root of `shaders/` and gives the other two dimensions folders of their own, several families reach its textured program through the fallback tree rather than shipping one, and the target its terrain writes first is not target zero. |
 | Mellow v3.3 | Drawn, and it exercises two more of them: it ships a three-dimensional volume as a raw blob, and it asks for a single-channel shadow buffer. |
 | Body Camera v1.6.1 | Drawn. It is one of the packs that branches on the star flag in the sky, so it is worth reading [the sky goes flat](#the-sky-goes-flat) alongside. |
-| Reverie Beta v0.9 | **Refused at load, and the log names what it asked for.** It declares features it cannot be drawn without, and this engine serves no feature flag at all, so it refuses every such declaration whatever it names rather than half drawing the pack. That is a gap here and not a fault of the pack: Iris draws it. See [the pack was refused](#the-pack-was-refused). |
+| Reverie Beta v0.9 | **Refused at load, and the log names what it asked for.** It declares four features it cannot be drawn without, and this engine has built one of them, so it refuses the pack on the other three rather than half drawing it. That is a gap here and not a fault of the pack: Iris draws it. See [the pack was refused](#the-pack-was-refused). |
 
 Start from what you are seeing. Each symptom below names its cause, and says how to confirm it
 rather than guess.

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -178,13 +178,21 @@ default is the tightest of them rather than the loosest.
 
 A word this cannot read leaves the default standing, which is what the reference does with it.
 
-**The safe zone's box widens on the width test alone now.** The width comes from a `const float
-voxelDistance`, which only counts where it sits on a line that survives the pack's own
-preprocessor and where it is wider than the shadow distance. The first condition is met for the
-corpus since custom images are served: `IRIS_FEATURE_CUSTOM_IMAGES` is posed, so the declarations
-behind it are live. What remains is the second, per pack: a `voxelDistance` narrower than the
-same pack's shadow distance still leaves the box nought blocks wide, the state chosen and the
-sweep running unchanged.
+**The safe zone's box can have a width now, where for most of the corpus it could not.** The width
+comes from a `const float voxelDistance`, and it only counts where it sits on a line that survives
+the pack's own preprocessor. Most packs that write one put it behind `IRIS_FEATURE_CUSTOM_IMAGES`,
+directly or through the coloured lighting the same flag gates, and while no such define was posed
+those lines were dead: the value never arrived, and the box came out nought blocks wide with the
+state still chosen, so the shape said safe zone and behaved as the plain sweep. Custom images being
+served, a pack that also turns its own coloured lighting on brings a width. A pack that declares the
+width outside any such condition always had one.
+
+That box is normally shorter than the shadow distance, so it settles nothing about how far the walk
+reaches. What it settles is what the SWEEP would have thrown away: a section inside it is kept
+whatever the sweep says. That is what a pack sampling its own voxel grid is owed, because the sweep
+is built from what the CAMERA can see extended towards the light, and a grid is read from places the
+camera cannot see at all. Without the box, a pack's voxel grid reads air where the world has blocks,
+anywhere outside that view.
 
 **How far the walk reaches is a separate question from the shape.** Whichever shape is chosen, a box
 around the camera is cut out of it wherever a distance bounds the walk, and that distance is

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -178,14 +178,13 @@ default is the tightest of them rather than the loosest.
 
 A word this cannot read leaves the default standing, which is what the reference does with it.
 
-**The safe zone's box is nought blocks wide here, and that is worth knowing before you write against
-it.** The width comes from a `const float voxelDistance`, which only counts where it sits on a line
-that survives the pack's own preprocessor and where it is wider than the shadow distance. Neither
-holds for the packs asking for this state today: most put the declaration behind
-`IRIS_FEATURE_CUSTOM_IMAGES`, which this engine poses for nothing it does not serve, and where one
-declares it live it is shorter than the shortest shadow distance the same pack offers. The state is
-still chosen and the sweep still runs. It is the widening that does not happen, and it will start
-happening on its own the day custom images are served.
+**The safe zone's box widens on the width test alone now.** The width comes from a `const float
+voxelDistance`, which only counts where it sits on a line that survives the pack's own
+preprocessor and where it is wider than the shadow distance. The first condition is met for the
+corpus since custom images are served: `IRIS_FEATURE_CUSTOM_IMAGES` is posed, so the declarations
+behind it are live. What remains is the second, per pack: a `voxelDistance` narrower than the
+same pack's shadow distance still leaves the box nought blocks wide, the state chosen and the
+sweep running unchanged.
 
 **How far the walk reaches is a separate question from the shape.** Whichever shape is chosen, a box
 around the camera is cut out of it wherever a distance bounds the walk, and that distance is


### PR DESCRIPTION
## What changes

The pack's storage pipe is served: `image.` directives become VMA-backed storage images the
geometry passes write and sample, `bufferObject.` blocks become storage buffers, and the
`shadowcomp` compute is translated with shaderc and dispatched at the head of the frame.
`IRIS_FEATURE_CUSTOM_IMAGES` is announced, so a pack that requires custom images loads instead of
being refused, and the voxel lighting of Complementary's top profiles, Euphoria Patches' coloured
lighting among them, draws instead of switching itself off behind a red overlay.

That light does not blink as the player moves. The glow of ores and lava flickered at every block
crossed, worst going up, a ring of dark on each jump and a constant shimmer flying upwards, and
nothing at all coming back down. The volume of block identities behind it is filled by the shadow
geometry, which this engine draws a frame ahead, so the compute read every cell against the block
next door for one frame. The volume is now moved onto the reading frame's camera block before the
dispatch. A pass of this engine also ends on a wait that names the compute stage and storage
access now, since a pack's compute samples the shadow map this engine wrote as attachments.

## How it differs from the reference, and for what obstacle

Iris runs `shadowcomp` inside its shadow render, before its gbuffers and inside one frame
(`ShadowRenderer.java:631`). This engine's shadow stage is deferred by a frame, a divergence
already carried and decided, so the compute runs at the head of the frame that reads it
(`PackChain.java:1457`): the same parity as its readers, which is what that moment translates to
here. What the deferral costs is the anchor, and the volume is MOVED rather than compensated when
read, because `cameraPositionInt` and `cameraPositionFract` are the pack's own to use elsewhere,
clouds included, and shifting them would break those. Only a volume the pack clears whose three
extents match one it does not is moved, which is the single case where a count of blocks is the
right unit, and the log names which volumes follow the camera and which keep the frame of lag.

## What proves it

- `gradlew build` green at every commit of the series, after the rebase onto `dev`.
- The out-of-game harness is not what this rests on: the translator additions are format and
  layout headers plus storage-block collection, and no corpus translation changes.
- In game on NeoForge, Complementary Unbound with Euphoria Patches and `COLORED_LIGHTING` forced
  on in the pack's own settings file, in a cave lit by an ore: the compute compiles and dispatches
  with no missing binding, the log reports the identity volume as moved onto each frame's camera
  block, and ores and lava colour the world around them.
- The settings change that used to lose the device, colour tracing raised while the world is open,
  survives up to 32 chunks: destruction goes through the game's two-deep deferred queue instead of
  freeing under two frames still in flight.

## What it leaves owing

- The coarse reflection volume that same pack declares keeps its frame of lag. It is stored at a
  quarter of the voxel position, one cell per four blocks, it has no uncleared twin, and nothing
  in an image directive tells the two apart.
- Composites and deferred passes that sample the volumes deserve their own look, the coloured fog
  and the world-space reflections among them.
- A declared storage image whose allocation failed leaves the graphics push writing a
  combined-image-sampler into a storage-image binding, which is silent without validation layers.
  The log names the failure when it happens.
- On MoltenVK `vertexPipelineStoresAndAtomics` is typically absent, and the log will say the voxel
  volume never fills there.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
