### PR TITLE
build: raise the version to 0.8.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.8.1-beta
 
 ### Changed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.8.0-beta
+mod_version=0.8.1-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

The version number, and the changelog section that was open above it becomes `0.8.1-beta`.
Nothing else: no code moves in this branch.

What the number covers is five fixes and one change, all of them already in `dev`. The one that
decides the release is the first: with `0.8.0-beta` installed, a resource reload with a pack
loaded takes the game to the crash screen, and moving Anisotropic Filtering under Video Settings
is a resource reload. A player reaches that without looking for it.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

- `gradlew build` green, and the jar it produces carries the new number.
- The release gate refuses a tag whose `origin/dev` tip is not exactly
  `build: raise the version to <version>`. This branch is what makes it stop refusing, and it is
  the last thing landing before the tag, so the tag goes on it rather than on a batch that
  arrived afterwards.

## What it leaves owing

Nothing in this branch. One batch stays out of this release on purpose, the one answering a
pack's switch for its geometry programs: it makes entities translucent where the reference draws
them solid, and it does not ship until that is understood.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
