### PR TITLE
docs: correct the pack mesh floor to twenty-four bytes

### DIFF
--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -41,8 +41,8 @@ from nothing, and merely repeats it everywhere else. Turning the terrain switch 
 game to rebuild the world, which is the same door F3+A uses; it does not ask for a restart.
 
 Sodium 0.9.2 added a shared geometry arena that does not call the accessor. It bakes the compact
-stride at construction and then refuses any other width, so a pack's mesh (thirty-two to forty bytes)
-dies with `Unsupported stride` on the first upload. A mixin on that constructor asks the accessor
+stride at construction and then refuses any other width, so a pack's mesh (twenty-four to forty
+bytes) dies with `Unsupported stride` on the first upload. A mixin on that constructor asks the accessor
 instead, at the same instant the section manager is built. 0.9.1 has no such class, and the mixin
 is skipped there.
 


### PR DESCRIPTION
## What changes

One figure on the terrain page. It gave a pack's chunk mesh a floor of thirty-two bytes where the format's real floor is twenty-four: the mesh appends only the elements the pack's six chunk programs read, each four bytes over Sodium's twenty, and a single element is enough to build the format. `TerrainMesh`'s javadoc already carried the right range, so the two sources disagreed and the page loses.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

The element table in `TerrainMesh`: five appendable elements, every one four bytes wide, appended only when the pack reads their name, and the format is built as soon as the list is non-empty. `gradlew build` green.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
