### PR TITLE
feat(screen): put the shadow map's section count on the F3 screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ what the next one holds.
   how many textures were cleared and how many were copied, then the labels, most frequent first.
   Always on, once per pack load. That is the number a Mac trace of queue submits is counting.
 
+- **The F3 screen says what the shadow map cost.** Two lines beside the version and the pack:
+  how many world sections were drawn into the map out of how many are loaded, at what render
+  distance, and what the walk for the light measured against. They are the lines Iris shows for
+  the same thing, in the same shape, so a screenshot taken under one can be read against a
+  screenshot taken under the other. Nothing has to be switched on for them to appear.
+
 ### Changed
 
 - **Chloride is no longer required, on either loader.** One thing was behind that

--- a/common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java
+++ b/common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java
@@ -2,6 +2,9 @@ package dev.vitrail.screen;
 
 import dev.vitrail.Vitrail;
 import dev.vitrail.render.PackChain;
+import dev.vitrail.sodium.ShadowTerrain;
+
+import net.minecraft.client.Minecraft;
 
 import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
 import net.minecraft.client.gui.components.debug.DebugScreenEntry;
@@ -48,7 +51,39 @@ public final class VitrailDebugEntry implements DebugScreenEntry {
 			if (!profile.isEmpty()) {
 				displayer.addToGroup(GROUP, PREFIX + "Profile: " + profile);
 			}
+			if (level != null) {
+				shadowLines(displayer);
+			}
 		}, () -> displayer.addToGroup(GROUP, PREFIX + undrawnLine()));
