### PR TITLE
feat(neoforge): stop needing Chloride to boot on Vulkan

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -5,10 +5,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        A world that looks entirely like vanilla is usually one of two things, and
-        [INSTALL.md](https://github.com/avpbynf/Vitrail-Shaders/blob/main/INSTALL.md) covers both:
-        the game came up on OpenGL, or Chloride is absent and the Vulkan surface never got a window
-        to draw into. Both say so in the log.
+        A world that looks entirely like vanilla is most often a game that came up on
+        OpenGL, which
+        [INSTALL.md](https://github.com/avpbynf/Vitrail-Shaders/blob/main/INSTALL.md) covers,
+        along with the two ways that failure hides itself. The log says which backend
+        the game is on.
 
   - type: textarea
     id: what
@@ -32,8 +33,8 @@ body:
     id: versions
     attributes:
       label: Versions
-      description: Vitrail and its loader, Minecraft, Sodium, Chloride, and anything else in `mods/`.
-      placeholder: Vitrail 0.6.0-beta on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
+      description: Vitrail and its loader, Minecraft, Sodium, and anything else in `mods/`.
+      placeholder: Vitrail 0.6.0-beta on NeoForge, MC 26.2, Sodium 0.9.1
     validations:
       required: true
 
@@ -54,8 +55,8 @@ body:
     attributes:
       label: Does it still happen with Vitrail taken out?
       description: >
-        Sodium and Chloride on their own, on the Vulkan backend, with the same pack folder in place.
-        It separates this engine from the two mods it cannot run without.
+        Sodium on its own, on the Vulkan backend, with the same pack folder in place.
+        It separates this engine from the one mod it cannot run without.
       options:
         - It stops when Vitrail is out
         - It happens without Vitrail too

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: Start from what you are seeing. Most of the shapes people report are named there, with the cause and how to confirm it rather than guess.
   - name: The game will not start, or the world looks vanilla
     url: https://github.com/avpbynf/Vitrail-Shaders/blob/main/INSTALL.md
-    about: The versions this needs, the two Chloride settings that have to come off, and what the absence of either looks like.
+    about: The versions this needs, what a game that came up on the wrong backend looks like, and the Chloride settings that have to come off if you run it.
   - name: What is already known to be missing
     url: https://github.com/avpbynf/Vitrail-Shaders/issues?q=is%3Aissue+is%3Aopen+label%3A%22known+limitation%22
     about: The gaps this engine already knows about are open as issues. A symptom that matches one is worth a comment there rather than a new report.

--- a/.github/ISSUE_TEMPLATE/pack-report.yml
+++ b/.github/ISSUE_TEMPLATE/pack-report.yml
@@ -71,8 +71,8 @@ body:
     id: versions
     attributes:
       label: Versions
-      description: Vitrail and its loader, Minecraft, Sodium, Chloride, and anything else in `mods/`.
-      placeholder: Vitrail 0.6.0-beta on NeoForge, MC 26.2, Sodium 0.9.1, Chloride 1.4.0
+      description: Vitrail and its loader, Minecraft, Sodium, and anything else in `mods/`.
+      placeholder: Vitrail 0.6.0-beta on NeoForge, MC 26.2, Sodium 0.9.1
     validations:
       required: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,5 +302,5 @@ jobs:
           # is what refuses to boot without it, which is where the requirement actually bites.
           dependencies: |
             sodium(required)
-            chloride(required)
+            chloride(optional)
             fabric-api(optional)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,16 @@ what the next one holds.
   under Video Settings picks what to come back to, and it comes back to Vulkan unless told
   otherwise.
 
-- **Fabric no longer requires Chloride.** It never had anything to do there: what Chloride is for
-  is the loading window NeoForge opens before the game, which Fabric has no equivalent of. NeoForge
-  still needs it.
-
 ### Changed
+
+- **Chloride is no longer required, on either loader.** One thing was behind that
+  requirement: NeoForge opens a loading window before the game exists, that window carries an
+  OpenGL context, and the game takes it over instead of making one, so the Vulkan surface is
+  asked for on a window built for OpenGL. Vitrail now refuses that window itself when the
+  backend is Vulkan, takes it off FML's hands at the end of mod loading, and closes it once
+  the game has drawn its first frame. Fabric opens no such window and never needed the help.
+  Chloride remains worth installing, its settings are still read and reported, and running it
+  alongside changes nothing.
 
 - **Opening a pack's settings no longer applies it.** Looking at another pack's pages used to load
   it first, on its own default profile, so anybody meaning to open a heavy pack, turn it down and

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,6 @@ are on.
 | NeoForge | 26.2.0.32-beta or later in the 26.2 line |
 | or Fabric Loader | 0.19.3 or later, with Fabric API |
 | Sodium | 0.9.x, the build for whichever loader is in front |
-| Chloride | any 26.2 build, to run on the Vulkan backend at all |
 | Java | 25, to build (the game brings its own runtime) |
 
 One jar for both loaders: each loader reads its own metadata out of it and
@@ -30,19 +29,22 @@ required, and they are the whole of what this mod takes from it: the key
 mapping and the client tick, which is what the settings screen is opened by.
 Nothing of the world's rendering goes through Fabric API.
 
-Sodium and Chloride are both declared as required dependencies, so the game will
-refuse to start without either of them. Do not update Sodium past 0.9.x: it has
-no stable API for what a shader engine needs from it. Chloride is pinned to no
-version at all, since nothing here calls into it.
+Sodium is declared as a required dependency, so the game will refuse to start
+without it. Do not update it past 0.9.x: it has no stable API for what a shader
+engine needs from it.
 
-Chloride is needed because without it the Vulkan backend has no window to draw
-into. NeoForge shows an early loading screen, and the game takes that window over
-rather than making one of its own, so the window it inherits was created for
-OpenGL and the Vulkan surface fails at boot with `GLFW error 65540 ... requires
-the window to have the client API set to GLFW_NO_API`. Chloride is what makes
-that window Vulkan capable. That mechanism is NeoForge's, and whether Fabric's
-window needs the same help has not been measured: Chloride is required on both
-because it is what every session of mine has run with.
+Chloride is no longer required. One thing was behind that requirement:
+NeoForge opens a loading window of its own before the game exists, that window
+carries an OpenGL context, and the game takes it over instead of making one, so
+the Vulkan surface is asked for on a window built for OpenGL and the boot fails
+with `GLFW error 65540 ... requires the window to have the client API set to
+GLFW_NO_API`. Vitrail refuses that window itself when the backend is Vulkan,
+takes it off FML's hands at the end of mod loading, and closes it once the game
+has drawn a first frame of its own, which is the whole of what Chloride was
+load bearing for here. Fabric opens no such window and never needed the help.
+Chloride remains worth installing, and running it alongside changes nothing:
+the two refusals nest, so exactly one of them ends up owning the window left
+over, and the other stands down.
 
 Worth knowing because the failure hides itself, and it hides itself twice over.
 Asked for Vulkan and unable to bring it up, the game falls back to OpenGL within
@@ -56,22 +58,22 @@ at startup, says it as an error when that backend is not Vulkan, and says it onc
 more in chat the first time a world is shown, naming the setting to change, so a
 picture that did not change is answered on the screen rather than by the file.
 
-Some of Chloride's own settings decide what reaches this engine, in
-`config/chloride-client.toml`, and they are entries inside its tables rather than
-keys of their own. `tileEntities`, `entities` and `monsters`, under `[culling]`,
-decide on their own which block entities, which mobs and which other entities are
-drawn at all, by distance: what they take out is never handed to the pack, so a
-chest, a sign, a boat or a mob that is not there is those settings rather than
-anything the pack does.
+If you do run it, some of Chloride's own settings decide what reaches this
+engine, in `config/chloride-client.toml`, and they are entries inside its tables
+rather than keys of their own. `tileEntities`, `entities` and `monsters`, under
+`[culling]`, decide on their own which block entities, which mobs and which other
+entities are drawn at all, by distance: what they take out is never handed to the
+pack, so a chest, a sign, a boat or a mob that is not there is those settings
+rather than anything the pack does.
 `chests` and `beds`, under `[fastBlocks]`, draw those blocks by a path this
 engine's final pass then covers over, so they go invisible with no other symptom.
 Which of the five a given Chloride writes on is its own business and changes with
 its versions, which is why none of them is described here as on or off.
 
-There is nothing to go looking for by hand. Vitrail reads that file at startup
-and, in the log, names each of them that is on with what it costs and what to set
-it to, names any it could not find, and says so when the file itself is not
-there.
+There is nothing to go looking for by hand: with Chloride installed, Vitrail
+reads that file at startup and, in the log, names each of them that is on with
+what it costs and what to set it to, names any it could not find, and says so
+when the file itself is not there.
 
 ## Other mods
 

--- a/README.md
+++ b/README.md
@@ -91,16 +91,17 @@ There is one jar and it runs on both loaders, NeoForge and Fabric. It is on
 attached to every [release](https://github.com/avpbynf/Vitrail-Shaders/releases)
 here, put there by the same run, so both places serve the same file.
 
-Put it in `mods/` next to Sodium and Chloride, and switch
-the game to Vulkan: `preferredGraphicsBackend:"vulkan"` in `options.txt`, or
+Put it in `mods/` next to Sodium, and switch the game to Vulkan:
+`preferredGraphicsBackend:"vulkan"` in `options.txt`, or
 Options, then Video Settings, in game. Nothing enforces that switch, though the
 mod says at startup which backend the game came up on, and says so as an error
 when it is not Vulkan. Shader packs go in `shaderpacks/`, as they always have,
 and are selected in game from Vitrail's settings screen.
 
-[INSTALL.md](INSTALL.md) has the versions this needs, the Chloride settings that
-have to come off, and what the absence of either looks like. Client only: it does
-nothing on a server and does not need to be installed on one.
+[INSTALL.md](INSTALL.md) has the versions this needs, what a game that came up on
+the wrong backend looks like, and the Chloride settings that have to come off if
+you run it. Client only: it does nothing on a server and does not need to be
+installed on one.
 
 To build from source:
 

--- a/common/src/main/java/dev/vitrail/HostReport.java
+++ b/common/src/main/java/dev/vitrail/HostReport.java
@@ -64,6 +64,9 @@ public final class HostReport {
 	 */
 	private static final String CHLORIDE_CONFIG = "config/chloride-client.toml";
 
+	/** Chloride, asked for by id because it is optional and most installs will not have it. */
+	private static final String CHLORIDE_ID = "chloride";
+
 	/**
 	 * Whether the chat line has been said, or found to have nothing to say, which closes it for the
 	 * session either way.
@@ -183,7 +186,13 @@ public final class HostReport {
 	 */
 	public static void say(Path gameDirectory) {
 		sayBackend();
-		sayChloride(gameDirectory.resolve(CHLORIDE_CONFIG));
+
+		// Asked before the file is looked for, and that question is the difference between a mod
+		// that is installed and has not written its settings yet, which is worth a line because its
+		// defaults are then in play, and a mod that is simply not there, which is worth none.
+		if (Vitrail.platform().isModLoaded(CHLORIDE_ID)) {
+			sayChloride(gameDirectory.resolve(CHLORIDE_CONFIG));
+		}
 	}
 
 	/**
@@ -211,8 +220,8 @@ public final class HostReport {
 	}
 
 	/**
-	 * Reads Chloride's file rather than Chloride, which nothing here calls into and which is depended
-	 * on for its window alone.
+	 * Reads Chloride's file rather than Chloride, which nothing here calls into and which the caller
+	 * has already established is installed.
 	 * <p>
 	 * <strong>An entry that is not there is said as well, and that is not tidiness.</strong> Some of
 	 * them are ones Chloride starts with on, so answering a missing line the way a line written

--- a/neoforge/src/main/java/dev/vitrail/neoforge/EarlyWindow.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/EarlyWindow.java
@@ -1,0 +1,135 @@
+package dev.vitrail.neoforge;
+
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.systems.GpuBackend;
+import com.mojang.blaze3d.vulkan.VulkanBackend;
+import net.neoforged.fml.loading.EarlyLoadingScreenController;
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.opengl.GL;
+
+/**
+ * Keeps the game from adopting NeoForge's early loading window when it is about to draw with Vulkan.
+ * <p>
+ * FML opens a window of its own before Minecraft exists, to draw the mod loading bar, and that
+ * window carries an OpenGL context. {@code Window.createGlfwWindow} then asks
+ * {@link EarlyLoadingScreenController#current()} and, when there is one, takes over its handle
+ * instead of calling {@code glfwCreateWindow}. The hints the backend set one line earlier are then
+ * hints on a window nobody creates: the Vulkan surface wants a window whose client API is
+ * {@code GLFW_NO_API}, it is handed one made for OpenGL, and the boot falls back. The shape this is
+ * recognised by is a log that says "Using graphics backend OpenGL" although {@code options.txt} asks
+ * for Vulkan.
+ * <p>
+ * The answer is to hand the game nothing under Vulkan, so it creates its own window with its own
+ * hints, and to dispose of the one FML is left holding once FML has stopped drawing into it. Nothing
+ * here touches {@code GLFW_CLIENT_API}: the backend already sets what it needs, it was simply never
+ * reached.
+ * <p>
+ * <strong>NeoForge only, and that is not a limitation.</strong> Fabric has no early loading window,
+ * so there is nothing to refuse there, and the Fabric bench boots on Vulkan with none of this.
+ */
+public final class EarlyWindow {
+
+	/** Whether FML was left holding a window because this is the refusal that answered the game. */
+	private static boolean claimed;
+
+	/** The window FML is still holding, zero once it has been disposed of. */
+	private static long orphan;
+
+	private EarlyWindow() {
+	}
+
+	/**
+	 * What the game is told when it asks for the early loading screen, which is nothing at all when
+	 * the backend is Vulkan.
+	 * <p>
+	 * <strong>Only a controller that was really there is claimed</strong>, and that is what makes
+	 * this safe beside another mod doing the same job. Two wrappers around one call nest, so only the
+	 * innermost reaches {@code current()}: it sees the controller and claims the window, and the
+	 * outer one is handed the null the inner one returned and claims nothing. Whichever way round the
+	 * two end up, exactly one of them ends up owning the orphan.
+	 *
+	 * @param backend    the backend the window is being built for, taken from the call rather than
+	 *                   from any state of ours: this runs before there is a device to ask
+	 * @param controller what the game would have been handed
+	 * @param claim      whether this is the call that decides the handle, and so the one that takes
+	 *                   ownership of what is left over
+	 * @return the controller where the window may be adopted, or null to make the game build its own
+	 */
+	public static EarlyLoadingScreenController hand(GpuBackend backend,
+			EarlyLoadingScreenController controller, boolean claim) {
+		if (!(backend instanceof VulkanBackend)) {
+			return controller;
+		}
+
+		if (claim && controller != null) {
+			claimed = true;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Takes the leftover window off FML's hands, without closing it.
+	 * <p>
+	 * Handing it over is what stops the background thread that has been drawing the loading bar into
+	 * it, and it leaves that window's OpenGL context current on this thread, which is why the
+	 * capabilities are built right after: FML goes on being asked to tick the screen it thinks it
+	 * still owns, and a tick is GL calls.
+	 * <p>
+	 * <strong>Before the call and not after, which is the whole of why the hook sits there.</strong>
+	 * {@code ClientModLoader.finish()} ticks that screen while it works and then closes the loading
+	 * screen renderer, which deletes GL objects. Each of those makes the window's context current on
+	 * its own, but both then run GL through capabilities this thread does not have, because the game
+	 * never adopted a GL window here, and building them is the half only this call does.
+	 * <p>
+	 * The window is deliberately still alive when this returns. Destroying it here, in the middle of
+	 * the game's own construction and with its context current on the thread, is what an earlier
+	 * attempt did and what took the process down with no stack to read.
+	 */
+	public static void takeOver() {
+		if (!claimed) {
+			return;
+		}
+
+		claimed = false;
+		EarlyLoadingScreenController controller = EarlyLoadingScreenController.current();
+		if (controller == null) {
+			return;
+		}
+
+		try {
+			orphan = controller.takeOverGlfwWindow();
+			GL.createCapabilities();
+		} catch (RuntimeException | LinkageError e) {
+			// Warned and swallowed. What is lost is a window that is already behind the game's own;
+			// what throwing would cost is the boot itself, for a tidying job.
+			Vitrail.logger().warn("Could not take NeoForge's early loading window over", e);
+		}
+	}
+
+	/**
+	 * Closes the leftover window, once a frame of the game's own has been through the screen.
+	 * <p>
+	 * The context goes first and the capabilities with it, so that nothing is left pointing at
+	 * functions that belong to a window about to stop existing. Called on every frame and does
+	 * nothing on all but the first.
+	 */
+	public static void close() {
+		if (orphan == 0L) {
+			return;
+		}
+
+		try {
+			GLFW.glfwMakeContextCurrent(0L);
+			GL.setCapabilities(null);
+			GLFW.glfwDestroyWindow(orphan);
+			Vitrail.logger().info("Closed the early loading window NeoForge was left holding");
+		} catch (RuntimeException | LinkageError e) {
+			Vitrail.logger().warn("Could not close the early loading window NeoForge was left "
+					+ "holding", e);
+		} finally {
+			orphan = 0L;
+		}
+	}
+}

--- a/neoforge/src/main/java/dev/vitrail/neoforge/VitrailNeoForge.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/VitrailNeoForge.java
@@ -13,6 +13,7 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.neoforge.client.event.FlipFrameEvent;
 import net.neoforged.neoforge.client.event.FrameGraphSetupEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import net.neoforged.neoforge.client.event.TextureAtlasStitchedEvent;
@@ -22,7 +23,9 @@ import net.neoforged.neoforge.common.NeoForge;
 
 /**
  * Which NeoForge event each stage of {@link EngineStages} is reached by. What happens at a stage is
- * written there and not here, because the Fabric module has to reach the same ones.
+ * written there and not here, because the Fabric module has to reach the same ones. The one
+ * listener that answers to nothing on the other side is {@link EarlyWindow}, which has no stage
+ * because it has no counterpart: the window it deals with is this loader's own.
  */
 @Mod(value = Vitrail.MOD_ID, dist = Dist.CLIENT)
 public final class VitrailNeoForge {
@@ -37,6 +40,13 @@ public final class VitrailNeoForge {
 				(_, modListScreen) -> new SettingsScreen(modListScreen));
 
 		VitrailKeys.register(modBus);
+
+		// The one listener here that is not a stage of the engine, and the only one that has to be
+		// on this side: it disposes of the loading window this loader is left holding when the game
+		// was made to build its own. Posted after the frame has gone through the screen, which is
+		// the first moment nothing is drawing into either window. It costs a field read a frame
+		// forever after, and the alternative is a listener that unregisters itself.
+		NeoForge.EVENT_BUS.addListener(FlipFrameEvent.class, _ -> EarlyWindow.close());
 
 		modBus.addListener(FMLClientSetupEvent.class, _ -> EngineStages.clientSetup());
 

--- a/neoforge/src/main/java/dev/vitrail/neoforge/mixin/MinecraftEarlyWindowMixin.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/mixin/MinecraftEarlyWindowMixin.java
@@ -1,0 +1,27 @@
+package dev.vitrail.neoforge.mixin;
+
+import dev.vitrail.neoforge.EarlyWindow;
+
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Where the early loading window stops being FML's, which is the last thing mod loading does.
+ * <p>
+ * The loading bar is drawn into that window right up to {@code ClientModLoader.finish()}, so taking
+ * it before is a black rectangle where the progress was. What happens here is the handover and
+ * nothing else; the window is closed a frame later, from {@code FlipFrameEvent}.
+ */
+@Mixin(Minecraft.class)
+public abstract class MinecraftEarlyWindowMixin {
+
+	@Inject(method = "<init>", at = @At(value = "INVOKE",
+			target = "Lnet/neoforged/neoforge/client/loading/ClientModLoader;finish()V"),
+			require = 1)
+	private void vitrail$takeTheEarlyWindowOver(CallbackInfo ci) {
+		EarlyWindow.takeOver();
+	}
+}

--- a/neoforge/src/main/java/dev/vitrail/neoforge/mixin/WindowEarlyScreenMixin.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/mixin/WindowEarlyScreenMixin.java
@@ -1,0 +1,44 @@
+package dev.vitrail.neoforge.mixin;
+
+import dev.vitrail.neoforge.EarlyWindow;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.platform.Window;
+import com.mojang.blaze3d.systems.GpuBackend;
+import net.neoforged.fml.loading.EarlyLoadingScreenController;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * The two places the window asks NeoForge for its early loading screen, and what
+ * {@link EarlyWindow} answers under Vulkan.
+ * <p>
+ * Two and not one because the game asks twice. The static call is where the handle is either taken
+ * over or created, so it is the one that decides and the one that takes ownership of what is left
+ * over. The constructor asks again afterwards, only to inherit the size of a window it thinks it
+ * adopted, and it has to be given the same answer or it reads the size of a window nobody adopted.
+ */
+@Mixin(Window.class)
+public abstract class WindowEarlyScreenMixin {
+
+	private static final String CURRENT =
+			"Lnet/neoforged/fml/loading/EarlyLoadingScreenController;current()"
+					+ "Lnet/neoforged/fml/loading/EarlyLoadingScreenController;";
+
+	@WrapOperation(method = "createGlfwWindow", at = @At(value = "INVOKE", target = CURRENT),
+			require = 1)
+	private static EarlyLoadingScreenController vitrail$refuseTheEarlyWindow(
+			Operation<EarlyLoadingScreenController> original,
+			@Local(argsOnly = true) GpuBackend backend) {
+		return EarlyWindow.hand(backend, original.call(), true);
+	}
+
+	@WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = CURRENT), require = 1)
+	private static EarlyLoadingScreenController vitrail$sayItAgainOnInit(
+			Operation<EarlyLoadingScreenController> original,
+			@Local(argsOnly = true) GpuBackend backend) {
+		return EarlyWindow.hand(backend, original.call(), false);
+	}
+}

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -32,6 +32,12 @@ description = '''OptiFine-format shader packs, on Minecraft's native Vulkan rend
 [[mixins]]
 config = "vitrail.mixins.json"
 
+# The engine's own mixins are in the common module and are listed above. This second config is
+# the handful that exist on this loader alone, which today is the refusal of the early loading
+# window: it names classes of NeoForge's, so it could not live where the Fabric module reads.
+[[mixins]]
+config = "vitrail-neoforge.mixins.json"
+
 [[dependencies.${mod_id}]]
 modId = "minecraft"
 type = "required"
@@ -52,15 +58,4 @@ type = "required"
 reason = "Vitrail renders through Sodium, which owns the Vulkan command submission."
 versionRange = "[0.9,0.10)"
 ordering = "AFTER"
-side = "CLIENT"
-
-# Any build will do: nothing here calls into Chloride, it only has to be present so that the window
-# is created without an OpenGL client API. Loading order is irrelevant for the same reason, since
-# the window exists long before mod construction.
-[[dependencies.${mod_id}]]
-modId = "chloride"
-type = "required"
-reason = "Without Chloride the window is created with an OpenGL client API and the Vulkan surface fails at boot."
-versionRange = "[0,)"
-ordering = "NONE"
 side = "CLIENT"

--- a/neoforge/src/main/resources/vitrail-neoforge.mixins.json
+++ b/neoforge/src/main/resources/vitrail-neoforge.mixins.json
@@ -1,0 +1,13 @@
+{
+	"required": true,
+	"minVersion": "0.8.5",
+	"package": "dev.vitrail.neoforge.mixin",
+	"compatibilityLevel": "JAVA_21",
+	"injectors": {
+		"defaultRequire": 1
+	},
+	"client": [
+		"MinecraftEarlyWindowMixin",
+		"WindowEarlyScreenMixin"
+	]
+}


### PR DESCRIPTION
Chloride was a required dependency for one reason, and that reason is now handled here.

NeoForge opens a loading window before the game exists, to draw the mod loading bar. That
window carries an OpenGL context, and `Window.createGlfwWindow` takes it over instead of
calling `glfwCreateWindow`, so the hints the Vulkan backend set one line earlier are hints on
a window nobody creates. The surface is then asked for on a window built for OpenGL, and the
boot falls back with `GLFW error 65540 ... requires the window to have the client API set to
GLFW_NO_API`. Chloride prevented that adoption, and nothing else it does is needed for a
Vulkan boot.

## What the module does now

Three hooks, all NeoForge only, because Fabric opens no such window.

- `WindowEarlyScreenMixin` wraps the two calls to `EarlyLoadingScreenController.current()`, in
  `Window.createGlfwWindow` and in the constructor. Under Vulkan both answer null, so the game
  builds its own window with its own hints.
- `MinecraftEarlyWindowMixin` takes the leftover window off FML's hands at the call to
  `ClientModLoader.finish()`, and rebuilds the GL capabilities. Before the call and not after:
  `finish()` ticks that screen while it works and then closes the loading screen renderer,
  which deletes GL objects, and both want a context on the thread the game moved to Vulkan.
- The window itself is destroyed one frame later, from `FlipFrameEvent`, with the context
  released and the capabilities cleared first.

Destroying it inside the constructor instead is what an earlier attempt did, and it took the
process down with no stack to read: `finish()` then ran its deletes against a dead context.

## Running next to Chloride

Nothing detects Chloride and nothing needs to. Only a controller that was really there is
claimed, and two wrappers around one call nest: the inner one sees the controller and claims
the window, the outer one is handed the null the inner one returned and claims nothing.
Whichever way round they end up, exactly one of them owns the orphan. If both somehow claimed
it, the second takeover throws and is caught, so one closes the window and the other logs a
warning.

## The rest

- The required dependency goes from `neoforge.mods.toml`, and the store relation from
  `required` to `optional`. Fabric's went in an earlier commit on `dev`.
- The host report no longer warns about a missing `chloride-client.toml` when the mod is not
  installed. That warning earned its place while the mod was required, since a missing file
  then meant its defaults were in play. Now it would fire on every install without it.
- INSTALL, the README, the issue templates and the changelog say what changed. What stays is
  the part that is still true: Chloride's own culling and fast block settings still decide what
  ever reaches this engine, for whoever runs it.

## Proven in game

Bench `avp 26.2 (vitrail)`, NeoForge 26.2.0.64, NVIDIA 610.88, three launches, no crash
report and no `hs_err` from any of them.

**Chloride out of `mods`.** `Using graphics backend Vulkan`, then
`Closed the early loading window NeoForge was left holding`, which only prints when all three
hooks ran. The pack was then read, translated and drawn: Complementary Unbound r5.8.1, ten
colour targets at 1920x1080, a world entered, left and rejoined.

**Chloride back in.** Same two lines, and the close line is ours, so the two refusals did sort
themselves out: we were the inner wrapper, we claimed the window, and Chloride claimed nothing.
No `Could not take` and no `Could not close` warning, so nothing was taken over twice. BSL
v10.1.3 loaded, a world played, the game quit cleanly.

**Fabric, Chloride out of `mods`.** `Using graphics backend Vulkan` and no early window line at
all, which is the right answer: none of this module's mixins is listed in `fabric.mod.json`, so
none of it loads there.
