### PR TITLE
fix(glsl): read every declarator of one declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ what the next one holds.
   the leftover programs ahead of their first draw. Those programs then paid for themselves
   at the first frame that needed them, which is a stutter where there had been none.
 
+- **Mellow draws again.** Since 0.7.5-beta the pack loaded, laid out its settings and then
+  drew nothing at all, the game's own picture staying on screen. One of its fullscreen
+  passes was refused at compile, and a pack one of whose passes does not compile draws
+  nothing at all. What that pass builds its outline from is a number its own settings fix
+  before anything is compiled, and the engine was treating it as one that could still
+  change. Any pack that writes a constant that way was open to the same.
+
+- **E-LITE compiles whole.** Twenty of its programs were refused, because one value the
+  engine supplies reached the shader a second time where the pack had already named it
+  itself. A line that names several values at once is now read to its end, so nothing is
+  supplied over a name the pack wrote.
+
 ## 0.8.0-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -945,6 +945,13 @@ public final class GlslTranslator {
 	/**
 	 * Records every name the unit declares under a built-in type, and among them the functions
 	 * whose name GLSL has since taken for itself.
+	 * <p>
+	 * A declaration declares more than one name when it carries commas, and only the first of them
+	 * follows the type. E-LITE writes {@code uniform int frameCounter, isEyeInWater, entityId},
+	 * and reading the first alone left the other two as names the unit never declares, which is
+	 * what decides whether the block supplies one: {@code entityId} was then written into the
+	 * block twice, once by the lift and once as a name nobody had declared, and the compiler
+	 * refuses a member declared twice.
 	 */
 	private void collectDeclarations() {
 		for (int index = 0; index < this.tokens.size(); index++) {
@@ -959,10 +966,81 @@ public final class GlslTranslator {
 			}
 
 			this.declaredNames.add(token.text());
+			this.declaredNames.addAll(continuationDeclarators(index));
 			if (LegacyGlsl.POST_120_BUILTINS.contains(token.text()) && callOpener(index) >= 0) {
 				this.shadowedBuiltins.add(token.text());
 			}
 		}
+	}
+
+	/**
+	 * The names a declaration declares after its first, which is every declarator past a comma.
+	 * <p>
+	 * A name is only taken where what FOLLOWS it says it is a declarator, which is a comma, a
+	 * semicolon, an initialiser or an array bracket. Reading the name alone is not enough, and a
+	 * parameter list is why: {@code TYPE_NAMES} carries no {@code const}, {@code in} or
+	 * {@code out}, so Bliss writing {@code float rayLength, const float steps} in a signature
+	 * ({@code lib/ROBOBO_sky.glsl:61}) offers {@code const} where a declarator would stand. What
+	 * follows it there is a type name and never one of the four, so it is refused.
+	 * <p>
+	 * Liveness is not consulted, here or anywhere else in this pass: a declaration is read whether
+	 * its branch is taken or not, and the tail of a list is read on the same terms as its head.
+	 * Making the pass live-aware would change what it answers for every declaration in the file
+	 * and belongs to a batch of its own.
+	 *
+	 * @param first the first declarator of the statement, the one the type stands in front of
+	 */
+	private List<String> continuationDeclarators(int first) {
+		int end = statementEnd(first);
+		if (end < 0) {
+			return List.of();
+		}
+
+		List<String> names = new ArrayList<>();
+		int depth = 0;
+		boolean expectName = false;
+
+		for (int index = significantAfter(first); index >= 0 && index <= end;
+				index = significantAfter(index)) {
+			Token token = this.tokens.get(index);
+			if (token.operator("(") || token.operator("[") || token.operator("{")) {
+				depth++;
+			} else if (token.operator(")") || token.operator("]") || token.operator("}")) {
+				if (depth == 0) {
+					return names;
+				}
+
+				depth--;
+			} else if (depth == 0 && token.operator(",")) {
+				expectName = true;
+			} else if (expectName) {
+				if (token.kind() != Kind.IDENTIFIER || !declaratorFollows(index)) {
+					return names;
+				}
+
+				names.add(token.text());
+				expectName = false;
+			}
+		}
+
+		return names;
+	}
+
+	/**
+	 * Whether the name at this position is followed by what only ever follows a declarator: the
+	 * comma before the next one, the semicolon that ends the declaration, an initialiser, or the
+	 * bracket of an array.
+	 */
+	private boolean declaratorFollows(int name) {
+		int next = significantAfter(name);
+		if (next < 0) {
+			return false;
+		}
+
+		Token token = this.tokens.get(next);
+
+		return token.operator(",") || token.operator(";") || token.operator("=")
+				|| token.operator("[");
 	}
 
 	/**
@@ -1498,9 +1576,15 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Whether the identifier at this position is being DECLARED rather than read, which is the same
-	 * test {@code collectDeclarations} makes: an identifier straight after a built-in type name is
-	 * being named, anywhere else it is being used.
+	 * Whether the identifier at this position is being DECLARED rather than read: an identifier
+	 * straight after a built-in type name is being named, anywhere else it is being used.
+	 * <p>
+	 * It answers for the head of a declaration and for nothing else, where
+	 * {@link #collectDeclarations} reads the whole list. A pack writing
+	 * {@code uniform mat4 gbufferModelView, modelViewMatrix} would be told the second name is a
+	 * use, and the injection below would land on the declarator. No pack of the corpus writes the
+	 * shape, and closing it is not this method's alone: {@code declaredUnderAType} makes the same
+	 * first-name-only test for the block, so the two move together or neither does.
 	 */
 	private boolean declaring(int index) {
 		int before = significantBefore(index);

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -1920,6 +1920,15 @@ public final class GlslTranslator {
 	 * An array size still needs a real constant, so a declaration whose initialiser is only literals
 	 * and type constructors is left alone. Parameters keep {@code const}: that spelling means
 	 * immutable, not compile-time, and the language allows it.
+	 * <p>
+	 * A name the unit {@code #define}s is left alone too, and it has to be: this pass reads tokens,
+	 * the macro is expanded later by the compiler, and what stands here is a name where a literal
+	 * will be. Mellow builds its outline offsets out of {@code OUTLINE_THICKNESS}, a constructor
+	 * multiplied by it four times over, and hands the array to {@code textureGatherOffsets}, which
+	 * takes nothing but a constant expression. Read as non-constant, the keyword came off a
+	 * declaration that was constant all along, one fullscreen pass of the pack would not compile,
+	 * and a pack one of whose passes does not compile draws nothing at all. What #157 was about is
+	 * a call and a uniform, neither of which a macro name is.
 	 */
 	private void demoteNonConstantInitialisers() {
 		int parens = 0;
@@ -1952,7 +1961,7 @@ public final class GlslTranslator {
 
 	/**
 	 * Whether this {@code const} declaration assigns something Vulkan will not take as a constant
-	 * expression: any identifier that is not a type constructor.
+	 * expression: any identifier that is neither a type constructor nor a macro this unit defines.
 	 */
 	private boolean nonConstantInitialiser(int keyword, int end) {
 		boolean seenEquals = false;
@@ -1967,7 +1976,8 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			if (!LegacyGlsl.TYPE_NAMES.contains(token.text())) {
+			if (!LegacyGlsl.TYPE_NAMES.contains(token.text())
+					&& !this.packMacros.contains(token.text())) {
 				return true;
 			}
 		}


### PR DESCRIPTION
## What changes

Two packs that would not compile do. Mellow loaded, laid out its settings and then drew nothing
at all, because one of its fullscreen passes was refused: it builds an array of texel offsets
from a value its own settings fix before anything is compiled, and the engine was reading that
value as one that could still change, so it took the pack's `const` off a declaration that was
constant all along and the lookup underneath would no longer take it. E-LITE lost twenty
programs because a line naming three values at once was read only as far as the first, which
left the other two looking like names the pack never wrote, and the engine then supplied one of
them beside the one the pack had already declared. A declaration is read to its end now, and a
name a `#define` will turn into a literal no longer counts as proof that an initialiser can
change.

## How it differs from the reference, and for what obstacle

It does not. Both are Vulkan being stricter than the OpenGL compilers Iris hands its GLSL to,
and both bring this engine back to what a pack may legally write rather than away from it.

## What proves it

- `gradlew build` green, at every commit of the series and not only at the tip.
- The out-of-game harness, `Traduction` over the seventeen packs of the test instance, with
  Distant Horizons declared. Entry points that compile: Mellow 250/254 to 254/254, E-LITE
  190/210 to 210/210, total 2958/3042 to 2982/3042. No other pack moves in either direction,
  and Mellow's 254/254 is the figure it last had in 0.7.4-beta, before the defect.
- Not tried in the game. Nothing here changes what is drawn once a pack compiles, and the two
  packs are refused or not at load.

## What it leaves owing

Sixty entry points across the corpus still do not compile, on causes this branch does not touch:
a pack writing a float inside a preprocessor expression, which OpenGL compilers accept and this
one refuses; a colour target bound as a writable image, which the engine serves nowhere; and a
handful of undeclared identifiers with no shared cause.

Two places make the same first-name-only reading of a declaration as the one this branch fixes,
`declaring` and `declaredUnderAType`, and a pack writing `uniform mat4 gbufferModelView,
modelViewMatrix` would have the rewrite land on the declarator. No pack of the corpus writes
that shape. Both are named where they stand and neither moves here, since they have to move
together.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
