### PR TITLE
fix(pack): read the directives the way Iris reads them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ what the next one holds.
   Chloride remains worth installing, its settings are still read and reported, and running it
   alongside changes nothing.
 
+- **The odd corners of a pack's properties read the way Iris reads them.** An `alphaTest.`, a
+  `texture.noise` or a `dimension.properties` line written under a setting's `#if` now comes and
+  goes with the setting, a world declared twice keeps the last declaration instead of the first,
+  a page laid out twice keeps its last line instead of both, and a pack writing
+  `shadow.enabled=false` gets what it asked for: nothing is ever drawn from the light. No known
+  pack is changed by any of this today.
+
 - **The settings screen reads a pack's layout the way Iris does.** The `*` token now pours out
   every setting no other page names, where the pack put it; a pack without a `screen=` line gets
   one page holding everything instead of an empty one; and a name Iris refuses to configure, a

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -429,6 +429,11 @@ public final class PackProgram {
 					dimensions);
 
 			Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
+			// The pack's own switch comes before its programs: the reference nulls its whole
+			// shadow renderer on shadow.enabled=false, however many shadow programs the pack
+			// ships, and only an explicit false moves anything.
+			boolean shadowOff =
+					properties.shadowEnabled(settings.globalDefines(options)).equals(Optional.of(false));
 
 			// What each pass is served by, read once and kept, because the passes are walked twice:
 			// the mesh is built out of what ALL of them ask for, and every one of them then declares
