### PR TITLE
docs: say where compute stops, the facade and not the backend

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -51,7 +51,9 @@ The engine refuses a pack rather than drawing something wrong with it, and it na
 **A pack can be refused for using a graphics feature this backend does not have.** Compute shaders,
 shader storage buffers, storage images, and one- or three-dimensional samplers are closed by the
 game's own compiler, not by missing effort here. A pack built around voxel lighting or GPU-side
-data structures will hit this.
+data structures will hit this. The Vulkan device can already run a compute dispatch and write a
+storage image when asked outside that compiler; that is a fact about the backend, not a pack
+feature, and no capability define is posed for it.
 
 Of the packs used for testing, Reverie is the one in that position, and it says so itself. A pack
 can declare the features it cannot be drawn without, and Reverie declares several. That line is read

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -204,6 +204,31 @@ assigns them and an intermediate module rewrites them afterwards. The same refle
 decides how a vertex stage's outputs meet a fragment stage's inputs, with an asymmetry of its own
 that is sharper still: that one is in [translation](../translation.md).
 
+## Compute and storage images: the facade vs the backend
+
+The Java device has no compute. Its shader-type enumeration is a vertex stage and a fragment stage,
+precompile accepts a render pipeline and nothing else, a texture's usage bits are copy, sample,
+attachment and cubemap, and bind-group reflection enumerates uniform buffers and sampled images.
+A pack compute unit that went through that path would compile as a vertex shader or not at all,
+and a storage image it declared would be bound to nothing. That is still true, and it is why this
+engine poses no `IRIS_FEATURE_` for custom images.
+
+The Vulkan backend behind that facade already has the rest. The device object hands out the
+`VkDevice`, the VMA allocator, and a graphics queue created with both the graphics and compute
+bits. It also creates a dedicated compute queue when the hardware has a spare family, and it
+enables `VK_KHR_push_descriptor` as a required extension. The GLSL compiler it embeds is shaderc,
+which has a compute kind the game never passes only because the Java enumeration has no constant
+for it. None of that needs a mixin: those methods are public.
+
+What does need going around is texture creation. The usage-bit mapping never sets the Vulkan
+storage bit, so a storage image has to be allocated through VMA rather than through
+`createTexture`. That is an extension of how the device is used, not of the device class.
+
+None of this is inference. A compute shader built with that shaderc, dispatched against a storage
+image allocated through VMA, writes texels the same frame reads back unchanged: the road is open,
+and what is missing is a stage in this engine that walks it rather than anything in the backend.
+Whether a pack's own compute is served is a separate question, answered where the pack's chain is.
+
 ## Small things that cost a lot to rediscover
 
 - **The shared sampler cache hands out shared objects.** Never close one; the cache owns it.

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -287,22 +287,28 @@ that shadows a builtin name is refused rather than resolved by precedence.
 
 Not every remaining failure is a translation gap, and the distinction is worth making.
 
-**Closed by the game's own rendering API.** Compute shaders, shader storage buffers, storage images,
-and one- and three-dimensional samplers. Same conclusion, three different mechanisms, and it is
-worth knowing which:
+**Closed by the game's own rendering API, for a pack that goes through the facade.** Compute shaders,
+shader storage buffers, storage images, and one- and three-dimensional samplers. Same conclusion
+for that path, three different mechanisms, and it is worth knowing which:
 
 - **Samplers are refused by name.** The compiler takes one as two-dimensional or as a cube, or as a
   texel buffer where the pipeline declared that name as a uniform rather than as a sampler, and
   rejects every other dimensionality.
-- **Compute has nowhere to go.** The game's shader-type enumeration carries a vertex stage and a
-  fragment stage and nothing else, and the device exposes no way to precompile anything but a render
-  pipeline.
-- **Storage buffers and storage images are worse than refused: they are ignored.** Reflection asks
-  for uniform buffers, sampled images, outputs and inputs, and never enumerates them. They pass
-  compilation and are then bound to nothing.
+- **Compute has nowhere to go through the Java facade.** The game's shader-type enumeration carries
+  a vertex stage and a fragment stage and nothing else, and the device exposes no way to precompile
+  anything but a render pipeline. The Vulkan backend behind that facade already has a compute-capable
+  queue, a public `VkDevice`, and the shaderc the game embeds, whose compute kind the facade never
+  passes. That path has been made to dispatch and to write. Translating a pack's own compute unit
+  is a separate question, because a translated unit still needs a stage that schedules it.
+- **Storage buffers and storage images are worse than refused on the facade: they are ignored.**
+  Reflection asks for uniform buffers, sampled images, outputs and inputs, and never enumerates
+  them. They pass compilation and are then bound to nothing. A storage image allocated through VMA
+  and bound as a push descriptor can still be written by a compute shader; the game's texture usage
+  bits never set the Vulkan storage flag, so `createTexture` cannot be that image.
 
-No amount of translation work makes any of the three pass. Vulkan itself supports all of them; it is
-the layer above that does not.
+No amount of translation work makes a pack compute unit or a pack storage image pass through the
+facade. Vulkan itself supports all of them. The layer above does not, and the backend below it
+does; [the game's graphics API](internals/game-graphics-api.md) says where the split sits.
 
 **Defects in the pack itself.** A conditional directive with no name is a pack bug and stays a
 failure.


### PR DESCRIPTION
## What changes

Three pages said a compute unit and a storage image were closed by the game, full stop. They are
closed to a pack going through the Java facade, and open to the Vulkan backend underneath it. The
pages now say which of the two each sentence is about, because that is the difference between a
wall and a road nobody has walked yet.

## How it differs from the reference, and for what obstacle

It does not. Nothing here changes what the engine draws.

## What proves it

- `gradlew build` green after the rebase onto `dev`.
- The facts about the facade are read off the game's own classes: the shader-type enumeration, the
  texture usage bits, and what bind-group reflection enumerates.
- That the backend takes the write is not inference. A compute shader built with the shaderc the
  game embeds, dispatched against a storage image allocated through VMA, wrote texels that were
  read back unchanged at the title screen. The one-shot that did it is not in this branch: it
  served its purpose, and a pack's own compute is served by the chain rather than by a probe.

## What it leaves owing

Nothing on its own. Worth knowing though: these pages say no capability define is posed for custom
images, and #165 is the branch that makes that false. Whichever lands second owes the correction.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
      Nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
