### PR TITLE
docs: say that the pack's compute and storage images run

### DIFF
--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -652,7 +652,7 @@ public final class TargetPlan {
 					.filter(name -> !ProgramNames.shadowComposite(ProgramNames.familyOf(name)))
 					.toList();
 			if (!shadow.isEmpty()) {
-				notes.add("shadow compute after the shadow map: " + shadow);
+				notes.add("shadow compute served: " + shadow);
 			}
 
 			if (!other.isEmpty()) {

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1441,8 +1441,14 @@ public final class PackChain {
 	}
 
 	/**
-	 * Dispatches {@code shadowcomp} after the shadow geometry, as Iris does at
-	 * {@code ShadowRenderer.java:631}.
+	 * Dispatches {@code shadowcomp} at the head of the frame, over the shadow geometry the frame
+	 * before it wrote.
+	 * <p>
+	 * Iris dispatches it inside its own shadow render ({@code ShadowRenderer.java:631-632}), which is
+	 * the same moment relative to the READERS: there the map is drawn and read within one frame,
+	 * here the shadow stage stands at the end of a frame and the map is one frame late, so the
+	 * moment that shares the frame of the gbuffers reading the volumes is this one. The caller in
+	 * {@code EngineStages} carries what putting it beside the shadow map instead would cost.
 	 */
 	public static void dispatchShadowCompute() {
 		PackChain chain = active;
@@ -1754,9 +1760,10 @@ public final class PackChain {
 			build(device);
 		}
 
-		// Pipelines compile before anything of the chain is drawn. The loading overlay is what the
-		// player sees for those frames, and drawable() keeps the terrain aside or the world would
-		// be drawn into a colour target this has no final ready to bring back.
+		// Pipelines compile before anything of the chain is drawn. The world is not drawn at all for
+		// those frames and the HUD is what the player sees, with a line above it saying the pack is
+		// still compiling; drawable() keeps the terrain aside or the world would be drawn into a
+		// colour target this has no final ready to bring back.
 		//
 		// The targets and the buffers first and the compilation second, which is not the order this
 		// had. What the warm up holds back is the drawing and not the frame, so the block ring and

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -68,9 +68,10 @@ import java.util.Set;
  * <p>
  * Complementary's floodfill lives in {@code shadowcomp.csh}. The Java facade has no compute, so
  * the pipeline is built the way the storage probe was: shaderc kind 2, a VMA storage image,
- * push descriptors. Iris runs it inside its shadow render ({@code ShadowRenderer.java:631},
- * {@code compositeRenderer.renderAll()}), before its gbuffers in the SAME frame; under this
- * engine's deferred shadow stage, the head of the frame is that moment's translation.
+ * push descriptors. Iris runs it inside its shadow render ({@code ShadowRenderer.java:631-632},
+ * the debug group and the {@code compositeRenderer.renderAll()} under it), before its gbuffers in
+ * the SAME frame. Under this engine's deferred shadow stage, the head of the frame is that
+ * moment's translation.
  *
  * @see <a href="https://github.com/IrisShaders/Iris">Iris ComputeProgram, LGPL-3.0</a>
  */

--- a/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
@@ -49,9 +49,9 @@ import java.util.stream.Stream;
  * <p>
  * <b>Two views and one screen</b>: the list of packs in the folder, {@link PackList}, and the pages of
  * the pack being configured, {@link OptionList}. The switch between them sits above the bottom row, and
- * it applies on the way through, which is Iris's own note and not a detail: picking a pack in the list
- * without applying and then opening the settings would otherwise open the settings of the pack before
- * it.
+ * it READS the pack whose settings are asked for rather than applying it. That is where this parts
+ * from Iris, which applies at that point for a reason that holds and at a price that does not, and
+ * {@link #switchView} carries the whole of it.
  * <p>
  * <b>Three buttons on the bottom row, and leaving applies.</b> Cancel drops what was clicked and
  * leaves, Apply writes and reloads without leaving, Done applies and leaves. That last one is Iris's

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,9 +59,11 @@ That choice has consequences worth knowing about, because they explain most of w
 observe:
 
 - **The cost is paid at load, not per frame.** Some of it lands at selection and the rest in the
-  frames just after, because pipelines are compiled one per frame on purpose rather than all at
-  once. Until the last one is ready the chain draws nothing at all and the game's own image is what
-  you see, which is also what happens for a moment after every resource reload.
+  frames just after, because pipelines are compiled on a budget of the frame rather than all at
+  once. Until the composites and the terrain are ready the chain draws nothing, and neither does the
+  world: the HUD stays up and a line above it says the pack is still compiling. The leftover
+  families compile on their first draw. The same wait comes back for a moment after every resource
+  reload.
 - **A pack that cannot be translated fails loudly**, not as a corrupt image twenty minutes later.
   When Vitrail refuses something, the log names it.
 - **Uniform and sampler binding is decided up front**, so a pack that asks for something the

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -48,18 +48,17 @@ words at the moment it happened.
 
 The engine refuses a pack rather than drawing something wrong with it, and it names the reason.
 
-**A pack can be refused for using a graphics feature this backend does not have.** Compute shaders,
-shader storage buffers, storage images, and one- or three-dimensional samplers are closed by the
-game's own compiler, not by missing effort here. A pack built around voxel lighting or GPU-side
-data structures will hit this. The Vulkan device can already run a compute dispatch and write a
-storage image when asked outside that compiler; that is a fact about the backend, not a pack
-feature, and no capability define is posed for it.
+**A pack can be refused for using a graphics feature this backend does not have.** The game's own
+compiler closes several of them by name, not by missing effort here, and
+[translation](translation.md) carries which. Storage images, storage buffers and a pack's shadow
+compute are no longer on that list: they are served beside that compiler rather than through it,
+which is what `IRIS_FEATURE_CUSTOM_IMAGES` announces and why voxel lighting draws. The full-screen
+shadow composites are a different family and are still skipped, the log naming them at load.
 
 Of the packs used for testing, Reverie is the one in that position, and it says so itself. A pack
 can declare the features it cannot be drawn without, and Reverie declares several. That line is read
 before any of its programs is translated, so the refusal names what the pack asked for and did not
-get (the log lists them) rather than the symptom that would have come later: a storage block,
-which compiles but never enters a bind group, so the draw would go against nothing.
+get, the log listing them, rather than the symptom that would have come later.
 
 **Any name this engine has not built refuses the declaration.** One name is built and served
 today, `CUSTOM_IMAGES`, so a pack that requires it alone loads; every other name still refuses

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -104,10 +104,12 @@ accident to debug.
 
 ### A copy is not a conversion
 
-Targets are copied only between two halves of one doubled target, where the format is the same on
-both sides by construction. Copying between two *different* formats passes every check and hands
-back nonsense: the texture copy reinterprets bits rather than converting them, and the only thing
-checked on the way in is that both formats carry a colour aspect. The game's colour target is
+The one copy left on a target is between the two halves of the shadow depth pair, where the format
+is the same on both sides by construction. The doubled colour targets are not copied at all: the two
+surfaces swap names at the end of the frame, which is the same fact for nothing. Copying between two
+*different* formats passes every check and hands back nonsense: the texture copy reinterprets bits
+rather than converting them, and the only thing checked on the way in is that both formats carry a
+colour aspect. The game's colour target is
 eight-bit RGBA and a typical pack target is a packed float triple; both are thirty-two bits per
 pixel and hold completely different things.
 
@@ -190,7 +192,7 @@ pack's own geometry must not be repainted. Only a depth tells those two pixels a
 game's target and reached the pack through the seed, which cost the albedo one trip through eight
 bits a channel: a pack that packs two values into each channel of a wider target lost the first of
 them there. They write the mask now and take that buffer in the pack's own targets, which was not
-open to them while the mask was a flag - the cut then compared the world's depth with one taken
+open to them while the mask was a flag. The cut then compared the world's depth with one taken
 before a single feature was drawn, and a mob standing in front of a block moves that depth by
 construction, so every pixel of it answered "the game drew in front" whatever mask it wrote.
 
@@ -221,9 +223,9 @@ blend then adds that darkness.
 What decides whether a family can come in at all is **the mesh the game binds for it**, not how
 interesting the family is. The door reads one vertex layout, the game's entity format, and names the
 attributes a pack expects out of its elements. A pipeline binding anything else would have every
-attribute read from the wrong offset - a picture, and a wrong one, with nothing to say so - so it is
-refused and named in the log instead. The glint is the one exception and it is a narrow one: it is
-drawn from a two-element quad the door decodes as well.
+attribute read from the wrong offset, which is a picture and a wrong one with nothing to say so, so
+it is refused and named in the log instead. The glint is the one exception and it is a narrow one:
+it is drawn from a two-element quad the door decodes as well.
 
 That layout is the game's own with **three elements appended**: the numbers a pack tells one kind of
 mob, block entity or held item apart by, then the middle of the sprite a face is mapped to and the

--- a/docs/internals/entities.md
+++ b/docs/internals/entities.md
@@ -16,13 +16,17 @@ colour attachment, so nothing writing more than one target can be written from i
 has no pass open at all and holds the whole group, which is what lets the engine open one pass over
 a **run** of draws and hand the pack every draw buffer it asked for.
 
-A run and not the group. One pass carries one set of attachments and one pipeline's worth of state,
-so the pass lasts exactly as long as consecutive draws keep asking for the same program, and
-anything else closes it: another program, geometry the engine does not serve, the end of the group.
-Nothing is reordered to make runs longer, because the order the game walks its draws in is the order
-things overlap in. A group whose last draw was the engine's is closed at the return of the group,
-which is not tidiness: the encoder allows one pass at a time, so a pass left standing does not leak,
-it makes the next thing the game draws throw.
+A run and not the group. One pass carries one set of attachments, so the run lasts as long as the
+draws that follow keep writing the same colour and depth images over the same area, whatever program
+they belong to: `GeometryHold` is what arbitrates that, and a different set of attachments, a
+different area, or anything that cannot be recorded inside a pass at all, which is a copy, a clear
+or a composite, is what ends it. Nothing is reordered to make runs longer, because the order the
+game walks its draws in is the order things overlap in. A run therefore outlives the group that
+started it, and the encoder still allows one pass at a time: a foreign `createRenderPass` ends the
+hold on its way in, which is what keeps a pass left standing from making the next thing the game
+draws throw. Two of them do not end it, and they are the point rather than an oversight: a leftover
+Immediate draw and Distant Horizons' own object renderer join the run when they write the same
+images, the way the reference leaves its framebuffer bound for them.
 
 **What decides which program serves a draw is the `RenderPipeline`**, not the render type and not
 the texture. That is the reference's key too, and the reason is that a render type is made per

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -220,8 +220,13 @@ The Java device has no compute. Its shader-type enumeration is a vertex stage an
 precompile accepts a render pipeline and nothing else, a texture's usage bits are copy, sample,
 attachment and cubemap, and bind-group reflection enumerates uniform buffers and sampled images.
 A pack compute unit that went through that path would compile as a vertex shader or not at all,
-and a storage image it declared would be bound to nothing. That is still true, and it is why this
-engine poses no `IRIS_FEATURE_` for custom images.
+and a storage image it declared would be bound to nothing. That is still true of the facade, and it
+is why nothing of a pack's compute goes through it: the pipeline is built against the backend below,
+and the walk is widened around the facade at three points. The reflected entry list gains the
+storage images and blocks it never enumerates, the layout emits a storage type for those names
+instead of a combined sampler or a uniform buffer, and the descriptor written at bind time carries
+the VMA handle and the three-dimensional view. `IRIS_FEATURE_CUSTOM_IMAGES` is posed on that road
+being open, and it is the only capability define this engine poses today.
 
 The Vulkan backend behind that facade already has the rest. The device object hands out the
 `VkDevice`, the VMA allocator, and a graphics queue created with both the graphics and compute
@@ -236,8 +241,10 @@ storage bit, so a storage image has to be allocated through VMA rather than thro
 
 None of this is inference. A compute shader built with that shaderc, dispatched against a storage
 image allocated through VMA, writes texels the same frame reads back unchanged: the road is open,
-and what is missing is a stage in this engine that walks it rather than anything in the backend.
-Whether a pack's own compute is served is a separate question, answered where the pack's chain is.
+and nothing of it was ever in the backend's way. The stage that walks it is `PackCompute`, which
+compiles a pack's `shadowcomp` and dispatches it at the head of the frame. Which programs it serves,
+and why that moment rather than beside the shadow map that feeds it, is answered where the pack's
+chain is.
 
 ## Small things that cost a lot to rediscover
 

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -188,9 +188,9 @@ than the directive gives them targets exist, so the two counts genuinely differ.
 target to carry both render-attachment and copy-destination usage. Allocation therefore happens
 outside any pass. Pack colour and shadow clears are remembered until the first pass that writes
 them and become that pass's load operation, which is `glClear` as the FBO is bound. A target this
-pass samples and will not write is flushed as one empty pass per size, eight attachments at a
-time, still a load-op rather than `clearColorTexture`. Being outside a pass is the caller's job,
-not something the refusal will catch. The device hands back a **fresh encoder wrapper on every
+pass samples and will not write is flushed as one empty pass per size, as many attachments at a
+time as the device says a pass may carry, still a load-op rather than `clearColorTexture`. Being
+outside a pass is the caller's job, not something the refusal will catch. The device hands back a **fresh encoder wrapper on every
 call**, over one backend, and the "in a render pass" guard is a field of the wrapper: an encoder
 taken for a clear knows nothing of a pass another wrapper opened. Each site here takes its own
 encoder, which is cheap and correct where it stands, and worth nothing as a check. That a copy does

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -133,6 +133,14 @@ what makes a pack's misspelled key visible: correct to ignore, wrong to lose.
 
 ### The shadow caster directives, and the two that are not flags
 
+**`shadow.enabled` comes before all of them.** It says whether the pack wants a shadow map at all,
+and an explicit `false` is the only value that moves anything: a pack that says nothing leaves the
+stage standing on whichever shadow programs it ships, which is how the reference reads it. Written
+false, nothing is ever drawn from the light, and the six directives below decide nothing because
+there is no map for them to decide about. Like them it takes a literal boolean and nothing else, a
+value that is not one being honoured nowhere, and like them it is read through the pack's own
+conditionals, so the line may sit inside a branch of the pack's own settings.
+
 `shadowTerrain`, `shadowTranslucent`, `shadowEntities`, `shadowPlayer`, `shadowBlockEntities` and
 `shadowLightBlockEntities` say which families a pack wants drawn into its shadow map. Four of them
 default to on; the two that default to off are `shadowPlayer` and `shadowLightBlockEntities`, which
@@ -379,6 +387,33 @@ This works because the backend refuses the declared type, not what actually sits
 The rename is applied in every program carrying the declaration, not only in the targeted stage: the
 reference renames only in the targeted stage, which leaves an unbound three-dimensional sampler
 alive elsewhere: tolerated by the old backend, refused by this one.
+
+## Images and buffers a pack asks the engine for
+
+Separate from the textures above, which are files the pack ships: these are memory the pack asks
+the engine to allocate, writes to from its own shaders, and reads back. They are what
+`IRIS_FEATURE_CUSTOM_IMAGES` announces, and a pack gates its voxel lighting on that define before
+writing a single one of them.
+
+**`image.NAME` declares one image.** The value is the reference's own word list: a sampler name, or
+`none` where the image is stored and never sampled; a pixel format, an internal format and a pixel
+type; whether the engine empties it every frame; whether the size is a fraction of the screen; then
+the dimensions, one, two or three of them, and exactly two where the size is a fraction. Sixteen
+images is the ceiling and a seventeenth is
+dropped, which is the reference's ceiling and not this engine's. A dimension may be written as the
+name of one of the pack's own settings rather than as a number, and it is looked up in the table the
+conditionals are evaluated against, which is how a pack sizes a volume with the same setting that
+switches its coloured lighting on.
+
+**`bufferObject.N` declares one shader storage block**, at an index of nought to twelve. The value
+is a size in bytes and an optional block name, or the reference's four-word relative form where the
+size follows the screen. A size below one disables the buffer rather than allocating an empty one.
+
+Both are read through the pack's conditionals like everything else in this file, which matters more
+here than anywhere: most of the corpus writes these lines behind the coloured-lighting setting, so
+read flat a pack would be handed volumes its own settings had already switched off. **A line that is
+live and cannot be read is named in the log and dropped**, one line each, rather than taking the
+declaration next to it with it.
 
 ## A pack is untrusted content
 

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -50,8 +50,10 @@ zero to the first empty slot drops real programs.
 
 A compute program hangs a single-letter suffix off a name that has to be valid without it, and the
 suffix is recognised on the numbered families and on two of the unnumbered names, not on the
-geometry names. Vitrail reads those files, names them in the log and runs none of them, so what
-their order would be is the reference's business and not this engine's yet.
+geometry names. Vitrail reads those files and names them in the log. One family of them runs, the
+shadow compute, translated like any other unit and dispatched once a frame. The rest are named and
+go no further, so what their order among themselves would be is the reference's business and not
+this engine's yet.
 
 Stages are never paired or cross-checked. A compute program and a fragment program with the same
 slot name coexist as independent entries, which is a real case.

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -32,9 +32,14 @@ what make a selection real. Clicking a pack while shaders are off also switches 
 the reference's answer to a real confusion: before it, a pack could not be picked at all in that
 state and nobody worked out that the toggle came first.
 
-**The switch between the two views applies on the way through.** The reference's own note gives the
-reason: without it, picking a pack in the list and then opening the settings would open the settings
-of the pack *before* it, since the pages are built from the pack that is loaded.
+**The switch between the two views reads the pack whose settings are asked for, and does not apply
+it.** The reference applies at that point, and its own note gives the reason: without something
+there, picking a pack in the list and then opening the settings would open the settings of the pack
+*before* it, since the pages are built from the pack that is loaded. The reason holds and the price
+does not. Applying is the whole of a pack switch, on that pack's own default profile, so anybody
+meaning to open a heavy pack, turn it down and then apply paid the heavy profile in full first.
+Reading the chosen pack's properties answers the same need for nothing, the loaded pack goes on
+drawing, and Apply stays the one thing that costs.
 
 Escape unwinds one step at a time: the hidden screen comes back, then one page, then the pack list,
 then the screen closes. Which view it opens on is a line of `vitrail/options.txt`, alongside that

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -336,7 +336,7 @@ The End's two pieces answer that uniform with the *custom sky* stage, and that i
 reference rather than chosen. The reference sets a stage at the head of each overworld method of the
 sky renderer and sets none in either End method; what it does set, once, is the custom-sky stage at
 the head of the whole sky pass, as a heuristic for sky mods drawing before the game does. The End
-branch never reaches a method that replaces it, so custom sky is what a pack reads there - for the
+branch never reaches a method that replaces it, so custom sky is what a pack reads there, for the
 End's own sky and for its flash alike. The flash is worth naming for what it is not: it is a clock,
 seeded every six hundred ticks and fading in and out over a stretch drawn at random, not an event
 anything in the world sets off.
@@ -412,13 +412,13 @@ The End is the case to be careful with, and in two ways at once. It draws no **d
 is the piece the horizon cone rides in: there is no band under the End's horizon to close, and
 nothing there gates itself on the directive that gates the cone. The disc is also the piece that
 cuts the layer in the overworld, so the End needs a piece of its own that cuts it, or its sky is
-drawn into the pack's target and then painted over with the game's - which in the End holds nothing
+drawn into the pack's target and then painted over with the game's, which in the End holds nothing
 but the frame's clear, the draw having been taken from it. The End's own sky is that piece.
 
-**Which is why the cut is a property of the piece and not of its blending.** The obvious reading -
-a piece that writes outright claims its pixels, a piece that blends does not - is right for seven of
-the eight and wrong for the End's sky, whose pipeline blends and whose mesh is nonetheless opaque at
-every vertex behind a texture with no transparent texel in it. Read off the blend, the End loses its
+**Which is why the cut is a property of the piece and not of its blending.** The obvious reading,
+that a piece which writes outright claims its pixels and a piece that blends does not, is right for
+seven of the eight and wrong for the End's sky, whose pipeline blends and whose mesh is nonetheless
+opaque at every vertex behind a texture with no transparent texel in it. Read off the blend, the End loses its
 sky to a flat fog colour and nothing in the log says so.
 
 ### The sun's path is tilted for the bodies as well as for the light

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -298,13 +298,16 @@ for that path, three different mechanisms, and it is worth knowing which:
   a vertex stage and a fragment stage and nothing else, and the device exposes no way to precompile
   anything but a render pipeline. The Vulkan backend behind that facade already has a compute-capable
   queue, a public `VkDevice`, and the shaderc the game embeds, whose compute kind the facade never
-  passes. That path has been made to dispatch and to write. Translating a pack's own compute unit
-  is a separate question, because a translated unit still needs a stage that schedules it.
+  passes. That path has been made to dispatch and to write, and a pack's own shadowcomp goes down
+  it: translated like any other unit, compiled by the same shaderc, dispatched at the head of the
+  frame. The other compute names are named in the log and go no further, translation included.
 - **Storage buffers and storage images are worse than refused on the facade: they are ignored.**
   Reflection asks for uniform buffers, sampled images, outputs and inputs, and never enumerates
-  them. They pass compilation and are then bound to nothing. A storage image allocated through VMA
-  and bound as a push descriptor can still be written by a compute shader; the game's texture usage
-  bits never set the Vulkan storage flag, so `createTexture` cannot be that image.
+  them. On the facade's own walk they pass compilation and are bound to nothing, so the walk is
+  widened around it: the reflected entries gain those names, the layout emits a storage type for
+  them, and the descriptor written at bind time carries the handle. The image itself is allocated
+  through VMA and bound as a push descriptor, because the game's texture usage bits never set the
+  Vulkan storage flag and `createTexture` therefore cannot be that image.
 
 No amount of translation work makes a pack compute unit or a pack storage image pass through the
 facade. Vulkan itself supports all of them. The layer above does not, and the backend below it


### PR DESCRIPTION
## What changes

The pack's storage images, storage buffers and shadow compute are served, and the public pages
still described the state before that: that no `IRIS_FEATURE_` was posed for custom images, that
what was missing was a stage walking the compute road, that a pack's compute files are read and
none of them run, and that a storage image or a storage block passes compilation and is bound to
nothing. `compatibility.md` said both things ten lines apart, one half denying the capability
define and the other naming it. Four more pages had gone stale on mechanisms of their own: the
settings screen reads the chosen pack instead of applying it, the chain compiles on a budget of
the frame with the world not drawn rather than one pipeline a frame over the game's own picture, a
geometry pass outlives the program and the group that opened it, the pending clears ask the device
how many attachments a pass may carry, and the doubled colour targets swap names where they used to
be copied.

Four sites in the engine said the same stale things and go with them, one of which the log prints
at every pack load: a note announcing "shadow compute after the shadow map" when the dispatch takes
the head of the frame. It now names what is served and leaves the moment to the code that decides
it.

The second commit writes down three directives that are honoured and were documented nowhere:
`image.NAME`, `bufferObject.N` and `shadow.enabled`.

## How it differs from the reference, and for what obstacle

It does not. The pages describe what this engine does, and where they name the reference they name
it as the thing being followed. One citation of `ShadowRenderer.java` that two engine files gave at
two different line numbers now gives the same one in both.

## What proves it

- `gradlew build` green.
- Every added sentence was checked against the code that implements it, and the two directive
  grammars against the readers in `ShaderProperties` and the records they build.
- Nothing changes in the image: the only non-documentation lines are comments, plus the one load
  note quoted above.

## What it leaves owing

`CustomImages.served()` is a hardcoded `true`, and a refusal branch still hangs off its false side,
including a message telling a player that this engine runs no compute pass. Nothing reaches it
today. Either the branch is worth keeping as the way back, in which case nothing here is owed, or it
is a switch nothing exercises and it should go, and that is a question for the code rather than for a
page.

The `SSBO` capability name is still refused although a pack's `bufferObject` blocks are now
allocated and bound, so a pack that requires that name does not load.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
