### PR TITLE
fix(screen): send the empty pack list to CurseForge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ what the next one holds.
 
 ## Unreleased
 
+### Changed
+
+- **The link under an empty pack folder opens the CurseForge shader search.** It used to open
+  the shader page on Modrinth, where this mod is not published.
+
 ### Fixed
 
 - **The game no longer crashes when resources reload with a pack loaded.** Moving

--- a/common/src/main/java/dev/vitrail/screen/PackList.java
+++ b/common/src/main/java/dev/vitrail/screen/PackList.java
@@ -71,8 +71,15 @@ public final class PackList extends AbstractSelectionList<PackList.BaseEntry> {
 	/** The least alpha the separators are ever drawn at once they are drawn, also Iris's. */
 	private static final float FAINTEST = 0.01F;
 
-	/** Where a pack comes from when the folder is empty, and the page Iris points at from here. */
-	private static final String PACK_SITE = "https://modrinth.com/shaders";
+	/**
+	 * Where a pack comes from when the folder is empty. Iris sends people to Modrinth from here,
+	 * which is a store this mod is not on, so the address is the CurseForge search instead. It asks
+	 * for the shader class and nothing else: the same search filtered on a game version answers
+	 * with the packs whose author has uploaded a file tagged for it, which is close to none of them
+	 * in the weeks after a game release, exactly when somebody arrives here with an empty folder.
+	 */
+	private static final String PACK_SITE =
+			"https://www.curseforge.com/minecraft/search?class=shaders";
 
 	private static final int ROW_HEIGHT = 20;
 
@@ -333,7 +340,7 @@ public final class PackList extends AbstractSelectionList<PackList.BaseEntry> {
 	/**
 	 * Somewhere to get a pack, through the game's own "do you want to open this link" screen so that
 	 * nothing is opened without being asked for and the address is shown before it is followed. Iris
-	 * offers the same page from the same place.
+	 * offers a page of its own from the same place.
 	 */
 	private void openPackSite() {
 		Screen here = this.minecraft.gui.screen();


### PR DESCRIPTION
## What changes

The shader pack screen offers somewhere to get a pack when the folder is empty, through the game's
own confirmation screen. That link opened the shader page on Modrinth, a store this mod is not
published on. It opens the CurseForge search for shader packs instead. The search asks for the
shader class and nothing else, no game version: filtered on one it answers with the packs whose
author has uploaded a file tagged for that version, which is close to none of them in the weeks
after a game release, which is exactly when somebody lands here with an empty folder. Nothing else
about the screen moves, and the address is still shown before anything is opened.

## How it differs from the reference, and for what obstacle

In one value, and it costs the image nothing. Iris points at `https://modrinth.com/shaders` from
this same place, which suits a mod published there. This one is on CurseForge, so copying the
reference's address would send people looking for a pack to a store that has nothing to do with the
mod they are running.

## What proves it

- `gradlew build` green, after the rebase.
- Not tried in game. The change is the value of one constant, handed to the same confirmation
  screen as before, which prints the address it is about to open.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
