### PR TITLE
fix(render): recompile a pack pipeline the reload dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Fixed
+
+- **The game no longer crashes when resources reload with a pack loaded.** Moving
+  Anisotropic Filtering or Texture Filtering under Video Settings, switching resource packs
+  and pressing F3 + T all reload every resource, and any of them took a world with a
+  shaderpack on straight to the crash screen, on "Pipeline is not valid".
+  The sky is drawn first in the frame and was the piece that fell over, but nothing the pack
+  draws was safe. The reload now costs what it always should have, a few frames while the
+  programs compile again.
+
+- A pack swapped while the engine was still warming up could kill the worker that compiles
+  the leftover programs ahead of their first draw. Those programs then paid for themselves
+  at the first frame that needed them, which is a stutter where there had been none.
+
 ## 0.8.0-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -856,9 +856,14 @@ final class GeometryProgram {
 			return false;
 		}
 
-		if (this.compiled) {
-			return true;
-		}
+		// NOT short-circuited on the flag below, which only says shaderc has been paid once.
+		// Every resource reload empties the device cache under a running session, and what
+		// lowers that flag is the chain noticing its own head recompiled, which happens later in
+		// the frame than the sky, the first thing the world draws. A program trusting the flag
+		// hands back a pipeline the cache no longer holds, and setPipeline compiles it from the
+		// game's shader sources, which carry no line of this pack: an invalid pipeline, and the
+		// frame throws by name in the middle of the sky. The call below is a computeIfAbsent, so
+		// it costs a lookup for as long as the cache holds the key.
 
 		// What the worker finished is handed to the cache here, on the render thread, and the
 		// precompile below finds it as a lookup. A cache that already holds the key kept a copy

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -317,6 +317,14 @@ public final class PackChain {
 	private volatile int familiesReady;
 
 	/**
+	 * Guards the six family program maps against the one pair of threads that ever touches
+	 * them at once: the pack-load worker copying the family it has just read, and the render
+	 * thread emptying every family when the pack goes. A plain map read while another thread
+	 * clears it is undefined rather than merely unlucky, so neither side is left to chance.
+	 */
+	private final Object familyMaps = new Object();
+
+	/**
 	 * Raised by {@link #release()} and read by the pack-load worker between two programs, which is
 	 * what stops a worker still compiling for a chain nothing will ever draw again. Volatile for
 	 * that one cross-thread read; everything else about the release stays on the render thread.
@@ -2879,11 +2887,21 @@ public final class PackChain {
 			return;
 		}
 
+		// Copied here, on the thread that has just filled this family, and never walked live:
+		// the maps behind it are emptied on the render thread when the pack goes, and an
+		// iterator standing in one then throws under the worker even though the released flag
+		// it reads every step is already up. Under the lock, because the copy itself is a read
+		// of the live map and the emptying is what it races.
+		List<DumpedProgram> programs;
+		synchronized (this.familyMaps) {
+			programs = List.copyOf(familyPrograms(family));
+		}
+
 		// The plate grows before the task that will empty it exists, so the corner's count can
 		// only ever run behind the truth, never past it.
-		this.warmTotal.addAndGet(familyPrograms(family).size());
+		this.warmTotal.addAndGet(programs.size());
 		compiles.add(CompletableFuture.runAsync(
-				() -> warmFamily(family, device), COMPILE_POOL));
+				() -> warmFamily(programs, device), COMPILE_POOL));
 	}
 
 	/**
@@ -2895,9 +2913,9 @@ public final class PackChain {
 	 * {@code vitrail/keep-first-draw-compiles} beside the pack keeps the old first-draw path for
 	 * a measurement, the way {@code keep-redone-work} does.
 	 */
-	private void warmFamily(int family, VulkanDevice device) {
+	private void warmFamily(List<DumpedProgram> programs, VulkanDevice device) {
 		try (GlslCompiler compiler = new GlslCompiler()) {
-			for (DumpedProgram program : familyPrograms(family)) {
+			for (DumpedProgram program : programs) {
 				if (this.released || disabled) {
 					return;
 				}
@@ -3327,12 +3345,14 @@ public final class PackChain {
 		DhLods.handBack();
 
 		this.terrain.release();
-		this.sky.release();
-		this.entities.release();
-		this.clouds.release();
-		this.weather.release();
-		this.particles.release();
-		this.distant.release();
+		synchronized (this.familyMaps) {
+			this.sky.release();
+			this.entities.release();
+			this.clouds.release();
+			this.weather.release();
+			this.particles.release();
+			this.distant.release();
+		}
 
 		if (this.block != null) {
 			this.block.close();


### PR DESCRIPTION
## What changes

Reloading resources while a shaderpack is loaded no longer takes the game down. Moving
Anisotropic Filtering or Texture Filtering under Video Settings, switching resource packs and
pressing F3 + T all reload every resource, which empties the device's pipeline cache, and a
geometry program was handing back a pipeline that cache no longer held. The device then
compiled it from the game's own shader sources, which carry no line of the pack, and the frame
threw on "Pipeline is not valid" inside `setPipeline`. The sky fell over because it is drawn
first, but nothing the pack draws was safe. A program now offers its pipeline to the cache
every time it prepares, which is a map probe while the cache holds it and a compile after a
reload emptied it.

The second commit closes a race beside it: the worker that compiles a family's leftover
pipelines ahead of their first draw walked the live map of programs, which the render thread
empties when the pack goes. It now walks a copy, and the copy and the emptying share a lock.
When that worker died, the programs it had not reached paid for themselves at their first
draw, which is a stutter where there had been none.

## How it differs from the reference, and for what obstacle

It does not. `docs/internals/game-graphics-api.md` already carried the rule this restores:
nothing may be compiled once and assumed to survive, because the cache is emptied whenever the
game reapplies its shader manager.

## What proves it

- `gradlew build` green.
- In the game, on Fabric with Sodium and nothing else beside this mod, Complementary Unbound
  r5.8.1, standing on an overworld plain in daylight. Before: the first resource reload logs
  `Couldn't find source for VERTEX shader (vitrail:pack/N/disc/world0/gbuffers_skybasic/vertex)`
  and the frame throws, which is the reported crash to the line. After: four reloads in a row,
  no error logged, the world still drawn by the pack after each of them.
- The out-of-game harness was not run. It reads packs and translates them, and this branch
  changes neither.

## What it leaves owing

Nothing. The reload still costs the few frames it takes to compile the pack's programs again,
which is what it costs on entering a world.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, in a new section: the one below it
      carries a tag.
- [x] Every place that states a fact this branch changed now states the new one. The javadoc on
      the method and the page above both already described the behaviour this restores.
