### PR TITLE
fix(settings): read the graphics API from the game's own directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ what the next one holds.
   under Video Settings picks what to come back to, and it comes back to Vulkan unless told
   otherwise.
 
+- **A switch that puts the game's own wait back after every render pass.** A pack's passes end on
+  a wait naming what the next one reads and writes, rather than on the game's wait for the whole of
+  memory. That is what makes the frame cheaper, and it is also the kind of thing a driver can honour
+  by accident, so a wrong image on one machine and a right one on another is exactly what a missing
+  wait looks like. An empty file `vitrail/full-pass-barrier` in the instance, or
+  `-Dvitrail.fullPassBarrier=true`, puts the wide wait back on both roads where one was traded away,
+  the close of a pack's pass and the filling of a mip chain. It is slower and it cannot be the cause
+  of anything, so an image that comes right with it has named the problem.
+
 - **The log names the first full frame's GPU stops.** One line says how many render passes opened,
   how many textures were cleared and how many were copied, then the labels, most frequent first.
   Always on, once per pack load. That is the number a Mac trace of queue submits is counting.

--- a/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
@@ -1,6 +1,7 @@
 package dev.vitrail.mixin;
 
 import dev.vitrail.render.MipmapCommands;
+import dev.vitrail.render.PassBarrier;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.textures.GpuTexture;
@@ -39,7 +40,9 @@ import java.util.function.Supplier;
  * below it, then the encoder's own full barrier once so the rest of the frame can sample the chain.
  * <p>
  * Closing a pass still runs the encoder's full barrier. Our own labels start with {@code Vitrail}
- * and get a write-then-sample barrier instead; the rest of the frame keeps the original wait.
+ * and get a write-then-sample barrier instead, the rest of the frame keeping the original wait.
+ * {@link PassBarrier} puts the original wait back on ours too, and sends the mip chain back to a
+ * pass per level, for a machine where the narrow one is suspected of a wrong image.
  */
 @Mixin(VulkanCommandEncoder.class)
 public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
@@ -91,7 +94,10 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 		Supplier<String> label = this.vitrail$closingLabel;
 		this.vitrail$closingLabel = null;
 		VkCommandBuffer commands = vitrail$commandBuffer();