+	}
+
+	/**
+	 * What the shadow map cost to fill, said the way the reference says it so that a capture of one
+	 * screen reads against a capture of the other.
+	 * <p>
+	 * The first line is Sodium's own shape for the camera, which Iris reuses for the light and
+	 * shows by default ({@code gui/debug/IrisDebugEntry}, raising its shadow flag around the ask):
+	 * sections drawn over sections loaded, then the render distance. <strong>The number to read
+	 * against Iris is the first one</strong>, both sides counting the sections that carry block
+	 * geometry and no others.
+	 * <p>
+	 * The second line is what Iris keeps for its debug options and this engine has no reason to
+	 * hide: the shape the walk measured against, and how many sections came back. Two counts that
+	 * differ by little say the cull is running and finding nothing to drop, which is a state worth
+	 * seeing rather than guessing at.
+	 */
+	private static void shadowLines(DebugScreenDisplayer displayer) {
+		ShadowTerrain.Walk walk = ShadowTerrain.lastWalk();
+		if (walk == null) {
+			displayer.addToGroup(GROUP, PREFIX + "Shadows: (unavailable)");
+			return;
+		}
+
+		displayer.addToGroup(GROUP, PREFIX + "Shadows: C: " + walk.drawn() + "/" + walk.total()
+				+ " D: " + Minecraft.getInstance().options.getEffectiveRenderDistance()
+				+ (walk.terrain() ? "" : " (no terrain)"));
+		displayer.addToGroup(GROUP, PREFIX + "Shadow cull: " + walk.kept() + " sections kept, "
+				+ walk.culling());
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -29,6 +29,8 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
 import net.minecraft.world.phys.Vec3;
 
+import org.jspecify.annotations.Nullable;
+
 import org.joml.FrustumIntersection;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
@@ -91,6 +93,28 @@ public final class ShadowTerrain {
 	 */
 	private static int measured = -1;
 
+	/**
+	 * What the last walk for the light kept, drew and measured against, held for the F3 line.
+	 * <p>
+	 * Held rather than asked for where it is shown, because by then the render lists belong to the
+	 * camera again: this stage walks at the END of a frame and hands them straight back, so a count
+	 * taken from the overlay would be the camera's under a shadow heading. Iris holds the same thing
+	 * for the same reason, a string taken inside its shadow scope and read outside it
+	 * ({@code shadows/ShadowRenderer.java:119} and {@code :606}).
+	 * <p>
+	 * A null {@link #walkCulling} means no walk has run under the pack now loaded, which the line
+	 * says in those words rather than showing the numbers of a pack that is no longer drawn.
+	 */
+	private static int walkKept;
+
+	private static int walkDrawn;
+
+	private static int walkTotal;
+
+	private static boolean walkTerrain;
+
+	private static @Nullable String walkCulling;
+
 	private ShadowTerrain() {
 	}
 
@@ -146,6 +170,7 @@ public final class ShadowTerrain {
 			// or the voxel volume keeps stale writes; the compute itself runs at the head of
 			// the frame, from the frame graph setup, whatever this stage does.
 			PackChain.clearCustomImages();
+			walkCulling = null;
 			return;
 		}
 
@@ -238,13 +263,17 @@ public final class ShadowTerrain {
 			// walked count is every section with something to render that the cull kept, which is
 			// what says how tight the cull was; the drawn count leaves out those carrying no block
 			// geometry, which are the ones a draw costs nothing for.
+			count(manager.getRenderLists());
+			walkTotal = manager.getTotalSections();
+			walkTerrain = casters.terrain();
+			walkCulling = cull.culling();
+
 			if (measuring && seen > 0) {
 				measured = BlockStateIds.generation();
-				SortedRenderLists lists = manager.getRenderLists();
 				Vitrail.logger().info("Shadow cull walked {} sections for the light against {} "
 						+ "for the camera, {} of the light's with geometry to draw, on block "
 						+ "table {}, culling {}",
-						sections(lists), seen, drawn(lists), measured, cull.culling());
+						walkKept, seen, walkDrawn, measured, walkCulling);
 			}
 
 			draw(renderer, minecraft, camera);
@@ -326,13 +355,14 @@ public final class ShadowTerrain {
 	}
 
 	/**
-	 * The kept sections that carry block geometry, which are the only ones the draw below spends
-	 * anything on: it walks {@code sectionsWithGeometryIterator} and steps over the rest
-	 * ({@code render/chunk/DefaultChunkRenderer}).
+	 * Both counts of the light's list, in one pass because the F3 line asks for them every frame
+	 * and not once a block table any more.
 	 * <p>
-	 * <strong>This is the count that compares with the reference, and the one beside it is
-	 * not.</strong> Iris puts a section count of its shadow list on the F3 screen and it is this
-	 * one: it takes {@code getSectionStatistics} inside its own shadow render list scope
+	 * <strong>The drawn count is the one that compares with the reference, and the kept count is
+	 * not.</strong> Only the sections carrying block geometry reach a draw, which walks
+	 * {@code sectionsWithGeometryIterator} and steps over the rest
+	 * ({@code render/chunk/DefaultChunkRenderer}), and it is that count Iris puts on the F3 screen:
+	 * it takes {@code getSectionStatistics} inside its own shadow render list scope
 	 * ({@code shadows/ShadowRenderer.java:606}, the scope opened at {@code :477}), which Sodium
 	 * answers from {@code getSectionsWithGeometryCount} and not from the list's size
 	 * ({@code render/chunk/RenderSectionManager.getVisibleChunkCount}).
@@ -343,14 +373,44 @@ public final class ShadowTerrain {
 	 * mask is what reaches a draw. So a section with nothing in it is on neither side of the
 	 * comparison, and the gap is the sections whose only content is a block entity or an animated
 	 * sprite.
+	 * <p>
+	 * One pass and not two, where Iris pays one for the single count it shows: the two sums walk
+	 * the same handful of per region lists, so asking for them apart would double a walk this
+	 * stage now makes on every frame.
 	 */
-	private static int drawn(SortedRenderLists lists) {
-		int count = 0;
+	private static void count(SortedRenderLists lists) {
+		int kept = 0;
+		int drawn = 0;
 		var iterator = lists.iterator(false);
 		while (iterator.hasNext()) {
-			count += iterator.next().getSectionsWithGeometryCount();
+			ChunkRenderList list = iterator.next();
+			kept += list.size();
+			drawn += list.getSectionsWithGeometryCount();
 		}
 
-		return count;
+		walkKept = kept;
+		walkDrawn = drawn;
+	}
+
+	/**
+	 * The last walk for the light, or null where none has run under the pack now loaded.
+	 *
+	 * @param kept    every section with something to render that the walk kept
+	 * @param drawn   those of them carrying block geometry, which is the count Iris shows
+	 * @param total   every section loaded, which is the denominator Sodium's own line carries
+	 * @param terrain whether the pack takes the world's own geometry into its map at all. The walk
+	 *                runs either way, the entities and the far terrain being decided apart from it,
+	 *                so a count without this flag beside it would announce sections that no draw
+	 *                ever reads. Iris says the same thing in the same place, {@code (no terrain)}
+	 *                appended to its own line ({@code shadows/ShadowRenderer.java:776})
+	 * @param culling the shape the walk measured against, in the words the log line uses
+	 */
+	public record Walk(int kept, int drawn, int total, boolean terrain, String culling) {
+	}
+
+	/** The last walk, for the one line that shows it. */
+	public static @Nullable Walk lastWalk() {
+		return walkCulling == null ? null
+				: new Walk(walkKept, walkDrawn, walkTotal, walkTerrain, walkCulling);
 	}
 }


### PR DESCRIPTION
## What changes

The engine's F3 lines named the version, the pack and its profile, and stopped there. The one number
that says what the shadow map cost to fill lived in a log line printed once per block table, which is
not where somebody comparing two screenshots can reach it. Two lines are added.

The first is the shape the reference gives the same number: sections drawn into the map, over
sections loaded, then the render distance. Both sides count only the sections that carry block
geometry, which are the only ones a draw spends anything on, so the two screens read against each
other without arithmetic. A pack that keeps the world's own geometry out of its map has that said on
the line, because the walk still runs for the entities and the far terrain and the count alone would
announce sections nothing reads.

The second line is what the walk measured against and how many sections it kept. Two counts that
differ by little say the cull is running and finding nothing to drop, which is a state worth seeing
rather than inferring.

The counts are taken where the walk makes them and held until the overlay asks, because by then the
render lists belong to the camera again: this engine walks for the light at the end of a frame and
hands them straight back.

## How it differs from the reference, and for what obstacle

The first line does not differ, and being comparable is its whole purpose. Iris shows a section count
of its own shadow list by default, raising its shadow flag around the ask so Sodium answers from the
shadow lists (`gui/debug/IrisDebugEntry`, and the redirect at
`compat/sodium/mixin/MixinRenderSectionManagerShadow.java:268-273`).

The second line is one the reference keeps behind its debug options, and those are only switched on
by themselves in a development environment (`mixin/MixinDebugScreenEntriesList.java`). There is no
obstacle to showing it, so it is shown.

## What proves it

- `gradlew build` green, after the rebase.
- The three Sodium members this leans on were checked with `javap` on the jar the build compiles
  against and on the newer one, so the calls are present in both.
- In the game, on the Fabric bench: the lines come up on the F3 screen with no configuration turned
  on by hand, and the numbers move with the pack's own shadow distance.

## What it leaves owing

The reference also names a colour space on that screen. This engine publishes one value and has no
screen to choose another, so the line would be a constant standing in two places at once. It waits
for something to choose.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
