### PR TITLE
build: compile against sodium 0.9.2-alpha.4

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -41,9 +41,9 @@ dependencies {
 	// up to the first import.
 	//
 	// Which of the two is compiled against was settled by comparing them class by class rather than
-	// by argument. Of the 688 classes the NeoForge jar carries, 659 are byte for byte identical to
-	// the Fabric one, 26 exist only there and are all under sodium's own neoforge and
-	// mixin.platform.neoforge packages, and 3 differ and are all sodium mixins. Everything this
+	// by argument. Of the 732 classes the NeoForge jar carries at 0.9.2-alpha.4, 704 are byte for
+	// byte identical to the Fabric one, 25 exist only there and are all under sodium's own neoforge
+	// and mixin.platform.neoforge packages, and 3 differ and are all sodium mixins. Everything this
 	// module names is in the identical set.
 	compileOnly("net.caffeinemc:sodium-fabric:${project.sodium_version}") {
 		transitive = false

--- a/common/src/main/java/dev/vitrail/mixin/ArenaAggregatorMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/ArenaAggregatorMixin.java
@@ -1,5 +1,6 @@
 package dev.vitrail.mixin;
 
+import net.caffeinemc.mods.sodium.client.gpu.arena.ArenaAggregator;
 import net.caffeinemc.mods.sodium.client.render.chunk.vertex.format.ChunkMeshFormats;
 import net.caffeinemc.mods.sodium.client.render.chunk.vertex.format.ChunkVertexType;
 import org.objectweb.asm.Opcodes;
@@ -18,17 +19,17 @@ import org.spongepowered.asm.mixin.injection.Redirect;
  * chunk renderer, and a region's device resources. Those three see the pack's mesh. The allocator
  * did not, so the resources asked it for forty and it threw {@code Unsupported stride}.
  * <p>
- * The class is absent from the 0.9.1 this module compiles against, which is why the target is a
- * name and why {@code @Pseudo} lets 0.9.1 skip the mixin rather than refuse to load. The redirect
- * is required when the class is there: a silent miss would be the same crash the player already
- * hit, arriving a world late.
+ * The class is absent from the 0.9.1 the mod still accepts at runtime, which is why
+ * {@code @Pseudo} lets 0.9.1 skip the mixin rather than refuse to load. The redirect is required
+ * when the class is there: a silent miss would be the same crash the player already hit, arriving
+ * a world late.
  * <p>
  * Construction is after {@code TerrainMesh.settle}, at the head of {@code initRenderer}, so
  * {@code getCurrent()} here is the format the builder is about to write. That is the same instant
  * {@code MixinSodiumWorldRendererInit} already chose, not a second one.
  */
 @Pseudo
-@Mixin(targets = "net.caffeinemc.mods.sodium.client.gpu.arena.ArenaAggregator", remap = false)
+@Mixin(value = ArenaAggregator.class, remap = false)
 public abstract class ArenaAggregatorMixin {
 
 	@Redirect(

--- a/common/src/main/java/dev/vitrail/mixin/MixinSodiumWorldRendererInit.java
+++ b/common/src/main/java/dev/vitrail/mixin/MixinSodiumWorldRendererInit.java
@@ -30,8 +30,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * constructor asks {@code ChunkMeshFormats.getCurrent}.</strong> That is narrower than saying
  * nothing holding a stride is alive here, and it is what was measured: this runs before
  * {@code deleteRendererState}, so the previous manager and its regions are still standing, and an
- * exhaustive pass over the 688 classes of the mod jar inside 0.9.1 finds no caller of that method on
- * the road between. Everything that will ask for the format is built afterwards, and every section
+ * exhaustive pass over every class of the mod jar, in 0.9.1 and again in 0.9.2-alpha.4, finds no
+ * caller of that method on the road between. Everything that will ask for the format is built afterwards, and every section
  * is meshed again after that.
  * <p>
  * <strong>{@code require = 1} because this injection is now the only writer of the answer</strong>,

--- a/common/src/main/java/dev/vitrail/render/EntityMesh.java
+++ b/common/src/main/java/dev/vitrail/render/EntityMesh.java
@@ -38,7 +38,7 @@ import org.jspecify.annotations.Nullable;
  * than deduced: under the lengthened field, on one bench and with only the jar changing, the spider,
  * the enderman, the warden, the charged creeper and the player's own arm were all gone, and only the
  * enderman's particles were left hanging where its body should have been. All three readings are off
- * the bytecode of the 0.9.1 this compiles against and not off a newer checkout.
+ * the bytecode of the shipped jars, 0.9.1 and 0.9.2-alpha.4, and not off a newer checkout.
  * <p>
  * A separate object fails that identity test, so the same {@code push} takes {@code copySlow}, which
  * asks {@code VertexSerializerRegistry} for a serializer from one format to the other.

--- a/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
@@ -229,14 +229,15 @@ public final class ShadowGeometry {
 	 * <strong>And the game's own list is empty for the whole session here.</strong>
 	 * {@code LevelRenderer.visibleSections()} is filled by {@code LevelExtractor.applyFrustum}, which
 	 * Sodium redirects to an empty method ({@code mixin/core/render/world/LevelExtractorMixin}, a
-	 * {@code @Redirect} on {@code applyFrustum}, read at the shipped 0.9.1 jar). Walked, it yields
-	 * nothing, once, for ever, and the count printed beside it reads as a world with no chests in it.
+	 * {@code @Redirect} on {@code applyFrustum}, identical in the shipped 0.9.1 and 0.9.2-alpha.4
+	 * jars). Walked, it yields nothing, once, for ever, and the count printed beside it reads as a
+	 * world with no chests in it.
 	 * Iris is NOT in that position and never was: it asks the game for them
 	 * ({@code shadows/ShadowRenderer.java:668}, through an invoker on the game's own
 	 * {@code extractVisibleBlockEntities}), and Sodium cancels that method at head and answers it from
 	 * {@code SodiumWorldRenderer.extractBlockEntities}, off the render lists of whatever walk last
-	 * filled them. Which class carries that cancel moved between the two versions, so it is the same
-	 * behaviour rather than the same mixin. This walk asks the same object directly, and inside the
+	 * filled them. Which class carries that cancel moved between the shipped jars and the newer
+	 * checkout, so it is the same behaviour rather than the same mixin. This walk asks the same object directly, and inside the
 	 * light's scope what it hands back is the light's sections.
 	 * <p>
 	 * <strong>Asked once per stage, and nothing enforces that but the call site.</strong> The door

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ fabric_loader_version=0.19.3
 moddev_version=2.0.143
 
 # Provided at runtime by the pack, never bundled.
-sodium_version=0.9.1+mc26.2
+sodium_version=0.9.2-alpha.4+mc26.2
 
 # Provided at runtime by whichever loader is in front, never bundled either. The Mixin version is
 # the one Fabric Loader ships; NeoForge carries the same upstream 0.8.7 under its own coordinates.


### PR DESCRIPTION
## What changes

The version of Sodium the build compiles against moves from 0.9.1+mc26.2 to 0.9.2-alpha.4+mc26.2, which is the version the launcher installs and players run. The accepted range does not move: the mod still declares Sodium 0.9.x on Fabric and [0.9,0.10) on NeoForge, and it still runs on a 0.9.1 runtime. With the arena class now on the compile classpath, the mixin that sizes 0.9.2's shared geometry arena names its target by class rather than by string, so javac checks the name; `@Pseudo` still lets a 0.9.1 runtime skip it. The comments that pinned their bytecode readings to the 0.9.1 the module used to compile against now cover both shipped jars.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

- `gradlew build` green.
- Every Sodium class the mixins target, disassembled in both jars and compared: seven are byte-identical, `SodiumWorldRenderer` only gains a method, `RenderSectionManager` keeps every member the accessors name, and `ArenaAggregator`'s constructor carries the exact `GETSTATIC` the redirect points at.
- In game on both loaders, each bench on Sodium 0.9.2-alpha.4 (Fabric with Complementary Unbound, NeoForge with Complementary Unbound plus Euphoria Patches): the backend is Vulkan, the 40 byte chunk mesh is accepted, the pack's chain compiles and draws, the shadow cull walks its sections, and the log carries no mixin failure.
- The same jar back on a 0.9.1 Sodium runtime: the arena mixin is skipped and the chain still draws.

## What it leaves owing

The Iris reference benches stay on Sodium 0.9.1, which is what Iris supports: a parity measurement against Iris still requires dropping our bench to 0.9.1 for the duration, and putting it back.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
