### PR TITLE
fix(pack): answer a pack's switch for the geometry too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,15 @@ what the next one holds.
   its sky and clouds are built from stayed empty. The compute now reads the same depth as the pass
   after it, which is what Iris gives it.
 
+- **A pack switching off one of its own programs is obeyed for the world, not only for its
+  full-screen passes.** A pack turns individual programs on and off from its settings, and the ones
+  that draw the world went on being drawn whatever the setting said. Where the pack offers a
+  plainer program behind the one it switched off, that plainer one now draws instead, which is what
+  the pack is asking for: Bliss draws its translucent entities and blocks through its ordinary
+  entity and block programs until you turn its translucent entities setting on. Where it offers
+  none, nothing is drawn: Bliss and BSL stop building a shadow map in the Nether, and Bliss in the
+  End as well, which is what both of them ask for there.
+
 - **Importing settings no longer acts on a screen you have already left.** The window that asks
   which file to read is the system's own and does not hold the game, so the settings screen can be
   closed while it is still up. Picking a file at that point queued its values anyway, into a page

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -696,7 +696,8 @@ public final class PackProgram {
 					() -> DimensionSet.discover(source));
 			ProgramResolver resolver = ProgramResolver.resolve(
 					source.derived(ProgramSet.class, () -> ProgramSet.enumerate(source, dimensions)),
-					dimensions);
+					dimensions, pack.properties().switchedOff(pack.settings().globalDefines(pack.options()),
+							pack.options()));
 
 			return new Reading(expander, targets, textures, resolver);
 		});
