### PR TITLE
chore: strip a tool trailer before the message is stored

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Drops a Co-authored-by line from the message before it is stored. commit-msg still refuses the
+# commit if one remains.
+#
+#     git config core.hooksPath .githooks
+
+set -eu
+
+file=$1
+tmp=$file.git-strip
+# The || is not decoration: grep exits 1 when it prints nothing, which an empty message does, and
+# set -e would then abort a commit this hook has no opinion about.
+grep -viE '^[[:space:]]*(Co-authored-by|Made-with|Generated-by):' "$file" > "$tmp" || true
+mv "$tmp" "$file"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,6 +242,12 @@ whoever never ran that command and for anything arriving from a fork. It is deli
 file: a workflow rewriting the same expression would be a second home for the rule, and the two
 would agree only until one of them changed.
 
+`.githooks/prepare-commit-msg` sits one step earlier and takes a `Co-authored-by`, `Made-with` or
+`Generated-by` line out of the message before it is stored. Nothing here forbids saying which tools
+built this project, and the readme says so plainly; what the log keeps is the reasoning for a
+change, and a trailer naming an editor is not that. The refusal in `commit-msg` stays either way,
+so a message that reaches it with one is still turned back.
+
 Catch it at the commit rather than at the request. A subject is amended in one gesture while it is
 still the last one, and rebuilt by hand once nine commits stand on top of it.
 


### PR DESCRIPTION
## What changes

A second hook, `prepare-commit-msg`, takes a tool trailer out of a commit message before it is
stored. `commit-msg` already refuses those three names and still does; what it cannot do is let the
commit through, because it fires after the message is written and leaves an amend as the only
answer. `CONTRIBUTING.md` says the pair exists, next to where it already explains the first one.

## How it differs from the reference, and for what obstacle

It does not. Nothing here is about the engine.

## What proves it

- `gradlew build` green after the rebase onto `dev`.
- The hook was exercised by accident while writing this branch: the commit that adds it was
  refused by `commit-msg`, because the message spelled the trailer names out to describe them.
  Reworded without them. That is the check working, and worth knowing before someone documents
  the rule again.

## What it leaves owing

Nothing. The hook only runs for a clone that has set `core.hooksPath`, which is the same condition
`commit-msg` has always had, and `commits.yml` is still the backstop for anything arriving from a
fork.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
      Nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
