### PR TITLE
perf(render): compile the on-demand families off the render thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,16 @@ what the next one holds.
 
 ### Fixed
 
+- **The freezes on first encounters are gone.** A pack's programs for the entities, the sky, the
+  clouds, the weather, the particles and the far terrain used to compile on the frame that first
+  drew each of them: around half a second frozen per program on a cold driver cache, over a
+  hundred programs on a big pack, spread across the first minutes of play and paid again behind
+  every portal. They are now compiled in the background while you play, and a frame only waits
+  for a program it reached before the background did. The action-bar line follows: it stays up,
+  as "compiling the rest in the background", while that work runs, and only says compiled once
+  nothing is compiling any more. An empty file `vitrail/keep-first-draw-compiles` in the
+  instance puts the old path back for a comparison.
+
 - **A pack's shadow compute is no longer built when the pack switched it off.** A pack turns
   whole programs on and off from its own settings, and the compute pass behind coloured lighting
   was read and handed to the compiler whichever way that setting stood. Switched off, the pack

--- a/common/src/main/java/dev/vitrail/dh/DhLods.java
+++ b/common/src/main/java/dev/vitrail/dh/DhLods.java
@@ -71,7 +71,22 @@ public final class DhLods {
 	private static final int UNREACHED = -1;
 
 	private static boolean resolved;
-	private static boolean usable;
+
+	/**
+	 * Volatile for the one reader off the render thread, {@code DistantProgram.warmAhead}: it
+	 * asks whether the far terrain family's pipelines are worth compiling ahead, and a stale
+	 * answer there costs a skipped or a wasted warm-up, never an image.
+	 */
+	private static volatile boolean usable;
+
+	/**
+	 * Whether DH's far terrain is currently taken out of it. False before {@link #install} first
+	 * resolves, and dropped for good when DH stops cooperating mid-session: once it falls it
+	 * never comes back up.
+	 */
+	public static boolean usable() {
+		return usable;
+	}
 
 	/** The road to DH's own switch that moves its water half behind the deferred stage. */
 	private static Field renderProxyField;

--- a/common/src/main/java/dev/vitrail/mixin/VulkanDeviceMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanDeviceMixin.java
@@ -97,6 +97,11 @@ public abstract class VulkanDeviceMixin implements StalePipelines {
 		return false;
 	}
 
+	@Override
+	public boolean vitrail$adopt(RenderPipeline pipeline, VulkanRenderPipeline compiled) {
+		return this.pipelineCache.putIfAbsent(pipeline, compiled) == null;
+	}
+
 	@Inject(method = "clearPipelineCache", at = @At("TAIL"), require = 1)
 	private void vitrail$destroySetAside(CallbackInfo callback) {
 		this.vitrail$setAside.forEach(VulkanRenderPipeline::destroy);

--- a/common/src/main/java/dev/vitrail/render/CloudProgram.java
+++ b/common/src/main/java/dev/vitrail/render/CloudProgram.java
@@ -15,6 +15,8 @@ import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 import net.minecraft.client.renderer.BindGroupLayouts;
 
 import java.util.List;
@@ -164,6 +166,16 @@ final class CloudProgram implements DumpedProgram {
 	@Override
 	public void forgetCompiled() {
 		this.body.forgetCompiled();
+	}
+
+	@Override
+	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
+		return this.body.warmAhead(device, compiler);
+	}
+
+	@Override
+	public void discardAhead() {
+		this.body.discardAhead();
 	}
 
 	/** @see GeometryProgram#decoded */

--- a/common/src/main/java/dev/vitrail/render/DistantProgram.java
+++ b/common/src/main/java/dev/vitrail/render/DistantProgram.java
@@ -1,5 +1,6 @@
 package dev.vitrail.render;
 
+import dev.vitrail.dh.DhLods;
 import dev.vitrail.glsl.DistantVertex;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.target.ChainPlan;
@@ -17,6 +18,8 @@ import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 import org.joml.Matrix4fc;
 
@@ -236,6 +239,23 @@ final class DistantProgram implements DumpedProgram {
 	@Override
 	public void forgetCompiled() {
 		this.body.forgetCompiled();
+	}
+
+	@Override
+	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
+		// Without DH standing, nothing ever draws these. And measured on a bench without that
+		// mod, the two dh programs also refused shaderc outright, so compiling ahead here bought
+		// nothing but refusal lines for programs no frame would ever ask for.
+		if (!DhLods.usable()) {
+			return false;
+		}
+
+		return this.body.warmAhead(device, compiler);
+	}
+
+	@Override
+	public void discardAhead() {
+		this.body.discardAhead();
 	}
 
 	/** @see GeometryProgram#decoded */

--- a/common/src/main/java/dev/vitrail/render/DumpedProgram.java
+++ b/common/src/main/java/dev/vitrail/render/DumpedProgram.java
@@ -3,6 +3,8 @@ package dev.vitrail.render;
 import dev.vitrail.uniform.WorldState;
 
 import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 /**
  * What {@link PackDump} needs of a program to be able to name it and read it back.
@@ -42,4 +44,25 @@ interface DumpedProgram {
 	 * A resource reload emptied the device cache, so the next {@link #compile} has to pay again.
 	 */
 	void forgetCompiled();
+
+	/**
+	 * Compiles this program's pipeline on the pack-load worker, so its first draw finds the work
+	 * already paid instead of paying shaderc on the render thread. The six on-demand families
+	 * override it; the terrain does not, compiling while the world is still held back.
+	 *
+	 * @param compiler the worker's own compiler, never the device's: the device's belongs to the
+	 *                 render thread along with the caches around it
+	 * @return true when a compiled pipeline is now waiting for {@link #compile} to adopt it
+	 */
+	default boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
+		return false;
+	}
+
+	/**
+	 * The chain released before anything drew this program, so no {@link #compile} will ever adopt
+	 * what the worker prepared: what waits is destroyed, and a worker still running stores nothing
+	 * more here.
+	 */
+	default void discardAhead() {
+	}
 }

