### PR TITLE
fix(pack): read a pack's screens the way Iris does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ what the next one holds.
   Chloride remains worth installing, its settings are still read and reported, and running it
   alongside changes nothing.
 
+- **The settings screen reads a pack's layout the way Iris does.** The `*` token now pours out
+  every setting no other page names, where the pack put it; a pack without a `screen=` line gets
+  one page holding everything instead of an empty one; and a name Iris refuses to configure, a
+  constant off its closed list, a toggle nothing tests or a value without a list of choices,
+  shows the same blank it shows there instead of becoming a slider or a toggle Iris never had.
+
 - **Opening a pack's settings no longer applies it.** Looking at another pack's pages used to load
   it first, on its own default profile, so anybody meaning to open a heavy pack, turn it down and
   then apply it paid the heavy profile in full first. The pages now open on the pack that was

--- a/common/src/main/java/dev/vitrail/pack/menu/MenuOption.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/MenuOption.java
@@ -21,7 +21,10 @@ public record MenuOption(String name, Form form, String defaultValue, List<Strin
 	private static final List<String> TOGGLE_VALUES = List.of("on", "off");
 
 	public enum Form {
-		/** A bare {@code #define}. The values are always exactly {@code on} and {@code off}. */
+		/**
+		 * A bare {@code #define}, or a configurable {@code const bool}. The values are always
+		 * exactly {@code on} and {@code off}.
+		 */
 		TOGGLE,
 		/** A value with at least two allowed values to walk through. */
 		CYCLE,
@@ -39,8 +42,11 @@ public record MenuOption(String name, Form form, String defaultValue, List<Strin
 	}
 
 	/**
-	 * A {@code const} declaration is a value like any other here; only a bare {@code #define} is
-	 * a toggle.
+	 * A {@code const bool} is a toggle exactly like a bare {@code #define}: the reference holds
+	 * both in one {@code BooleanOption} and its screen clicks both. Only the constants holding a
+	 * number cycle through a list. This is only ever reached for a constant the closed list of
+	 * {@link dev.vitrail.pack.option.ConstOptions} admits; any other constant never becomes an
+	 * option at all.
 	 *
 	 * @param slider whether {@code sliders=} names it. Honoured only for a {@link Form#CYCLE}.
 	 */
@@ -48,6 +54,11 @@ public record MenuOption(String name, Form form, String defaultValue, List<Strin
 		if (option.kind() == PackOption.Kind.TOGGLE) {
 			return new MenuOption(option.name(), Form.TOGGLE, option.defaultOff() ? "off" : "on",
 					TOGGLE_VALUES, false);
+		}
+
+		if (option.kind() == PackOption.Kind.CONST && "bool".equals(option.constType())) {
+			return new MenuOption(option.name(), Form.TOGGLE,
+					"true".equals(option.defaultText()) ? "on" : "off", TOGGLE_VALUES, false);
 		}
 
 		List<String> values = new ArrayList<>(option.values());

--- a/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
@@ -86,7 +86,15 @@ public final class PackMenu {
 
 		List<String> warnings = new ArrayList<>();
 		Map<String, MenuOption> options = new LinkedHashMap<>();
-		Map<String, MenuPage> pages = new LinkedHashMap<>();
+		Map<String, List<MenuSlot>> slotsByPage = new LinkedHashMap<>();
+
+		// Where each * sits. The dump happens after every page has claimed its names, because
+		// the token means "everything no page shows", and what a later page shows is not known
+		// while an earlier one is being walked.
+		record Rest(List<MenuSlot> slots, int at) {
+		}
+		List<Rest> rests = new ArrayList<>();
+		Set<String> subPlaced = new HashSet<>();
 
 		for (Map.Entry<String, List<ShaderProperties.ScreenToken>> page : layout.entrySet()) {
 			String where = page.getKey().isEmpty() ? "screen" : "screen." + page.getKey();
@@ -108,6 +116,9 @@ public final class PackMenu {
 						} else {
 							slots.add(new MenuSlot.Option(options.computeIfAbsent(name,
 									_ -> MenuOption.of(declared, sliders.contains(name)))));
+							if (!page.getKey().isEmpty()) {
+								subPlaced.add(name);
+							}
 						}
 					}
 					case ShaderProperties.ScreenToken.Link(String target) -> {
@@ -126,21 +137,45 @@ public final class PackMenu {
 							slots.add(PROFILES);
 						}
 					}
-					case ShaderProperties.ScreenToken.Rest _ -> {
-						warnings.add(where + " asks for *, which no page shows yet");
-						slots.add(BLANK);
-					}
+					case ShaderProperties.ScreenToken.Rest _ ->
+							rests.add(new Rest(slots, slots.size()));
 				}
 			}
 
-			pages.put(page.getKey(), new MenuPage(page.getKey(), slots,
-					properties.columns(page.getKey()).orElse(slots.size() > WIDE_PAGE ? 3 : 2)));
+			slotsByPage.put(page.getKey(), slots);
 		}
 
-		if (!pages.containsKey("")) {
-			warnings.add("The pack lays out no main screen");
-			pages.put("", new MenuPage("", List.of(), 2));
+		// A pack that lays out no main screen means "everything", not "nothing": the reference
+		// reads the missing line as a single *. That token goes first, ahead of any * a sub-page
+		// carries, where the reference promises no winner at all, its dump walking a hash map.
+		if (!slotsByPage.containsKey("")) {
+			List<MenuSlot> main = new ArrayList<>();
+			rests.add(0, new Rest(main, 0));
+			slotsByPage.put("", main);
 		}
+
+		// The first * takes every offered setting no SUB-page names, in the order the pack
+		// declares them, and a second one takes what remains, which by then is nothing. What the
+		// main screen names pours out again on purpose: the reference fills its leftover list
+		// only after its main screen is built, so those names dump twice there, and a pack that
+		// laid its columns out against that must keep its shape here.
+		if (!rests.isEmpty()) {
+			List<MenuSlot> spill = new ArrayList<>();
+			for (PackOption declared : index.all()) {
+				if (subPlaced.contains(declared.name()) || !index.offers(declared)) {
+					continue;
+				}
+
+				spill.add(new MenuSlot.Option(options.computeIfAbsent(declared.name(),
+						_ -> MenuOption.of(declared, sliders.contains(declared.name())))));
+			}
+
+			rests.get(0).slots().addAll(rests.get(0).at(), spill);
+		}
+
+		Map<String, MenuPage> pages = new LinkedHashMap<>();
+		slotsByPage.forEach((name, slots) -> pages.put(name, new MenuPage(name, slots,
+				properties.columns(name).orElse(slots.size() > WIDE_PAGE ? 3 : 2))));
 
 		Map<String, Map<String, String>> profiles = new LinkedHashMap<>();
 		for (String name : properties.profiles().keySet()) {

--- a/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
@@ -101,6 +101,11 @@ public final class PackMenu {
 							warnings.add(where + " names " + name
 									+ ", which the pack does not declare");
 							slots.add(BLANK);
+						} else if (declared.kind() == PackOption.Kind.CONST
+								&& !index.offers(declared)) {
+							warnings.add(where + " names " + name
+									+ ", declared but not a setting");
+							slots.add(BLANK);
 						} else {
 							slots.add(new MenuSlot.Option(options.computeIfAbsent(name,
 									_ -> MenuOption.of(declared, sliders.contains(name)))));

--- a/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
@@ -101,8 +101,7 @@ public final class PackMenu {
 							warnings.add(where + " names " + name
 									+ ", which the pack does not declare");
 							slots.add(BLANK);
-						} else if (declared.kind() == PackOption.Kind.CONST
-								&& !index.offers(declared)) {
+						} else if (!index.offers(declared)) {
 							warnings.add(where + " names " + name
 									+ ", declared but not a setting");
 							slots.add(BLANK);

--- a/common/src/main/java/dev/vitrail/pack/option/ConstOptions.java
+++ b/common/src/main/java/dev/vitrail/pack/option/ConstOptions.java
@@ -1,0 +1,72 @@
+package dev.vitrail.pack.option;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The constants a pack is allowed to configure, and it is a closed list.
+ * <p>
+ * A {@code const} declaration is not a setting just because it carries a value list: the
+ * reference only configures the names it knows the engine reads, twenty five of them plus
+ * seven spellings generated per shadow color buffer ({@code OptionAnnotatedSource.java:55-96},
+ * eight buffers per {@code PackShadowDirectives.java:19}). Every other constant is a plain
+ * constant of the program, whatever its comment offers.
+ * <p>
+ * The line this draws is visible on screen: BSL declares {@code shadowMapBias} with a value
+ * list, and the reference shows nothing for it. Treating every constant as a setting instead
+ * put a slider there, made the name rewritable in place, and let it into the table
+ * {@code shaders.properties} conditionals read, three things a pack author never saw happen.
+ */
+public final class ConstOptions {
+
+	private static final Set<String> NAMES = names();
+
+	private ConstOptions() {
+	}
+
+	/** Whether a {@code const} of this name is a setting rather than a plain constant. */
+	public static boolean isOption(String name) {
+		return NAMES.contains(name);
+	}
+
+	private static Set<String> names() {
+		Set<String> names = new HashSet<>(Set.of(
+				"shadowMapResolution",
+				"shadowDistance",
+				"voxelDistance",
+				"shadowDistanceRenderMul",
+				"entityShadowDistanceMul",
+				"shadowIntervalSize",
+				"generateShadowMipmap",
+				"generateShadowColorMipmap",
+				"shadowHardwareFiltering",
+				"shadowtex0Mipmap",
+				"shadowtexMipmap",
+				"shadowtex1Mipmap",
+				"shadowtex0Nearest",
+				"shadowtexNearest",
+				"shadow0MinMagNearest",
+				"shadowtex1Nearest",
+				"shadow1MinMagNearest",
+				"wetnessHalflife",
+				"drynessHalflife",
+				"eyeBrightnessHalflife",
+				"centerDepthHalflife",
+				"sunPathRotation",
+				"ambientOcclusionLevel",
+				"superSamplingLevel",
+				"noiseTextureResolution"));
+
+		for (int i = 0; i < 8; i++) {
+			names.add("shadowcolor" + i + "Mipmap");
+			names.add("shadowColor" + i + "Mipmap");
+			names.add("shadowcolor" + i + "Nearest");
+			names.add("shadowColor" + i + "Nearest");
+			names.add("shadowcolor" + i + "MinMagNearest");
+			names.add("shadowColor" + i + "MinMagNearest");
+			names.add("shadowHardwareFiltering" + i);
+		}
+
+		return Set.copyOf(names);
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/option/OptionIndex.java
+++ b/common/src/main/java/dev/vitrail/pack/option/OptionIndex.java
@@ -5,6 +5,7 @@ import dev.vitrail.pack.source.ShaderPackSource;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -40,15 +41,24 @@ public final class OptionIndex {
 	// silently leaves those options with nothing to cycle through.
 	private static final Pattern VALUE_LIST = Pattern.compile("//[^\\[]*\\[(.*?)]");
 	private static final Pattern TRAILING_COMMENT = Pattern.compile("//.*");
+	// The reference's own strictness, detail for detail: no space between # and the keyword,
+	// the name alone, and nothing after it, so a trailing comment on the #ifdef line keeps it
+	// from counting as a reference there too. The name class is the one this index can hold;
+	// the reference would also take a name opening on a digit, which no declaration here can.
+	private static final Pattern CONDITIONAL =
+			Pattern.compile("^\\s*#(?:ifdef|ifndef)\\s+([A-Za-z_]\\w*)\\s*$");
 
 	private final Map<String, PackOption> byName;
+	private final Set<String> conditionalReferences;
 
-	private OptionIndex(Map<String, PackOption> byName) {
+	private OptionIndex(Map<String, PackOption> byName, Set<String> conditionalReferences) {
 		this.byName = Map.copyOf(byName);
+		this.conditionalReferences = Set.copyOf(conditionalReferences);
 	}
 
 	public static OptionIndex build(ShaderPackSource source) throws IOException {
 		Map<String, PackOption> found = new LinkedHashMap<>();
+		Set<String> referenced = new HashSet<>();
 
 		for (Path file : source.sourceFiles()) {
 			String where = source.rel(file);
@@ -59,10 +69,15 @@ public final class OptionIndex {
 				if (option != null) {
 					found.putIfAbsent(option.name(), option);
 				}
+
+				Matcher conditional = CONDITIONAL.matcher(lines.get(i));
+				if (conditional.matches()) {
+					referenced.add(conditional.group(1));
+				}
 			}
 		}
 
-		return new OptionIndex(found);
+		return new OptionIndex(found, referenced);
 	}
 
 	private static PackOption parse(String line, String where, int lineNumber) {
@@ -99,6 +114,38 @@ public final class OptionIndex {
 
 	public Optional<PackOption> get(String name) {
 		return Optional.ofNullable(this.byName.get(name));
+	}
+
+	/**
+	 * Whether any {@code #ifdef} or {@code #ifndef} in the pack tests this name. The reference
+	 * only offers a toggle whose name something tests; a bare define nothing reads is scenery,
+	 * not a setting. Its scope there is the include component of the declaring file, and the
+	 * whole pack here: this index deliberately has no include graph, and a name tested in a
+	 * file its declaration never reaches is a difference no measured pack exhibits.
+	 */
+	public boolean referenced(String name) {
+		return this.conditionalReferences.contains(name);
+	}
+
+	/**
+	 * Whether a declaration is a setting at all, and it is the reference's own sieve
+	 * ({@code OptionAnnotatedSource.getOptionSet}): a toggle something tests, a value with a
+	 * list to cycle through, or a constant that clears three bars at once. Its name has to be
+	 * on the closed list of {@link ConstOptions}; a {@code const bool} then needs something
+	 * testing it, a constant holding a number needs a list of values; and {@code uint} never
+	 * qualifies, the reference reading only {@code int}, {@code float} and {@code bool} as
+	 * configurable. The index still holds what fails here, because it deliberately holds every
+	 * declaration: this answers what a screen may offer and a settings file may change.
+	 */
+	public boolean offers(PackOption option) {
+		return switch (option.kind()) {
+			case TOGGLE -> referenced(option.name());
+			case VALUE -> option.hasValueList();
+			case CONST -> ConstOptions.isOption(option.name())
+					&& !"uint".equals(option.constType())
+					&& ("bool".equals(option.constType()) ? referenced(option.name())
+							: option.hasValueList());
+		};
 	}
 
 	public Collection<PackOption> all() {

--- a/common/src/main/java/dev/vitrail/pack/option/OptionRewriter.java
+++ b/common/src/main/java/dev/vitrail/pack/option/OptionRewriter.java
@@ -53,7 +53,16 @@ public final class OptionRewriter {
 
 		Matcher constant = CONSTANT.matcher(line);
 		if (constant.matches()) {
-			OptionValue value = chosen.get(constant.group(3));
+			// A constant off the closed list is never a setting. A chosen value for one can
+			// still arrive, from a hand-written line of the pack's settings file, and it has to
+			// change nothing: the reference does not hold such a name as an option, so a shared
+			// file must not edit the declaration here either. This line-at-a-time rewriter has
+			// no option index, so the list is the whole of its gate: a hand-written value for a
+			// listed name the index refuses, for want of a value list or of anything testing
+			// it, is still applied here where the reference would drop it. Only a hand can
+			// write that line, no screen offering the name.
+			OptionValue value = ConstOptions.isOption(constant.group(3))
+					? chosen.get(constant.group(3)) : null;
 			if (value == null) {
 				return line;
 			}

--- a/common/src/main/java/dev/vitrail/pack/option/SettingSet.java
+++ b/common/src/main/java/dev/vitrail/pack/option/SettingSet.java
@@ -73,11 +73,36 @@ public final class SettingSet {
 		return this.variantName;
 	}
 
-	/** Everything defined, for reading {@code shaders.properties}, which may test any of it. */
+	/**
+	 * Everything defined, for reading {@code shaders.properties}, which may test any of it.
+	 * Any setting, that is: a constant {@link OptionIndex#offers} refuses stays out of this
+	 * table the way it stays out of the reference's, so a conditional testing its name reads it
+	 * exactly as it reads a name the pack never declared. And a boolean constant enters only
+	 * while it is TRUE, because that is how the reference's preprocessor defines its booleans
+	 * ({@code PropertiesPreprocessor.getBooleanValues}): an {@code #ifdef} on one declared
+	 * false has to read false, whatever text the declaration carries.
+	 */
 	public Map<String, String> globalDefines(OptionIndex index) {
 		Map<String, String> defines = new LinkedHashMap<>(this.engine);
 
 		for (PackOption option : index.all()) {
+			if (option.kind() == PackOption.Kind.CONST) {
+				if (!index.offers(option)) {
+					continue;
+				}
+
+				if ("bool".equals(option.constType())) {
+					OptionValue held = this.chosen.get(option.name());
+					boolean on = held == null ? "true".equals(option.defaultText())
+							: held.isBoolean() && held.asBoolean();
+					if (on) {
+						defines.put(option.name(), "true");
+					}
+
+					continue;
+				}
+			}
+
 			OptionValue value = this.chosen.get(option.name());
 			if (value == null) {
 				// Left as the pack ships it. A setting commented out is simply not defined.

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -736,7 +736,11 @@ public final class ShaderProperties {
 				return this.defines.containsKey(name);
 			}
 
-			if (option.kind() != PackOption.Kind.CONST || !"bool".equals(option.constType())) {
+			// A constant the index does not offer is not a setting, so its name answers here
+			// the way an undeclared one does. Its declared value must not answer either: the
+			// reference never carries it into this table, whatever the declaration says.
+			if (option.kind() != PackOption.Kind.CONST || !"bool".equals(option.constType())
+					|| !this.options.offers(option)) {
 				return true;
 			}
 

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -282,9 +282,12 @@ button something to do.
 The screen itself is described by the pack: a root screen key and per-page keys, and a screen is
 built from **every** token those keys carry, not from the identifiers alone. A blank is layout and
 there are hundreds of them in the corpus; a link opens another page; one token selects a profile;
-and what is left over still has to land somewhere. Reading only the identifiers drops a third of
-what the pack wrote and takes the shape of the screen with it. A name exposed on a screen may be
-declared nowhere in the pack,
+and what is left over still has to land somewhere: the `*` token pours out every setting no other
+page names, where it stands, and what the main screen names comes out of it again, because the
+reference builds its leftover list only after its main screen and packs laid their columns against
+that. A pack that writes no root screen key at all is read as a main screen holding exactly that
+token, one page with everything on it rather than an empty one. A name exposed
+on a screen may be declared nowhere in the pack,
 so the screen has to tolerate an orphan name: neither crash on it nor fabricate a setting for it.
 
 ## Assembling a program's source

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -220,7 +220,9 @@ and `bool` as configurable. Every other `const` is a plain constant of the progr
 comment offers: it appears on no screen, no settings file line can rewrite it, and conditionals
 read its name exactly as they read a name the pack never declared. Through those bars, a
 `const bool` is a toggle like a bare define, and a numeric constant cycles through its bracketed
-values.
+values. The same two demands hold for the defines: a bare toggle is only a setting while an
+`#ifdef` or `#ifndef` somewhere tests it, and a define carrying a value is only one with a
+bracketed list beside it.
 
 The scan deliberately runs with no preprocessor and no comment-block removal, so declarations
 sitting inside a documentation block enter the index. That is a fidelity choice, not an oversight:

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -212,6 +212,16 @@ constant. A define carrying a value but no bracketed list stays a value setting 
 choices: it is not a toggle. The allowed values come from a bracketed comment on the declaration
 line.
 
+**A constant is only a setting when its name is on a closed list**, the same twenty five names and
+per-buffer spellings Iris configures and nothing else, and the list is necessary rather than
+sufficient: a `const bool` also needs an `#ifdef` testing its name, a constant holding a number
+needs its bracketed list, and a `uint` never qualifies, the reference reading only `int`, `float`
+and `bool` as configurable. Every other `const` is a plain constant of the program, whatever its
+comment offers: it appears on no screen, no settings file line can rewrite it, and conditionals
+read its name exactly as they read a name the pack never declared. Through those bars, a
+`const bool` is a toggle like a bare define, and a numeric constant cycles through its bracketed
+values.
+
 The scan deliberately runs with no preprocessor and no comment-block removal, so declarations
 sitting inside a documentation block enter the index. That is a fidelity choice, not an oversight:
 filtering them is a separate decision that also moves every measurement.
@@ -229,7 +239,7 @@ landing on top of whatever the pack uses that word for.
 
 The rewrite rules are asymmetric on purpose: a true boolean uncomments the define, a false boolean
 comments it out, a value rewrites the define's value, and a value on a constant rewrites only its
-right-hand side. A
+right-hand side, when that constant's name is on the closed list at all. A
 boolean lands on a constant in one of two ways: on a `const bool` it is written out as `true` or
 `false`, since a constant is read as an expression rather than tested for existence and commenting
 the line out would leave the name undeclared; on a constant holding a number it is ignored and the
@@ -245,9 +255,11 @@ expansion walks over its define lines, like a real preprocessor.
 
 Unifying them is a mistake, and the asymmetry is the whole point: the properties table has to be
 complete before its first line is read, because that file may test any setting, while a source file
-has to meet the pack's own defaults where the pack wrote them. Constants are settings like any
-other and are in both tables under their declared value: the split is about *when* a default
-arrives, never about which kind of setting it is.
+has to meet the pack's own defaults where the pack wrote them. A constant that really is a setting
+sits in the properties table under its current value, and a boolean one only while it is true,
+which is the polarity the reference's preprocessor gives its booleans: an `#ifdef` on one declared
+false reads false. No constant is ever in the per-unit table, no preprocessor being able to test
+one. A constant that is not a setting enters neither.
 
 ### Profiles
 

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -280,7 +280,9 @@ does not declare is not greyed at all: it becomes a blank.
 
 A slot naming an option the pack does not declare does not throw. It becomes a **blank**, and a line
 in the log names the slot and the setting it wanted. Packs in the test corpus do ship such slots,
-and a pack with one broken name is still a working pack.
+and a pack with one broken name is still a working pack. A slot naming a constant that is not a
+setting gets the same blank and its own line: such a name is a plain constant of the program, and
+the reference's screen shows nothing for it either.
 
 The log reports those together with the links that lead nowhere, in one line that says the entries
 concerned are shown "blank or greyed". Both kinds are in it, and which you get depends on which kind

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -280,9 +280,10 @@ does not declare is not greyed at all: it becomes a blank.
 
 A slot naming an option the pack does not declare does not throw. It becomes a **blank**, and a line
 in the log names the slot and the setting it wanted. Packs in the test corpus do ship such slots,
-and a pack with one broken name is still a working pack. A slot naming a constant that is not a
-setting gets the same blank and its own line: such a name is a plain constant of the program, and
-the reference's screen shows nothing for it either.
+and a pack with one broken name is still a working pack. A slot naming a declaration that is not a
+setting gets the same blank and its own line: a toggle nothing tests, a value with no list of
+choices, or a constant off the closed list of configurable ones. The reference's screen shows
+nothing for any of them either.
 
 The log reports those together with the links that lead nowhere, in one line that says the entries
 concerned are shown "blank or greyed". Both kinds are in it, and which you get depends on which kind


### PR DESCRIPTION
## What changes

The settings model reads a pack's screens the way Iris does, on the points where it did not. A `const` is only a setting on the closed list Iris configures, and through the same bars: a value list on the numeric ones, something testing the boolean ones, no `uint`; a `const bool` that qualifies clicks as a toggle. A name Iris refuses, a constant off that list, a toggle nothing tests or a value without a bracketed list, shows the blank its author saw instead of an option Iris never had. The `*` token pours out every setting no other page names, a pack with no `screen=` line reads as a main screen holding exactly that token, and a constant that is not a setting leaves the table `shaders.properties` conditionals read, with the reference's polarity on the boolean ones (defined only while true).

## How it differs from the reference, and for what obstacle

Three details, none reachable by the corpus.

- Iris scopes an `#ifdef` reference to the include component of the declaring file (`ShaderPackOptions.java:28-44`); this index deliberately has no include graph (`OptionIndex` javadoc), so the scope is the whole pack. Costs nothing until a pack tests a name in a file its declaration never reaches.
- With several `*` tokens, Iris empties its leftover list into one screen without promising which, its dump walking a `HashMap` (`OptionMenuContainer.java:23,44`); here the first in declaration order takes everything, the implicit main first of all. Same set, fixed home.
- The order of the poured-out options is this index's declaration order; Iris walks its option set, booleans before values per file (`OptionMenuContainer.java:36-37`). Matching it would need Iris's whole option-set structure; the cost is cell order on `*` pages.

And one residue, hand-reachable only: the line-at-a-time rewriter gates on the closed list alone, so a hand-written settings-file line naming a listed constant the index refuses (no list, nothing testing it) is still applied where Iris would drop it. No screen offers such a name.

## What proves it

- `gradlew build` green, on every commit of the series.
- The harness on the eight-pack corpus, built from this tree and from `dev`, outputs diffed: `Verdicts`, `Chaine`, `Cibles`, `Reglages` byte-identical; `Ecran` moves by exactly one slot, `Snowy_Winter` on Bliss's Seasons page, verified in the pack itself: its only `#ifdef` is commented out, so Iris blanks it too.
- A two-pack synthetic corpus exercising all four behaviours (a `*` with a refused constant and a redumped main-screen toggle, a pack with no `screen=`), run against this tree and against the pre-batch build as negative control. `Ecran` recounts the dump with its own copy of the sieve and agrees.
- Not tried in game: opening the screen on a pack with a `*` is the remaining look, and no corpus pack ships one.

## What it leaves owing

The in-game look above, and the rewriter residue named in section two.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
