### PR TITLE
fix(mixin): order what the next pass writes, not just what it reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,9 +63,10 @@ what the next one holds.
 - **A pack's frame opens fewer GPU stops.** Clears ride as the first pass's load, leftover
   sampled-before-write clears share one empty pass per size, mip chains blit instead of drawing
   each level, consecutive geometry that writes the same images stays in one pass, ping-pong
-  targets swap names instead of copying texels back, and our own passes wait only for
-  sample-after-write. Same picture. Written for the extra submits a Mac report was counting;
-  whether the frame rate moves is still that machine's to measure.
+  targets swap names instead of copying texels back, and our own passes end on a wait naming what
+  the next one samples and what it writes, rather than on the game's wait for the whole of memory.
+  Same picture. Written for the extra submits a Mac report was counting; whether the frame rate
+  moves is still that machine's to measure.
 
 - **Pass uniforms reuse scratch matrices** instead of allocating a model-view-projection and a
   normal matrix on every fill. Same numbers.

--- a/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
@@ -63,7 +63,22 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 	/**
 	 * The game ends every pass with a full memory barrier. Iris does not: it binds an FBO and
 	 * draws. On MoltenVK that full barrier is a Metal wait, which is the extra queue-submit count
-	 * on Apple Silicon. Our own passes only need write-then-sample, so they get that instead.
+	 * on Apple Silicon. Our own passes need write-then-sample and write-then-write, and get a
+	 * dependency naming those two rather than the whole of memory.
+	 * <p>
+	 * <strong>Write-then-write is half of it, and leaving it out is what an FBO gives for free.</strong>
+	 * Under OpenGL two draws into the bound framebuffer land in the order they were issued, so Iris
+	 * never has to say it; two Vulkan passes writing the same image are ordered by nothing at all.
+	 * That is every target the chain turns over, and the emptying now rides the load-op of the pass
+	 * that first attaches it rather than being a clear of its own, so a pass and the clear meant to
+	 * precede it are two writes to one image with no dependency between them.
+	 * <p>
+	 * <strong>What the masks deliberately leave out, and the day that stops being safe.</strong>
+	 * A pass of ours writes colour and depth attachments and nothing else, so the source names
+	 * those two. Nothing downstream is a compute dispatch, an image store or a shader storage
+	 * buffer, so the destination names no compute stage and no storage access. The day a pack's
+	 * compute programs are dispatched, both ends stop covering what the frame does, and the
+	 * dependency has to be widened here rather than worked around where it shows.
 	 */
 	@Redirect(method = "submitRenderPass", at = @At(value = "INVOKE",
 			target = "Lcom/mojang/blaze3d/vulkan/VulkanCommandEncoder;memoryBarrier("
@@ -103,10 +118,20 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR)
+				// The writes sit here beside the reads, and each of the three is reached every frame:
+				// a colour target the next pass writes, or that the emptying writes through its
+				// load-op; the depth image the next geometry pass tests and writes, and that the
+				// shadow map's own emptying clears; and the mip blit filling the levels of a target
+				// whose base the pass that just closed wrote. Named as reads alone, all three were
+				// write-after-write with nothing between them, which a driver is free to run in
+				// either order.
 				.dstAccessMask(KHRSynchronization2.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT_KHR
 						| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR
 						| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT_KHR
-						| KHRSynchronization2.VK_ACCESS_2_TRANSFER_READ_BIT_KHR);
+						| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_TRANSFER_READ_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR);
 		VkDependencyInfo info = VkDependencyInfo.calloc(stack)
 				.sType$Default()
 				.pMemoryBarriers(barrier);

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -578,6 +578,16 @@ final class ColorTargets {
 	 * The texels stay where they are. A copy would be a GPU stop, and both halves already carry
 	 * the same format. Mip levels past nought are rebuilt from nought before any program reads
 	 * one, the same as they were when this used to copy.
+	 * <p>
+	 * Iris copies here and says in the same breath that it would rather not:
+	 * {@code FinalPassRenderer} carries "we merely copy it from alt to main, this works for the
+	 * most part but it's not perfect", the better approach being framebuffers for every other
+	 * frame. This backend builds its pass descriptor per frame, so it can have that for nothing.
+	 * <p>
+	 * <strong>The debug labels cross over and are not corrected.</strong> A surface is named at
+	 * allocation and keeps that name, so after an odd number of frames the texture labelled
+	 * {@code Vitrail colortexN alt} is the main half. It costs nothing at runtime and it misreads
+	 * badly in a GPU capture, which is where a target is looked up by name.
 	 */
 	void swapBack(List<Integer> targets) {
 		for (int index : targets) {

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2603,8 +2603,8 @@ public final class PackChain {
 
 		List<Integer> back = unfolded.swapBack();
 		if (!back.isEmpty()) {
-			Vitrail.logger().info("{} targets are copied back from their far half at the end of every "
-					+ "frame, because the pack keeps them and the chain left them there: {}",
+			Vitrail.logger().info("{} targets swap their two halves at the end of every frame, because "
+					+ "the pack keeps them and the chain left them on the far one: {}",
 					back.size(), back);
 		}
 

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -109,7 +109,11 @@ On top of that, submitting a render pass ends it with a **full memory barrier**:
 all commands, memory read and memory write. The other operations that touch textures (clearing,
 copying, uploading) end the same way. That is still what the game does for its own passes.
 
-Passes this engine labels (`Vitrail ...`) close with a write-then-sample barrier instead. Consecutive
+Passes this engine labels (`Vitrail ...`) close with a narrower barrier instead, naming what the
+rest of the frame samples of the pass **and** what it writes over it. Both halves are needed and only
+the first is obvious: two Vulkan passes writing one image are ordered by nothing, where the bound
+framebuffer of OpenGL orders them for free, and the emptying of a target now rides the load-op of
+a pass rather than being a clear of its own, which makes it one of those writes. Consecutive
 geometry that writes the same colour and depth images stays in one pass, which is what Iris does by
 leaving `defaultFB` bound (`IrisRenderingPipeline.bindDefault`). A later composite, a copy, or a
 different framebuffer ends that hold first. Mip chains are filled with `vkCmdBlitImage` on the

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -203,9 +203,12 @@ is dead and nothing says so.
 
 **Synchronisation is free and it is not cheap.** The Vulkan command encoder places a global memory
 barrier after every render pass the game itself closes, and again after every clear and every copy.
-Passes this engine labels close with a write-then-sample barrier instead. Writing a target in one
-pass and reading it in the next therefore requires nothing at all from this engine, and images stay
-in one layout end to end with no transitions to manage. The other side of that coin is that each
+Passes this engine labels close with a narrower one instead, which names both what the rest of the
+frame samples of the pass and what it writes over it: the second half is the one an OpenGL engine
+never has to say, since the bound framebuffer orders two draws into it and two Vulkan passes into
+one image are ordered by nothing. Writing a target in one pass and reading it in the next therefore
+requires nothing at all from this engine, and images stay in one layout end to end with no
+transitions to manage. The other side of that coin is that each
 closed pass, each standalone clear and each copy is still a GPU stop; that is the real cost model
 for anything that adds one, and the reason matching geometry is kept in one pass.
 


### PR DESCRIPTION
## What changes

A pass this engine opens no longer ends on a wait that covers only what the rest of the frame
will READ of it. The wait now covers what will be written over it as well.

The wait replaced the game's own, which is a full memory barrier after every pass and the
largest part of the extra GPU stops a pack frame was paying. What replaced it named colour and
depth attachment writes as its source and nothing but reads as its destination, so every write
landing on a target one of our passes had just written was ordered by nothing at all: the next
pass attaching the same image, the emptying that now rides that pass's load-op instead of being
a clear of its own, the shadow map's own clear, and the mip blit that fills the levels of a
target whose base the pass just wrote. What a frame draws in that state is whatever order the
driver picked, so a composite can be built on a target that was cleared after it was filled, or
filled after it was cleared. The three write bits go in beside the reads.

Nothing is added back. The barrier was already being issued at exactly this point, and the
change is the value of one access mask. Pass, clear and copy counts are untouched, which is
what the load line reports.

The second commit is text: the line printed at load still said the kept targets were copied
back from their far half, which stopped being true when that copy became a name swap.

## How it differs from the reference, and for what obstacle

It does not. It is the opposite: the wait is what an OpenGL engine gets for free and never has
to write. Two draws into a bound framebuffer land in the order they were issued, which is what
Iris relies on by keeping `defaultFB` bound (`IrisRenderingPipeline.bindDefault`), and two
Vulkan passes writing one image are ordered by nothing. Saying the first half of that guarantee
and not the second was the gap.

## What proves it

- `gradlew build` green.
- In the game on BOTH loaders, frozen world, ComplementaryReimagined r5.8.1 at the Low preset,
  which is the configuration the picture was reported wrong in. Same image before and after the
  change, and the same image on Fabric as on NeoForge: over a mean of sixty frames each, a
  static region of ground agrees to R0.0 G+0.2 B-0.5 out of 255, and the rest of the frame to
  about two units, which is the water and the clouds moving between two clients.
- The two loaders make the same frame and not merely the same picture: 63 identical load-time
  lines, and a per-pass census agreeing pass for pass and reason for reason, 4 clears and 1 copy
  on each. The only extra pass on one side is the game's own 3d crosshair, which exists when the
  reticle is on a block.
- The masks were read against what the frame actually does rather than widened by reflex. A pass
  of ours writes colour and depth attachments and nothing else, and nothing downstream is a
  compute dispatch, an image store or a shader storage buffer, so no compute stage and no
  storage access is named. The javadoc says that, and says it stops holding the day a pack's
  compute programs are dispatched.
- The other two mechanisms of the same batch were read line by line and neither can produce
  this. The ping-pong swap is a rename of two map entries with no cross-frame holder of either
  half, symmetric under resize and under a skipped pass, and Iris's own `FinalPassRenderer`
  carries the comment that a real swap is what it would rather do. The leftover Immediate fold
  only joins a pass whose colour images, depth image and render area are all identical, refuses
  any descriptor carrying a clear, and resets the scissor first. Both are deterministic.
- Not proven here, and this is the honest limit: **the wrong picture this fixes has never been
  seen on this machine.** The same jar draws the scene correctly on an NVIDIA desktop driver,
  which is free to order those writes the way the missing dependency happened to need. The
  defect it answers is a report from Apple Silicon under MoltenVK, and only that machine can
  say whether the picture comes back.

## What it leaves owing

Confirmation from the reporting machine.

One thing named and left alone: a target surface keeps the name it was allocated under, so
after an odd number of frames the texture labelled `alt` is the main half. It costs nothing at
runtime and it misreads in a GPU capture, which is where a target is looked up by name. Said in
the javadoc rather than fixed, since fixing it means renaming a live Vulkan object every frame.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