-		if (label != null && vitrail$ours(label)) {
+		// The wide wait first, so that arming it takes every pass back to what the game does and
+		// leaves nothing of the narrow one standing. {@link PassBarrier} carries why that switch
+		// exists at all.
+		if (label != null && !PassBarrier.full() && vitrail$ours(label)) {
 			vitrail$framebufferBarrier(commands, stack);
 		} else {
 			VulkanCommandEncoder.memoryBarrier(commands, stack);
@@ -151,7 +157,12 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 
 	@Override
 	public boolean vitrail$generateMipmaps(GpuTexture texture) {
-		if (this.currentRenderPass != null || !(texture instanceof VulkanGpuTexture image)) {
+		// Refused while the wide wait is armed, so the caller goes back to a pass per level and
+		// every one of those ends on the game's own barrier. The switch would otherwise leave the
+		// mip chain on transfer barriers alone, and a reporter whose image is still wrong with it on
+		// would clear the synchronisation for a road it never put back.
+		if (PassBarrier.full() || this.currentRenderPass != null
+				|| !(texture instanceof VulkanGpuTexture image)) {
 			return false;
 		}
 

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -432,8 +432,10 @@ final class GeometryProgram {
 		this.path = loaded.path();
 		this.gameTransforms = loaded.readsGameTransforms();
 		this.blockLabel = () -> "Vitrail " + pass.family() + " OfGlobals";
-		this.passLabel = () -> "Vitrail " + pass.family();
-		this.shadowLabel = () -> "Vitrail shadow " + pass.family();
+		String passName = "Vitrail " + pass.family();
+		String shadowName = "Vitrail shadow " + pass.family();
+		this.passLabel = () -> passName;
+		this.shadowLabel = () -> shadowName;
 		TranslatedUnit.Notes notes = loaded.program().stages().get(ProgramStage.FRAGMENT).notes();
 		int outputs = notes.fragmentOutputs();
 

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -80,6 +80,14 @@ final class PackCompute implements AutoCloseable {
 	private static final int SHADERC_VULKAN_1_2 = 4202496;
 	private static final int SHADERC_COMPUTE = 2;
 
+	/**
+	 * A common ceiling on a pushed descriptor set, the same one the graphics side carries in
+	 * {@link PackPass}. Nothing in the game asks the device for its own, so a dispatch past this
+	 * is named and still made: the failure, if it comes, is a driver error that the line makes
+	 * readable.
+	 */
+	private static final int PUSH_DESCRIPTORS = 32;
+
 	private final List<Pass> passes;
 	private boolean announced;
 
@@ -329,6 +337,15 @@ final class PackCompute implements AutoCloseable {
 				ComputeShader.Compiled compiled = ComputeShader.compile(vulkan, this.label, spirv);
 				this.shaderModule = compiled.module();
 				this.entries = compiled.entries();
+				// Named and still dispatched, which is what the graphics path does with the same
+				// ceiling: a device is only obliged to allow this many descriptors in one pushed
+				// set, and going past it is undefined rather than slow. Said here, once, so that a
+				// driver error later has a line in the log that predicted it.
+				if (this.entries.size() > PUSH_DESCRIPTORS) {
+					Vitrail.logger().warn("shadow compute {} pushes {} descriptors in one set, past "
+							+ "the {} a device commonly allows at once", this.path,
+							this.entries.size(), PUSH_DESCRIPTORS);
+				}
 			} catch (Exception e) {
 				Vitrail.logger().warn("shadow compute {} SPIR-V failed: {}", this.path, e.toString());
 				return;

--- a/common/src/main/java/dev/vitrail/render/PassBarrier.java
+++ b/common/src/main/java/dev/vitrail/render/PassBarrier.java
@@ -1,0 +1,86 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+
+import net.minecraft.client.Minecraft;
+
+import java.nio.file.Files;
+
+/**
+ * Whether a pass of ours closes on the game's full memory barrier instead of the narrow one.
+ * <p>
+ * The game ends every render pass by waiting for the whole of memory. Iris binds a framebuffer and
+ * draws, so it waits for nothing, and on a backend where each pass is a queue submission that wait
+ * is the cost the whole pass work is aimed at. What replaces it names the stages and the accesses
+ * a pass of ours really leaves behind and really hands on, which is correct exactly as long as the
+ * list is complete.
+ * <p>
+ * <strong>The list has had to grow three times, and each time the miss was invisible here.</strong>
+ * A dependency a driver honours by accident gives the right picture on the machine that wrote it
+ * and a wrong one somewhere else, with nothing in any log to say which. That is not a defect this
+ * engine can find by reading itself: it needs the machine that shows it, and the person in front of
+ * that machine needs a way to answer the question in one launch rather than in a build.
+ * <p>
+ * So: a file {@code vitrail/full-pass-barrier} in the game directory, or
+ * {@code -Dvitrail.fullPassBarrier=true} where somebody has a launcher to type it in. Either puts
+ * the game's own wait back on both roads where this engine traded one away: the close of a pass of
+ * ours, and the mip chain, which gave up a pass per level and the barrier each of those ended on.
+ * It is slower and it cannot be the cause of anything, so an image that comes right with it names
+ * the synchronisation.
+ * <p>
+ * Asked once and the answer kept: it arms a launch, not a frame.
+ */
+public final class PassBarrier {
+
+	private static final boolean PROPERTY = Boolean.getBoolean("vitrail.fullPassBarrier");
+
+	private static final String ARM_FILE = "full-pass-barrier";
+
+	/** Null until the game directory can be resolved, which is not true on the first calls. */
+	private static Boolean armed;
+
+	private static boolean announced;
+
+	private PassBarrier() {
+	}
+
+	/** True while every pass, ours included, is to close on the game's full memory barrier. */
+	public static boolean full() {
+		if (PROPERTY) {
+			announce();
+
+			return true;
+		}
+
+		if (armed == null) {
+			Minecraft minecraft = Minecraft.getInstance();
+			if (minecraft == null || minecraft.gameDirectory == null) {
+				return false;
+			}
+
+			armed = Files.isRegularFile(minecraft.gameDirectory.toPath()
+					.resolve("vitrail").resolve(ARM_FILE));
+		}
+
+		if (armed) {
+			announce();
+		}
+
+		return armed;
+	}
+
+	/**
+	 * Said once, and it has to be said: a session running on the wide barrier is measuring a
+	 * different engine, and a frame rate read there means nothing beside one read without it.
+	 */
+	private static void announce() {
+		if (announced) {
+			return;
+		}
+
+		announced = true;
+		Vitrail.logger().warn("Every render pass closes on the game's full memory barrier, asked "
+				+ "for by vitrail/{} or by -Dvitrail.fullPassBarrier. The image is the safe one and "
+				+ "the frame is slower; remove it to go back to the narrow wait", ARM_FILE);
+	}
+}

--- a/common/src/main/java/dev/vitrail/settings/GraphicsApiChoice.java
+++ b/common/src/main/java/dev/vitrail/settings/GraphicsApiChoice.java
@@ -2,6 +2,8 @@ package dev.vitrail.settings;
 
 import dev.vitrail.Vitrail;
 
+import net.minecraft.client.Minecraft;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -55,10 +57,14 @@ public enum GraphicsApiChoice {
 	/**
 	 * What the instance asks for, or {@link #DEFAULT} where it asks for nothing this understands.
 	 * <p>
-	 * Resolved against the working directory rather than a game directory: the launcher runs the
-	 * game with the instance as its working directory, and at the moment this is first read there is
-	 * nothing else to ask. A typo reads as the default and says so, because a setting that silently
-	 * means something else is worse than one that is ignored out loud.
+	 * Resolved against the game's own directory, which exists by the time this is asked even though
+	 * the mod does not: {@code Minecraft} assigns its static instance and its game directory in the
+	 * first lines of its constructor, and the read this answers is the one further down that same
+	 * constructor. The working directory is the fallback for the case where even that is not up
+	 * yet, and the launcher makes the two the same anyway.
+	 * <p>
+	 * A typo reads as the default and says so, because a setting that silently means something else
+	 * is worse than one that is ignored out loud.
 	 */
 	public static GraphicsApiChoice read() {
 		Path file = file();
@@ -96,7 +102,16 @@ public enum GraphicsApiChoice {
 		}
 	}
 
+	/**
+	 * Where the choice lives, under the game's directory, or under the working directory while the
+	 * game has none to give.
+	 */
 	private static Path file() {
-		return Path.of("vitrail", FILE);
+		Minecraft minecraft = Minecraft.getInstance();
+		Path directory = minecraft == null ? null : minecraft.gameDirectory.toPath();
+
+		return directory == null
+				? Path.of("vitrail", FILE)
+				: directory.resolve("vitrail").resolve(FILE);
 	}
 }

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -256,6 +256,12 @@ has diverged from the plan, and the pack is not the suspect.
 **Shader sources under the instance are read live.** Changing GLSL needs no rebuild. Only engine
 changes need one.
 
+**The narrowed synchronisation can be put back.** An empty file `vitrail/full-pass-barrier` in the
+instance, or `-Dvitrail.fullPassBarrier=true` among the JVM arguments, closes every pass on the
+game's full memory barrier and sends the mip chain back to a pass per level. It is slower and it
+cannot be the cause of a wrong image, so it is the first thing to ask of a machine that draws one
+this one does not.
+
 **The card's time per pass is in the log on request.** Started with `-Dvitrail.passTimings=N`
 among the JVM arguments, the game prints every N seconds a table of GPU time per render pass
 label, the game's and Sodium's passes beside the pack's, sorted by cost, with the share of the pass

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -117,7 +117,16 @@ a pass rather than being a clear of its own, which makes it one of those writes.
 geometry that writes the same colour and depth images stays in one pass, which is what Iris does by
 leaving `defaultFB` bound (`IrisRenderingPipeline.bindDefault`). A later composite, a copy, or a
 different framebuffer ends that hold first. Mip chains are filled with `vkCmdBlitImage` on the
-frame's command buffer, the Vulkan form of `glGenerateMipmap`, rather than a pass per level.
+frame's command buffer, the Vulkan form of `glGenerateMipmap`, rather than a pass per level, which
+gives up the barrier each of those passes ended on and keeps transfer barriers between the levels
+instead.
+
+**Both of those trades are on one switch**, because a narrow dependency that a driver honours by
+accident looks exactly like a correct one until somebody else's machine draws it. A file
+`vitrail/full-pass-barrier` in the instance, or `-Dvitrail.fullPassBarrier=true`, puts the game's own
+wait back at the close of our passes and sends the mip chain back to a pass per level. It is slower
+and it cannot be the cause of anything, which is the whole point: an image that comes right with it
+has named the synchronisation rather than the pass that shows it.
 
 The practical consequence is that reading in pass N+1 what pass N wrote still requires no
 synchronisation code of our own: close, open, bind. But the barrier exists only if the pass is

--- a/neoforge/src/main/java/dev/vitrail/neoforge/EarlyWindow.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/EarlyWindow.java
@@ -95,6 +95,11 @@ public final class EarlyWindow {
 		claimed = false;
 		EarlyLoadingScreenController controller = EarlyLoadingScreenController.current();
 		if (controller == null) {
+			// Somebody else took it between the refusal and here. Said rather than passed over: what
+			// is left is a window nothing will close, alive behind the game's own for the rest of the
+			// session, and a line is the only thing that would ever point at it.
+			Vitrail.logger().warn("NeoForge's early loading window was claimed and is gone by the "
+					+ "time it should have been taken over, so it stays open behind the game");
 			return;
 		}
 


### PR DESCRIPTION
## What changes

Five things found by reading the release rather than by playing it, each small and each its own
commit.

**The graphics API choice was written where nothing read it.** The screen wrote it beside the game
directory and the boot read it beside the working directory. Under every launcher that sets one from
the other those are the same place, and where they are not, the setting did nothing at all: the
screen said Vulkan, the boot found no file, and a crashed startup walked the backend down as if the
setting had never been added. The read now asks the game for its directory, which is available by
then even though this mod is not.

**A pack's compute dispatch could push more descriptors than a device is obliged to allow**, with
nothing said. The graphics side has carried that ceiling since it was written, and it is named at
compile now on both sides.

**The NeoForge handover walked out silently when the early window was already gone**, leaving a
window nothing will ever close, alive behind the game's own for the rest of the session.

**The narrowed synchronisation is on a switch.** Two roads gave up a barrier the game issues: the
close of one of our passes, and the mip chain, which is a blit chain instead of a pass per level.
Both are correct as long as the list of what a pass hands on is complete, and that list has had to
grow three times. A file `vitrail/full-pass-barrier` in the instance, or
`-Dvitrail.fullPassBarrier=true`, puts the wide wait back on both. It is slower and it cannot be the
cause of a wrong image, so it is the first thing to ask of a machine that draws one this one does
not.

**A geometry pass built its label string every time it was asked for it**, and it is asked more than
once per pass per frame.

## How it differs from the reference, and for what obstacle

It does not. The barrier switch has no equivalent there because the question does not arise: Iris
binds a framebuffer and draws, so it issues no barrier to narrow.

## What proves it

- `gradlew build` green, after the rebase.
- The out-of-game harness compiles against this branch and `Bloc` passes whole; nothing here is on
  a road the corpus tools measure.
- The premise behind the first commit was checked in the decompiled game rather than assumed: the
  constructor assigns its static instance and its game directory in its first lines and reads the
  clean-startup flag much further down.
- Not tried in the game. Nothing here changes an image, and the one switch that could is off unless
  a file is put there by hand.

## What it leaves owing

The switch covers the two places a barrier was traded away and nothing else, which is what its own
page says. If a third is ever traded, it has to be added there rather than worked around where it
shows.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
