### PR TITLE
fix(render): owe a clear again when the frame never paid it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ what the next one holds.
   itself. A line that names several values at once is now read to its end, so nothing is
   supplied over a name the pack wrote.
 
+- **A pack could come up with something wrong smeared across the picture, and stay that way
+  until it was loaded again.** Not a flicker and not a glitch that passes: a patch of colour
+  or noise that is simply there, on a machine where it happens and never on the one next to
+  it. What was behind it: the images a pack draws into are wiped once when they are built, at
+  every pack load and again whenever the window changes size, and that wipe was ticked off
+  the list the moment it was scheduled instead of when it happened. One frame that drew none
+  of the pack lost it, and the seconds a pack spends compiling are exactly those frames. The
+  images a pack carries from one frame to the next are never scheduled again after that, so
+  they kept whatever the graphics driver had left lying in them.
+
 ## 0.8.0-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -237,6 +237,32 @@ final class ColorTargets {
 	private int screenWidth;
 	private int screenHeight;
 	private boolean clearOwed;
+
+	/**
+	 * Whether the full round of emptying a reallocation asks for is still owed, which is a different
+	 * question from {@link #clearOwed} and is why it is a field of its own.
+	 * <p>
+	 * A round is WRITTEN in one part and RECORDED in another, and the two are not finished at the
+	 * same moment. The constants, the noise field and the pack's own textures are written where the
+	 * round is decided, so they are done the instant {@link #clear} runs, and {@code clearOwed} is
+	 * all they need. The per target emptying is only recorded there and paid afterwards, by the
+	 * load-op of the first pass that attaches the surface or by the flush that takes what is left,
+	 * so it can be lost outright: the frame that recorded it may open no pass at all, and the next
+	 * one drops what it finds. This flag is what carries the recording across such a frame.
+	 * <p>
+	 * <strong>What it watches is the record, not the texels.</strong> It comes down when nothing is
+	 * left on the books, and an entry leaves them where a pass descriptor is BUILT rather than where
+	 * one opens. A frame that builds descriptors and opens none of them therefore clears the books
+	 * without emptying anything, and this comes down with them. That gap is older than this flag and
+	 * it is where the remaining hole is, not in the carrying.
+	 * <p>
+	 * Warm up is the case this exists for, and it is the ordinary road rather than an odd one: the
+	 * terrain opens the targets and hands the frame straight back, once per frame, for as long as
+	 * programs are still compiling. Carrying {@code clearOwed} itself across those frames would
+	 * rewrite every constant and re-upload every texture the pack ships on each one of them.
+	 */
+	private boolean fullDeferOwed;
+
 	private boolean broken;
 
 	/**
@@ -405,7 +431,14 @@ final class ColorTargets {
 	}
 
 	/**
-	 * Clears both halves of what the pack asked to have cleared, and pays any full clear owed.
+	 * Records the emptying that the main and the alternate surface of each target the pack asked to
+	 * have cleared are owed, and of every other target as well while a round is a full one.
+	 * <p>
+	 * A record is paid afterwards, by the load-op of the first pass that attaches the surface or by
+	 * the flush that takes whatever is left, and {@link #fullDeferOwed} is what carries it over a
+	 * frame that pays nothing. The rest of a full round is not a target at all, the constants, the
+	 * noise field and the textures the pack ships, and that part is written here and now on
+	 * {@link #clearOwed} alone, once per reallocation and never again while one is merely carried.
 	 * <p>
 	 * The shadow map is deliberately not in this list. It is drawn at the end of a frame for the
 	 * next one, so what it holds when the frame opens is exactly what the gbuffers are about to
@@ -417,9 +450,19 @@ final class ColorTargets {
 	 *            reflections, because the pack reads that channel as something of its own
 	 */
 	void clear(CommandEncoder encoder, Vector4fc fog) {
-		boolean full = this.clearOwed;
+		// Entries still standing are the last frame's, recorded and never paid, and the wipe below
+		// drops them without emptying a texel. So a full round that got no further than being
+		// recorded is owed again, and stays owed while anything of it is still on the books.
+		this.fullDeferOwed &= !this.pendingClears.isEmpty();
 
-		if (full) {
+		boolean full = this.clearOwed || this.fullDeferOwed;
+
+		// The written part, on the flag a reallocation raises and nothing carries forward. Hanging
+		// it off `full` instead would run all of this on every frame of a warm up, where the targets
+		// are opened and the frame handed back before any pass exists: four clears of their own, the
+		// noise field written out again, and every texture the pack ships uploaded again, once per
+		// frame for as long as programs are still compiling.
+		if (this.clearOwed) {
 			clear(encoder, this.black, OPAQUE_BLACK);
 			clear(encoder, this.white, OPAQUE_WHITE);
 			clear(encoder, this.grey, MID_GREY);
@@ -450,10 +493,14 @@ final class ColorTargets {
 			defer(this.altSide.get(index), colour);
 		}
 
-		// Last, so the debt is only ever paid off by a clear that got all the way through. Written
-		// off at the top, an upload that threw halfway - the noise field is the one that reads a file
-		// - left the pack sampling whatever the driver had put in a texture nobody had written, for
-		// the rest of the session and without a line to say so.
+		// Last, so a throw above leaves both flags standing. Written off at the top, an upload that
+		// threw halfway left the pack sampling whatever the driver had put in a texture nobody had
+		// written, for the rest of the session and without a line to say so.
+		//
+		// The written part is done by the time this line runs and is written off here. The record
+		// has only just been made, so it is owed from here until the check at the top of the next
+		// round finds the books clear.
+		this.fullDeferOwed = full;
 		this.clearOwed = false;
 	}
 


### PR DESCRIPTION
## What changes

When a pack's colour targets are built, which is at every pack load and again at every window
resize, all of them are emptied once. That round is two halves paid at two different moments. The
constants, the noise field and the textures the pack ships are written on the spot. The per target
emptying is only recorded, and paid afterwards by the load-op of the first render pass that
attaches the surface, or by a flush that takes whatever is left.

One flag carried both halves, and it came down as soon as the recording was made rather than when
anything was emptied. So a frame that records and then opens no pass loses what it recorded: the
next frame drops the entries it finds and the flag is already down. Those frames are not rare,
they are the whole of a pack's warm up. And the targets that suffer are the ones a pack keeps
from one frame to the next, because every later round skips those by design, so they could stay
unwritten for as long as the pack was loaded, handing the pack whatever the driver had left in
them.

The two halves now have a flag each. What is recorded stays owed until a frame empties a texel;
what is written on the spot keeps the flag a reallocation raises, so a warm up does not rewrite
every constant and re-upload every texture the pack ships once per frame.

## How it differs from the reference, and for what obstacle

It does not. Iris keeps one framebuffer bound and clears it, so it has no deferral to lose. This
only puts back the guarantee the deferral was meant to preserve.

## What proves it

- `gradlew build` green.
- In the game, Complementary Reimagined r5.8.1 as a zip, one spot with the view pinned to the
  same heading on both runs, the engine's own per frame count of what it opens. A steady frame
  clears **five** textures with this branch and **five** without it, for one queue submit either
  way. That count is the one this could have inflated, and it does not move. The pass count sits
  at 28 to 31 against 29 to 32, which is the scene rather than the branch: nothing here can
  remove a pass.
- Read against every caller of the flush that discharges a recording. It runs at the opening of
  each geometry pass and of each of the pack's own passes, so a frame that draws carries nothing
  forward, and the frames that carry something are the warm up, where what is left is map writes.

The defect itself is not reproduced on screen and that is a scope: what it leaves behind is a
target holding uninitialised memory, which a driver is free to hand back as zeroes. That is the
whole reason it can be right on one machine and wrong on another.

## What it leaves owing

One thing, older than this branch and untouched by it. A recorded emptying is taken off the books
when a render pass is BUILT rather than when it opens, so a pass that is then abandoned takes the
colour with it. The check this branch adds cannot see that case, because it looks at what is left
standing and nothing is. Two places do it, the feature layer's compose and the flush itself.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
