### PR TITLE
fix(render): hold the far terrain's water behind the world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,16 @@ what the next one holds.
 
 ### Fixed
 
+- **Distant Horizons' far water no longer paints over you.** In third person, with far water
+  behind, the character came out washed out or gone entirely, and the part of him it covered
+  followed the part of the far water behind him. Everything drawn between the two halves of the
+  far terrain was covered the same way: mobs on the ground, particles, and the hand. The far
+  water is drawn after them and had no idea they were there. It now stands behind whatever the
+  game drew before it. What a pack reads under `dhDepthTex0` and `dhDepthTex1` is still the far
+  terrain and nothing else, with one thing given up: where the near world hides far water
+  outright, those names answer with the far terrain behind the water rather than with the water,
+  on a texel where neither is visible.
+
 - **Opening a world no longer crashes while leftover families are still being translated.**
   The frame used to walk those program maps as soon as the composites and the terrain were
   ready, which is the same moment the worker is still filling them.

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -14,22 +14,36 @@ import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.IndexType;
+import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.buffers.Std140Builder;
+import com.mojang.blaze3d.pipeline.BindGroupLayout;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.platform.CompareOp;
+import com.mojang.blaze3d.shaders.ShaderSource;
+import com.mojang.blaze3d.shaders.ShaderType;
+import com.mojang.blaze3d.shaders.UniformType;
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuTexture;
 import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BindGroupLayouts;
 import net.minecraft.client.renderer.MappableRingBuffer;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import net.minecraft.world.phys.Vec3;
+
+import org.joml.Vector2f;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -170,6 +184,8 @@ public final class DistantDraw {
 				new Element("distant_shadow_water", "dh_shadow", true, true));
 	}
 
+	private static final String SEED_LABEL = "Vitrail far terrain occlusion";
+
 	/** The key one half of DH's geometry is drawn under, in each of the two images. */
 	private static String key(boolean water, boolean shadow) {
 		return (shadow ? "distant_shadow" : "distant") + (water ? "_water" : "");
@@ -181,6 +197,85 @@ public final class DistantDraw {
 
 	/** What the far terrain's own depth image holds, which is the format the game's own depth has. */
 	private static final GpuFormat DEPTH_FORMAT = GpuFormat.D32_FLOAT;
+
+	/** One float a texel, which is all a depth carried out of one volume into another is. */
+	private static final GpuFormat CARRIED_FORMAT = GpuFormat.R32_FLOAT;
+
+	private static final Identifier SEED_VERTEX_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "distant/occlusion_vertex");
+	private static final Identifier SEED_FRAGMENT_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "distant/occlusion_fragment");
+
+	private static final String SEED_WORLD = "InWorld";
+	private static final String SEED_FAR = "InFar";
+	private static final String SEED_BLOCK = "OfDistantOcclusion";
+
+	/** One vec2 under std140, which is what the slot HOLDS; how far apart slots start is the
+	 * device's answer and {@link Occlusion#slotBytes} alone carries it. */
+	private static final int SEED_BLOCK_BYTES = 16;
+
+	/** Two triangles, the quad every full screen pass of this engine draws. */
+	private static final int SEED_VERTICES = 6;
+
+	private static final String SEED_VERTEX = """
+			#version 460 core
+
+			in vec3 Position;
+			in vec2 UV0;
+
+			out vec2 ofTexCoord;
+
+			void main() {
+				ofTexCoord = UV0;
+				gl_Position = vec4(Position.xy * 2.0 - 1.0, 0.0, 1.0);
+			}
+			""";
+
+	/**
+	 * Carries the world's depth into the volume the far terrain is rasterised in, and leaves the
+	 * nearer of the two behind.
+	 * <p>
+	 * The two things this does besides the multiply and the add are the two
+	 * {@link dev.vitrail.uniform.ClipSpace#distantDepth} says its caller owes it, and the off-game
+	 * harness measures why each is there rather than asserting it. Nought is the clear value of a
+	 * reversed Z and means the game drew nothing at that texel, so it stands for the game's own far
+	 * plane rather than for a surface, and carrying it over would lay a lid across every LOD past
+	 * the game's render distance. And everything nearer than that mod's own near plane, which is at
+	 * most seven and a half blocks out, carries past one, which is right and has to be said in
+	 * range.
+	 */
+	private static final String SEED_FRAGMENT = """
+			#version 460 core
+
+			layout(std140) uniform OfDistantOcclusion {
+				vec2 ofDistantDepth;
+			};
+
+			uniform sampler2D InWorld;
+			uniform sampler2D InFar;
+
+			in vec2 ofTexCoord;
+
+			layout(location = 0) out vec4 ofFragData0;
+
+			void main() {
+				float world = texture(InWorld, ofTexCoord).r;
+				float carried = world == 0.0
+						? 0.0
+						: clamp(ofDistantDepth.x * world + ofDistantDepth.y, 0.0, 1.0);
+
+				ofFragData0 = vec4(carried);
+				gl_FragDepth = max(carried, texture(InFar, ofTexCoord).r);
+			}
+			""";
+
+	private static final ShaderSource SEED_SOURCE = (id, type) -> {
+		if (type == ShaderType.FRAGMENT) {
+			return SEED_FRAGMENT_ID.equals(id) ? SEED_FRAGMENT : null;
+		}
+
+		return SEED_VERTEX_ID.equals(id) ? SEED_VERTEX : null;
+	};
 
 	private final PackChain owner;
 	private final Path packPath;
