### PR TITLE
fix(sodium): count the shadow sections that carry geometry

### DIFF
--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -232,11 +232,19 @@ public final class ShadowTerrain {
 			// numbers mean the cull did not happen, and nothing on screen would say so. The table is
 			// named because a second load of the same pack prints this again, word for word: it is
 			// what tells the two readings apart, not a property of the cull itself.
+			//
+			// Two counts of the light's list rather than one, because they answer different
+			// questions and only the second one compares with anything outside this engine. The
+			// walked count is every section with something to render that the cull kept, which is
+			// what says how tight the cull was; the drawn count leaves out those carrying no block
+			// geometry, which are the ones a draw costs nothing for.
 			if (measuring && seen > 0) {
 				measured = BlockStateIds.generation();
+				SortedRenderLists lists = manager.getRenderLists();
 				Vitrail.logger().info("Shadow cull walked {} sections for the light against {} "
-						+ "for the camera, on block table {}, culling {}",
-						sections(manager.getRenderLists()), seen, measured, cull.culling());
+						+ "for the camera, {} of the light's with geometry to draw, on block "
+						+ "table {}, culling {}",
+						sections(lists), seen, drawn(lists), measured, cull.culling());
 			}
 
 			draw(renderer, minecraft, camera);
@@ -305,12 +313,42 @@ public final class ShadowTerrain {
 		}
 	}
 
+	/** Every section a walk kept, which is what says how tight the shape it measured against was. */
 	private static int sections(SortedRenderLists lists) {
 		int count = 0;
 		var iterator = lists.iterator(false);
 		while (iterator.hasNext()) {
 			ChunkRenderList list = iterator.next();
 			count += list.size();
+		}
+
+		return count;
+	}
+
+	/**
+	 * The kept sections that carry block geometry, which are the only ones the draw below spends
+	 * anything on: it walks {@code sectionsWithGeometryIterator} and steps over the rest
+	 * ({@code render/chunk/DefaultChunkRenderer}).
+	 * <p>
+	 * <strong>This is the count that compares with the reference, and the one beside it is
+	 * not.</strong> Iris puts a section count of its shadow list on the F3 screen and it is this
+	 * one: it takes {@code getSectionStatistics} inside its own shadow render list scope
+	 * ({@code shadows/ShadowRenderer.java:606}, the scope opened at {@code :477}), which Sodium
+	 * answers from {@code getSectionsWithGeometryCount} and not from the list's size
+	 * ({@code render/chunk/RenderSectionManager.getVisibleChunkCount}).
+	 * <p>
+	 * What the two differ by is narrow, and naming it is what says how far apart the numbers may
+	 * stand. A render list holds every section with anything to render at all, block entities and
+	 * animated sprites counted in ({@code RenderSectionFlags.MASK_NEEDS_RENDER}); one bit of that
+	 * mask is what reaches a draw. So a section with nothing in it is on neither side of the
+	 * comparison, and the gap is the sections whose only content is a block entity or an animated
+	 * sprite.
+	 */
+	private static int drawn(SortedRenderLists lists) {
+		int count = 0;
+		var iterator = lists.iterator(false);
+		while (iterator.hasNext()) {
+			count += iterator.next().getSectionsWithGeometryCount();
 		}
 
 		return count;


### PR DESCRIPTION
## What changes

The line the engine prints once per block table gave one section count for the light, and that
count was every section the walk kept. It reads as the number drawn into the shadow map and it is
not one: a section whose only content is a block entity or an animated sprite is carried in a
render list and then stepped over by the draw. The line now carries both numbers, the kept count
that says how tight the walk's shape was and the count with block geometry that is what the draw
spends anything on.

The two are printed rather than one replacing the other because they answer different questions,
and because every reading already taken off the kept count keeps comparing with itself.

## How it differs from the reference, and for what obstacle

It does not, and the point of the second count is to be comparable with it. Iris shows a section
count of its own shadow list on the F3 screen, taken inside its shadow render list scope
(`shadows/ShadowRenderer.java:606`, scope opened at `:477`), and Sodium answers that from
`getSectionsWithGeometryCount` rather than from the list's size. Read against the kept count alone
the two screens would be reporting different quantities.

## What proves it

- `gradlew build` green.
- The three Sodium members this leans on were checked with `javap` on the jar the build compiles
  against, and on the newer one as well, so the added call is present in both.
- No behaviour changes, nothing but a log line and the counting behind it, and the new count is
  computed only on the frame that prints.
- Not tried in the game. The line appears on entering a world with a pack loaded.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
      This changes nothing a player sees, only what a log line reports.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load. Nothing under `docs/` or `README.md` quotes this line.