--- a/common/src/main/java/dev/vitrail/render/EntityProgram.java
+++ b/common/src/main/java/dev/vitrail/render/EntityProgram.java
@@ -19,6 +19,8 @@ import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 import org.joml.Matrix4fc;
 
@@ -355,6 +357,16 @@ final class EntityProgram implements DumpedProgram {
 	@Override
 	public void forgetCompiled() {
 		this.body.forgetCompiled();
+	}
+
+	@Override
+	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
+		return this.body.warmAhead(device, compiler);
+	}
+
+	@Override
+	public void discardAhead() {
+		this.body.discardAhead();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -3,6 +3,7 @@ package dev.vitrail.render;
 import dev.vitrail.glsl.LegacyGlsl;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.glsl.TranslatedUnit;
+import dev.vitrail.mixin.GpuDeviceAccessor;
 import dev.vitrail.pack.program.AlphaTest;
 import dev.vitrail.pack.program.ProgramStage;
 import dev.vitrail.pack.program.RenderStage;
@@ -21,6 +22,7 @@ import dev.vitrail.Vitrail;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.platform.CompareOp;
+import com.mojang.blaze3d.preprocessor.GlslPreprocessor;
 import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.buffers.Std140Builder;
@@ -41,6 +43,11 @@ import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
+import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
+import com.mojang.blaze3d.vulkan.glsl.ShaderCompileException;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BindGroupLayouts;
 import net.minecraft.client.renderer.MappableRingBuffer;
@@ -402,6 +409,21 @@ final class GeometryProgram {
 	private boolean drew;
 	private boolean broken;
 	private boolean compiled;
+
+	/**
+	 * The pipeline the pack-load worker built for this program, waiting for a render-thread
+	 * {@link #compile} to hand it to the device's cache, which is the one step the worker may not
+	 * take itself. Written and cleared under this program's monitor, on whichever side gets there
+	 * first.
+	 */
+	private VulkanRenderPipeline ahead;
+
+	/**
+	 * Set by {@link #discardAhead()} when the chain released before anything drew this program:
+	 * from then on the worker destroys what it built instead of storing it, since no compile of a
+	 * released chain will ever come to adopt it.
+	 */
+	private boolean discarded;
 
 	/** Targets already reported as read on the half this pass writes. Said once each, not per frame. */
 	private final Set<Integer> collisions = new HashSet<>();
@@ -838,6 +860,19 @@ final class GeometryProgram {
 			return true;
 		}
 
+		// What the worker finished is handed to the cache here, on the render thread, and the
+		// precompile below finds it as a lookup. A cache that already holds the key kept a copy
+		// somebody compiled meanwhile, so ours dies instead, never having been bound anywhere.
+		VulkanRenderPipeline ready = this.ahead;
+		if (ready != null) {
+			this.ahead = null;
+			boolean adopted = ((GpuDeviceAccessor) device).vitrail$backend()
+					instanceof StalePipelines cache && cache.vitrail$adopt(this.pipeline, ready);
+			if (!adopted) {
+				ready.destroy();
+			}
+		}
+
 		CompiledRenderPipeline compiled = device.precompilePipeline(this.pipeline, this.source);
 		if (!compiled.isValid()) {
 			// Handing back an invalid pipeline throws inside setPipeline, in the middle of Sodium's
@@ -868,6 +903,102 @@ final class GeometryProgram {
 	 */
 	void forgetCompiled() {
 		this.compiled = false;
+	}
+
+	/**
+	 * Builds this program's compiled pipeline on the pack-load worker, through the same public
+	 * steps the device takes, so the first draw finds the half second of shaderc already paid.
+	 * <p>
+	 * <strong>Deliberately not {@code precompilePipeline}</strong>: the device keeps its results
+	 * in plain maps only the render thread may touch, and its compiler is one shared instance on
+	 * the same rule. Everything used here instead is safe off the thread. The worker's own
+	 * {@code GlslCompiler} carries shaderc, the SPIRV-Cross reflection opens a context per call,
+	 * and the three calls underneath ({@code vkCreateShaderModule}, the set layout, the pipelines)
+	 * create device-level objects Vulkan lets any thread create. What the worker may not do is
+	 * write the cache, and {@link #compile} does that half, adopting the object built here.
+	 * <p>
+	 * A compile the pack's GLSL refuses stores nothing and says so in one line, because a refusal
+	 * only this path reproduces would otherwise never be seen at all; the first draw then retries
+	 * on the device's own path, which latches {@link #broken} and prints the authoritative one.
+	 *
+	 * @param compiler the worker's own compiler, never the device's
+	 * @return true when a compiled pipeline now waits for {@link #compile} to adopt it
+	 */
+	boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
+		synchronized (this) {
+			if (this.compiled || this.broken || this.discarded || this.ahead != null) {
+				return false;
+			}
+		}
+
+		VulkanRenderPipeline built;
+		try {
+			IntermediaryShaderModule vertex =
+					intermediary(compiler, this.pipeline.getVertexShader(), ShaderType.VERTEX);
+			try {
+				IntermediaryShaderModule fragment =
+						intermediary(compiler, this.pipeline.getFragmentShader(), ShaderType.FRAGMENT);
+				try {
+					GlslCompiler.CompiledModules modules =
+							compiler.compile(device, this.pipeline, vertex, fragment);
+					built = VulkanRenderPipeline.compile(device, modules.layout(), this.pipeline,
+							modules.vertex(), modules.fragment());
+				} finally {
+					// vkCreateShaderModule consumes pCode at the call, by spec, so the buffers
+					// behind the intermediaries are done once compile returns. The device keeps
+					// its own in a cache instead, which is why its path has no close: here
+					// nothing keeps them.
+					fragment.close();
+				}
+			} finally {
+				vertex.close();
+			}
+		} catch (ShaderCompileException e) {
+			// The first draw retries on the device's own path, which latches broken and prints
+			// the pack's defect properly. Said here as well because a refusal the device path
+			// does NOT reproduce would otherwise never be seen at all.
+			Vitrail.logger().info("{} stays for its first draw: {}", this.path, e.getMessage());
+
+			return false;
+		}
+
+		synchronized (this) {
+			if (this.compiled || this.broken || this.discarded) {
+				built.destroy();
+
+				return false;
+			}
+
+			this.ahead = built;
+		}
+
+		return true;
+	}
+
+	/** One stage the way the device reads it: the pipeline's defines injected, then shaderc. */
+	private IntermediaryShaderModule intermediary(GlslCompiler compiler, Identifier id,
+			ShaderType type) throws ShaderCompileException {
+		String text = this.source.get(id, type);
+		if (text == null) {
+			throw new ShaderCompileException("no source for " + id);
+		}
+
+		return compiler.createIntermediary(id.toDebugFileName(),
+				GlslPreprocessor.injectDefines(text, this.pipeline.getShaderDefines()), type);
+	}
+
+	/**
+	 * The chain released before anything drew this program, so no {@link #compile} will ever come
+	 * for what the worker prepared. What already waits is destroyed on the spot, which is safe for
+	 * an object nothing ever bound; what the worker is still building is destroyed by the worker
+	 * itself when it finds this flag.
+	 */
+	synchronized void discardAhead() {
+		this.discarded = true;
+		if (this.ahead != null) {
+			this.ahead.destroy();
+			this.ahead = null;
+		}
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2,6 +2,7 @@ package dev.vitrail.render;
 
 import dev.vitrail.dh.DhLods;
 import dev.vitrail.glsl.PackProgram;
+import dev.vitrail.mixin.GpuDeviceAccessor;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.program.TerrainPass;
@@ -33,6 +34,8 @@ import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 import net.minecraft.client.GraphicsPreset;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
@@ -61,6 +64,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -296,6 +305,39 @@ public final class PackChain {
 	private int warmed;
 	private boolean familyPrefetchStarted;
 	private volatile int familiesReady;
+
+	/**
+	 * Raised by {@link #release()} and read by the pack-load worker between two programs, which is
+	 * what stops a worker still compiling for a chain nothing will ever draw again. Volatile for
+	 * that one cross-thread read; everything else about the release stays on the render thread.
+	 */
+	private volatile boolean released;
+
+	/**
+	 * Every pack-load worker still running, whichever chain started it, held for the one caller
+	 * that must see them out: shutdown. A release only raises its chain's {@link #released} and
+	 * moves on, the worker stopping at its next program; and a pack swap detaches its chain
+	 * without waiting either, so the worker shutdown must see out is not always the active
+	 * chain's. Shutdown tears the device down behind them, and a device call still in flight then
+	 * is a crash at exit, so {@link #close} waits the set out, bounded.
+	 */
+	private static final Set<CompletableFuture<Void>> WARMUPS = ConcurrentHashMap.newKeySet();
+
+	/**
+	 * Whether this chain's pack-load worker is done, whatever it managed: what lets
+	 * {@link #tickCompileHint} keep its line up through the background compiles and close it with
+	 * a "compiled" that really means nothing is compiling any more. Raised on every road out of
+	 * the worker, the refused and the stopped included, because a line that can never close is
+	 * worse than one that closes early.
+	 */
+	private volatile boolean familiesWarmed;
+
+	/**
+	 * Whether {@link #tickCompileHint} has already said, once, that the rest compiles in the
+	 * background. Render thread only, and per chain like the flag above, so a swap starts the
+	 * next pack's accounting afresh.
+	 */
+	private boolean backgroundHintShown;
 	private boolean geometryReady;
 	private boolean announced;
 
@@ -1326,8 +1368,8 @@ public final class PackChain {
 	 * frame, with the world not drawn, is the same work without that picture.
 	 * <p>
 	 * Complementary Unbound is still not compiled all at once. Its families translate on a worker
-	 * while this thread compiles the composites and the terrain; leftover pipelines compile on
-	 * their first draw rather than holding the world back.
+	 * while this thread compiles the composites and the terrain, and the same worker then compiles
+	 * their pipelines; nothing of the leftovers holds the world back.
 	 */
 	public static void pumpWarmup() {
 		PackChain chain = active;
@@ -1365,9 +1407,9 @@ public final class PackChain {
 	}
 
 	/**
-	 * Keeps the action-bar line up while the world is waiting on this pack, then says once that
-	 * it is done. Leftover families compile on their first draw and must not bring either line
-	 * back once the player is already walking.
+	 * Keeps the action-bar line up while the world is waiting on this pack, keeps it up in its
+	 * background form while the pack-load worker is still compiling the leftover families, then
+	 * says once that everything is done.
 	 */
 	private static boolean compileHintShown;
 
@@ -1387,12 +1429,28 @@ public final class PackChain {
 			return;
 		}
 
-		compileHintShown = false;
 		PackChain chain = active;
 		if (disabled || !chainWanted || chain == null || !chain.drawable()) {
+			compileHintShown = false;
 			return;
 		}
 
+		// The world draws while the worker still compiles the leftover families behind it. Said
+		// ONCE and left to fade, never pinned: the worker runs a minute of normal play on a big
+		// pack, and a line re-set every tick would own the action bar for all of it, over any
+		// server title or other mod's message. The closing line below still keeps its meaning of
+		// "nothing is compiling".
+		if (!chain.familiesWarmed) {
+			if (!chain.backgroundHintShown) {
+				chain.backgroundHintShown = true;
+				minecraft.gui.hud.setOverlayMessage(
+						Component.translatable(ScreenText.COMPILING_BACKGROUND), false);
+			}
+
+			return;
+		}
+
+		compileHintShown = false;
 		minecraft.gui.hud.setOverlayMessage(Component.translatable(ScreenText.COMPILED), false);
 	}
 
@@ -1686,6 +1744,8 @@ public final class PackChain {
 		if (chain != null) {
 			chain.release();
 		}
+
+		awaitFamilyWarmups();
 
 		// The far terrain's two corner rings and the one-texel constants survive every release on
 		// purpose, so the shutdown is the one caller that really frees them.
@@ -2446,11 +2506,13 @@ public final class PackChain {
 	 * emptied its cache, which it does at every resource reload: the alternative is to ask for all
 	 * of them every frame, which pays the whole compilation in the one frame after a reload.
 	 * <p>
-	 * After the composites, terrain pipelines compile a call. The other families translate on a
-	 * worker and shaderc on their first draw: Complementary Unbound's leftover pipelines are the
-	 * minute between packs, and holding the world for them is that minute. {@link #pumpWarmup}
-	 * repeats the compiles for as long as a short budget on the frame allows. shaderc itself stays
-	 * on the render thread: the device cache is not safe off it.
+	 * After the composites, terrain pipelines compile a call. The other families translate AND
+	 * compile on a worker: Complementary Unbound's leftover pipelines are the minute between
+	 * packs, and holding the world for them is that minute. A first draw the worker has not
+	 * reached yet still pays shaderc on the render thread, which is the fallback and no longer
+	 * the rule. {@link #pumpWarmup} repeats the compiles here for as long as a short budget on
+	 * the frame allows. The device cache itself is only ever written on the render thread: the
+	 * worker builds the objects, {@code GeometryProgram.compile} hands them over.
 	 *
 	 * @return false while a program is still missing, in which case nothing of the chain is drawn.
 	 *         What the screen holds for those frames is the terrain's answer and not this one, and
@@ -2489,19 +2551,18 @@ public final class PackChain {
 		startFamilyPrefetch();
 
 		// Terrain is the world frame. Complementary Unbound's leftover families are the minute
-		// between packs; they compile on their first draw. Terrain is a handful of pipelines, and
-		// the first world frame hitches without them.
+		// between packs; the worker compiles them while the world is already being played, and a
+		// first draw that outruns it falls back here. Terrain is a handful of pipelines, and the
+		// first world frame hitches without them.
 		//
-		// THE LEFTOVERS ARE NOT COMPILED AHEAD, and that is a decision rather than an omission.
-		// Doing it a program a frame, here, cost two minutes at two frames a second on entering a
-		// world with Complementary Unbound: one shaderc compile is about half a second and a frame
-		// is worth sixteen milliseconds, so there is no per-frame budget it fits in and spreading
-		// it only spaces the stalls out. It also pays for families the session may never draw. On
-		// first draw the cost is bounded by what is actually on screen.
-		//
-		// What would remove it rather than move it is compiling off the render thread, which turns
-		// on whether the device call underneath is safe there; nothing here has established that,
-		// and this engine has already paid for device work on the wrong thread.
+		// THE LEFTOVERS ARE NOT COMPILED ON THIS THREAD, and that is a decision rather than an
+		// omission. Doing it a program a frame, here, cost two minutes at two frames a second on
+		// entering a world with Complementary Unbound: one shaderc compile is about half a second
+		// and a frame is worth sixteen milliseconds, so there is no per-frame budget it fits in
+		// and spreading it only spaces the stalls out. What removed the stalls rather than moving
+		// them is the worker: precompilePipeline is not safe off the render thread, its caches
+		// and its compiler being shared and unguarded, but the create calls under it are once
+		// those are bypassed, and warmFamilies says how the two halves are split.
 		if (compileNext(device, this.terrain.programs())) {
 			return false;
 		}
@@ -2521,9 +2582,14 @@ public final class PackChain {
 	private static final long WARM_BUDGET_NANOS = 80_000_000L;
 
 	/**
-	 * Translates the six families on a worker. Translation does not touch the device; shaderc
-	 * does, and stays on the render thread. Complementary Unbound's entities still cost, and
-	 * that cost is this worker rather than holding the world back.
+	 * Translates the six families on a worker, then compiles their pipelines on it too.
+	 * Complementary Unbound's entities still cost their minute, and that minute is this worker
+	 * rather than holding the world back or, as it stood before the worker learnt to compile, a
+	 * hitch of half a second per program on whichever frame first drew each of them.
+	 * <p>
+	 * All six translations before the first compile, deliberately: a family's translation is what
+	 * its first draw needs even to fall back on the render thread, so no family's reading waits
+	 * behind another family's shaderc.
 	 */
 	private void startFamilyPrefetch() {
 		synchronized (this) {
@@ -2534,14 +2600,91 @@ public final class PackChain {
 			this.familyPrefetchStarted = true;
 		}
 
-		Util.backgroundExecutor().execute(() -> {
-			prefetchFamily(this.sky::prefetch);
-			prefetchFamily(this.entities::prefetch);
-			prefetchFamily(this.clouds::prefetch);
-			prefetchFamily(this.weather::prefetch);
-			prefetchFamily(this.particles::prefetch);
-			prefetchFamily(this.distant::prefetch);
-		});
+		// Read on the thread loading the pack, before the worker exists, and carried into it as
+		// a value: read lazily from the worker instead, it would race the reset a pack swap does
+		// on the render thread.
+		boolean keepOld = PassTimings.keepFirstDrawCompiles();
+		CompletableFuture<Void> warmup;
+		try {
+			warmup = CompletableFuture.runAsync(() -> {
+				try {
+					Vitrail.logger().info("The pack-load worker starts on the six families");
+					prefetchFamily(this.sky::prefetch);
+					prefetchFamily(this.entities::prefetch);
+					prefetchFamily(this.clouds::prefetch);
+					prefetchFamily(this.weather::prefetch);
+					prefetchFamily(this.particles::prefetch);
+					prefetchFamily(this.distant::prefetch);
+					warmFamilies(keepOld);
+				} catch (Throwable e) {
+					// Throwable and not RuntimeException: runAsync swallows what its runnable
+					// throws, so anything that dies here unlogged reads as the worker having
+					// finished. The families it did not reach fall back to the first-draw path
+					// either way.
+					Vitrail.logger().error("The pack-load worker died", e);
+				} finally {
+					this.familiesWarmed = true;
+				}
+			}, Util.backgroundExecutor());
+		} catch (RejectedExecutionException e) {
+			// The executor only refuses while the client shuts down. The families keep their
+			// first-draw path, and the flag closes the hint rather than leaving a line that can
+			// never end.
+			this.familiesWarmed = true;
+
+			return;
+		}
+
+		WARMUPS.add(warmup);
+		warmup.whenComplete((unused, e) -> WARMUPS.remove(warmup));
+	}
+
+	/**
+	 * Compiles every program the six families read, still on the worker, with a compiler of the
+	 * worker's own: the device's precompile keeps its results in maps only the render thread may
+	 * touch, so each pipeline is built through the same public steps instead and
+	 * {@code GeometryProgram.compile} hands the finished object to the cache on the render
+	 * thread. {@code GeometryProgram.warmAhead} says why every step of that is safe off the
+	 * thread, and {@code vitrail/keep-first-draw-compiles} beside the pack keeps the old
+	 * first-draw path for a measurement, the way {@code keep-redone-work} does.
+	 * <p>
+	 * Walked in {@code familyPrograms} order, which serves the sky and the entities first: those
+	 * two are on screen the moment the world is, and the far terrain comes last.
+	 */
+	private void warmFamilies(boolean keepOld) {
+		GpuDevice front = RenderSystem.tryGetDevice();
+		if (front == null || keepOld
+				|| !(((GpuDeviceAccessor) front).vitrail$backend()
+						instanceof VulkanDevice device)) {
+			Vitrail.logger().info("The worker leaves the leftover families to their first draw: "
+					+ "{}", front == null ? "no device"
+							: keepOld ? "keep-first-draw-compiles"
+									: "the backend is not the Vulkan one");
+
+			return;
+		}
+
+		long start = System.nanoTime();
+		int walked = 0;
+		int served = 0;
+		try (GlslCompiler compiler = new GlslCompiler()) {
+			for (int family = 0; family < FAMILIES; family++) {
+				for (DumpedProgram program : familyPrograms(family)) {
+					if (this.released || disabled) {
+						return;
+					}
+
+					walked++;
+					if (program.warmAhead(device, compiler)) {
+						served++;
+					}
+				}
+			}
+		}
+
+		Vitrail.logger().info("{} of {} leftover pipelines compiled ahead of their first draw, "
+				+ "{} ms off the render thread", served, walked,
+				(System.nanoTime() - start) / 1_000_000L);
 	}
 
 	private void prefetchFamily(Runnable prefetch) {
@@ -2552,6 +2695,28 @@ public final class PackChain {
 		}
 
 		this.familiesReady++;
+	}
+
+	/**
+	 * Waits out, bounded, every worker still running at shutdown, whichever chain started it.
+	 * Nothing device-side can START once a chain is released; what the bound really covers is the
+	 * one compile possibly in flight, about half a second, and a worker still translating holds
+	 * no device work at all. The bound itself is for a worker wedged in the driver, which may not
+	 * be allowed to hold the quit.
+	 */
+	private static void awaitFamilyWarmups() {
+		CompletableFuture<?>[] running = WARMUPS.toArray(new CompletableFuture<?>[0]);
+		if (running.length == 0) {
+			return;
+		}
+
+		try {
+			CompletableFuture.allOf(running).get(2, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		} catch (ExecutionException | TimeoutException ignored) {
+			// The runnable logs its own failures, and a timeout leaves nothing to do but quit.
+		}
 	}
 
 	private Collection<? extends DumpedProgram> familyPrograms(int index) {
@@ -2602,7 +2767,7 @@ public final class PackChain {
 	 * compiles one program a frame, so every load, every resource reload and every portal used to
 	 * spend {@code programs.size()} frames with the world drawn into a target nothing read: three
 	 * seconds of a screen with no world in it, at every F3+T. Terrain pipelines take that same
-	 * road after the composites. Leftover families compile on their first draw.
+	 * road after the composites. Leftover families compile on the worker.
 	 * <p>
 	 * The empty chain answers no rather than yes on a vacuous count. A place with no program has no
 	 * final either, so nothing would ever bring that target back, and {@link #warm} refuses it in
@@ -2917,6 +3082,16 @@ public final class PackChain {
 	}
 
 	private void release() {
+		// The worker's flag first, so a compile still running for this chain stores nothing more
+		// into programs nothing will ever draw again; what it already stored is destroyed with the
+		// walk below, which is safe for objects nothing ever bound. Only families the worker
+		// finished translating are walked, for the reason rotate() gives.
+		this.released = true;
+		int ready = this.familiesReady;
+		for (int family = 0; family < ready && family < FAMILIES; family++) {
+			familyPrograms(family).forEach(DumpedProgram::discardAhead);
+		}
+
 		CustomImages.clear();
 		this.compute.close();
 		this.targets.release();

--- a/common/src/main/java/dev/vitrail/render/ParticleProgram.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleProgram.java
@@ -13,6 +13,8 @@ import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 import java.util.List;
 import java.util.Set;
@@ -179,6 +181,16 @@ final class ParticleProgram implements DumpedProgram {
 	@Override
 	public void forgetCompiled() {
 		this.body.forgetCompiled();
+	}
+
+	@Override
+	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
+		return this.body.warmAhead(device, compiler);
+	}
+
+	@Override
+	public void discardAhead() {
+		this.body.discardAhead();
 	}
 
 	/** @see GeometryProgram#decoded */

--- a/common/src/main/java/dev/vitrail/render/PassTimings.java
+++ b/common/src/main/java/dev/vitrail/render/PassTimings.java
@@ -121,6 +121,14 @@ public final class PassTimings {
 	/** Negative until the property and the file have been read, which needs the game directory. */
 	private static int keepRedone = -1;
 
+	private static final boolean FIRST_DRAW_PROPERTY =
+			Boolean.getBoolean("vitrail.keepFirstDrawCompiles");
+
+	private static final String FIRST_DRAW_ARM_FILE = "keep-first-draw-compiles";
+
+	/** Negative until the property and the file have been read, which needs the game directory. */
+	private static int keepFirstDraw = -1;
+
 	/** What an arming file with nothing in it asks for. */
 	private static final int ARMED_BY_FILE_SECONDS = 5;
 
@@ -267,6 +275,7 @@ public final class PassTimings {
 		// next pack load rather than by the next launch.
 		censusSeconds = -1;
 		keepRedone = -1;
+		keepFirstDraw = -1;
 		censusOpenLabel = null;
 		censusLabels.clear();
 		censusReopens.clear();
@@ -311,6 +320,21 @@ public final class PassTimings {
 		}
 
 		return keepRedone == 1;
+	}
+
+	/**
+	 * Puts back the render-thread first-draw compiles of the six on-demand families, so that the
+	 * hitch and its absence are read off ONE jar, for the reason {@link #keepRedoneWork} gives.
+	 * Armed by {@code vitrail/keep-first-draw-compiles} beside the pack or by
+	 * {@code -Dvitrail.keepFirstDrawCompiles}, read again at every pack load, and off otherwise,
+	 * so a player never carries the old path.
+	 */
+	public static boolean keepFirstDrawCompiles() {
+		if (keepFirstDraw < 0) {
+			keepFirstDraw = FIRST_DRAW_PROPERTY || armFile(FIRST_DRAW_ARM_FILE) != null ? 1 : 0;
+		}
+
+		return keepFirstDraw == 1;
 	}
 
 	/** The arming file of that name beside the pack, or null where there is none to read. */

--- a/common/src/main/java/dev/vitrail/render/SkyProgram.java
+++ b/common/src/main/java/dev/vitrail/render/SkyProgram.java
@@ -13,6 +13,8 @@ import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 import org.joml.Matrix4fc;
 import org.joml.Vector4fc;
@@ -168,6 +170,16 @@ final class SkyProgram implements DumpedProgram {
 	@Override
 	public void forgetCompiled() {
 		this.body.forgetCompiled();
+	}
+
+	@Override
+	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
+		return this.body.warmAhead(device, compiler);
+	}
+
+	@Override
+	public void discardAhead() {
+		this.body.discardAhead();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/StalePipelines.java
+++ b/common/src/main/java/dev/vitrail/render/StalePipelines.java
@@ -1,6 +1,7 @@
 package dev.vitrail.render;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
 
 import java.util.List;
 
@@ -33,4 +34,17 @@ public interface StalePipelines {
 	 * The compiled objects themselves are kept aside and freed at the next safe purge.
 	 */
 	List<RenderPipeline> vitrail$dropEntityPipelines();
+
+	/**
+	 * Hands the cache a pipeline the pack-load worker compiled off the render thread, so the next
+	 * {@code precompilePipeline} of that key is a lookup rather than half a second of shaderc.
+	 * <p>
+	 * Render thread only, like every touch of the cache: the worker builds the object, this call is
+	 * the one step it may not do itself. From here the pipeline is the cache's, freed by
+	 * {@code clearPipelineCache} with everything else it holds.
+	 *
+	 * @return false when the cache already held one for that key, in which case nothing moved and
+	 *         the caller still owns what it offered
+	 */
+	boolean vitrail$adopt(RenderPipeline pipeline, VulkanRenderPipeline compiled);
 }

--- a/common/src/main/java/dev/vitrail/render/WeatherProgram.java
+++ b/common/src/main/java/dev/vitrail/render/WeatherProgram.java
@@ -13,6 +13,8 @@ import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 import java.util.List;
 import java.util.Set;
@@ -191,6 +193,16 @@ final class WeatherProgram implements DumpedProgram {
 	@Override
 	public void forgetCompiled() {
 		this.body.forgetCompiled();
+	}
+
+	@Override
+	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
+		return this.body.warmAhead(device, compiler);
+	}
+
+	@Override
+	public void discardAhead() {
+		this.body.discardAhead();
 	}
 
 	/** @see GeometryProgram#decoded */

--- a/common/src/main/java/dev/vitrail/screen/ScreenText.java
+++ b/common/src/main/java/dev/vitrail/screen/ScreenText.java
@@ -178,7 +178,15 @@ public final class ScreenText {
 	public static final String COMPILING = "overlay.vitrail.compiling";
 
 	/**
-	 * The same line once the world can be drawn. Said once, then vanilla fades it.
+	 * The same line once the world draws but the pack-load worker is still compiling the
+	 * on-demand families behind it. Said once and left to fade rather than pinned: the worker
+	 * runs through normal play, where the action bar belongs to servers and other mods too.
+	 */
+	public static final String COMPILING_BACKGROUND = "overlay.vitrail.compiling_background";
+
+	/**
+	 * The same line once the world can be drawn and the worker is done. Said once, then vanilla
+	 * fades it.
 	 */
 	public static final String COMPILED = "overlay.vitrail.compiled";
 

--- a/common/src/main/resources/assets/vitrail/lang/de_de.json
+++ b/common/src/main/resources/assets/vitrail/lang/de_de.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "Shader konnte nicht neu geladen werden! Grund: %s",
 	"options.vitrail.other_backend": "Vitrail zeichnet auf dem %s-Backend nichts: seine Shader laufen nur auf Vulkan. Setze %s unter Optionen, Grafikeinstellungen auf \"%s\" und starte das Spiel neu.",
 	"overlay.vitrail.compiling": "Vitrail kompiliert die Shader noch",
+	"overlay.vitrail.compiling_background": "Vitrail kompiliert den Rest im Hintergrund",
 	"overlay.vitrail.compiled": "Vitrail-Shader kompiliert",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/en_us.json
+++ b/common/src/main/resources/assets/vitrail/lang/en_us.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "Failed to reload shaders! Reason: %s",
 	"options.vitrail.other_backend": "Vitrail draws nothing on the %s backend: its shaders run on Vulkan only. Set %s to \"%s\" under Options, Video Settings, and restart the game.",
 	"overlay.vitrail.compiling": "Vitrail is still compiling shaders",
+	"overlay.vitrail.compiling_background": "Vitrail is compiling the rest in the background",
 	"overlay.vitrail.compiled": "Vitrail shaders compiled",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/es_es.json
+++ b/common/src/main/resources/assets/vitrail/lang/es_es.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "¡Error al recargar los Shaders! Razón: %s",
 	"options.vitrail.other_backend": "Vitrail no dibuja nada en el backend %s: sus shaders solo funcionan en Vulkan. Ajusta %s a \"%s\" en Opciones, Ajustes de vídeo, y reinicia el juego.",
 	"overlay.vitrail.compiling": "Vitrail sigue compilando los shaders",
+	"overlay.vitrail.compiling_background": "Vitrail compila el resto en segundo plano",
 	"overlay.vitrail.compiled": "Shaders de Vitrail compilados",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/fr_fr.json
+++ b/common/src/main/resources/assets/vitrail/lang/fr_fr.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "Échec lors du rechargement des shaders ! Raison : %s",
 	"options.vitrail.other_backend": "Vitrail ne dessine rien sur le backend %s : ses shaders ne tournent que sur Vulkan. Réglez %s sur \"%s\" dans Options, Paramètres vidéo, puis redémarrez le jeu.",
 	"overlay.vitrail.compiling": "Vitrail compile encore les shaders",
+	"overlay.vitrail.compiling_background": "Vitrail compile le reste en arrière-plan",
 	"overlay.vitrail.compiled": "Vitrail a fini de compiler les shaders",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/it_it.json
+++ b/common/src/main/resources/assets/vitrail/lang/it_it.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "Impossibile ricaricare le shaders! Motivo: %s",
 	"options.vitrail.other_backend": "Vitrail non disegna nulla sul backend %s: le sue shader funzionano solo su Vulkan. Imposta %s su \"%s\" in Opzioni, Impostazioni video, e riavvia il gioco.",
 	"overlay.vitrail.compiling": "Vitrail sta ancora compilando gli shader",
+	"overlay.vitrail.compiling_background": "Vitrail compila il resto in background",
 	"overlay.vitrail.compiled": "Shader di Vitrail compilati",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/ja_jp.json
+++ b/common/src/main/resources/assets/vitrail/lang/ja_jp.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "シェーダーの再読み込みに失敗しました！ 理由: %s",
 	"options.vitrail.other_backend": "Vitrail は %s バックエンドでは何も描画しません。シェーダーは Vulkan でのみ動作します。設定、ビデオ設定で %s を \"%s\" にしてゲームを再起動してください。",
 	"overlay.vitrail.compiling": "Vitrailはまだシェーダーをコンパイルしています",
+	"overlay.vitrail.compiling_background": "Vitrailは残りをバックグラウンドでコンパイルしています",
 	"overlay.vitrail.compiled": "Vitrailのシェーダーのコンパイルが完了しました",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/ko_kr.json
+++ b/common/src/main/resources/assets/vitrail/lang/ko_kr.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "셰이더를 새로고침하지 못하였습니다: %s",
 	"options.vitrail.other_backend": "Vitrail은 %s 백엔드에서 아무것도 그리지 않습니다. 셰이더는 Vulkan에서만 작동합니다. 설정, 비디오 설정에서 %s을(를) \"%s\"(으)로 설정하고 게임을 다시 시작하세요.",
 	"overlay.vitrail.compiling": "Vitrail이 셰이더를 아직 컴파일하고 있습니다",
+	"overlay.vitrail.compiling_background": "Vitrail이 나머지를 백그라운드에서 컴파일하고 있습니다",
 	"overlay.vitrail.compiled": "Vitrail 셰이더 컴파일이 끝났습니다",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/nl_nl.json
+++ b/common/src/main/resources/assets/vitrail/lang/nl_nl.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "Shaders herladen is mislukt! Reden: %s",
 	"options.vitrail.other_backend": "Vitrail tekent niets op de %s-backend: zijn shaders draaien alleen op Vulkan. Zet %s onder Opties, Video-instellingen op \"%s\" en herstart het spel.",
 	"overlay.vitrail.compiling": "Vitrail compileert de shaders nog",
+	"overlay.vitrail.compiling_background": "Vitrail compileert de rest op de achtergrond",
 	"overlay.vitrail.compiled": "Vitrail-shaders gecompileerd",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/pl_pl.json
+++ b/common/src/main/resources/assets/vitrail/lang/pl_pl.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "Nie udało się przeładować Shaderów! Powód: %s",
 	"options.vitrail.other_backend": "Vitrail nic nie rysuje na backendzie %s: jego shadery działają tylko na Vulkanie. Ustaw %s na \"%s\" w Opcje, Ustawienia grafiki, i uruchom grę ponownie.",
 	"overlay.vitrail.compiling": "Vitrail nadal kompiluje shadery",
+	"overlay.vitrail.compiling_background": "Vitrail kompiluje resztę w tle",
 	"overlay.vitrail.compiled": "Shadery Vitrail skompilowane",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/pt_br.json
+++ b/common/src/main/resources/assets/vitrail/lang/pt_br.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "Falha ao recarregar sombreadores! Motivo: %s",
 	"options.vitrail.other_backend": "O Vitrail não desenha nada no backend %s: seus shaders só funcionam em Vulkan. Defina %s como \"%s\" em Opções, Configurações de vídeo, e reinicie o jogo.",
 	"overlay.vitrail.compiling": "Vitrail ainda está compilando os shaders",
+	"overlay.vitrail.compiling_background": "Vitrail está compilando o resto em segundo plano",
 	"overlay.vitrail.compiled": "Shaders do Vitrail compilados",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/ru_ru.json
+++ b/common/src/main/resources/assets/vitrail/lang/ru_ru.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "Не удалось перезагрузить шейдеры. Причина: %s",
 	"options.vitrail.other_backend": "Vitrail ничего не рисует на бэкенде %s: его шейдеры работают только на Vulkan. Установите %s в значение \"%s\" в меню Настройки, Настройки графики, и перезапустите игру.",
 	"overlay.vitrail.compiling": "Vitrail всё ещё компилирует шейдеры",
+	"overlay.vitrail.compiling_background": "Vitrail компилирует остальное в фоновом режиме",
 	"overlay.vitrail.compiled": "Шейдеры Vitrail скомпилированы",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/tr_tr.json
+++ b/common/src/main/resources/assets/vitrail/lang/tr_tr.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "Shaderları yenileme başarısız! Sebep: %s",
 	"options.vitrail.other_backend": "Vitrail %s arka ucunda hiçbir şey çizmez: shaderları yalnızca Vulkan üzerinde çalışır. Seçenekler, Görüntü Ayarları altında %s ayarını \"%s\" yapın ve oyunu yeniden başlatın.",
 	"overlay.vitrail.compiling": "Vitrail shader'ları hâlâ derliyor",
+	"overlay.vitrail.compiling_background": "Vitrail geri kalanını arka planda derliyor",
 	"overlay.vitrail.compiled": "Vitrail shader'ları derlendi",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/uk_ua.json
+++ b/common/src/main/resources/assets/vitrail/lang/uk_ua.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "Не вдалося перезавантажити шейдери! Причина: %s",
 	"options.vitrail.other_backend": "Vitrail нічого не малює на бекенді %s: його шейдери працюють лише на Vulkan. Установіть %s у значення \"%s\" у меню Налаштування, Налаштування графіки, і перезапустіть гру.",
 	"overlay.vitrail.compiling": "Vitrail досі компілює шейдери",
+	"overlay.vitrail.compiling_background": "Vitrail компілює решту у фоновому режимі",
 	"overlay.vitrail.compiled": "Шейдери Vitrail скомпільовано",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/zh_cn.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_cn.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "重新加载光影包失败！原因：%s",
 	"options.vitrail.other_backend": "Vitrail 在 %s 后端下不绘制任何内容：其光影只能在 Vulkan 上运行。请在选项、视频设置中将 %s 设为 \"%s\"，然后重新启动游戏。",
 	"overlay.vitrail.compiling": "Vitrail 仍在编译着色器",
+	"overlay.vitrail.compiling_background": "Vitrail 正在后台编译其余着色器",
 	"overlay.vitrail.compiled": "Vitrail 着色器已编译完成",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/common/src/main/resources/assets/vitrail/lang/zh_tw.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_tw.json
@@ -52,6 +52,7 @@
 	"options.vitrail.reload_failed": "無法重新載入光影！原因：%s",
 	"options.vitrail.other_backend": "Vitrail 在 %s 後端下不會繪製任何內容：其光影只能在 Vulkan 上執行。請在選項、影像設定中將 %s 設為 \"%s\"，然後重新啟動遊戲。",
 	"overlay.vitrail.compiling": "Vitrail 仍在編譯著色器",
+	"overlay.vitrail.compiling_background": "Vitrail 正在背景編譯其餘著色器",
 	"overlay.vitrail.compiled": "Vitrail 著色器已編譯完成",
 	"key.category.vitrail.keybinds": "Vitrail"
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,8 +62,9 @@ observe:
   frames just after, because pipelines are compiled on a budget of the frame rather than all at
   once. Until the composites and the terrain are ready the chain draws nothing, and neither does the
   world: the HUD stays up and a line above it says the pack is still compiling. The leftover
-  families compile on their first draw. The same wait comes back for a moment after every resource
-  reload.
+  families compile in the background while you play, the line says so once, once more when
+  everything is done, and a first draw that outruns that work compiles on the spot. The same
+  wait comes back for a moment after every resource reload.
 - **A pack that cannot be translated fails loudly**, not as a corrupt image twenty minutes later.
   When Vitrail refuses something, the log names it.
 - **Uniform and sampler binding is decided up front**, so a pack that asks for something the


### PR DESCRIPTION
## What changes

The six on-demand geometry families (sky, entities, clouds, weather, particles, far terrain)
used to compile at their first draw, on the render thread: about half a second of shaderc and
driver work per program on a cold driver cache, and a big pack serves over a hundred programs,
so first encounters with new content froze the game for seconds, well into play and again behind
every portal. The pack-load worker that already translated these families now compiles their
pipelines too, with a compiler of its own, and the render thread only hands the finished object
to the device cache at the program's first prepare. The action-bar line follows: it announces the
background work once the world draws, and only says compiled once nothing is compiling any more.
The far terrain family is skipped while Distant Horizons is absent, shutdown waits out a worker
still compiling, and an empty `vitrail/keep-first-draw-compiles` beside the pack restores the old
path so before and after read off one jar.

## How it differs from the reference, and for what obstacle

It does not, for anything a pack can see: the same programs compile from the same translated
text, earlier and on another thread. A first draw the worker has not reached yet compiles on the
spot exactly as before, so no frame ever draws a family with anything but the pack's own program.

## What proves it

- `gradlew build` green on both loaders.
- In the game, Fabric bench, Complementary Unbound r5.8.1, world join: the worker reports 101 of
  113 leftover pipelines compiled ahead in 5.7 s on a warm driver cache, about a minute on a
  cold one, with no engine error and the first-draw log lines unchanged. Same shape on the
  NeoForge bench, 99 of 113.
- An ordinary play session on the full instance no longer shows the multi-second freezes on
  first encounters that motivated the branch.
- The off-game harness was not run: nothing of translation, targets or chains moves.

## What it leaves owing

- Programs drawn in the first moments of a world still pay their compile on the render thread,
  bounded by what is on screen, until the worker reaches them.
- A resource reload empties the device cache, and those recompiles still land on the render
  thread at first draw.
- The worker is sequential: a cold driver cache spends about a minute in the background on a big
  pack. Parallel workers could shorten it.
- The composites and the terrain keep their existing road, compiled while the world is held.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