@@ -211,6 +306,37 @@ public final class DistantDraw {
 	private GpuTextureView depthView;
 	private int depthWidth;
 	private int depthHeight;
+
+	/**
+	 * Where the WATER half is really rasterised: the image above with the world's own depth seeded
+	 * into it. Null until a frame that draws the far terrain asks for it.
+	 * <p>
+	 * <strong>A second image and not the first one seeded, and that difference is the whole of what
+	 * a pack reads.</strong> {@code dhDepthTex} has to go on meaning the far terrain and nothing
+	 * else, so the image the two takes are drawn from stays as pure as it is today. This one holds
+	 * the far terrain AND the world, and only a depth test ever reads it.
+	 */
+	private GpuTexture blended;
+	private GpuTextureView blendedView;
+
+	/**
+	 * What was seeded into it, kept because the take that follows the water half has no other way
+	 * of telling the world back out again: a texel where the world won holds the world's own depth,
+	 * and it is only recognisable against the value that was put there. The game's live depth is no
+	 * substitute, the world's translucents having written it by the time that take runs.
+	 */
+	private TargetSurface worldCarried;
+
+	private int blendedWidth;
+	private int blendedHeight;
+
+	/** Whether this frame really seeded the pair above, which is what the water half asks. */
+	private boolean seeded;
+
+	/** Said once, and it costs the occlusion alone: the water half falls back on the pure image. */
+	private boolean seedBroken;
+
+	private RenderPipeline seedPipeline;
 
 	/** Whether anything was drawn into that image this frame, which is what the takes ask. */
 	private boolean drew;
@@ -248,6 +374,15 @@ public final class DistantDraw {
 	 * It outlives the pack for the reason the ring above does.
 	 */
 	private static final Corners SHADOW_CORNERS = new Corners("Vitrail far terrain shadow sections");
+
+	/**
+	 * The one slot a frame the seeding pass reads its pair out of.
+	 * <p>
+	 * Static and never closed on a pack load, for the reason the two rings above are not: a load
+	 * tears the chain down in the middle of a frame whose passes already hold slices of it. It
+	 * costs a few dozen bytes and it turns where they turn.
+	 */
+	private static final Occlusion OCCLUSION = new Occlusion();
 
 	/** What DH has handed over on the frame being drawn, one list per half of its geometry. */
 	private List<DhLods.Section> opaqueSections = List.of();
@@ -382,6 +517,128 @@ public final class DistantDraw {
 	/** The image the far terrain left its depth in, or null when it drew nothing this frame. */
 	GpuTextureView served() {
 		return this.drew ? this.depthView : null;
+	}
+
+	/**
+	 * The image the water half was really rasterised against, the far terrain and the world both,
+	 * or null on a frame that was not seeded and where the image above therefore holds the water
+	 * itself.
+	 */
+	GpuTextureView blendedServed() {
+		return this.seeded ? this.blendedView : null;
+	}
+
+	/** What was seeded into it, or null on the same frames. Always null or non-null together. */
+	GpuTextureView worldServed() {
+		return this.seeded ? this.worldCarried.view() : null;
+	}
+
+	/**
+	 * Seeds the world's own depth under the far terrain's water half, so that the player and
+	 * everything else drawn between the two halves stands in front of it.
+	 * <p>
+	 * <strong>What this closes, and it is a divergence rather than a gap being filled.</strong> The
+	 * water half is drawn at {@code RenderStage.TERRAIN_TRANSLUCENT}, which is after the entities,
+	 * the block entities and the hand, and until this it was rasterised against an image holding
+	 * the far terrain alone. Nothing held it back, so it painted over the player in third person,
+	 * over every entity on the ground and over the hand. Iris is in the same position and does the
+	 * same thing: it binds that mod's own depth to its water target
+	 * ({@code compat/dh/DHCompatInternal.java:161-176}), it CANCELS that mod's apply step outright
+	 * as soon as a pack is loaded ({@code compat/dh/LodRendererEvents.java}, the before-apply event),
+	 * and that step compares nothing anyway, its Blaze pipeline carrying
+	 * {@code withDepthTest(NONE)}, {@code withDepthWrite(false)} and a dummy depth image
+	 * ({@code common/render/blaze/apply/BlazeDhApplyRenderer.java}). So the picture this engine gave
+	 * was Iris's picture, and what is written here parts from it on purpose.
+	 * <p>
+	 * <strong>WHEN it is taken decides what the water ends up hidden behind, and one frame stage
+	 * too early costs the player's own body.</strong> It is taken from the water half's own draw,
+	 * at the last instant before that half is recorded, and nowhere earlier. Taken at the end of the
+	 * game's opaque features instead, which is where this first stood, the depth it reads carries
+	 * the opaque world, the entities, the block entities and the hand, and NOT the geometry the game
+	 * types translucent: a player's own skin is drawn with {@code entityTranslucent}, because a skin
+	 * may carry a transparent outer layer, so in third person the body arrives after that point
+	 * while the cape, which is solid, arrives before it. What that showed on screen was a player
+	 * whose cape stood in front of the far water and whose head and arms did not, which is the
+	 * defect this exists to close wearing half a disguise.
+	 * <p>
+	 * Once a frame, and the flag that says so falls at the frame boundary with every other per frame
+	 * fact of this class. Quiet on every frame with no far terrain in it, and quiet once it has
+	 * failed: what is lost then is the occlusion alone, the water half falling back on the image it
+	 * used to be drawn against.
+	 *
+	 * @param main the game's own target, whose depth is the world as it stands
+	 */
+	private void seedWater(GpuDevice device, RenderTarget main) {
+		// And not at all once the take that follows this half has given up on its own three image
+		// conversion: seeding without it would leave dhDepthTex0 answering the far terrain with no
+		// water for the rest of this load, which is a worse name than an unoccluded water.
+		if (this.broken || this.seedBroken || !this.drew
+				|| this.targets.depth().distantRefused()) {
+			return;
+		}
+
+		try {
+			// Asked for INSIDE the catch and not handed in: the first frame of a pack allocates it
+			// here, and an allocation that gave way outside would land in the caller's own catch,
+			// which hands the far terrain back to that mod for the rest of the pack rather than
+			// costing the occlusion alone.
+			this.seeded = seed(device, main, this.owner.quad(device));
+		} catch (RuntimeException e) {
+			this.seedBroken = true;
+			Vitrail.logger().error("Vitrail stopped seeding the world's depth under the far terrain's "
+					+ "water after an error, so that water paints over whatever the game drew between "
+					+ "the two halves of the far terrain for the rest of this pack", e);
+		}
+	}
+
+	private boolean seed(GpuDevice device, RenderTarget main, GpuBuffer quad) {
+		GpuTextureView world = main.getDepthTextureView();
+		// The two sizes agree by construction, {@link #record} having just called ensureDepth on
+		// this very target, and the comparison stands as the precondition of a pass that samples
+		// one image at the size of another: a seed drawn across two sizes would stretch the world's
+		// depth over the screen rather than fail. What it does NOT cover is the frame of a resize
+		// itself, where ensureDepth has just remade the far terrain's image and emptied it, so the
+		// water half of that one frame is held back by the world alone and not by the far terrain's
+		// own opaque half. One frame, and the colour of that half is already on screen.
+		if (world == null || quad == null || main.width != this.depthWidth
+				|| main.height != this.depthHeight) {
+			return false;
+		}
+
+		Vector2f pair = new Vector2f();
+		if (!this.values.world().distantDepthPair(pair)) {
+			return false;
+		}
+
+		// The pipeline before the images, so that a driver which will not have this shader never
+		// allocates the two it would then hold for the rest of the pack. The refusal that comes
+		// later, after a resource reload has emptied the device's cache, hands them back itself.
+		RenderPipeline compiled = seedPipeline(device);
+		if (compiled == null || !ensureBlended(device, this.depthWidth, this.depthHeight)) {
+			return false;
+		}
+
+		GpuBufferSlice block = OCCLUSION.write(device, pair);
+
+		// Neither attachment is cleared, and neither needs to be: the draw covers both whole, the
+		// depth test being ALWAYS and the colour written on every texel.
+		try (RenderPass pass = device.createCommandEncoder().createRenderPass(
+				() -> SEED_LABEL, this.worldCarried.view(), Optional.empty(), this.blendedView,
+				java.util.OptionalDouble.empty())) {
+			pass.setPipeline(compiled);
+			RenderSystem.bindDefaultUniforms(pass);
+			pass.setVertexBuffer(0, quad.slice());
+			pass.setUniform(SEED_BLOCK, block);
+			// NEAREST on both, and it is what makes this a rewrite of the value rather than of the
+			// image: one destination texel covers one source texel in each.
+			pass.bindTexture(SEED_WORLD, world,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+			pass.bindTexture(SEED_FAR, this.depthView,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+			pass.draw(SEED_VERTICES, 1, 0, 0);
+		}
+
+		return true;
 	}
 
 	/**
@@ -523,8 +780,25 @@ public final class DistantDraw {
 					+ "Horizons' own shader steadily rather than as a flicker");
 		}
 
-		RenderPassDescriptor descriptor = program.descriptor(main.getColorTextureView(),
-				this.depthView);
+		// The world's depth goes under this half here and not one stage earlier, which is what
+		// makes the player's own body stand in front of the water rather than only his cape:
+		// seedWater says why. Once a frame, and only for the half that needs it.
+		if (element.afterDeferred() && !this.seeded) {
+			seedWater(device, main);
+		}
+
+		// The water half rasterises against the seeded image where there is one, and that is the
+		// whole of the occlusion: the depth test does the rest. Everything else, the opaque half
+		// and both halves of the light, keeps the pure image, which is what the two takes read.
+		//
+		// The flag is the whole of the question and no size is compared beside it, which is only
+		// true since the seed moved into this method: it and ensureDepth now run in the same call,
+		// so the pair cannot be left at a size the far terrain's own image has moved off.
+		GpuTextureView into = element.afterDeferred() && this.seeded
+				? this.blendedView
+				: this.depthView;
+
+		RenderPassDescriptor descriptor = program.descriptor(main.getColorTextureView(), into);
 		if (descriptor == null && !program.plain()) {
 			return refuse(element, "unallocated:" + element.element(), "one of the pack's colour "
 					+ "targets had no image yet on some frame, so the pass this half wanted could not "
@@ -556,7 +830,7 @@ public final class DistantDraw {
 
 		try (RenderPass pass = descriptor == null
 				? encoder.createRenderPass(() -> "Vitrail " + element.element(),
-						main.getColorTextureView(), Optional.empty(), this.depthView,
+						main.getColorTextureView(), Optional.empty(), into,
 						java.util.OptionalDouble.empty())
 				: GeometryHold.open(encoder, descriptor)) {
 			pass.setPipeline(pipeline);
@@ -630,6 +904,95 @@ public final class DistantDraw {
 		device.createCommandEncoder().clearDepthTexture(this.depth, 0.0);
 
 		return true;
+	}
+
+	/**
+	 * Makes the water half's own pair of images exist, or remakes them after a resize. Called only
+	 * from the seed, so a session whose pack draws no far terrain never pays for them.
+	 *
+	 * @return whether there is anywhere to seed into
+	 */
+	private boolean ensureBlended(GpuDevice device, int width, int height) {
+		if (this.blended != null && this.blendedWidth == width && this.blendedHeight == height) {
+			return true;
+		}
+
+		releaseBlended();
+		this.blendedWidth = width;
+		this.blendedHeight = height;
+		if (width <= 0 || height <= 0) {
+			return false;
+		}
+
+		// Two usages here and three on the pure image beside it: this one is drawn into and read by
+		// the take that follows the water half, and never cleared, the seed covering it whole.
+		this.blended = device.createTexture(() -> "Vitrail far terrain depth with the world",
+				GpuTexture.USAGE_RENDER_ATTACHMENT | GpuTexture.USAGE_TEXTURE_BINDING,
+				DEPTH_FORMAT, width, height, 1, 1);
+		this.blendedView = device.createTextureView(this.blended);
+		this.worldCarried = new TargetSurface("Vitrail world depth in the far terrain's volume",
+				CARRIED_FORMAT, false, width, height);
+
+		// Said out loud rather than left to be discovered, like every other pair this engine
+		// allocates: this is the cost of the far terrain's water standing behind the world, and of
+		// nothing else.
+		Vitrail.logger().info("The world's depth is carried into the far terrain's volume in two "
+				+ "images at {}x{}, {} MiB", width, height,
+				(2L * this.worldCarried.bytes()) / (1024L * 1024L));
+
+		return true;
+	}
+
+	/**
+	 * The seeding pipeline, compiled the first time it is asked for and kept.
+	 * <p>
+	 * Asked of the device every frame rather than trusted to a flag, like every other pipeline of
+	 * this engine: the compiled form lives in a cache the game empties at each resource reload, and
+	 * the call is a {@code computeIfAbsent} that costs nothing once it has been made.
+	 */
+	private RenderPipeline seedPipeline(GpuDevice device) {
+		if (this.seedPipeline == null) {
+			this.seedPipeline = buildSeed();
+		}
+
+		if (device.precompilePipeline(this.seedPipeline, SEED_SOURCE).isValid()) {
+			return this.seedPipeline;
+		}
+
+		// Handed back and not merely refused: this road is reached after frames have drawn, the
+		// compile being asked again at every resource reload, so the two images would otherwise
+		// stay resident for the rest of the pack with nothing left to write them.
+		this.seedBroken = true;
+		this.seedPipeline = null;
+		releaseBlended();
+		Vitrail.logger().error("The far terrain's occlusion pass did not compile, so its water paints "
+				+ "over whatever the game drew between the two halves of the far terrain");
+
+		return null;
+	}
+
+	private static RenderPipeline buildSeed() {
+		return RenderPipeline.builder()
+				.withLocation(
+						Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pipeline/distant_occlusion"))
+				.withVertexShader(SEED_VERTEX_ID)
+				.withFragmentShader(SEED_FRAGMENT_ID)
+				.withBindGroupLayout(BindGroupLayouts.GLOBALS)
+				.withBindGroupLayout(BindGroupLayout.builder()
+						.withUniform(SEED_BLOCK, UniformType.UNIFORM_BUFFER)
+						.withSampler(SEED_WORLD)
+						.withSampler(SEED_FAR)
+						.build())
+				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
+				.withColorTargetState(new ColorTargetState(Optional.empty(), CARRIED_FORMAT,
+						ColorTargetState.WRITE_ALL))
+				// ALWAYS and not the reversed test every other pass of this engine carries: what is
+				// written is already the nearer of the two, worked out in the shader, and a test
+				// against what the image held would keep the frame before it instead.
+				.withDepthStencilState(new DepthStencilState(CompareOp.ALWAYS_PASS, true))
+				.withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
+				.withCull(false)
+				.build();
 	}
 
 	/**
@@ -841,12 +1204,17 @@ public final class DistantDraw {
 	 */
 	void rotate() {
 		this.drew = false;
+		// Dropped here and not where the seed is written, for the reason every per frame flag of
+		// this class is dropped here: a frame that draws no far terrain would otherwise hand the
+		// take an image seeded a frame ago, against a camera that has moved.
+		this.seeded = false;
 		this.shadowOpaque = this.opaqueSections;
 		this.shadowWater = this.waterSections;
 		this.opaqueSections = List.of();
 		this.waterSections = List.of();
 		CORNERS.rotate();
 		SHADOW_CORNERS.rotate();
+		OCCLUSION.rotate();
 		if (this.read) {
 			this.programs.values().forEach(DistantProgram::rotate);
 		}
@@ -871,6 +1239,9 @@ public final class DistantDraw {
 		CORNERS.forget();
 		SHADOW_CORNERS.forget();
 
+		this.seedBroken = false;
+		this.seedPipeline = null;
+		releaseBlended();
 		releaseDepth();
 	}
 
@@ -883,6 +1254,26 @@ public final class DistantDraw {
 	static void close() {
 		CORNERS.close();
 		SHADOW_CORNERS.close();
+		OCCLUSION.close();
+	}
+
+	private void releaseBlended() {
+		if (this.blendedView != null) {
+			this.blendedView.close();
+			this.blendedView = null;
+		}
+
+		if (this.blended != null) {
+			this.blended.close();
+			this.blended = null;
+		}
+
+		if (this.worldCarried != null) {
+			this.worldCarried.close();
+			this.worldCarried = null;
+		}
+
+		this.seeded = false;
 	}
 
 	private void releaseDepth() {
@@ -1038,6 +1429,56 @@ public final class DistantDraw {
 		}
 
 		/** Frees the ring itself, which only {@link DistantDraw#close()} may ask for. */
+		void close() {
+			if (this.buffer != null) {
+				this.buffer.close();
+				this.buffer = null;
+			}
+		}
+	}
+
+	/**
+	 * The one slot a frame the seeding pass reads its pair out of.
+	 * <p>
+	 * A ring and not one buffer, for the reason every other per frame block of this engine is one:
+	 * the backend keeps two submissions in flight, and a buffer written again while a frame that
+	 * has not finished is still reading it is two frames of camera at once. It turns where
+	 * {@link DistantDraw#rotate} turns, and it is never closed on a pack load: see {@link Corners}.
+	 */
+	private static final class Occlusion {
+
+		private MappableRingBuffer buffer;
+
+		/**
+		 * Writes this frame's pair and hands back the slice the pass binds. Never null: an
+		 * allocation that fails throws out of the ring's own constructor, and the caller's own
+		 * catch is what covers it.
+		 */
+		GpuBufferSlice write(GpuDevice device, Vector2f pair) {
+			if (this.buffer == null) {
+				this.buffer = new MappableRingBuffer(() -> SEED_LABEL,
+						GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, slotBytes(device));
+			}
+
+			try (GpuBufferSlice.MappedView view = this.buffer.currentBuffer().map(false, true)) {
+				Std140Builder.intoBuffer(view.data()).putVec2(pair.x, pair.y);
+			}
+
+			return this.buffer.currentBuffer().slice(0, SEED_BLOCK_BYTES);
+		}
+
+		/** How wide one slot has to be, which is the device's answer and not a number of ours. */
+		private static int slotBytes(GpuDevice device) {
+			return Mth.roundToward(SEED_BLOCK_BYTES,
+					device.getDeviceInfo().limits().minUniformOffsetAlignment());
+		}
+
+		void rotate() {
+			if (this.buffer != null) {
+				this.buffer.rotate();
+			}
+		}
+
 		void close() {
 			if (this.buffer != null) {
 				this.buffer.close();

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -1761,6 +1761,11 @@ public final class FrameState implements WorldState {
 	}
 
 	@Override
+	public boolean distantDepthPair(Vector2f dest) {
+		return this.view.distantDepthPair(dest);
+	}
+
+	@Override
 	public Matrix4fc dhProjection() {
 		return this.view.dhProjection();
 	}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2312,7 +2312,8 @@ public final class PackChain {
 		GpuTextureView distantServed = this.distant.served();
 		if (distantServed != null) {
 			this.targets.depth().takeDistantScene(device.createCommandEncoder(), device, this.quad,
-					distantServed, distantServed.getWidth(0), distantServed.getHeight(0));
+					this.distant.blendedServed(), this.distant.worldServed(), distantServed,
+					distantServed.getWidth(0), distantServed.getHeight(0));
 		}
 
 		drawRange(device, ready, deferredEnd(), this.programs.size(), this.targets.depth().scene(),
@@ -2626,12 +2627,13 @@ public final class PackChain {
 	/**
 	 * The quad every full screen pass of this engine draws, made the first time anything asks for it.
 	 * <p>
-	 * Its own method rather than a line of {@link #prepare}, because the two depths a pack is served
-	 * are copied with it from entry points that never go through prepare at all:
-	 * {@link #markPreHandDepth} and {@link #markSceneDepth} answer events of their own, and a frame
-	 * reaches either of them whether or not the chain drew. Each asks here and gets the one buffer.
+	 * Its own method rather than a line of {@link #prepare}, because what needs it is reached from
+	 * entry points that never go through prepare at all: {@link #markPreHandDepth} and
+	 * {@link #markSceneDepth} answer events of their own, and a frame reaches either of them whether
+	 * or not the chain drew. {@code DistantDraw} is the third, asking from inside the far terrain's
+	 * own draw. Each asks here and gets the one buffer.
 	 */
-	private GpuBuffer quad(GpuDevice device) {
+	GpuBuffer quad(GpuDevice device) {
 		if (this.quad == null) {
 			ByteBuffer vertices = ByteBuffer.allocateDirect(QUAD.length * Float.BYTES)
 					.order(ByteOrder.nativeOrder());

--- a/common/src/main/java/dev/vitrail/render/PackDepth.java
+++ b/common/src/main/java/dev/vitrail/render/PackDepth.java
@@ -92,8 +92,15 @@ final class PackDepth {
 			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/depth_window_vertex");
 	private static final Identifier FRAGMENT_ID =
 			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/depth_window_fragment");
+	private static final Identifier DISTANT_FRAGMENT_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/distant_window_fragment");
 
 	private static final String SAMPLER = "InSampler";
+
+	/** The three the take that follows the far terrain's water half reads; see its own fragment. */
+	private static final String BLENDED = "InBlended";
+	private static final String CARRIED = "InCarried";
+	private static final String PURE = "InPure";
 
 	/** Two triangles, the quad every full screen pass of this engine draws. */
 	private static final int VERTICES = 6;
@@ -102,6 +109,9 @@ final class PackDepth {
 	private static final GpuFormat FORMAT = GpuFormat.R32_FLOAT;
 
 	private static final String LABEL = "Vitrail depth window";
+
+	/** Its own, and not the one above: the frame's pass census names a pass by its label. */
+	private static final String DISTANT_LABEL = "Vitrail far terrain depth window";
 
 	private static final String VERTEX = """
 			#version 460 core
@@ -137,8 +147,52 @@ final class PackDepth {
 			}
 			""", ClipSpace.REVERSED.z, ClipSpace.REVERSED.w);
 
+	/**
+	 * The same conversion, out of three images instead of one, for the take that follows the far
+	 * terrain's water half.
+	 * <p>
+	 * <strong>What the three are for is keeping {@code dhDepthTex0} the far terrain and nothing
+	 * else.</strong> The water half is rasterised against an image the world's own depth was seeded
+	 * into, so that it stands behind the player; that image therefore holds the world wherever the
+	 * world won, and handing it to a pack would say there is far terrain in front of every wall.
+	 * The seed was kept as it was written, so a texel still carrying it is a texel the world won
+	 * and the answer there is the pure image, which holds the far terrain hidden behind the world
+	 * or nothing at all. Everywhere else the blended image is the far terrain's own, water
+	 * included.
+	 * <p>
+	 * What is lost, and it is worth naming: far WATER hidden behind the near world answers with the
+	 * far terrain behind it rather than with the water, its own depth having been thrown away by
+	 * the very test that keeps it off the player. It is a texel where nothing of the far terrain is
+	 * visible, and the answer given there is a surface that is really there rather than one that is
+	 * not.
+	 */
+	private static final String DISTANT_FRAGMENT = String.format(Locale.ROOT, """
+			#version 460 core
+
+			uniform sampler2D InBlended;
+			uniform sampler2D InCarried;
+			uniform sampler2D InPure;
+
+			in vec2 ofTexCoord;
+
+			layout(location = 0) out vec4 ofFragData0;
+
+			void main() {
+				float blended = texture(InBlended, ofTexCoord).r;
+				float far = blended > texture(InCarried, ofTexCoord).r
+						? blended
+						: texture(InPure, ofTexCoord).r;
+
+				ofFragData0 = vec4(%s * far + %s);
+			}
+			""", ClipSpace.REVERSED.z, ClipSpace.REVERSED.w);
+
 	private static final ShaderSource SOURCE = (id, type) -> {
 		if (type == ShaderType.FRAGMENT) {
+			if (DISTANT_FRAGMENT_ID.equals(id)) {
+				return DISTANT_FRAGMENT;
+			}
+
 			return FRAGMENT_ID.equals(id) ? FRAGMENT : null;
 		}
 
@@ -149,6 +203,14 @@ final class PackDepth {
 
 	/** Said once and not per frame, so that a driver that will not have this shader is readable. */
 	private boolean refused;
+
+	/**
+	 * The same pair for the three image take, latched apart: a driver that refuses that one still
+	 * has the one above, and what falls back is the far terrain's water and not every depth a pack
+	 * reads.
+	 */
+	private RenderPipeline distantPipeline;
+	private boolean distantRefused;
 
 	private TargetSurface opaque;
 	private TargetSurface scene;
@@ -301,8 +363,19 @@ final class PackDepth {
 	 * render pass, and only on the frames the pack really drew the far terrain, like the take above.
 	 */
 	boolean takeDistantScene(CommandEncoder encoder, GpuDevice device, GpuBuffer quad,
-			GpuTextureView distant, int width, int height) {
-		if (!ensureDistant(width, height) || !fill(encoder, device, quad, distant, this.distantScene)) {
+			GpuTextureView blended, GpuTextureView carried, GpuTextureView pure, int width,
+			int height) {
+		if (!ensureDistant(width, height)) {
+			return false;
+		}
+
+		// One image where the frame seeded nothing under the water half, and then the pure image
+		// carries that water itself and is the whole answer; three where it did, and then the water
+		// is in the blended one and the pure one is what the world is told back out with.
+		boolean filled = (blended == null || carried == null)
+				? fill(encoder, device, quad, pure, this.distantScene)
+				: fillDistant(encoder, device, quad, blended, carried, pure);
+		if (!filled) {
 			return false;
 		}
 
@@ -351,6 +424,21 @@ final class PackDepth {
 	 */
 	GpuTextureView preHand() {
 		return this.preHandWritten ? this.preHand.view() : null;
+	}
+
+	/**
+	 * Whether the three image conversion has given up for this load, which is what stops the far
+	 * terrain's water being seeded at all.
+	 * <p>
+	 * <strong>The two refusals have to recover in the same direction, and that is the whole of why
+	 * this is asked.</strong> {@code DistantDraw} handing its own seed back sends the water half
+	 * into the pure image, so {@code dhDepthTex0} is whole again and only the occlusion is lost.
+	 * This one on its own would leave the seed running and the water landing in an image nothing
+	 * reads, and then that name would answer the far terrain with no water at all, on every texel
+	 * rather than on the few the design gives up.
+	 */
+	boolean distantRefused() {
+		return this.distantRefused;
 	}
 
 	/**
@@ -635,6 +723,61 @@ final class PackDepth {
 	}
 
 	/**
+	 * Draws the far terrain's scene image out of the three the seeded water half leaves behind.
+	 * Falls back on the pure image alone where the three image pipeline will not compile, which
+	 * costs the water rather than the whole name.
+	 */
+	private boolean fillDistant(CommandEncoder encoder, GpuDevice device, GpuBuffer quad,
+			GpuTextureView blended, GpuTextureView carried, GpuTextureView pure) {
+		if (quad == null || this.distantScene == null) {
+			return false;
+		}
+
+		RenderPipeline compiled = distantPipeline(device);
+		if (compiled == null) {
+			return fill(encoder, device, quad, pure, this.distantScene);
+		}
+
+		try (RenderPass pass = encoder.createRenderPass(() -> DISTANT_LABEL,
+				this.distantScene.view(), Optional.empty())) {
+			pass.setPipeline(compiled);
+			RenderSystem.bindDefaultUniforms(pass);
+			pass.setVertexBuffer(0, quad.slice());
+			pass.bindTexture(BLENDED, blended,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+			pass.bindTexture(CARRIED, carried,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+			pass.bindTexture(PURE, pure,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+			pass.draw(VERTICES, 1, 0, 0);
+		}
+
+		return true;
+	}
+
+	/** The three image pipeline, on the same terms as the one below. */
+	private RenderPipeline distantPipeline(GpuDevice device) {
+		if (this.distantRefused) {
+			return null;
+		}
+
+		if (this.distantPipeline == null) {
+			this.distantPipeline = buildDistant();
+		}
+
+		if (device.precompilePipeline(this.distantPipeline, SOURCE).isValid()) {
+			return this.distantPipeline;
+		}
+
+		this.distantRefused = true;
+		this.distantPipeline = null;
+		Vitrail.logger().error("The far terrain's depth conversion did not compile, so dhDepthTex0 "
+				+ "answers the far terrain without its water rather than a depth carrying the world");
+
+		return null;
+	}
+
+	/**
 	 * The pipeline, compiled the first time it is asked for and kept.
 	 * <p>
 	 * The compiled form lives in the device cache, which the game empties at every resource reload,
@@ -660,6 +803,26 @@ final class PackDepth {
 				+ "pack reads the far plane rather than a depth in the wrong direction");
 
 		return null;
+	}
+
+	private static RenderPipeline buildDistant() {
+		return RenderPipeline.builder()
+				.withLocation(
+						Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pipeline/distant_window"))
+				.withVertexShader(VERTEX_ID)
+				.withFragmentShader(DISTANT_FRAGMENT_ID)
+				.withBindGroupLayout(BindGroupLayouts.GLOBALS)
+				.withBindGroupLayout(BindGroupLayout.builder()
+						.withSampler(BLENDED)
+						.withSampler(CARRIED)
+						.withSampler(PURE)
+						.build())
+				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
+				.withColorTargetState(new ColorTargetState(Optional.empty(), FORMAT,
+						ColorTargetState.WRITE_ALL))
+				.withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
+				.withCull(false)
+				.build();
 	}
 
 	private static RenderPipeline build() {

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -5,6 +5,7 @@ import dev.vitrail.uniform.ViewSource;
 
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
+import org.joml.Vector2f;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.joml.Vector4f;
@@ -165,6 +166,15 @@ public final class ViewMatrices implements ViewSource {
 	private boolean distantSeeded;
 
 	/**
+	 * Whether the volume above is really Distant Horizons' this frame, rather than the frame's own
+	 * standing in for it. Kept apart from {@link #distantSeeded}, which is about there having been a
+	 * frame before rather than about there being a row now: this one falls back to false the moment
+	 * that mod stops drawing, and {@link #distantDepthPair} is the one answer that must not be given
+	 * out of two volumes that are the same one.
+	 */
+	private boolean distantVolume;
+
+	/**
 	 * What Distant Horizons drew this frame with, or nothing when it drew nothing. See
 	 * {@link #advanceDistant} for why the three move together.
 	 */
@@ -309,7 +319,8 @@ public final class ViewMatrices implements ViewSource {
 		// which is every session without Distant Horizons. On the frames with a row the two bases
 		// agree, the row being replaced either way.
 		this.distantProjection.set(this.rendered);
-		if (offset != 0.0F) {
+		this.distantVolume = offset != 0.0F;
+		if (this.distantVolume) {
 			// Row z, column z and column w, in JOML's column first spelling: what DH calls m22 and
 			// m23 are m22 and m32 here, and the two conventions number the pair the other way round.
 			this.distantProjection.m22(scale);
@@ -666,6 +677,18 @@ public final class ViewMatrices implements ViewSource {
 	@Override
 	public Matrix4fc drawnDistantProjection() {
 		return this.distantProjection;
+	}
+
+	/**
+	 * Read off the RENDERED matrix and the row spliced into it, which are the two the images were
+	 * really written with. The published pair is no use here: it has been through
+	 * {@link ClipSpace#toLegacyDepth} and describes the window a pack reads, where both of the
+	 * images this pair stands between are the device's own.
+	 */
+	@Override
+	public boolean distantDepthPair(Vector2f dest) {
+		return this.distantVolume && ClipSpace.distantDepth(this.rendered,
+				this.distantProjection.m22(), this.distantProjection.m32(), dest);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/uniform/ClipSpace.java
+++ b/common/src/main/java/dev/vitrail/uniform/ClipSpace.java
@@ -2,6 +2,7 @@ package dev.vitrail.uniform;
 
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
+import org.joml.Vector2f;
 import org.joml.Vector4f;
 
 /**
@@ -63,5 +64,73 @@ public final class ClipSpace {
 		dest.m32(m32);
 
 		return dest;
+	}
+
+	/**
+	 * The pair that turns a depth the game rasterised into the same point's depth in the volume
+	 * Distant Horizons rasterises its far terrain in: {@code far = pair.x * world + pair.y}.
+	 * <p>
+	 * <strong>Why a pair and not a matrix.</strong> The two volumes share every row but one.
+	 * {@code RenderUtil.setDhProjectionMatrix} overwrites the z row of the game's own matrix with
+	 * clip planes of its own and touches nothing else, and {@code render/ViewMatrices} splices that
+	 * row into the frame's matrix the same way. So the two projections have the same w row, and the
+	 * clip w a vertex comes out with is the same number under both. Write the eye distance the game
+	 * measures as {@code t}: the game's depth is {@code -m22 + m32 / t}, the far terrain's is
+	 * {@code -scale + offset / t}, and eliminating {@code t} between the two leaves an affine map in
+	 * the depth alone. There is nothing to approximate and no matrix to invert.
+	 * <p>
+	 * <strong>It holds under the walk bob, which is the half that is easy to get wrong.</strong>
+	 * The bob, the damage tilt, the nausea and the portal are all applied to the RIGHT of the
+	 * projection, so they multiply the two IMAGES this pair stands between identically and cancel
+	 * out of the ratio: what plays the part of {@code t} above stops being the eye distance and
+	 * becomes the bobbed one, the same number for both. The pair is therefore exact for a walking
+	 * player and not merely close, which a derivation written on a still camera would never have
+	 * said.
+	 * <p>
+	 * That is not the claim {@code render/ViewMatrices.advanceDistantVolume} makes, and the two only
+	 * look as though they disagree. That one compares the volume this engine rasterises the far
+	 * terrain in against the volume this mod would have rasterised it in, and those two really do
+	 * part under the bob, because this mod overwrites the row of a matrix the bob has already been
+	 * multiplied into. This one compares the two images that exist.
+	 * <p>
+	 * <strong>The premise is asked of the matrix rather than assumed of it.</strong> Four entries
+	 * carry it: the z row has to be nought outside its own two terms, so that the depth is a
+	 * function of the eye distance alone, and the w row has to be the perspective's, so that the
+	 * clip w is the same number under both. They hold on every frame the engine splits the bob out
+	 * of the projection, which is the ordinary one. They do NOT hold on a frame it could not, where
+	 * {@code render/CapturedProjection} hands back the composed matrix and the bob's own terms sit
+	 * in that row: this answers false there, and the far terrain's water goes back to being drawn
+	 * against the far terrain alone, which is where it stood before any of this.
+	 * <p>
+	 * <strong>Two things the caller owes, and neither is optional.</strong> A game depth of nought
+	 * is the clear value of a reversed Z and means nothing was drawn there, so it has to be left
+	 * alone rather than converted: it stands for the game's own far plane, which is far nearer than
+	 * this mod's, and converting it would put a lid over every LOD past the game's render distance.
+	 * And the result has to be clamped, because everything closer than this mod's near plane
+	 * converts to more than one, and that plane is at most seven and a half blocks out:
+	 * {@code core/util/RenderUtil.setDhProjectionMatrix} caps it there with a {@code Math.min}, and
+	 * only while this mod is not overriding the near plane on the player's height.
+	 *
+	 * @param rendered the frame's own projection as the device took it, reversed Z over zero to one
+	 * @param scale    the z term of the row this mod drew with, {@code dh/DhDepth} reads it
+	 * @param offset   the w term of that row, nought while this mod has drawn no frame
+	 * @param dest     filled with the multiply and then the add, and left alone when this answers
+	 *                 false
+	 * @return false when there is no conversion to be had: this mod having no volume yet, a
+	 *         projection with no perspective in it, or a frame whose projection carries terms the
+	 *         derivation above has no place for
+	 */
+	public static boolean distantDepth(Matrix4fc rendered, float scale, float offset,
+			Vector2f dest) {
+		float worldOffset = rendered.m32();
+		if (offset == 0.0F || worldOffset == 0.0F || rendered.m02() != 0.0F
+				|| rendered.m12() != 0.0F || rendered.m23() != -1.0F || rendered.m33() != 0.0F) {
+			return false;
+		}
+
+		float multiply = offset / worldOffset;
+		dest.set(multiply, rendered.m22() * multiply - scale);
+
+		return true;
 	}
 }

--- a/common/src/main/java/dev/vitrail/uniform/ViewSource.java
+++ b/common/src/main/java/dev/vitrail/uniform/ViewSource.java
@@ -1,6 +1,7 @@
 package dev.vitrail.uniform;
 
 import org.joml.Matrix4fc;
+import org.joml.Vector2f;
 import org.joml.Vector4fc;
 
 /**
@@ -148,6 +149,17 @@ public interface ViewSource {
 	 * this stands to {@code dhProjection}.
 	 */
 	Matrix4fc drawnDistantProjection();
+
+	/**
+	 * The multiply and the add that carry a depth the game rasterised into the volume above, in the
+	 * convention the device rasterises in at both ends. False while the two volumes are the same
+	 * one, which is every frame Distant Horizons has drawn nothing on.
+	 * <p>
+	 * Not published to a pack and not meant to be: this is the one value of this interface that
+	 * belongs to a pass of the engine rather than to a name a pack reads.
+	 * {@link ClipSpace#distantDepth} derives it and the off-game harness proves it.
+	 */
+	boolean distantDepthPair(Vector2f dest);
 
 	Matrix4fc dhPreviousProjection();
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -400,6 +400,15 @@ list of its far terrain for the light, so a hill behind the camera lays a shadow
 front of it there and does not here: the mod hands its geometry over once a frame, on its own pass,
 and there is no second list to ask for.
 
+**Its far water stands behind the world**, which is worth saying because it takes an extra image
+to be true. That mod draws its water half after the entities, the block entities and the hand,
+against a depth image holding the far terrain and nothing else, so left alone it paints over all
+three and over the player in third person. Vitrail carries the world's own depth into that mod's
+volume before the water is drawn and lets the depth test hold it back. What a pack reads under the
+`dhDepthTex` names is untouched by that and is still the far terrain alone, with one thing given
+up: where the near world hides far water outright, that name answers with the far terrain behind
+the water rather than with the water, on a texel where neither is visible.
+
 One limit stays whatever the log says: past Distant Horizons' own far plane there is nothing drawn,
 and the picture there is the pack's sky, exactly as without the mod.
 


### PR DESCRIPTION
## What changes

Distant Horizons' far water stops painting over everything the game drew before it. Its two
halves are drawn at two different points of the frame, the opaque one from the head of the
game's opaque chunk group and the water one from the head of the translucent group, and the
water half was rasterised against a depth image holding the far terrain alone. Nothing held it
back, so in third person a distant sea washed the character out or removed him outright, and
the part of him it covered followed the part of far water behind him. Mobs on the ground,
particles and the hand were covered the same way. The world's own depth is now carried into
that mod's volume and seeded under the water half, so the water is hidden by whatever stands in
front of it.

It is seeded from the water half's own draw and not one frame stage earlier, and that is not a
detail: a player's skin is drawn with an entityTranslucent render type, because a skin may carry
a transparent outer layer, so the body arrives after the game's opaque features while the cape,
which is solid, arrives before them. Seeded at the earlier point, only the cape stood in front
of the water.

The carry is one multiply and one add, `ClipSpace.distantDepth`. The two projections share every
row but the z one, so eliminating the eye distance between them leaves an affine map in the depth
alone, exact rather than approximate, and exact under the walk bob as well since the bob
multiplies both matrices on the right. The premise is asked of the matrix rather than assumed of
it, and a frame whose projection cannot be split goes without the occlusion instead.

What a pack reads under `dhDepthTex0` and `dhDepthTex1` is untouched. The seeded image is a
second one, used only as the water half's depth attachment, and the take that follows the water
subtracts the world back out of it by comparing against the seed kept beside it.

## How it differs from the reference, and for what obstacle

It diverges, deliberately, and this is the whole of it.

- What Iris does: it binds that mod's own depth to its water target,
  `compat/dh/DHCompatInternal.java:161-176`, it turns on that mod's deferred transparency so the
  water half lands after the entities, `compat/dh/LodRendererEvents.java` in the before-render
  event, and it cancels that mod's own apply step outright as soon as a pack is loaded,
  `setupBeforeApplyShaderEvent` in the same file. That apply step compares nothing in any case:
  its pipeline carries `withDepthTest(NONE)`, `withDepthWrite(false)` and a dummy depth image,
  `common/render/blaze/apply/BlazeDhApplyRenderer.java`.
- What is done here instead: `render/DistantDraw.seedWater` puts the world's depth under the
  water half before it is drawn, so the depth test holds it back.
- What it costs the image: far water hidden behind the near world no longer contributes its own
  depth to `dhDepthTex0` there, and that texel answers with the far terrain behind it instead. It
  is a texel where nothing of the far terrain is visible either way.

The reference build was run on the same pack and looked at in third person: the player's body is
transparent there and his cape is not, which is the same signature. It was a flat test world with
no far water in it, so it confirms the shape of the defect on that side without isolating its
cause; the three source facts above are what the divergence rests on.

## What proves it

- `gradlew build` green, and `-PlintReport` adds no warning in the files this touches.
- The off-game harness. The carry has a section of its own in `Bloc`, a hundred pairs of volumes
  against both matrices done out in full, off-axis points, and four states of the walk bob. Two
  figures come out of it that are the reason the pass has a branch and a clamp: the game's own far
  plane carries to a depth well inside that mod's volume, so a cleared texel taken for a depth
  would cap every LOD at the game's render distance, and everything nearer than that mod's near
  plane carries past one. Five wrong forms, the missing premise guard among them, are held against
  the same hundred pairs and have to fail.
- `FarTerrain`, `Chaine`, `Cibles` and `Uniformes` over the eight pack corpus, unchanged against
  the same tools built from `dev`.
- In the game, on Bliss v2.1.2, a coastal world at a short render distance with that mod switched
  on at both of its switches, third person with far water behind: the character is opaque over his
  whole height, where before the fix the parts of him with far water behind were see-through. The
  engine says on its own line that the world's depth is carried into that mod's volume, and no
  refusal follows it.

## What it leaves owing

- The far terrain's own per frame state is dropped in `PackChain.closeFrame` only once six
  families have been read, so during the first frames of a pack load a frame can seed and never
  be rotated. It costs one frame of a stale occlusion, and it is the same window the far depth
  image's own per frame clear already sits in.
- Nothing else. The opaque half, the shadow halves and the two takes are untouched.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
