### PR TITLE
feat(settings): choose the backend a crashed startup comes back to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Added
+
+- **A crash during startup no longer takes the graphics backend with it.** The game resets the
+  preferred graphics API, and the fullscreen mode, whenever the previous startup did not finish,
+  and it does that for any crash rather than for a backend that failed. Since nothing of this mod
+  is drawn off Vulkan, that turned one crash into a restart to set it back by hand. A selector
+  under Video Settings picks what to come back to, and it comes back to Vulkan unless told
+  otherwise.
+
+- **Fabric no longer requires Chloride.** It never had anything to do there: what Chloride is for
+  is the loading window NeoForge opens before the game, which Fabric has no equivalent of. NeoForge
+  still needs it.
+
 ## 0.7.5-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/mixin/MinecraftStartupGuardMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/MinecraftStartupGuardMixin.java
@@ -1,0 +1,37 @@
+package dev.vitrail.mixin;
+
+import dev.vitrail.render.StartupGuard;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * The one read the whole "last startup ended badly" rescue hangs off.
+ * <p>
+ * The constructor reads {@code startedCleanly} ONCE into a local, then tests that local twice: once
+ * to drop fullscreen, once to walk the preferred graphics API down to Default and then to OpenGL.
+ * Answering that single read is therefore the whole intervention, and it is why this is one hook
+ * rather than three: no message is suppressed by hand and no branch is duplicated here, so a change
+ * in what the game rescues follows automatically.
+ * <p>
+ * The write just after it is untouched. The game still sets the flag false and saves it, so the
+ * marker keeps working for everything else that reads it, and the next clean startup still clears
+ * it the way it always did.
+ *
+ * @see StartupGuard
+ */
+@Mixin(Minecraft.class)
+public abstract class MinecraftStartupGuardMixin {
+
+	@WrapOperation(method = "<init>", at = @At(value = "FIELD",
+			target = "Lnet/minecraft/client/Options;startedCleanly:Z", opcode = Opcodes.GETFIELD),
+			require = 1)
+	private boolean vitrail$keepTheChosenBackend(Options options, Operation<Boolean> original) {
+		return StartupGuard.startedCleanly(options, original.call(options));
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/StartupGuard.java
+++ b/common/src/main/java/dev/vitrail/render/StartupGuard.java
@@ -1,0 +1,95 @@
+package dev.vitrail.render;
+
+import dev.vitrail.settings.GraphicsApiChoice;
+import dev.vitrail.Vitrail;
+
+import net.minecraft.client.Options;
+import net.minecraft.client.PreferredGraphicsApi;
+
+/**
+ * Keeps the graphics API across a startup that ended badly, instead of losing it to a crash that had
+ * nothing to do with the backend.
+ * <p>
+ * <strong>What the game does, and why it costs a launch every time.</strong> {@code Minecraft} reads
+ * {@code Options.startedCleanly} once at the head of its constructor, sets it false, and saves.
+ * Anything that dies before startup finishes leaves it false, and the NEXT launch takes both of
+ * these:
+ * <pre>
+ *   Detected unexpected shutdown during last game startup: resetting fullscreen mode
+ *   Detected unexpected shutdown during last game startup: resetting preferred graphics API to Default
+ * </pre>
+ * and a third, forcing OpenGL, if the launch after that is dirty too. Measured here: a Distant
+ * Horizons failure over a native library it could not extract, nothing to do with graphics, took the
+ * backend down with it and cost a restart to put back.
+ * <p>
+ * <strong>Both messages hang off that one read</strong>, which is why answering it is the whole
+ * intervention: the fullscreen mode is kept by the same stroke, and it was the second half of the
+ * same complaint.
+ * <p>
+ * The rescue is not wrong in itself, it is wrong here. It exists for a machine whose Vulkan cannot
+ * start, and for a vanilla player who wandered into the setting it is the way back. For a player who
+ * installed this mod it empties the session instead of saving it: the mod draws nothing off Vulkan
+ * and says so. Which is why the default is to come back to Vulkan, and why the other two answers
+ * exist beside it.
+ */
+public final class StartupGuard {
+
+	private static GraphicsApiChoice choice;
+
+	private StartupGuard() {
+	}
+
+	/**
+	 * Answers the game's question about the last startup, having first put the API back where the
+	 * player asked for it to be.
+	 *
+	 * @param options the game's options, already loaded, and the only thing that exists this early
+	 * @param cleanly what the field really holds
+	 * @return what the game should believe, which decides both resets it is about to consider
+	 */
+	public static boolean startedCleanly(Options options, boolean cleanly) {
+		if (cleanly) {
+			return true;
+		}
+
+		GraphicsApiChoice asked = asked();
+		if (asked == GraphicsApiChoice.GAME) {
+			return false;
+		}
+
+		PreferredGraphicsApi wanted = asked == GraphicsApiChoice.OPENGL
+				? PreferredGraphicsApi.OPENGL
+				: PreferredGraphicsApi.VULKAN;
+		// Set rather than merely kept: a launch that already walked the setting down to Default, or
+		// on to OpenGL, would otherwise stay there for good. Coming BACK is what was asked for.
+		if (options.preferredGraphicsBackend().get() != wanted) {
+			options.preferredGraphicsBackend().set(wanted);
+		}
+
+		Vitrail.logger().warn("The last startup ended badly. The game was about to reset the "
+				+ "graphics API and the fullscreen mode; both are kept and the API is put back to "
+				+ "{}, because a crash during startup is almost never the backend. Change this under "
+				+ "Video Settings, in this mod's page, or in vitrail/graphics-api.txt",
+				wanted.getSerializedName());
+
+		// True, so neither reset runs. The game still wrote the flag false and saved it just before
+		// this, so the marker itself goes on working for whatever else reads it.
+		return true;
+	}
+
+	/** Read once: this is asked inside a constructor, and the answer cannot change during it. */
+	private static GraphicsApiChoice asked() {
+		GraphicsApiChoice known = choice;
+		if (known == null) {
+			known = GraphicsApiChoice.read();
+			choice = known;
+		}
+
+		return known;
+	}
+
+	/** The screen has just written a new choice, so the next startup reads it rather than the old one. */
+	public static void forget() {
+		choice = null;
+	}
+}

--- a/common/src/main/java/dev/vitrail/screen/ScreenText.java
+++ b/common/src/main/java/dev/vitrail/screen/ScreenText.java
@@ -31,6 +31,21 @@ public final class ScreenText {
 	public static final String PACKS_TITLE = "options.vitrail.packs_title";
 
 	/**
+	 * The selector for what a startup that ended badly comes back to, its tooltip, and its three
+	 * values.
+	 * <p>
+	 * The two backends are named here rather than borrowed from the game's own setting, which was
+	 * the first shape of this and was wrong: its Vulkan entry reads "Prefer Vulkan (Experimental)",
+	 * which is right where it stands and runs off the end of a row here. A value in a selector is a
+	 * name, not a sentence.
+	 */
+	public static final String CRASH_API = "options.vitrail.crash_graphics_api";
+	public static final String CRASH_API_TOOLTIP = "options.vitrail.crash_graphics_api_tooltip";
+	public static final String CRASH_API_VULKAN = "options.vitrail.crash_graphics_api.vulkan";
+	public static final String CRASH_API_OPENGL = "options.vitrail.crash_graphics_api.opengl";
+	public static final String CRASH_API_GAME = "options.vitrail.crash_graphics_api.game";
+
+	/**
 	 * How far the light reaches, on the video settings page this engine owns, with its two
 	 * tooltips: what the setting does, and what it says instead while a pack has taken the distance
 	 * out of the player's hands. Iris's {@code options.iris.shadowDistance} and its
@@ -152,6 +167,9 @@ public final class ScreenText {
 	public static final String OTHER_BACKEND = "options.vitrail.other_backend";
 	public static final String GRAPHICS_API = "options.graphicsApi";
 	public static final String GRAPHICS_API_VULKAN = "options.graphicsApi.vulkan";
+
+	/** The game's own label for the other one, used by {@link #CRASH_API} for the same reason. */
+	public static final String GRAPHICS_API_OPENGL = "options.graphicsApi.opengl";
 
 	/**
 	 * The group that key sits in. Nothing names it and nothing can: the game builds it from the

--- a/common/src/main/java/dev/vitrail/settings/GraphicsApiChoice.java
+++ b/common/src/main/java/dev/vitrail/settings/GraphicsApiChoice.java
@@ -1,0 +1,102 @@
+package dev.vitrail.settings;
+
+import dev.vitrail.Vitrail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+/**
+ * What the graphics API becomes after a startup that ended badly.
+ * <p>
+ * The game keeps a flag, {@code Options.startedCleanly}, and anything that dies before startup
+ * finishes leaves it false. The next launch then walks the preferred API down to Default, and the
+ * launch after that forces OpenGL. One crash from any mod at all therefore costs a restart to put
+ * Vulkan back by hand, and the crash is almost never the backend's doing.
+ * <p>
+ * <strong>Why this is a file of its own and not a line of {@code pack.txt}.</strong> It is read
+ * inside {@code Minecraft}'s constructor, before this mod is constructed and before there is a
+ * platform to ask for a game directory. Everything in {@code pack.txt} is read much later, by
+ * something that already exists. Sharing that file would mean loading the pack settings machinery at
+ * a moment when the game itself is half built.
+ * <p>
+ * One word, and an unreadable or absent file reads as the default. That default is {@link #VULKAN}
+ * and not the game's own behaviour, deliberately: this mod draws nothing off Vulkan and says so, so
+ * a reset does not rescue the session, it empties it.
+ */
+public enum GraphicsApiChoice {
+
+	/** Come back to Vulkan, which is what a mod that only draws there wants. */
+	VULKAN("vulkan"),
+
+	/** Come back to OpenGL, for a machine where Vulkan really cannot start. */
+	OPENGL("opengl"),
+
+	/** Leave the game alone: reset to Default, then force OpenGL on the launch after. */
+	GAME("game");
+
+	/** What a fresh install does, and it is the whole point of the setting. */
+	public static final GraphicsApiChoice DEFAULT = VULKAN;
+
+	private static final String FILE = "graphics-api.txt";
+
+	private final String word;
+
+	GraphicsApiChoice(String word) {
+		this.word = word;
+	}
+
+	public String word() {
+		return this.word;
+	}
+
+	/**
+	 * What the instance asks for, or {@link #DEFAULT} where it asks for nothing this understands.
+	 * <p>
+	 * Resolved against the working directory rather than a game directory: the launcher runs the
+	 * game with the instance as its working directory, and at the moment this is first read there is
+	 * nothing else to ask. A typo reads as the default and says so, because a setting that silently
+	 * means something else is worse than one that is ignored out loud.
+	 */
+	public static GraphicsApiChoice read() {
+		Path file = file();
+		String asked;
+		try {
+			if (!Files.isRegularFile(file)) {
+				return DEFAULT;
+			}
+
+			asked = Files.readString(file, StandardCharsets.UTF_8).trim().toLowerCase(Locale.ROOT);
+		} catch (IOException | RuntimeException ignored) {
+			return DEFAULT;
+		}
+
+		for (GraphicsApiChoice choice : values()) {
+			if (choice.word.equals(asked)) {
+				return choice;
+			}
+		}
+
+		Vitrail.logger().warn("vitrail/{} says \"{}\", which is not one of vulkan, opengl or game, "
+				+ "so the default is used", FILE, asked);
+
+		return DEFAULT;
+	}
+
+	/** Writes the choice where {@link #read} will find it. Failure costs the next session, not this one. */
+	public static void write(Path gameDirectory, GraphicsApiChoice choice) {
+		Path file = gameDirectory.resolve("vitrail").resolve(FILE);
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, choice.word + "\n", StandardCharsets.UTF_8);
+		} catch (IOException | RuntimeException e) {
+			Vitrail.logger().error("Vitrail could not write the graphics API choice to {}", file, e);
+		}
+	}
+
+	private static Path file() {
+		return Path.of("vitrail", FILE);
+	}
+}

--- a/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
+++ b/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
@@ -1,9 +1,11 @@
 package dev.vitrail.sodium;
 
 import dev.vitrail.render.PackChain;
+import dev.vitrail.render.StartupGuard;
 import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.screen.ScreenText;
 import dev.vitrail.screen.SettingsScreen;
+import dev.vitrail.settings.GraphicsApiChoice;
 import dev.vitrail.settings.PackFile;
 import dev.vitrail.Vitrail;
 
@@ -69,6 +71,10 @@ public final class ConfigEntry implements ConfigEntryPoint {
 	private static final Identifier SHADOW_DISTANCE =
 			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "shadow_distance");
 
+	/** Which backend a startup that ended badly comes back to. */
+	private static final Identifier GRAPHICS_API =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "graphics_api");
+
 	/** What the selector offers while the pack draws the world, and what it offers otherwise. */
 	private static final Set<TextureFilteringMethod> WITHOUT_RGSS =
 			Set.of(TextureFilteringMethod.NONE, TextureFilteringMethod.ANISOTROPIC);
