### PR TITLE
fix(pack): drop a compute the pack's own switch turns off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,21 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack's shadow compute is no longer built when the pack switched it off.** A pack turns
+  whole programs on and off from its own settings, and the compute pass behind coloured lighting
+  was read and handed to the compiler whichever way that setting stood. Switched off, the pack
+  also takes away the colour tables and the image formats that pass reads, so what reached the
+  compiler was not a shader at all and it was refused. The refusal came out as a warning, and
+  there was nothing on screen to say a pass had been meant to run. BSL with its multicoloured
+  blocklight off, Bliss, and both Complementary outside their coloured lighting profiles were all
+  in that state.
+
+- **A pack's storage images keep the words it wrote around them.** Translation rebuilt those
+  declarations from the type onwards and dropped `writeonly`, `readonly`, `restrict` and
+  `coherent` on the way, whichever side of `uniform` the pack put them. On Vulkan the first of
+  those is what makes an image with no declared format legal at all, and it is the one the packs
+  that ship a voxel volume write.
+
 - **Distant Horizons' far water no longer paints over you.** In third person, with far water
   behind, the character came out washed out or gone entirely, and the part of him it covered
   followed the part of the far water behind him. Everything drawn between the two halves of the

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -291,6 +291,14 @@ public final class GlslTranslator {
 	private final Map<String, String> samplers = new LinkedHashMap<>();
 
 	/**
+	 * What a pack wrote in front of an opaque uniform's type, by the name it declared:
+	 * {@code writeonly}, {@code readonly}, {@code coherent} and their kind. Lifting the
+	 * declaration into the header rebuilds it from the type onwards, so anything in front of the
+	 * type is only still in the shader because it is kept here.
+	 */
+	private final Map<String, String> memoryQualifiers = new LinkedHashMap<>();
+
+	/**
 	 * The sampler this unit reads {@code centerDepthSmooth} out of, or null where nothing was moved.
 	 * The header declares it, because the statement it was taken out of may still declare other
 	 * names and cannot carry a second declaration.
@@ -2759,7 +2767,7 @@ public final class GlslTranslator {
 		}
 
 		Map<String, String> found = new LinkedHashMap<>();
-		if (!readDeclarators(parts, cursor + 1, type, found)) {
+		if (!readDeclarators(parts, cursor + 1, type, "", found)) {
 			return null;
 		}
 
@@ -2862,20 +2870,31 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Vulkan GLSL requires a format on a storage image. Iris's GL bind supplies it at bind time,
-	 * so Complementary writes {@code writeonly uniform uimage3D voxel_img} with none. The format
-	 * comes off the {@code image.} directive and is written here, in the header: the body
-	 * declaration has already been lifted, so a layout qualifier inserted into the token stream
-	 * would qualify a statement that is no longer in the shader.
+	 * Vulkan GLSL requires a format on a storage image, unless the image is write-only. Iris's GL
+	 * bind supplies the format at bind time, so Complementary writes
+	 * {@code writeonly uniform uimage3D voxel_img} with none, and BSL writes
+	 * {@code writeonly uniform image3D lightimg0} the same way. The format comes off the
+	 * {@code image.} directive and is written here, in the header: the body declaration has
+	 * already been lifted, so a layout qualifier inserted into the token stream would qualify a
+	 * statement that is no longer in the shader.
+	 * <p>
+	 * The pack's own memory qualifiers are written back for the same reason, and they are what
+	 * carries a declaration whose format we never learn: a pack switches its images off with the
+	 * setting that switches off the program reading them, and then the {@code image.} lines go
+	 * with it while the {@code writeonly} on the declaration stays. Dropping it turned a legal
+	 * declaration into one shaderc refuses.
 	 */
-	private static String declareOpaque(TranslatedUnit.Uniform sampler) {
+	private String declareOpaque(TranslatedUnit.Uniform sampler) {
+		String memory = this.memoryQualifiers.getOrDefault(sampler.name(), "");
+		String tail = (memory.isEmpty() ? "" : memory + " ") + "uniform " + sampler.declaration()
+				+ ";";
 		if (!isImageType(sampler.type())) {
-			return "uniform " + sampler.declaration() + ";";
+			return tail;
 		}
 
 		return CustomImages.layoutFormat(sampler.name())
-				.map(format -> "layout(" + format + ") uniform " + sampler.declaration() + ";")
-				.orElse("uniform " + sampler.declaration() + ";");
+				.map(format -> "layout(" + format + ") " + tail)
+				.orElse(tail);
 	}
 
 	private static boolean isImageType(String type) {
@@ -2896,13 +2915,23 @@ public final class GlslTranslator {
 		}
 
 		List<Integer> parts = significantRange(start, end);
-		int cursor = parts.indexOf(keyword);
-		if (cursor < 0) {
+		int keywordAt = parts.indexOf(keyword);
+		if (keywordAt < 0) {
 			return;
 		}
 
-		cursor++;
+		// Both sides of the keyword, because the corpus uses both. BSL and Complementary's voxel
+		// volume write writeonly uniform image3D, the qualifier in front, and Bliss and
+		// Complementary's player atlas write uniform readonly and uniform writeonly, the
+		// qualifier behind. Reading only what follows the keyword lost the first form.
+		List<String> memory = new ArrayList<>();
+		for (int part = 0; part < keywordAt; part++) {
+			rememberMemoryQualifier(memory, this.tokens.get(parts.get(part)));
+		}
+
+		int cursor = keywordAt + 1;
 		while (cursor < parts.size() && isQualifier(this.tokens.get(parts.get(cursor)))) {
+			rememberMemoryQualifier(memory, this.tokens.get(parts.get(cursor)));
 			cursor++;
 		}
 
@@ -2920,7 +2949,10 @@ public final class GlslTranslator {
 		// collectComparisonSamplers, so this only has to record it under the same spelling.
 		String plain = withoutComparison(type);
 
-		if (!readDeclarators(parts, cursor + 1, plain, opaque ? this.samplers : this.blockMembers)) {
+		// Recorded for an opaque uniform alone, which is the only declaration these can be
+		// written on and the only one that reads them back out of the header.
+		if (!readDeclarators(parts, cursor + 1, plain, opaque ? String.join(" ", memory) : "",
+				opaque ? this.samplers : this.blockMembers)) {
 			return;
 		}
 
@@ -3589,8 +3621,15 @@ public final class GlslTranslator {
 		return type.substring(0, type.length() - SHADOW_SHAPE.length());
 	}
 
-	/** Records each declarator of one declaration. False if none could be read. */
-	private boolean readDeclarators(List<Integer> parts, int from, String type,
+	/**
+	 * Records each declarator of one declaration. False if none could be read.
+	 *
+	 * @param memory the memory qualifiers written in front of the type, kept beside the name
+	 *               rather than in the declaration so that the type stays the first word of it.
+	 *               Empty for everything but an opaque uniform, which is the only declaration
+	 *               these can be written on.
+	 */
+	private boolean readDeclarators(List<Integer> parts, int from, String type, String memory,
 			Map<String, String> target) {
 		int cursor = from;
 		boolean any = false;
@@ -3603,6 +3642,10 @@ public final class GlslTranslator {
 
 			if (token.kind() != Kind.IDENTIFIER) {
 				return false;
+			}
+
+			if (!memory.isEmpty()) {
+				this.memoryQualifiers.put(token.text(), memory);
 			}
 
 			StringBuilder declaration = new StringBuilder(type).append(' ').append(token.text());
@@ -4374,6 +4417,15 @@ public final class GlslTranslator {
 		}
 
 		return found;
+	}
+
+	/** Adds a memory qualifier to what a declaration carries, in the order the pack wrote it. */
+	private static void rememberMemoryQualifier(List<String> memory, Token token) {
+		String text = token.text();
+		if (token.kind() == Kind.IDENTIFIER && LegacyGlsl.MEMORY_QUALIFIERS.contains(text)
+				&& !memory.contains(text)) {
+			memory.add(text);
+		}
 	}
 
 	private static boolean isQualifier(Token token) {

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -184,17 +184,60 @@ public final class TargetPlan {
 
 		List<ProgramSet.ProgramKey> entries = fragmentsOf(programs, draft.place);
 
+		Map<String, String> defines = settings.globalDefines(options);
 		read(source, options, settings, properties, entries, draft);
-		walk(properties, options, settings.globalDefines(options), entries, filter, draft);
-
-		draft.computes = programs.keys().stream()
-				.filter(key -> key.stage() == ProgramStage.COMPUTE && key.dimension().equals(draft.place))
-				.map(key -> key.name().baseName())
-				.sorted()
-				.distinct()
-				.toList();
+		walk(properties, options, defines, entries, filter, draft);
+		computes(properties, options, defines, programs, draft);
 
 		return new TargetPlan(draft);
+	}
+
+	/**
+	 * The compute programs of this place, minus the ones the pack's own switch turns off.
+	 * <p>
+	 * Iris refuses a disabled program at the source: its provider hands back nothing for the name,
+	 * so no family is read and none is compiled, computes included
+	 * ({@code ShaderPack.java:261-265} fills the list, {@code :290-294} refuses on it). Here the
+	 * toggles are applied where each list is built, and this one was left out while nothing ran
+	 * it. BSL conditions its three {@code shadowcomp} programs on
+	 * {@code MULTICOLORED_BLOCKLIGHT}, and the setting takes with it both the {@code image.}
+	 * directives that give those images a format and the colour tables the compute indexes, so a
+	 * pack switched off does not merely draw nothing: it does not compile.
+	 */
+	private static void computes(ShaderProperties properties, OptionIndex options,
+			Map<String, String> defines, ProgramSet programs, Draft draft) {
+		Map<String, Boolean> toggles = properties.programToggles(defines, options);
+		Map<String, String> conditions = properties.programConditions(defines);
+		Set<String> kept = new TreeSet<>();
+		Map<String, String> off = new LinkedHashMap<>();
+
+		for (ProgramSet.ProgramKey key : programs.keys()) {
+			if (key.stage() != ProgramStage.COMPUTE || !key.dimension().equals(draft.place)) {
+				continue;
+			}
+
+			// The file the pack ships with its extension taken off, which is the name Iris looks
+			// up, and NOT the base name. A compute hangs off a composite by a letter, so
+			// world0/composite21_a is a name of its own and a pack switching off
+			// world0/composite21 has said nothing about it. Iris keeps those computes and runs
+			// them with no fragment stage at all, CompositeRenderer.java:135-141.
+			String file = key.file();
+			int dot = file.lastIndexOf('.');
+			String path = dot < 0 ? file : file.substring(0, dot);
+			String name = key.name().baseName();
+			if (Boolean.FALSE.equals(toggles.get(path))) {
+				off.put(name, conditions.getOrDefault(path, "shaders.properties"));
+				continue;
+			}
+
+			kept.add(name);
+		}
+
+		// Several files answer for one name once the letter is off it, and the name runs as soon
+		// as one of them is on: what the plan carries downstream is the name.
+		off.keySet().removeAll(kept);
+		draft.computes = List.copyOf(kept);
+		draft.disabledComputes.putAll(off);
 	}
 
 	/**
@@ -660,6 +703,16 @@ public final class TargetPlan {
 			}
 		}
 
+		// Named apart from the passes the engine leaves out, because nothing here is missing: the
+		// pack asked for these to be absent, and a reader who finds a compute in the folder and no
+		// dispatch in the log is owed the setting that answers for it.
+		if (!draft.disabledComputes.isEmpty()) {
+			notes.add("compute programs this place ships and the pack switches off: "
+					+ draft.disabledComputes.entrySet().stream()
+							.map(entry -> entry.getKey() + " (" + entry.getValue() + ")")
+							.collect(Collectors.joining(", ")));
+		}
+
 		if (!draft.shadowComposites.isEmpty()) {
 			notes.add("shadow composites skipped, they draw full screen over the shadow colour "
 					+ "buffers on a flip counter of their own and this engine runs no stage there, "
@@ -817,6 +870,7 @@ public final class TargetPlan {
 
 		private final List<String> running = new ArrayList<>();
 		private final Map<String, String> disabled = new LinkedHashMap<>();
+		private final Map<String, String> disabledComputes = new LinkedHashMap<>();
 		private final Set<String> shadowComposites = new TreeSet<>();
 		private final Set<Integer> written = new TreeSet<>();
 		private final Set<Integer> sampled = new TreeSet<>();

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -252,8 +252,8 @@ None of this is inference. A compute shader built with that shaderc, dispatched 
 image allocated through VMA, writes texels the same frame reads back unchanged: the road is open,
 and nothing of it was ever in the backend's way. The stage that walks it is `PackCompute`, which
 compiles a pack's `shadowcomp` and dispatches it at the head of the frame. Which programs it serves,
-and why that moment rather than beside the shadow map that feeds it, is answered where the pack's
-chain is.
+including the pack's own switch deciding whether it serves any at all, and why that moment rather
+than beside the shadow map that feeds it, is answered where the pack's chain is.
 
 ## Small things that cost a lot to rediscover
 

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -51,9 +51,9 @@ zero to the first empty slot drops real programs.
 A compute program hangs a single-letter suffix off a name that has to be valid without it, and the
 suffix is recognised on the numbered families and on two of the unnumbered names, not on the
 geometry names. Vitrail reads those files and names them in the log. One family of them runs, the
-shadow compute, translated like any other unit and dispatched once a frame. The rest are named and
-go no further, so what their order among themselves would be is the reference's business and not
-this engine's yet.
+shadow compute, translated like any other unit and dispatched once a frame wherever the pack's own
+toggle keeps it. The rest are named and go no further, so what their order among themselves would
+be is the reference's business and not this engine's yet.
 
 Stages are never paired or cross-checked. A compute program and a fragment program with the same
 slot name coexist as independent entries, which is a real case.
@@ -125,6 +125,12 @@ conditions `world0/composite1` and `world-1/composite1` on two different express
 bare key when the qualified one is absent would run in the Nether a pass the pack switched off
 there. Deriving that key by substituting characters in the folder name misses instead, silently, on
 every pack with an unusual dimension name.
+
+**A compute is looked up under the file it ships in, letter included.** A compute hangs off a
+name by a single letter, so `world0/composite21_a` is a key of its own and a pack switching off
+`world0/composite21` has said nothing about it. The reference keeps such a compute and runs it
+with no fragment stage at all, which is why the lookup cannot fall back to the name the letter
+came off.
 
 Both an empty value and a non-evaluable expression mean enabled: this file is read fail-open.
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -300,7 +300,9 @@ for that path, three different mechanisms, and it is worth knowing which:
   queue, a public `VkDevice`, and the shaderc the game embeds, whose compute kind the facade never
   passes. That path has been made to dispatch and to write, and a pack's own shadowcomp goes down
   it: translated like any other unit, compiled by the same shaderc, dispatched at the head of the
-  frame. The other compute names are named in the log and go no further, translation included.
+  frame. Only where the pack keeps it, and a pack that switches the program off takes with it the
+  declarations that program reads, so one switched off does not draw nothing, it does not compile.
+  The other compute names are named in the log and go no further, translation included.
 - **Storage buffers and storage images are worse than refused on the facade: they are ignored.**
   Reflection asks for uniform buffers, sampled images, outputs and inputs, and never enumerates
   them. On the facade's own walk they pass compilation and are bound to nothing, so the walk is


### PR DESCRIPTION
## What changes

A compute program a pack switches off from its own settings is no longer read, translated or
handed to the compiler: it is dropped where the plan lists this place's computes, and the log
names it once with the setting that answers for it. Before, the switched-off compute was
compiled anyway, and since the setting also takes away the colour tables and image formats that
pass reads, the compile failed as a warning on every load, with nothing saying a pass had been
meant to run. Alongside it, translation now keeps the memory qualifiers a pack writes around a
storage image (`writeonly`, `readonly`, `restrict`, `coherent`), whichever side of `uniform`
they were written: lifting the declaration into the header rebuilt it from the type onwards and
dropped them, and `writeonly` is what makes an image with no declared format legal on Vulkan.

## How it differs from the reference, and for what obstacle

It does not. Iris refuses a disabled program at the source: the provider hands back nothing for
the name, so nothing is compiled (`ShaderPack.java:261-265`, `:290-294`). The lookup runs on the
file path with its letter suffix, not the base name, because the reference keeps a compute whose
own path was not switched off even when the name it hangs off was (`CompositeRenderer.java:135-141`).

## What proves it

- `gradlew build` green after the rebase.
- In the game, Fabric bench, one evening: Complementary Unbound logs
  `compute programs this place ships and the pack switches off: shadowcomp (false)` with zero
  compile errors where every load used to warn; Bliss logs `setup (false), shadowcomp (false)`;
  BSL names its own setting, `shadowcomp (MULTICOLORED_BLOCKLIGHT)`. Raising Complementary's
  profile in the pack screen loads, compiles and serves the compute again without a relaunch,
  Nether included.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
