### PR TITLE
build: set the version to 0.8.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.8.0-beta
 
 ### Added
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.7.5-beta
+mod_version=0.8.0-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

`mod_version` moves from 0.7.5-beta to 0.8.0-beta and the changelog's `Unreleased` section takes
the version's name. Nothing else: this is the commit the release workflow checks the tag against.

## How it differs from the reference, and for what obstacle

It does not; no engine line moves.

## What proves it

- `gradlew build` green after the rebase.
- The release script refuses a tag that disagrees with `mod_version`, which is the check this
  commit exists to satisfy.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
