### PR TITLE
fix(render): publish the far distance on Iris's condition alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,19 @@ what the next one holds.
   outright, those names answer with the far terrain behind the water rather than with the water,
   on a texel where neither is visible.
 
+- **Entering a world with Distant Horizons no longer washes the distance out to the sky colour.**
+  Until that mod has drawn its first frame, which on a world it has no cache for takes a moment,
+  a pack was told how far the far terrain reached in the wrong unit, and the number it got was
+  sixteen times too small: a dozen blocks or so, rather than the thousands that mod actually
+  draws. A pack that fogs by that number then fogged out everything past the end of its own nose,
+  so the whole distance came back as flat sky until the far terrain appeared. Bliss shows it
+  plainly. The number no longer waits on that first frame.
+
+  Two smaller things move with it. Turning that mod's rendering off now gives a pack back the
+  game's own distance, which is what Iris gives it. And a pack that leaves its shadow planes for
+  the engine to resolve gets a shadow box sized for whichever terrain is really being drawn. No
+  pack shipped today asks for that on its default settings.
+
 - **Opening a world no longer crashes while leftover families are still being translated.**
   The frame used to walk those program maps as soon as the composites and the terrain were
   ready, which is the same moment the worker is still filling them.

--- a/common/src/main/java/dev/vitrail/dh/DhDepth.java
+++ b/common/src/main/java/dev/vitrail/dh/DhDepth.java
@@ -146,7 +146,9 @@ public final class DhDepth {
 	 * unclamped one the class comment carries, and since the clamp only ever pulls that plane in, it
 	 * is always the further out of the two. Its far is out by the ratio of the two formulas.
 	 *
-	 * @param dest filled with the near plane and then the far one, and left alone on false
+	 * @param dest filled with the near plane and then the far one. Left alone where {@link #zRow}
+	 *             answered nothing, but carrying that row where this refused it for its shape, so a
+	 *             caller reads the pair only on true
 	 */
 	public static boolean planes(Vector2f dest) {
 		if (!zRow(dest)) {
@@ -165,15 +167,49 @@ public final class DhDepth {
 	}
 
 	/**
-	 * How far DH draws, in blocks, or -1 when it cannot be asked. Blocks and not chunks, because
-	 * blocks is what a pack does arithmetic with and what Iris publishes under the same name.
+	 * How far DH draws, in blocks, or -1 for the game's own distance to stand in: because that mod's
+	 * rendering is switched off, or because it can no longer be asked. Not because it has yet to
+	 * draw, which is the point of asking it here rather than off a drawn matrix. Blocks and not chunks, because blocks is
+	 * what a pack does arithmetic with and what Iris publishes under the same name.
+	 * <p>
+	 * <strong>The question asked here is Iris's, to the term.</strong> It answers
+	 * {@code getEffectiveRenderDistance()} on {@code configs == null || !dhEnabled} and
+	 * {@code chunkRenderDistance * 16} otherwise, {@code compat/dh/DHCompatInternal.java:102-109},
+	 * and its {@code dhEnabled} is a kept copy of {@code configs.graphics().renderingEnabled()},
+	 * {@code compat/dh/DHCompatInternal.java:141-154}.
+	 * <p>
+	 * <strong>The switch half is read here because the number is consumed on this side of the
+	 * engine too</strong>, and not only by a pack that could be told the far terrain is gone by the
+	 * {@code DISTANT_HORIZONS} symbol dropping. {@code render/ViewMatrices} resolves a shadow plane
+	 * a pack left at -1 off this value, under no symbol at all, so a player turning that mod's
+	 * rendering off would otherwise keep a shadow box sized for a far terrain nothing is drawing.
+	 * Iris sizes that same box off the same gated answer, {@code shadows/ShadowRenderer.java:429}.
+	 * <p>
+	 * <strong>Iris looks its own compat layer up by name too</strong>, one layer further out and
+	 * over its own classes rather than that mod's, {@code compat/dh/DHCompat.java:57-86}, and
+	 * answers the game's own distance once that lookup has failed, {@code :113-114}. <strong>It is
+	 * not the same latch, and the difference is the interesting half.</strong> Iris only lets that
+	 * failure stand quietly where the mod is absent; with the mod loaded it rethrows,
+	 * {@code :78-82}, so a player either gets the far terrain or gets a crash naming it. The latches
+	 * here degrade instead, mid-session and on a warning, which is deliberate: the reads are of that
+	 * mod's own private fields by name, so they can fail on a version this repository has never
+	 * seen, and a far terrain that goes flat is a picture while a frame that throws is not.
+	 * <p>
+	 * <strong>Where this parts from Iris on the switch itself:</strong> Iris keeps one copy of it
+	 * and feeds both the preprocessor symbol and this number from that copy, so the two cannot
+	 * disagree. Here the switch is read live at every asking, twice in an ordinary frame and several
+	 * times more in one that rereads the pack, and every one of those reads sits on the render
+	 * thread with the pack reread between them synchronously
+	 * ({@code render/PackChain} does it in the frame that saw the flip). A frame whose symbol and
+	 * whose number disagreed would need that mod to write its configuration off the render thread,
+	 * which has not been observed here and is not something this can rule out.
 	 */
 	public static int renderDistanceBlocks() {
 		if (!resolved) {
 			resolve();
 		}
 
-		if (!usable || !distanceUsable) {
+		if (!usable || !distanceUsable || !renderingEnabled()) {
 			return -1;
 		}
 
@@ -188,11 +224,31 @@ public final class DhDepth {
 			return (valueMethod.invoke(value) instanceof Integer chunks) ? chunks * CHUNK : -1;
 		} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
 			distanceUsable = false;
-			Vitrail.logger().warn("Distant Horizons' render distance cannot be read, so a pack is "
-					+ "given the game's own distance and clip planes instead of that mod's, for the "
-					+ "rest of this session", e);
+			Vitrail.logger().warn("Distant Horizons' render distance cannot be read, so for the rest "
+					+ "of this session a pack is given the game's own distance, counted in CHUNKS, "
+					+ "while it is still told the far terrain is there and still given that mod's "
+					+ "clip planes. A pack that measures a length against that distance will fog "
+					+ "the far terrain far too close", e);
 			return -1;
 		}
+	}
+
+	/**
+	 * Whether this engine is still reading that mod at all, which is a question about the latches
+	 * and not about the far terrain.
+	 * <p>
+	 * It exists for the frame rather than for a pack: the three answers a frame takes are three
+	 * separate reads, any of which can drop this on a reflective failure, and the frame that drop
+	 * lands in would otherwise go out holding answers from both sides of it.
+	 * {@code render/FrameState} takes all three, then asks this, then publishes, and takes the whole
+	 * fallback where it is false. No reflection here, only the flag.
+	 * <p>
+	 * <strong>It answers for this latch and not for the narrower one beside it.</strong>
+	 * {@link #renderDistanceBlocks} has a latch of its own that leaves this standing, and that one
+	 * is not an incoherent frame but a lasting parting, written up where it is warned about.
+	 */
+	public static boolean usable() {
+		return usable;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -434,30 +434,57 @@ public final class FrameState implements WorldState {
 				renderDistance);
 
 		// And what Distant Horizons drew with, which is nothing at all on the sessions that have no
-		// far terrain. The three are taken together or not at all, the distance first: advanceDistant
-		// says what a frame that served two of them from DH and the third from the game costs.
+		// far terrain. The distance answers on its own and the two planes answer on theirs, which is
+		// how Iris asks them, and advanceDistant carries what the pair being short of the distance
+		// costs.
 		//
-		// What they carry is the projection DH drew the PREVIOUS frame with, and that is worth
+		// What the planes carry is the projection DH drew the PREVIOUS frame with, and that is worth
 		// saying rather than hiding. DH fills its render parameter from the opaque chunk pass, while
 		// the pack's frame opens ahead of it at the first sky draw. Reading them later would not
 		// mend it: the block is written once, here, so a value taken after it would reach a pack one
 		// frame later still. What it costs is nothing measurable, both planes moving with DH's own
 		// settings and with the player's height above the world rather than with the camera.
+		//
+		// And the volume beside them, which is the row rather than the pair of planes the planes
+		// were worked out from: a row put back together out of two planes would be the same
+		// arithmetic done twice and rounded twice. Handed a zero offset where there is no row to be
+		// had, and then the volume published is the frame's own, which is what a pack reads where
+		// this engine draws no far terrain at all.
+		//
+		// ALL THREE ARE TAKEN BEFORE ANY OF THEM IS PUBLISHED, and that is what stands in for the
+		// coupling rather than the coupling itself. Each of the three reads can latch this engine's
+		// whole view of that mod off on a reflective failure, and the frame that latch lands in is
+		// the only frame that could hold answers from both sides of it: far terrain still on screen,
+		// and the numbers that place it disagreeing. Ordering the reads mends nothing, it only
+		// chooses which of them is the stale one, so the frame asks after all three instead and
+		// takes the fallback whole. On a latch inside the distance or inside the planes that is what
+		// this method already did while the three moved together. On a latch inside the row it is
+		// new: that read used to come after the pair was published, so the frame went out with a
+		// real distance, real planes and a volume that had given up.
+		//
+		// It does NOT cover the three partings that OUTLIVE the coupling: the ordinary one this
+		// batch exists for, one that is Iris's own answer, and one that is a hole older than any of
+		// this. They are named one by one in ViewMatrices.advanceDistant.
 		int distance = DhDepth.renderDistanceBlocks();
-		if (distance >= 0 && DhDepth.planes(this.distantPlanes)) {
-			this.view.advanceDistant(this.distantPlanes.x, this.distantPlanes.y, distance);
-		} else {
-			this.view.advanceDistant(ViewMatrices.FALLBACK_PLANE, ViewMatrices.FALLBACK_PLANE, -1);
+
+		boolean planes = DhDepth.planes(this.distantPlanes);
+		float near = planes ? this.distantPlanes.x : ViewMatrices.FALLBACK_PLANE;
+		float far = planes ? this.distantPlanes.y : ViewMatrices.FALLBACK_PLANE;
+
+		boolean row = DhDepth.zRow(this.distantPlanes);
+		float scale = row ? this.distantPlanes.x : 0.0F;
+		float offset = row ? this.distantPlanes.y : 0.0F;
+
+		if (!DhDepth.usable()) {
+			distance = -1;
+			near = ViewMatrices.FALLBACK_PLANE;
+			far = ViewMatrices.FALLBACK_PLANE;
+			scale = 0.0F;
+			offset = 0.0F;
 		}
 
-		// And the volume itself, which is the row rather than the pair of planes the planes were
-		// worked out from: a row put back together out of two planes would be the same arithmetic
-		// done twice and rounded twice. Handed a zero offset where there is no row to be had, and
-		// then the volume published is the frame's own, which is what a pack reads where this engine
-		// draws no far terrain at all.
-		boolean row = DhDepth.zRow(this.distantPlanes);
-		this.view.advanceDistantVolume(row ? this.distantPlanes.x : 0.0F,
-				row ? this.distantPlanes.y : 0.0F);
+		this.view.advanceDistant(near, far, distance);
+		this.view.advanceDistantVolume(scale, offset);
 
 		this.view.advanceShadow(sunAngle(isDay()) / 360.0F, this.directives.sunPathRotation(),
 				this.directives.shadowIntervalSize(), this.shift.unshifted(),

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -175,8 +175,10 @@ public final class ViewMatrices implements ViewSource {
 	private boolean distantVolume;
 
 	/**
-	 * What Distant Horizons drew this frame with, or nothing when it drew nothing. See
-	 * {@link #advanceDistant} for why the three move together.
+	 * What Distant Horizons answers for this frame, or what stands in where it answers nothing. The
+	 * distance falls back on one question and the two planes on another, which is how Iris asks
+	 * them, and the distance is a setting rather than something read off a matrix that was drawn.
+	 * See {@link #advanceDistant}.
 	 */
 	private float dhNear = FALLBACK_PLANE;
 	private float dhFar = FALLBACK_PLANE;
@@ -250,15 +252,54 @@ public final class ViewMatrices implements ViewSource {
 	}
 
 	/**
-	 * Takes what Distant Horizons drew this frame with, or puts the three values back where they
-	 * stand when it drew nothing.
+	 * Takes what Distant Horizons drew this frame with, or puts each value back where it stands when
+	 * that mod answers nothing for it.
 	 * <p>
-	 * The three move together on purpose, and {@code render/FrameState} takes them that way. A pack
-	 * that has been told the far terrain is there works its fog out of the render distance and
-	 * rebuilds a position out of the planes, so a frame that served two of the three from DH and the
-	 * third from the game would fog the far terrain against a distance a fifteenth of the one it
-	 * stands at. The render distance is the one to watch, and the two packs read most closely here
-	 * do different things with it: BSL v10.1.3 widens the fog it already had,
+	 * <strong>The distance answers on its own, and the two planes on theirs, because that is how
+	 * Iris asks them.</strong> No two of the three share a question there: the distance falls back on
+	 * {@code configs == null || !dhEnabled} ({@code compat/dh/DHCompatInternal.java:102-109}), the
+	 * far plane on the first half of that alone ({@code :115-116}) and the near plane on a proxy
+	 * being up ({@code :127-128}). This engine held the three together instead until the fallback
+	 * was measured, and what that cost is the whole reason the coupling is gone: the planes are read
+	 * off the matrix DH really drew with, so they are short until that mod has drawn a frame, and
+	 * holding the distance back with them published the game's distance in CHUNKS on a frame where
+	 * the pack had already been told the far terrain was there. A number in chunks read as blocks is
+	 * short by the chunk at best and by that mod's whole reach at worst, and a pack that divides a
+	 * length by it repaints everything past a handful of blocks with the sky: Bliss v2.1.2 divides
+	 * by it in three files, {@code shaders/dimensions/composite1.fsh:1307} among them.
+	 * <p>
+	 * <strong>What the coupling protected, it never protected.</strong> The fear was a pack fogging
+	 * the far terrain against one road while rebuilding its position out of the other, and the fear
+	 * was sound while the remedy was not. Three partings outlive the coupling and are answered one
+	 * by one below, and a fourth case is listed under them that is not a parting at all. What the
+	 * fear is really about is far terrain on screen under a FALLBACK PLANE, which is the first of
+	 * them alone. The third puts far terrain on screen under real planes and a wrong distance,
+	 * which is a different wound and an older one.
+	 * <ul>
+	 * <li><strong>The planes short, the distance real.</strong> The ordinary case, and the whole
+	 * reason for the batch: that mod has drawn nothing, so there is no far-terrain fragment for a
+	 * fallback plane to place wrongly. Two ways reach it with terrain on screen and neither is new
+	 * here: a z row {@code dh/DhDepth.planes} refuses while {@code zRow} accepts, a far plane at
+	 * infinity; and the first frame that mod draws, where the planes are still the previous frame's
+	 * because the block is written once at the first sky draw, which {@code render/FrameState} says
+	 * where it publishes them. The planes fell back on both roads before this batch too. Holding the
+	 * distance down beside them repaired no plane, it only made the distance wrong as well.</li>
+	 * <li><strong>The distance short, the planes real, and that mod's rendering switched off.</strong>
+	 * Iris publishes the game's distance beside real planes there too, and a pack has been told the
+	 * far terrain is gone and has dropped its distant road, so nothing reads the pair.</li>
+	 * <li><strong>The distance short, the planes real, and the distance alone lost to a reflective
+	 * failure.</strong> <strong>This one is a hole rather than an answer, and it is older than this
+	 * batch.</strong> That latch leaves {@code dh/DhDepth.present} standing, so the pack keeps its
+	 * distant road while being handed the game's distance in CHUNKS for the rest of the session,
+	 * which is the very confusion this method exists to describe. The batch neither opens it nor
+	 * closes it, the coupling never closed it either, and {@code dh/DhDepth} now warns in those
+	 * words where it fires.</li>
+	 * <li><strong>Everything short at once.</strong> A read that put the whole reading of that mod
+	 * out. {@code render/FrameState} takes its three answers before publishing any, so the fallback
+	 * is taken whole rather than half published.</li>
+	 * </ul>
+	 * The distance is the one to watch, and the two packs read most closely here do different things
+	 * with it: BSL v10.1.3 widens the fog it already had,
 	 * {@code fogFar = max(fogFar, float(dhRenderDistance))} at
 	 * {@code shaders/lib/atmospherics/fog.glsl:137}, while Complementary Unbound r5.8.1 replaces the
 	 * distance outright, {@code float renderDistance = float(dhRenderDistance);} at
@@ -266,10 +307,16 @@ public final class ViewMatrices implements ViewSource {
 	 *
 	 * @param near     DH's own near plane in blocks, or {@link #FALLBACK_PLANE} for none
 	 * @param far      DH's own far plane in blocks, or {@link #FALLBACK_PLANE} for none
-	 * @param distance how far DH draws in blocks, or -1 for none, in which case the game's own
-	 *                 render distance in CHUNKS is published instead. The change of unit is Iris's
-	 *                 own and it is what packs are written against: without the mod the name
-	 *                 answers {@code getEffectiveRenderDistance}, and with it, chunks times sixteen
+	 * @param distance how far DH draws in blocks, or -1 where its rendering is switched off or can
+	 *                 no longer be read, in which case the game's own render distance in CHUNKS is
+	 *                 published instead. The change of unit
+	 *                 is Iris's own and it is what packs are written against: without the mod the
+	 *                 name answers {@code getEffectiveRenderDistance}, and with it, chunks times
+	 *                 sixteen. It is read a second time inside this class, where a shadow plane the
+	 *                 pack left at -1 is resolved off it, so the two units travel together there as
+	 *                 well, and no pack of the corpus reaches that road on its defaults: the one
+	 *                 branch of Bliss that writes both planes at -1 sits behind a setting shipped
+	 *                 off
 	 */
 	void advanceDistant(float near, float far, int distance) {
 		this.dhNear = near;

--- a/common/src/main/java/dev/vitrail/uniform/ViewSource.java
+++ b/common/src/main/java/dev/vitrail/uniform/ViewSource.java
@@ -168,8 +168,11 @@ public interface ViewSource {
 	float dhFarPlane();
 
 	/**
-	 * How far the far terrain reaches, in BLOCKS while Distant Horizons is drawing one and in
-	 * CHUNKS while it is not. The change of unit is Iris's own and packs are written against it:
+	 * How far the far terrain reaches, in BLOCKS while Distant Horizons' rendering is switched on
+	 * and this engine can still read it, and in CHUNKS otherwise. It does not wait on that mod
+	 * having drawn: the distance is a setting rather than something read off a drawn matrix, which
+	 * is the whole of what {@code render/ViewMatrices.advanceDistant} carries. The change of unit
+	 * is Iris's own and packs are written against it:
 	 * without the mod the name answers {@code getEffectiveRenderDistance} and with it, that mod's
 	 * own chunk setting times sixteen.
 	 */

--- a/common/src/main/java/dev/vitrail/uniform/values/DhValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/DhValues.java
@@ -12,14 +12,18 @@ import dev.vitrail.uniform.UniformShape;
  * the translation stage measured, and it is what Iris does as well: it registers all six without a
  * condition.
  * <p>
- * What each of them answers is {@code render/ViewMatrices}'s and moves with the frame. The two
- * planes and the render distance are DH's own the moment DH has drawn one. Without one the planes
- * fall back to Iris's 0.01, {@code compat/dh/DHCompat.java:94} and {@code :104}, deliberately a
- * number no pack can mistake for a real distance; the render distance falls back to the game's own
- * in chunks, which is Iris's fallback as well, {@code compat/dh/DHCompat.java:114}, and the change
- * of unit that comes with it is on {@code uniform/ViewSource}. The three matrices stay the game's
- * own on both roads, and ViewMatrices says why that is a divergence with a reason under it rather
- * than a gap.
+ * What each of them answers is {@code render/ViewMatrices}'s and moves with the frame. <strong>The
+ * two planes and the render distance fall back on questions of their own, and that is Iris's shape
+ * rather than a convenience.</strong> The planes are DH's own the moment DH has drawn a frame, and
+ * without one they fall back to Iris's 0.01, {@code compat/dh/DHCompat.java:94} and {@code :104},
+ * deliberately a number no pack can mistake for a real distance. The render distance answers
+ * earlier than that, as soon as that mod holds a configuration and its rendering switch is on,
+ * because it is a setting rather than something read off a drawn matrix; it falls back to the
+ * game's own in chunks, which is Iris's fallback as well, {@code compat/dh/DHCompat.java:114}, and
+ * the change of unit that comes with it is on {@code uniform/ViewSource}. What holding the
+ * distance back to the planes cost is on {@code render/ViewMatrices.advanceDistant}. The three
+ * matrices stay the game's own on both roads, and ViewMatrices says why that is a divergence with a
+ * reason under it rather than a gap.
  */
 public final class DhValues {
 


### PR DESCRIPTION
## What changes

The distance Distant Horizons draws to was held back whenever its own clip planes could not be
read. Those planes are taken off the matrix that mod really drew with, so they are missing until it
has drawn a frame, and until then a pack was handed the game's render distance counted in CHUNKS
where every pack reads BLOCKS. Sixteen times short. A pack that measures its fog against that number
fogs out everything past a dozen blocks, which is the distance washing out to the sky colour on
entering a world under Bliss v2.1.2, for as long as the far terrain takes to appear.

The three values are asked separately now, because that is how the reference asks them: no two of
its three share a question. The switch half of the distance was missing here as well, and it is read
on this side of the engine too, since a shadow plane a pack leaves at -1 is resolved off it under no
preprocessor symbol at all. A player turning that mod's rendering off kept a shadow box built for a
far terrain nothing was drawing.

What stands in for the coupling is narrower and is written out where it lives: any of the three
reads can latch this engine's whole view of that mod off, so the frame takes all three answers
before publishing any of them and takes the fallback whole where the reading is off.

## How it differs from the reference, and for what obstacle

It does not, and closing the gap is the point. Iris asks the three on three conditions
(`compat/dh/DHCompatInternal.java:102-134`, and the fallbacks at `compat/dh/DHCompat.java:94`,
`:104` and `:114`); this engine held them together and so failed the distance whenever the planes
failed. The three partings that outlive the coupling are named one by one in the javadoc, including
the one that stays open and is now warned about in the log in those words.

## What proves it

- `gradlew build` green, after the rebase.
- The off-game harness compiles against this branch and its four corpus-free tools, which are the
  ones that exercise the published matrices and the shadow cut, return output identical to `dev` to
  the character.
- The three citations into the reference were rechecked line by line rather than trusted.
- Tried in the game, on a world that mod has no cache for, under Bliss, with its rendering
  on. The window is short: it lasts while that mod has yet to draw its first frame, which on
  a small world is under a second. Caught by shooting the window once a second through world
  entry and comparing the first frame each side draws with the pack compiled. Without this
  branch that frame has its distance flattened to sky colour, hills a few dozen blocks out
  included, and the frame after it is already clean. With it, that first frame is clean.
- What that does not cover: one frame on each side, and the two runs were not at the same
  point of chunk loading, so the reading rests on near ground being hazed rather than on far
  ground being absent.

## What it leaves owing

One condition the two answers no longer share, and it cannot be settled from this repository:
`distantVolume` is documented as falling back the moment that mod stops drawing, while the distance
now falls back on the rendering switch and the z row is not gated on that switch at all. Whether
that mod clears its projection when the switch goes off decides whether that matters, and only that
mod can say.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