@@ -90,7 +96,9 @@ public final class ConfigEntry implements ConfigEntryPoint {
 				// already writes over its video settings, translated everywhere this mod is not.
 				.addPage(builder.createOptionPage()
 						.setName(Component.translatable("options.videoTitle"))
-						.addOptionGroup(builder.createOptionGroup().addOption(shadowDistance(builder))))
+						.addOptionGroup(builder.createOptionGroup()
+								.addOption(shadowDistance(builder))
+								.addOption(graphicsApi(builder))))
 				// RGSS is shader code, written into the game's own terrain shader and into Sodium's,
 				// so it is worth nothing while the pack's terrain program is the one drawing: the
 				// player moves the selector and the image does not move. ANISOTROPIC keeps working,
@@ -115,6 +123,48 @@ public final class ConfigEntry implements ConfigEntryPoint {
 								.setAllowedValuesProvider(
 										state -> TerrainDraw.asked() ? WITHOUT_RGSS : EVERY_METHOD,
 										ConfigState.UPDATE_ON_REBUILD));
+	}
+
+	/**
+	 * Which backend the game comes back to after a startup that ended badly.
+	 * <p>
+	 * The game's own answer is to walk the preferred API down to Default, then to OpenGL, whenever
+	 * the previous startup did not finish. That rescue is meant for a machine whose Vulkan cannot
+	 * start; here it fires for any crash at all, from any mod, and empties the session rather than
+	 * saving it, since nothing of this engine is drawn off Vulkan. So the default here is Vulkan.
+	 * <p>
+	 * The two other answers are real answers and not politeness. OpenGL is for a machine where Vulkan
+	 * really does not start, and leaving it to the game is for anyone who would rather have the
+	 * vanilla behaviour back.
+	 * <p>
+	 * Written through {@link GraphicsApiChoice} into a file of its own, which is what lets it be read
+	 * inside {@code Minecraft}'s constructor, long before this screen or the mod exists.
+	 * {@link StartupGuard#forget} is what makes the next startup read the new value.
+	 *
+	 * @see StartupGuard
+	 */
+	private static OptionBuilder graphicsApi(ConfigBuilder builder) {
+		return builder.createEnumOption(GRAPHICS_API, GraphicsApiChoice.class)
+				.setName(Component.translatable(ScreenText.CRASH_API))
+				.setTooltip(_ -> Component.translatable(ScreenText.CRASH_API_TOOLTIP))
+				.setDefaultValue(GraphicsApiChoice.DEFAULT)
+				.setBinding(chosen -> {
+					GraphicsApiChoice.write(Vitrail.platform().gameDirectory(), chosen);
+					StartupGuard.forget();
+				}, GraphicsApiChoice::read)
+				.setElementNameProvider(chosen -> Component.translatable(switch (chosen) {
+					case VULKAN -> ScreenText.CRASH_API_VULKAN;
+					case OPENGL -> ScreenText.CRASH_API_OPENGL;
+					case GAME -> ScreenText.CRASH_API_GAME;
+				}))
+				// Empty for the same reason the slider above leaves it empty, and required for the
+				// same reason: Sodium refuses to build a stateful option without one, at the loading
+				// screen rather than at compile time. The binding has already written the file.
+				//
+				// No impact is declared either, and that is not an omission: this decides what a
+				// LATER launch starts on and costs the running frame nothing at all. Sodium's own
+				// impact labels are about the frame being drawn.
+				.setStorageHandler(() -> {});
 	}
 
 	/**

--- a/common/src/main/resources/assets/vitrail/lang/de_de.json
+++ b/common/src/main/resources/assets/vitrail/lang/de_de.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Shaderpakete",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "Max. Schattendistanz",
 	"options.vitrail.shadow_distance_tooltip": "Erlaubt es dir, die maximale Distanz für Schatten zu ändern. Gelände und Objekte, die weiter entfernt sind als die eingestellte Distanz, werden keine Schatten werfen. Das Senken der Distanz kann die Leistung erheblich verbessern.",
 	"options.vitrail.shadow_distance_forced": "Dein aktuelles Shaderpaket hat bereits eine Distanz für Schatten gesetzt; du kannst sie nicht ändern.",

--- a/common/src/main/resources/assets/vitrail/lang/en_us.json
+++ b/common/src/main/resources/assets/vitrail/lang/en_us.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Shader Packs",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "Max Shadow Distance",
 	"options.vitrail.shadow_distance_tooltip": "Allows you to change the maximum distance for shadows. Terrain and entities beyond this distance will not cast shadows. Lowering the shadow distance can significantly increase performance.",
 	"options.vitrail.shadow_distance_forced": "Your current shader pack has already set a render distance for shadows; you cannot change it.",

--- a/common/src/main/resources/assets/vitrail/lang/es_es.json
+++ b/common/src/main/resources/assets/vitrail/lang/es_es.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Shader Packs",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "Máxima Distancia de Sombras",
 	"options.vitrail.shadow_distance_tooltip": "Te permite cambiar la distáncia máxima para las sombras. El terreno y las entidades tras esta distáncia no emitirán sombras. Reducir la distáncia de sombras puede incrementar el rendimiento significativamente.",
 	"options.vitrail.shadow_distance_forced": "Tu shader pack ya ha establecido una distáncia de renderizado para las sombreas; no puedes cambiarla.",

--- a/common/src/main/resources/assets/vitrail/lang/fr_fr.json
+++ b/common/src/main/resources/assets/vitrail/lang/fr_fr.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Packs de shaders",
+	"options.vitrail.crash_graphics_api": "Backend après un plantage",
+	"options.vitrail.crash_graphics_api_tooltip": "Contrôle le backend graphique repris quand le démarrage précédent n'a pas abouti. Sinon le jeu retombe sur OpenGL, où les packs de shaders ne sont pas dessinés du tout.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Défaut du jeu",
 	"options.vitrail.shadow_distance": "Distance maximale des ombres",
 	"options.vitrail.shadow_distance_tooltip": "Permet de changer la distance maximale des ombres. Le terrain et les entités au-delà de cette distance ne projettent pas d'ombre. Baisser la distance des ombres peut améliorer nettement les performances.",
 	"options.vitrail.shadow_distance_forced": "Votre pack de shaders a déjà fixé sa propre distance de rendu des ombres; vous ne pouvez pas la changer.",

--- a/common/src/main/resources/assets/vitrail/lang/it_it.json
+++ b/common/src/main/resources/assets/vitrail/lang/it_it.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Pacchetti di shader",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "Massima Distanza delle ombre",
 	"options.vitrail.shadow_distance_tooltip": "Permette di cambiare la massima distanza per le ombre. Terreno ed entità oltre questa distanza non creeranno ombre. Abbassare questa opzione può aumentare la tua performance di molto.",
 	"options.vitrail.shadow_distance_forced": "La tua shader pack corrente ha già una distanza per le ombre e non puoi cambiarla.",

--- a/common/src/main/resources/assets/vitrail/lang/ja_jp.json
+++ b/common/src/main/resources/assets/vitrail/lang/ja_jp.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "シェーダーパック",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "影の最大描画距離",
 	"options.vitrail.shadow_distance_tooltip": "影が描画される最大の距離を設定できます。 指定された値より遠くの地形やエンティティには影が描画されません。 最大描画距離を下げることで、パフォーマンスが向上することがあります。",
 	"options.vitrail.shadow_distance_forced": "お使いのシェーダーパックでは既に最大描画距離が設定されているため、ここでは変更できません。",

--- a/common/src/main/resources/assets/vitrail/lang/ko_kr.json
+++ b/common/src/main/resources/assets/vitrail/lang/ko_kr.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "셰이더 팩",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "그림자 렌더링 거리",
 	"options.vitrail.shadow_distance_tooltip": "그림자가 표시되는 최대 거리를 조정할 수 있습니다. 이 거리보다 멀리 있는 개체와 지형은 그림자를 표시하지 않습니다. 그림자 거리를 줄이면 성능을 향상시킬 수 있습니다.",
 	"options.vitrail.shadow_distance_forced": "현재 사용하고 있는 셰이더 팩은 이미 그림자 렌더링 거리가 설정되어 있어 바꿀 수 없습니다.",

--- a/common/src/main/resources/assets/vitrail/lang/nl_nl.json
+++ b/common/src/main/resources/assets/vitrail/lang/nl_nl.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Shader Packs",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "Maximale Schaduwafstand",
 	"options.vitrail.shadow_distance_tooltip": "Hiermee kunt u de maximale afstand voor schaduwen wijzigen. Terrein en entiteiten buiten deze afstand zullen geen schaduwen werpen. Het verkleinen van de Schaduwafstand kan de prestaties aanzienlijk verbeteren.",
 	"options.vitrail.shadow_distance_forced": "Uw huidig shader-pack heeft al een weergaveafstand voor schaduwen ingesteld; je kunt het niet veranderen.",

--- a/common/src/main/resources/assets/vitrail/lang/pl_pl.json
+++ b/common/src/main/resources/assets/vitrail/lang/pl_pl.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Pakiety shaderów",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "Maksymalna odległość cieni",
 	"options.vitrail.shadow_distance_tooltip": "Umożliwia zmianę maksymalnej odległości wyświetlania cieni. Teren i obiekty znajdujące się poza tą odległością nie będą rzucać cieni. Zmniejszenie odległości cieni może znacznie zwiększyć wydajność.",
 	"options.vitrail.shadow_distance_forced": "Twój aktualny pakiet Shaderów ma już ustawioną odległość renderowania cieni; nie możesz jej zmienić.",

--- a/common/src/main/resources/assets/vitrail/lang/pt_br.json
+++ b/common/src/main/resources/assets/vitrail/lang/pt_br.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Pacotes de sombreadores",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "Distância das sombras",
 	"options.vitrail.shadow_distance_tooltip": "Permite alterar a distância máxima das sombras. O terreno e as entidades além dessa distância não projetarão sombras. O desempenho do jogo pode ser melhorado significativamente ao reduzir este valor.",
 	"options.vitrail.shadow_distance_forced": "Seu pacote de sombreadores já definiu um valor da distância das sombras e você não poderá alterá-lo.",

--- a/common/src/main/resources/assets/vitrail/lang/ru_ru.json
+++ b/common/src/main/resources/assets/vitrail/lang/ru_ru.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Наборы шейдеров",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "Дальность теней",
 	"options.vitrail.shadow_distance_tooltip": "Позволяет изменять максимальное расстояние видимости теней. Блоки и сущности за его пределами не будут иметь теней. Снижая этот параметр, вы можете значительно улучшить производительность.",
 	"options.vitrail.shadow_distance_forced": "Ваш текущий набор шейдеров уже установил своё расстояние для теней; вы не сможете его изменить.",

--- a/common/src/main/resources/assets/vitrail/lang/tr_tr.json
+++ b/common/src/main/resources/assets/vitrail/lang/tr_tr.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Shader Paketleri",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "Mak. Gölge Uzaklığı",
 	"options.vitrail.shadow_distance_tooltip": "Gölgeler için maksimum ucaklığı değiştirmeye yarar. Bu uzaklığın ötesindeki araziye ve varlıklara gölge uygulanmaz. Gölge uzaklığını azaltmak, performansı önemli ölçüde arttırabilir.",
 	"options.vitrail.shadow_distance_forced": "Mevcut shader paketiniz, zaten gölgeler için ayarlı bir görüntüleme uzaklığına sahip; bunu değiştiremezsin.",

--- a/common/src/main/resources/assets/vitrail/lang/uk_ua.json
+++ b/common/src/main/resources/assets/vitrail/lang/uk_ua.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "Пакети шейдерів",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "Макс. відстань тіней",
 	"options.vitrail.shadow_distance_tooltip": "Дозволяє змінювати максимальну відстань для тіней. Місцевість та сутності за межами цієї відстані не відкидають тіні. Зменшення відстані тіней може значно підвищити продуктивність.",
 	"options.vitrail.shadow_distance_forced": "Ваш поточний пакет шейдерів уже встановив відстань візуалізації для тіней; ви не можете змінити це.",

--- a/common/src/main/resources/assets/vitrail/lang/zh_cn.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_cn.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "光影包",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "最大阴影距离",
 	"options.vitrail.shadow_distance_tooltip": "允许更改阴影的最远距离。超出此距离的地形和实体不会投射阴影。降低阴影距离可以显著提高性能。",
 	"options.vitrail.shadow_distance_forced": "你不能改变当前的光影包已经为阴影设置的渲染距离。",

--- a/common/src/main/resources/assets/vitrail/lang/zh_tw.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_tw.json
@@ -1,5 +1,10 @@
 {
 	"options.vitrail.packs_title": "光影包",
+	"options.vitrail.crash_graphics_api": "Backend after a crash",
+	"options.vitrail.crash_graphics_api_tooltip": "Controls which graphics backend is used again when the previous startup did not finish. Otherwise the game falls back to OpenGL, where shader packs are not drawn at all.",
+	"options.vitrail.crash_graphics_api.vulkan": "Vulkan",
+	"options.vitrail.crash_graphics_api.opengl": "OpenGL",
+	"options.vitrail.crash_graphics_api.game": "Game default",
 	"options.vitrail.shadow_distance": "最大陰影距離",
 	"options.vitrail.shadow_distance_tooltip": "能讓您變更陰影的最大距離。超出此距離的地形和實體將不會有陰影。降低陰影距離能顯著提升效能。",
 	"options.vitrail.shadow_distance_forced": "您無法變更目前光影包所設定的陰影顯示距離。",

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -23,6 +23,7 @@
 		"CustomSubmitMixin",
 		"DebugScreenEntriesMixin",
 		"DebugScreenEntryListMixin",
+		"MinecraftStartupGuardMixin",
 		"MixinDefaultChunkRenderer",
 		"DefaultFluidRendererMixin",
 		"EntityRenderDispatcherMixin",

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -31,7 +31,6 @@
 		"fabricloader": ">=${fabric_loader_version}",
 		"minecraft": ">=${minecraft_version} <26.3",
 		"sodium": "0.9.x",
-		"chloride": "*",
 		"fabric-key-mapping-api-v1": "*",
 		"fabric-lifecycle-events-v1": "*"
 	},


### PR DESCRIPTION
## What changes

The game resets the preferred graphics API, and the fullscreen mode with it, whenever the previous startup did not finish, walking the API down to Default and then to OpenGL. It does that for any crash at all rather than for a backend that failed, so one failure from any mod cost a restart to put Vulkan back by hand; the one measured here was Distant Horizons failing over a native library it could not extract. Both resets hang off a single read of `Options.startedCleanly`, so answering that read is the whole intervention and the window mode is kept by the same stroke. A selector in the video settings picks what to come back to, Vulkan by default, with OpenGL for a machine where it really does not start and one answer that leaves the game alone. Fabric also stops declaring Chloride, which it never needed.

## How it differs from the reference, and for what obstacle

It does not. Iris has nothing here: it runs on OpenGL, so the backend the game falls back to is the one it wants, and the rescue costs it nothing.

## What proves it

- `gradlew build` green.
- In the game, on the NeoForge bench: a real dirty startup, left by the Distant Horizons failure, was answered by the guard on the next launch. The log carries the line naming what was kept, and the backend came up Vulkan instead of OpenGL. The selector shows in the Sodium screen, on Vulkan, and its file survives a restart.
- The Fabric half is measured rather than reasoned: the bench boots on Vulkan with Chloride removed, BSL drawing at over two hundred frames a second.

## What it leaves owing

The guard prevents a reset, it does not undo one that already stuck: an instance whose backend was walked down to Default before this lands, and which then started cleanly once, stays there and has to be set back by hand a last time.

NeoForge still requires Chloride. Its stated reason is real, and the branch that would remove it is not ready.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry.
- [x] Every place that states a fact this branch changed now states the new one.