@@ -1409,7 +1410,8 @@ public final class PackProgram {
 
 		DimensionSet dimensions = DimensionSet.discover(source);
 		ProgramSet programs = ProgramSet.enumerate(source, dimensions);
-		ChainPlan chain = ChainPlan.of(targets, ProgramResolver.resolve(programs, dimensions),
+		ChainPlan chain = ChainPlan.of(targets, ProgramResolver.resolve(programs, dimensions,
+				properties.switchedOff(settings.globalDefines(options), options)),
 				refusals, families);
 
 		Map<String, Loaded> loaded = new LinkedHashMap<>();

--- a/common/src/main/java/dev/vitrail/pack/load/PackLoader.java
+++ b/common/src/main/java/dev/vitrail/pack/load/PackLoader.java
@@ -15,7 +15,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -59,7 +58,6 @@ public final class PackLoader {
 			ShaderProperties properties = ShaderProperties.parse(source);
 			OptionIndex options = source.options();
 			ProgramSet programs = ProgramSet.enumerate(source, dimensions);
-			ProgramResolver resolved = ProgramResolver.resolve(programs, dimensions);
 			PackStats stats = PackStats.measure(source, options);
 
 			// Every entry point is flattened, and the text is then thrown away. This stage is
@@ -69,12 +67,15 @@ public final class PackLoader {
 
 			// The file has conditionals of its own, and they read the settings, so the toggles
 			// can only be known once the settings are.
-			Set<String> disabled = new LinkedHashSet<>();
-			properties.programToggles(settings.globalDefines(options), options).forEach((program, on) -> {
-				if (!on) {
-					disabled.add(program);
-				}
-			});
+			Set<String> disabled = properties.switchedOff(settings.globalDefines(options), options);
+
+			// Resolved as the pack SHIPS, with no toggle applied, and the empty set says so rather
+			// than standing for one nobody worked out. This report runs before the machine's own
+			// symbols are installed and against the pack's defaults rather than the player's
+			// settings, so the answer it would give to a toggle is not the answer the chain gets:
+			// a pack branching a program on DISTANT_HORIZONS reads it off here and on there. The
+			// count above carries the same reserve and carried it before this line existed.
+			ProgramResolver resolved = ProgramResolver.resolve(programs, dimensions, Set.of());
 
 			// This walk is a diagnosis of a pack and not a step of a load: it is made the first
 			// time a pack is read and never again for the same one, so what it costs is left out

--- a/common/src/main/java/dev/vitrail/pack/program/ProgramResolver.java
+++ b/common/src/main/java/dev/vitrail/pack/program/ProgramResolver.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Works out, for one dimension, which file actually serves each program.
@@ -27,11 +28,23 @@ public final class ProgramResolver {
 		this.byDimension = Map.copyOf(byDimension);
 	}
 
-	public static ProgramResolver resolve(ProgramSet programs, DimensionSet dimensions) {
+	/**
+	 * @param switchedOff the programs the pack's own settings turn off, under the paths it wrote,
+	 *                    from {@link dev.vitrail.pack.source.ShaderProperties#switchedOff}. One of
+	 *                    those counts as not shipped rather than as served by nothing, so the
+	 *                    chain carries on to the next candidate and a family whose parent is still
+	 *                    there keeps drawing through the parent. Skipping the family outright
+	 *                    would leave the geometry unserved, which the reference does not do and
+	 *                    which is worse than serving it: a pack that switches off its translucent
+	 *                    entity program is asking for those entities to be drawn by its ordinary
+	 *                    entity program, not for them to disappear.
+	 */
+	public static ProgramResolver resolve(ProgramSet programs, DimensionSet dimensions,
+			Set<String> switchedOff) {
 		// One index per dimension of what that dimension ships, keyed by program name.
 		Map<String, Map<String, String>> shipped = new LinkedHashMap<>();
 		for (ProgramSet.ProgramKey key : programs.keys()) {
-			if (key.stage() == ProgramStage.FRAGMENT) {
+			if (key.stage() == ProgramStage.FRAGMENT && !switchedOff.contains(pathOf(key))) {
 				shipped.computeIfAbsent(key.dimension(), _ -> new LinkedHashMap<>())
 						.put(key.name().baseName(), key.file());
 			}
@@ -62,6 +75,13 @@ public final class ProgramResolver {
 		}
 
 		return new ProgramResolver(resolved);
+	}
+
+	/** The file the pack ships with its extension taken off, which is how a toggle names it. */
+	private static String pathOf(ProgramSet.ProgramKey key) {
+		String file = key.file();
+		int dot = file.lastIndexOf('.');
+		return dot < 0 ? file : file.substring(0, dot);
 	}
 
 	public List<Resolution> resolutions(String dimension) {

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -590,6 +590,28 @@ public final class ShaderProperties {
 	}
 
 	/**
+	 * The programs this file switches off, under the paths the pack wrote, extension excluded.
+	 * <p>
+	 * The shape the resolution wants: a switched-off program is one the place does not ship, so
+	 * what serves the name is whatever the fallback tree offers next, and only a name whose whole
+	 * chain is switched off or absent ends up served by nothing. That is the reference's
+	 * behaviour and not an interpretation of it: a disabled name gets no source there
+	 * ({@code ShaderPack.java:290-294}), {@code ProgramSet.get} then answers empty
+	 * ({@code programs/ProgramSet.java:279-285}), and the resolver walks to the parent
+	 * ({@code programs/ProgramFallbackResolver.java:27-42}).
+	 */
+	public Set<String> switchedOff(Map<String, String> defines, OptionIndex options) {
+		Set<String> off = new LinkedHashSet<>();
+		programToggles(defines, options).forEach((program, on) -> {
+			if (!on) {
+				off.add(program);
+			}
+		});
+
+		return Set.copyOf(off);
+	}
+
+	/**
 	 * The same programs with the expression left as written, so that a log can say which setting
 	 * switched a pass off rather than only that something did. The key is the path the pack wrote,
 	 * {@code world0/composite1} or {@code composite} at the root, and never the bare name: BSL

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -323,19 +323,25 @@ public final class TargetPlan {
 			List<Integer> writes = writesOf(name, ProgramNames.shadowGeometry(family), draft);
 			draft.effective.put(name, writes);
 
+			// The key is the path the pack wrote and only that. BSL conditions world0/composite1
+			// and world-1/composite1 on two different expressions, so falling back to the bare
+			// name would run in the Nether a pass the pack switched off there.
+			//
+			// Read before the geometry leaves the walk, and it used to be read after: a pack
+			// switches off a shadow or a gbuffers program the same way it switches off a
+			// composite, and this walk answered the switch for one family and not the other. What
+			// draws instead is settled where the programs are resolved, which reads the same
+			// answer and lets the fallback tree carry on past the name.
+			String path = draft.place.isEmpty() ? name : draft.place + "/" + name;
+			if (Boolean.FALSE.equals(toggles.get(path))) {
+				draft.disabled.put(name, conditions.getOrDefault(path, "shaders.properties"));
+				continue;
+			}
+
 			// A geometry pass writes the half it reads and flips nothing, so keeping it in the walk
 			// costs nothing and holds the side the gbuffers programs read, six families of which run.
 			if (!fullscreen) {
 				steps.add(new TargetSchedule.Step(name, writes, false));
-				continue;
-			}
-
-			// The key is the path the pack wrote and only that. BSL conditions world0/composite1
-			// and world-1/composite1 on two different expressions, so falling back to the bare
-			// name would run in the Nether a pass the pack switched off there.
-			String path = draft.place.isEmpty() ? name : draft.place + "/" + name;
-			if (Boolean.FALSE.equals(toggles.get(path))) {
-				draft.disabled.put(name, conditions.getOrDefault(path, "shaders.properties"));
 				continue;
 			}
 
@@ -654,10 +660,15 @@ public final class TargetPlan {
 	}
 
 	/**
-	 * Full screen programs this place ships and does not run, by bare name, with the reason. The
-	 * reason is the pack's own expression when the pack switched it off, {@code MOTION_BLUR} or
-	 * {@code false}, and {@link #LEFT_OUT} when {@code passes=} did, so a log can tell the two
-	 * apart by printing {@code name (reason)}.
+	 * Programs this place ships and does not run, by bare name, with the reason. The reason is the
+	 * pack's own expression when the pack switched it off, {@code MOTION_BLUR} or {@code false},
+	 * and {@link #LEFT_OUT} when {@code passes=} did, so a log can tell the two apart by printing
+	 * {@code name (reason)}.
+	 * <p>
+	 * Geometry is in here as well as the full screen passes, and what that means for the two is
+	 * not the same thing. A full screen pass switched off does not run at all. A geometry program
+	 * switched off is not drawn under its own name, and what draws instead is whatever the
+	 * fallback tree offers next, which is settled where the programs are resolved and not here.
 	 */
 	public Map<String, String> disabled() {
 		return this.disabled;
@@ -861,7 +872,7 @@ public final class TargetPlan {
 		// In frame order rather than sorted, so that the line reads the way the chain runs, and
 		// each one carries what switched it off: the pack's own expression, or the filter.
 		if (!draft.disabled.isEmpty()) {
-			notes.add("full screen programs this place ships and does not run: "
+			notes.add("programs this place ships and does not run: "
 					+ draft.disabled.entrySet().stream()
 							.map(entry -> entry.getKey() + " (" + entry.getValue() + ")")
 							.collect(Collectors.joining(", ")));

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -91,6 +91,13 @@ Resolution stops at a name it has already walked, so a mis-edited table cannot l
 report anything either: the chain simply ends, and the program comes out unserved exactly as if it
 had no parent.
 
+**A program the pack switched off counts as missing here**, and that is the whole of what the
+switch does to the geometry: the walk carries on to the parent, so a pack that ships a translucent
+entity program and switches it off is asking for those entities to be drawn by its ordinary entity
+program rather than not drawn. Only a name whose whole chain is switched off or absent comes out
+unserved, and for the shadow family, whose root has no parent, that closes the stage instead of
+opening it on a program the pack never wrote.
+
 ## shaders.properties
 
 Only `=` separates a key from its value, and **there is no end-of-line comment**: everything after


### PR DESCRIPTION
## What changes

A pack that switches one of its own programs off from its settings is obeyed for the world's
geometry, not only for its full-screen passes. A switched-off name counts as a name the place does
not ship, so the fallback tree serves whatever stands behind it, and Bliss draws its translucent
entities and blocks through its ordinary entity and block programs until its own setting turns them
on. Where nothing stands behind the name, nothing is drawn, and a shadow root has no parent: Bliss
and BSL build no shadow map in the Nether, and Bliss none in the End. Photon switches its Nether
shadow root off too and keeps a map there, the `shadow_entities` it also ships being left on. The
census the engine prints at load still reads the pack whole, on purpose: it runs against the pack's
defaults and before the machine's own symbols are installed, so a toggle answered there would not be
the answer the chain gets.

**One image defect stays, and it is not this branch's.** Under Bliss a translucent entity comes out see-through,
the player in third person included, where Iris draws it solid. The fallback is not the cause; what
the serving file writes is. Bliss's `gbuffers_entities` declares `RENDERTARGETS:1,8,15,2` and leaves
the fourth unwritten unless `PARTICLE_RENDERING_FIX` is on, while the row is drawn in the translucent
phase, where colortex2 holds the composed world: the mob's colour lands in gbuffers nothing reads any
more, and the world shows through. BSL pins it as the counter-case, shipping no translucent entity
program either, writing colortex0 first, which is its scene target, and drawing solid mobs. Bliss
closes the hole with `separateEntityDraws = false`, written under the same condition as the two
toggles, and that directive is not read here at all.

## How it differs from the reference, and for what obstacle

It does not. The reference gives a disabled program no source
(`shaderpack/ShaderPack.java:290-294`), its `ProgramSet.get` then answers empty
(`shaderpack/programs/ProgramSet.java:279-285`), and the resolver walks to the parent
(`shaderpack/programs/ProgramFallbackResolver.java:27-42`). The buffers a row writes are the
resolved source's own there as they are here (`pipeline/IrisRenderingPipeline.java:686-687`).

## What proves it

- `gradlew build` green after the rebase.
- The off-game harness over the eight packs of the corpus, against the same tools built from `dev`.
  `Traduction` and `Chaine` do not move. `Cibles` gains the geometry programs a place ships and does
  not run, on five places: Bliss in all three, BSL and Photon in the Nether. `Entites` drops three
  shadow rows to unserved, Bliss in the Nether and the End and BSL in the Nether.
- In the game: the Nether shadow map obeys the pack in both directions, zero sections drawn with the
  branch against 1652 without it. On the Fabric bench with Bliss at its defaults, the arena's tinted
  glass wall and its mobs, a 60 frame mean against the same scene under `dev` and under Iris: where
  the branch differs from `dev`, its picture sits four levels from Iris against five for `dev` over the
  whole frame and six against eleven over the wall, three pixels out of four landing nearer Iris. The
  load log names the programs the place ships and does not run, the two translucent ones of Bliss
  among them.

## What it leaves owing

The see-through entity under Bliss, which is the `separateEntityDraws` directive rather than this
change and wants a branch of its own. A pass in the game on Bliss in third person once `separateEntityDraws` is read, showing a
translucent entity solid.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.