@@ -440,6 +445,10 @@ public final class PackProgram {
 			Map<TerrainPass, Served> served = new LinkedHashMap<>();
 			Set<String> reads = new LinkedHashSet<>();
 			for (TerrainPass pass : TerrainPass.values()) {
+				if (pass.shadow() && shadowOff) {
+					continue;
+				}
+
 				Optional<ProgramResolver.Resolution> resolution = resolver.lookup(place, pass.program());
 				if (resolution.isEmpty()) {
 					continue;

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -428,6 +428,8 @@ public final class PackProgram {
 			ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
 					dimensions);
 
+			Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
+
 			// What each pass is served by, read once and kept, because the passes are walked twice:
 			// the mesh is built out of what ALL of them ask for, and every one of them then declares
 			// that whole mesh. Expanding the includes a second time would be the same files read
@@ -453,7 +455,7 @@ public final class PackProgram {
 					continue;
 				}
 
-				AlphaTest alphaTest = pass.alphaTest(properties, servedBy);
+				AlphaTest alphaTest = pass.alphaTest(overrides, servedBy);
 				served.put(pass, new Served(path, units, alphaTest));
 				reads.addAll(ProgramTranslator.reads(units.get(ProgramStage.VERTEX), inputs,
 						alphaTest, pass.covers(), pass.program(), textures.volumes()));
@@ -551,6 +553,8 @@ public final class PackProgram {
 			ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
 					dimensions);
 
+			Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
+
 			record Served(String path, Map<ProgramStage, ExpandedUnit> units, AlphaTest alphaTest,
 					GeometryElement element) {
 			}
@@ -575,7 +579,7 @@ public final class PackProgram {
 					continue;
 				}
 
-				AlphaTest alphaTest = properties.alphaTest(servedBy).orElse(element.alphaTest());
+				AlphaTest alphaTest = overrides.getOrDefault(servedBy, element.alphaTest());
 				served.put(element.element(), new Served(path, units, alphaTest, element));
 				reads.addAll(ProgramTranslator.reads(units.get(ProgramStage.VERTEX), element.inputs(),
 						alphaTest, element.coverage(), element.program(), textures.volumes()));
@@ -856,6 +860,8 @@ public final class PackProgram {
 			ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
 					dimensions);
 
+			Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
+
 			Map<String, Map<ProgramStage, ExpandedUnit>> expanded = new LinkedHashMap<>();
 			Map<String, Loaded> translated = new LinkedHashMap<>();
 			Map<String, Loaded> loaded = new LinkedHashMap<>();
@@ -880,7 +886,7 @@ public final class PackProgram {
 					continue;
 				}
 
-				AlphaTest alphaTest = properties.alphaTest(servedBy).orElse(element.alphaTest());
+				AlphaTest alphaTest = overrides.getOrDefault(servedBy, element.alphaTest());
 				// What two pieces have to agree on to be one translation, and the element is not part
 				// of it. The threshold is, because it is written into the fragment stage: two pieces of
 				// one program discarding at different alphas are two texts, and sharing one would draw

--- a/common/src/main/java/dev/vitrail/pack/program/TerrainPass.java
+++ b/common/src/main/java/dev/vitrail/pack/program/TerrainPass.java
@@ -2,6 +2,8 @@ package dev.vitrail.pack.program;
 
 import dev.vitrail.pack.source.ShaderProperties;
 
+import java.util.Map;
+
 /**
  * The passes the chunk renderer draws the world in, and what a pack owes each of them.
  * <p>
@@ -162,12 +164,14 @@ public enum TerrainPass {
 	/**
 	 * The alpha test this pass is drawn under, once the pack has had its say.
 	 *
-	 * @param servedBy the program that really serves this pass, which is the name the pack writes
-	 *                 the override under. A pack shipping one {@code gbuffers_terrain} and a line
-	 *                 {@code alphaTest.gbuffers_terrain=GREATER 0.1} moves both the solid and the
-	 *                 cutout pass with it, which is what Iris does and what Bliss counts on
+	 * @param overrides what {@link ShaderProperties#alphaTests} resolved under the settings in
+	 *                  force
+	 * @param servedBy  the program that really serves this pass, which is the name the pack writes
+	 *                  the override under. A pack shipping one {@code gbuffers_terrain} and a line
+	 *                  {@code alphaTest.gbuffers_terrain=GREATER 0.1} moves both the solid and the
+	 *                  cutout pass with it, which is what Iris does and what Bliss counts on
 	 */
-	public AlphaTest alphaTest(ShaderProperties properties, String servedBy) {
-		return properties.alphaTest(servedBy).orElse(this.fallback);
+	public AlphaTest alphaTest(Map<String, AlphaTest> overrides, String servedBy) {
+		return overrides.getOrDefault(servedBy, this.fallback);
 	}
 }

--- a/common/src/main/java/dev/vitrail/pack/source/DimensionSet.java
+++ b/common/src/main/java/dev/vitrail/pack/source/DimensionSet.java
@@ -1,5 +1,6 @@
 package dev.vitrail.pack.source;
 
+import dev.vitrail.pack.option.EngineDefines;
 import dev.vitrail.pack.target.TargetPlan;
 
 import java.io.IOException;
@@ -33,6 +34,13 @@ public final class DimensionSet {
 	private static final Pattern DECLARATION =
 			Pattern.compile("^\\s*dimension\\.([A-Za-z0-9_-]+)\\s*=(.*)$");
 
+	/**
+	 * Any line the reference's properties reader would keep: not a comment, and carrying an
+	 * equals sign. What it decides is only whether the file counts as saying something, see
+	 * {@link #discover}.
+	 */
+	private static final Pattern ANY_KEY = Pattern.compile("^\\s*[^#!\\s][^=]*=.*$");
+
 	private static final String PROPERTIES = "dimension.properties";
 
 	/** What the three conventional folders mean when no {@code dimension.properties} says. */
@@ -61,21 +69,52 @@ public final class DimensionSet {
 
 		Optional<java.nio.file.Path> properties = source.file(PROPERTIES);
 		if (properties.isPresent()) {
+			// The engine's table and never the pack's settings: the reference preprocesses this
+			// file before the include graph exists, so a conditional here can only see the
+			// environment defines (ShaderPack.java:125-126). A declaration in a dead branch is
+			// no declaration.
+			Map<String, String> defines = EngineDefines.table(EngineDefines.machine());
+			ConditionStack conditions = new ConditionStack();
+
+			// A folder to the LAST worlds it was assigned, in first-assignment order. The
+			// reference reads this file as ordered properties, so re-assigning dimension.<folder>
+			// keeps the key's place, drops the earlier line's worlds entirely, and it is the
+			// FOLDER that is the key: two lines about one folder are one entry, two folders
+			// claiming one world are settled by whichever entry sits later.
+			Map<String, String> assignments = new LinkedHashMap<>();
+
 			for (String line : source.readLines(properties.get())) {
+				Matcher directive = ShaderProperties.DIRECTIVE.matcher(line);
+				if (directive.matches()) {
+					ShaderProperties.applyDirective(directive.group(1), line, conditions, defines);
+					continue;
+				}
+
+				if (!conditions.active()) {
+					continue;
+				}
+
 				Matcher declaration = DECLARATION.matcher(line);
 				if (declaration.matches()) {
-					found.add(declaration.group(1));
+					assignments.put(declaration.group(1), declaration.group(2));
+				}
+
+				// ANY live key suppresses the conventional folders, well formed or not: the
+				// reference's test is that the parsed file is not empty (ShaderPack.java:127),
+				// not that it holds a dimension line.
+				if (ANY_KEY.matcher(line).matches()) {
 					declared = true;
-					// One line carries as many worlds as the pack cares to group on that folder,
-					// separated by spaces. The first declaration of a world wins, so that a file
-					// naming one twice reads the same way twice rather than by map order.
-					for (String world : declaration.group(2).trim().split("\\s+", -1)) {
-						if (!world.isEmpty()) {
-							places.putIfAbsent(normalise(world), declaration.group(1));
-						}
-					}
 				}
 			}
+
+			assignments.forEach((folder, worlds) -> {
+				found.add(folder);
+				for (String world : worlds.trim().split("\\s+", -1)) {
+					if (!world.isEmpty()) {
+						places.put(normalise(world), folder);
+					}
+				}
+			});
 		}
 
 		for (String directory : source.topLevelDirectories()) {

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -258,8 +258,13 @@ public final class ShaderProperties {
 			// The name of the page, "" for the one the pack opens on. A sub page is referred to
 			// from its parent by its own name, so the two are joined by name rather than nested.
 			String page = screen.group(1) == null ? "" : screen.group(1).substring(1);
-			List<String> layout = builder.screens.computeIfAbsent(page, _ -> new ArrayList<>());
-			List<ScreenToken> slots = builder.screenLayout.computeIfAbsent(page, _ -> new ArrayList<>());
+			// A second line for the same page REPLACES the first, which is how the reference
+			// reads the pair: the last assignment of a key is the key. Only the layout starts
+			// over; the token census below keeps counting what the pack wrote, dead line or not.
+			List<String> layout = new ArrayList<>();
+			List<ScreenToken> slots = new ArrayList<>();
+			builder.screens.put(page, layout);
+			builder.screenLayout.put(page, slots);
 
 			// A run of SPACES and not a run of whitespace. The list directives are the only ones Iris
 			// splits on more than one space, and even there a tab is not a separator; every other

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -45,7 +45,8 @@ public final class ShaderProperties {
 	// three of its continuations on a blank line, and its main screen swallowed the commented
 	// block underneath.
 	private static final Pattern CONTINUATION = Pattern.compile("\\\\\\r?\\n[ \\t]*");
-	private static final Pattern DIRECTIVE = Pattern.compile("^\\s*#\\s*(if|ifdef|ifndef|else|elif|endif)\\b.*$");
+	// Package visible rather than private: DimensionSet walks its own file with the same stack.
+	static final Pattern DIRECTIVE = Pattern.compile("^\\s*#\\s*(if|ifdef|ifndef|else|elif|endif)\\b.*$");
 
 	private static final Pattern PROFILE = Pattern.compile("^\\s*profile\\.(\\w+)\\s*=\\s*(.*)$");
 	private static final Pattern PROGRAM_ENABLED = Pattern.compile("^\\s*program\\.(.+?)\\.enabled\\s*=\\s*(.*)$");
@@ -157,10 +158,8 @@ public final class ShaderProperties {
 	private final List<BlendDirective> blend;
 	private final Map<String, String> sizeBuffers;
 	private final List<FlipDirective> flips;
-	private final Map<String, AlphaTest> alphaTest;
 	private final Map<String, String> malformedAlphaTests;
 	private final Map<String, Integer> ignoredPrefixes;
-	private final String noiseTexturePath;
 	private final int directiveCount;
 	private final int continuationCount;
 	private final boolean present;
@@ -186,10 +185,8 @@ public final class ShaderProperties {
 		this.blend = List.copyOf(builder.blend);
 		this.sizeBuffers = Map.copyOf(builder.sizeBuffers);
 		this.flips = List.copyOf(builder.flips);
-		this.alphaTest = Map.copyOf(builder.alphaTest);
 		this.malformedAlphaTests = Map.copyOf(builder.malformedAlphaTests);
 		this.ignoredPrefixes = Map.copyOf(builder.ignoredPrefixes);
-		this.noiseTexturePath = builder.noiseTexturePath;
 		this.directiveCount = builder.directiveCount;
 		this.continuationCount = builder.continuationCount;
 		this.present = builder.present;
@@ -294,12 +291,16 @@ public final class ShaderProperties {
 			return;
 		}
 
+		// Consumed here for the census only; the values come out of alphaTests, which walks the
+		// conditionals, because the reference reads this family off its preprocessed copy of the
+		// file. Not every family: it reads the screens and the sliders off the raw one.
 		Matcher alpha = ALPHA_TEST.matcher(line);
 		if (alpha.matches()) {
 			String value = alpha.group(2).trim();
-			AlphaTest.parse(value).ifPresentOrElse(
-					test -> builder.alphaTest.put(alpha.group(1), test),
-					() -> builder.malformedAlphaTests.put(alpha.group(1), value));
+			if (AlphaTest.parse(value).isEmpty()) {
+				builder.malformedAlphaTests.put(alpha.group(1), value);
+			}
+
 			return;
 		}
 
@@ -457,14 +458,13 @@ public final class ShaderProperties {
 			}
 		}
 
-		// The path is relative to shaders/, as every path in this file is. Four packs of the
-		// corpus write the line, and their water and clouds are built against that image: the
-		// generated noise is a stand in with the same look and none of the same values.
+		// Consumed here for the census only; the path comes out of noiseTexturePath, which walks
+		// the conditionals like the other directive readers below.
 		Matcher noise = TEXTURE_NOISE.matcher(line);
 		if (noise.matches()) {
-			builder.noiseTexturePath = noise.group(1).trim();
 			return;
 		}
+
 
 		// Consumed and not kept: the rest of the family is read by customTextures, which walks the
 		// conditionals. Falling through here would leave those lines among the keys nothing reads
@@ -768,7 +768,7 @@ public final class ShaderProperties {
 		}
 	}
 
-	private static void applyDirective(String keyword, String line, ConditionStack conditions,
+	static void applyDirective(String keyword, String line, ConditionStack conditions,
 			Map<String, String> defines) {
 		switch (keyword) {
 			case "ifdef", "ifndef" -> {
@@ -828,7 +828,7 @@ public final class ShaderProperties {
 	/**
 	 * The textures the pack supplies with a file of its own, by the key it wrote, in that order,
 	 * with the conditionals around each line evaluated. {@code texture.noise} is not among them:
-	 * it is answered by {@link #noiseTexturePath()} and is not one of these.
+	 * it is answered by {@link #noiseTexturePath} and is not one of these.
 	 * <p>
 	 * Conditionally and not flat, for the reason every other reader here is conditional.
 	 * Complementary writes two of its {@code customTexture} lines under {@code #if} on its own
@@ -1388,14 +1388,25 @@ public final class ShaderProperties {
 	}
 
 	/**
-	 * What alpha a program discards at, when the pack overrides the default of the pass it is drawn
-	 * in. Empty for a line this could not read, which {@link #malformedAlphaTests()} names.
-	 *
-	 * @param program the name of the file that serves the pass, not the name the pass asked for
+	 * What alpha each program discards at, where the pack overrides the default of the pass it is
+	 * drawn in, keyed by the name of the file that serves the pass and not the name the pass asked
+	 * for. A line this could not read is absent, and {@link #malformedAlphaTests()} names it.
+	 * <p>
+	 * Conditionally and not flat: the reference reads this family off its preprocessed copy of
+	 * the file, so an override written under a setting's {@code #if} has to come and go with the
+	 * setting. Six of the eight packs of the corpus write these lines, and none under a
+	 * conditional, which is what kept a flat read invisible.
 	 */
-	public Optional<AlphaTest> alphaTest(String program) {
-		return Optional.ofNullable(this.alphaTest.get(program));
+	public Map<String, AlphaTest> alphaTests(Map<String, String> defines) {
+		Map<String, AlphaTest> overrides = new LinkedHashMap<>();
+		for (Matcher line : live(ALPHA_TEST, defines)) {
+			AlphaTest.parse(line.group(2).trim())
+					.ifPresent(test -> overrides.put(line.group(1), test));
+		}
+
+		return overrides;
 	}
+
 
 	/**
 	 * The {@code alphaTest} lines that name neither a function and a reference nor {@code off}.
@@ -1420,9 +1431,17 @@ public final class ShaderProperties {
 		return new TreeMap<>(this.ignoredPrefixes);
 	}
 
-	/** The pack's own noise image, {@code texture.noise}, relative to {@code shaders/}. */
-	public Optional<String> noiseTexturePath() {
-		return Optional.ofNullable(this.noiseTexturePath);
+	/**
+	 * The pack's own noise image, {@code texture.noise}, relative to {@code shaders/}, read under
+	 * the conditionals with the last live line winning.
+	 */
+	public Optional<String> noiseTexturePath(Map<String, String> defines) {
+		String path = null;
+		for (Matcher line : live(TEXTURE_NOISE, defines)) {
+			path = line.group(1).trim();
+		}
+
+		return Optional.ofNullable(path);
 	}
 
 	/**
@@ -1566,10 +1585,8 @@ public final class ShaderProperties {
 		private final List<BlendDirective> blend = new ArrayList<>();
 		private final Map<String, String> sizeBuffers = new LinkedHashMap<>();
 		private final List<FlipDirective> flips = new ArrayList<>();
-		private final Map<String, AlphaTest> alphaTest = new LinkedHashMap<>();
 		private final Map<String, String> malformedAlphaTests = new LinkedHashMap<>();
 		private final Map<String, Integer> ignoredPrefixes = new LinkedHashMap<>();
-		private String noiseTexturePath;
 		private int directiveCount;
 		private int continuationCount;
 		private boolean present;

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -124,6 +124,8 @@ public final class ShaderProperties {
 	// The noise image is answered here because everything else about it is settled: one path, one
 	// sampler, every stage. The general family is not, and is read by customTextures instead.
 	private static final Pattern TEXTURE_NOISE = Pattern.compile("^\\s*texture\\.noise\\s*=\\s*(.*)$");
+	private static final Pattern SHADOW_ENABLED =
+			Pattern.compile("^\\s*shadow\\.enabled\\s*=\\s*(.*)$");
 	private static final Pattern CUSTOM_TEXTURE =
 			Pattern.compile("^\\s*((?:texture|customTexture)\\.[^=\\s]+)\\s*=\\s*(.*)$");
 	private static final Pattern IMAGE = Pattern.compile("^\\s*image\\.[^=\\s.]+\\s*=\\s*(.*)$");
@@ -470,6 +472,13 @@ public final class ShaderProperties {
 			return;
 		}
 
+		// Consumed on the casters' rule: a value that is not a boolean is honoured nowhere, so
+		// it has to stay visible among the keys nothing reads. The state itself comes out of
+		// shadowEnabled, under the conditionals.
+		Matcher shadowEnabled = SHADOW_ENABLED.matcher(line);
+		if (shadowEnabled.matches() && truth(shadowEnabled.group(1).trim()) != null) {
+			return;
+		}
 
 		// Consumed and not kept: the rest of the family is read by customTextures, which walks the
 		// conditionals. Falling through here would leave those lines among the keys nothing reads
@@ -1412,6 +1421,23 @@ public final class ShaderProperties {
 		return overrides;
 	}
 
+	/**
+	 * Whether the pack switches its whole shadow map on or off, {@code shadow.enabled}, under the
+	 * conditionals. Empty when the pack says nothing, which leaves the stage standing on its
+	 * programs; the reference reads it the same way and only an explicit {@code false} moves
+	 * anything there ({@code IrisRenderingPipeline.java:464}, {@code orElse(true)}).
+	 */
+	public Optional<Boolean> shadowEnabled(Map<String, String> defines) {
+		Boolean state = null;
+		for (Matcher line : live(SHADOW_ENABLED, defines)) {
+			Boolean value = truth(line.group(1).trim());
+			if (value != null) {
+				state = value;
+			}
+		}
+
+		return Optional.ofNullable(state);
+	}
 
 	/**
 	 * The {@code alphaTest} lines that name neither a function and a reference nor {@code off}.

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -137,7 +137,7 @@ public final class PackValues {
 			values.separateAo = properties.separateAo(settings.globalDefines(options));
 			values.particleOrdering = properties.particleOrdering(settings.globalDefines(options));
 			values.declare(properties, settings.globalDefines(options));
-			values.readNoise(properties, source);
+			values.readNoise(properties, source, settings.globalDefines(options));
 			values.packImages =
 					PackImages.read(properties, settings.globalDefines(options), source);
 
@@ -666,8 +666,9 @@ public final class PackValues {
 	 * of any kind falls back to the generated field and is named in the notes: the stand in looks
 	 * like noise too, which is exactly why silence here would cost somebody a day.
 	 */
-	private void readNoise(ShaderProperties properties, ShaderPackSource source) {
-		String path = properties.noiseTexturePath().orElse(null);
+	private void readNoise(ShaderProperties properties, ShaderPackSource source,
+			Map<String, String> defines) {
+		String path = properties.noiseTexturePath(defines).orElse(null);
 		if (path == null) {
 			return;
 		}

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -443,13 +443,13 @@ public final class TerrainDraw {
 	 * What it decides is whether a mob keeps the game's own ground oval. Iris takes that oval away
 	 * for as long as its shadow renderer stands ({@code pipeline/IrisRenderingPipeline.java:1101-1104}),
 	 * and the renderer is made with the shadow targets ({@code :451-469}), whatever the distance is
-	 * set to. Two edges of that condition are not read the same way here, and both are on the side
+	 * set to. One edge of that condition is not read the same way here, and it is on the side
 	 * of the stage rather than of this line. Iris allocates the targets for a pack that merely
 	 * samples {@code shadowtex} from a composite ({@code :767-768}), with no shadow program at all,
 	 * and takes the oval away under it; here a pack without a shadow program gets no stage and keeps
-	 * its oval. And Iris reads a {@code shadow.enabled} line of the pack's properties ({@code :464}),
-	 * which this engine reads nowhere: the stage stands on the programs alone. What either costs is
-	 * one oval more or less under a pack of which the corpus has none.
+	 * its oval. A pack's {@code shadow.enabled=false} closes the stage on both engines the same way:
+	 * Iris nulls its renderer ({@code :464}) and here no shadow program is loaded at all. What the
+	 * remaining edge costs is one oval more or less under a pack of which the corpus has none.
 	 */
 	public static boolean shadowMapServed() {
 		TerrainDraw self = PackChain.terrain();


### PR DESCRIPTION
## What changes

An `alphaTest.` or `texture.noise` line used to be read flat, so one written under a setting's `#if` applied whether the setting was on or off. Both now come and go with the setting, the last live line winning, because Iris parses these families off its preprocessed copy of the file. `dimension.properties` used to ignore its conditionals and keep the FIRST declaration of a doubled world; it now walks under the engine's environment table, the way Iris preprocesses it before the include graph exists, the folder is the properties key, so a re-declared folder drops its earlier worlds whole, and any live key in the file, well formed or not, suppresses the conventional folders. A second `screen=` line for the same page used to add onto the first; it now replaces it. And `shadow.enabled` was read nowhere, so a pack writing `false` still got its whole shadow stage: an explicit `false`, evaluated under the conditionals, now loads no terrain shadow program, which closes the stage the way Iris nulls its renderer. Absent or `true` changes nothing.

## How it differs from the reference, and for what obstacle

- **`scale.<pass>` stays unserved.** Iris shrinks a composite pass's viewport (`CompositeRenderer.java:317-321`); here a composite pass fills its whole target, and `ChainPlan.java:574-581` carries the obstacle: the shape of this engine's render passes. Cost: a pack scaling a composite draws it full size. No pack of the corpus writes the directive.
- **The environment table lacks names Iris defines unconditionally**: `IRIS_TAG_SUPPORT=2`, `IRIS_REQUIRES_SEPARATE_ENTITY_DRAWS`, the `MC_<gl-extension>` family (`StandardMacros.java:58-61,97-99`). Each is a promise about a capability this engine may not hold, so posting one is a decision per name rather than a copy; until then a conditional testing one of them reads live on Iris and dead here. This predates the branch and becomes visible through it, `dimension.properties` conditionals now reading that table.
- **On `shadow.enabled=false` the entity and far-terrain shadow programs still translate.** Nothing ever draws them, the shadow stage being the only place that would, so the cost is a wasted translation and no image.

## What proves it

- `gradlew build` green on every commit of the series.
- The harness on the eight-pack corpus, built from this tree and from `dev`: `Ecran`, `Verdicts`, `Chaine`, `Cibles`, `Reglages` byte-identical, `Terrain` identical once sorted (its rows print in a different order on two runs of the same build).
- A synthetic pack with the directives under `#ifdef`, in duplicate, and a re-declared folder key, probed against both builds: the old code shows the flat reads and first-wins, the new one shows dead branches dropping, last-wins everywhere, the replaced folder losing its earlier worlds, and `shadow.enabled` coming and going with its setting.
- Not tried in game: no pack of the corpus writes any of these lines under a conditional or twice, so there is nothing to look at.

## What it leaves owing

`scale.<pass>` and the environment-table names above.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
