### PR TITLE
Release 0.8.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.8.1-beta
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ what the next one holds.
 
 ## Unreleased
 
+### Changed
+
+- **The link under an empty pack folder opens the CurseForge shader search.** It used to open
+  the shader page on Modrinth, where this mod is not published.
+
 ### Fixed
 
 - **The game no longer crashes when resources reload with a pack loaded.** Moving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Fixed
+
+- **The game no longer crashes when resources reload with a pack loaded.** Moving
+  Anisotropic Filtering or Texture Filtering under Video Settings, switching resource packs
+  and pressing F3 + T all reload every resource, and any of them took a world with a
+  shaderpack on straight to the crash screen, on "Pipeline is not valid".
+  The sky is drawn first in the frame and was the piece that fell over, but nothing the pack
+  draws was safe. The reload now costs what it always should have, a few frames while the
+  programs compile again.
+
+- A pack swapped while the engine was still warming up could kill the worker that compiles
+  the leftover programs ahead of their first draw. Those programs then paid for themselves
+  at the first frame that needed them, which is a stutter where there had been none.
+
 ## 0.8.0-beta
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ what the next one holds.
   itself. A line that names several values at once is now read to its end, so nothing is
   supplied over a name the pack wrote.
 
+- **A pack could come up with something wrong smeared across the picture, and stay that way
+  until it was loaded again.** Not a flicker and not a glitch that passes: a patch of colour
+  or noise that is simply there, on a machine where it happens and never on the one next to
+  it. What was behind it: the images a pack draws into are wiped once when they are built, at
+  every pack load and again whenever the window changes size, and that wipe was ticked off
+  the list the moment it was scheduled instead of when it happened. One frame that drew none
+  of the pack lost it, and the seconds a pack spends compiling are exactly those frames. The
+  images a pack carries from one frame to the next are never scheduled again after that, so
+  they kept whatever the graphics driver had left lying in them.
+
 ## 0.8.0-beta
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ what the next one holds.
   the leftover programs ahead of their first draw. Those programs then paid for themselves
   at the first frame that needed them, which is a stutter where there had been none.
 
+- **Mellow draws again.** Since 0.7.5-beta the pack loaded, laid out its settings and then
+  drew nothing at all, the game's own picture staying on screen. One of its fullscreen
+  passes was refused at compile, and a pack one of whose passes does not compile draws
+  nothing at all. What that pass builds its outline from is a number its own settings fix
+  before anything is compiled, and the engine was treating it as one that could still
+  change. Any pack that writes a constant that way was open to the same.
+
+- **E-LITE compiles whole.** Twenty of its programs were refused, because one value the
+  engine supplies reached the shader a second time where the pack had already named it
+  itself. A line that names several values at once is now read to its end, so nothing is
+  supplied over a name the pack wrote.
+
 ## 0.8.0-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -945,6 +945,13 @@ public final class GlslTranslator {
 	/**
 	 * Records every name the unit declares under a built-in type, and among them the functions
 	 * whose name GLSL has since taken for itself.
+	 * <p>
+	 * A declaration declares more than one name when it carries commas, and only the first of them
+	 * follows the type. E-LITE writes {@code uniform int frameCounter, isEyeInWater, entityId},
+	 * and reading the first alone left the other two as names the unit never declares, which is
+	 * what decides whether the block supplies one: {@code entityId} was then written into the
+	 * block twice, once by the lift and once as a name nobody had declared, and the compiler
+	 * refuses a member declared twice.
 	 */
 	private void collectDeclarations() {
 		for (int index = 0; index < this.tokens.size(); index++) {
@@ -959,10 +966,81 @@ public final class GlslTranslator {
 			}
 
 			this.declaredNames.add(token.text());
+			this.declaredNames.addAll(continuationDeclarators(index));
 			if (LegacyGlsl.POST_120_BUILTINS.contains(token.text()) && callOpener(index) >= 0) {
 				this.shadowedBuiltins.add(token.text());
 			}
 		}
+	}
+
+	/**
+	 * The names a declaration declares after its first, which is every declarator past a comma.
+	 * <p>
+	 * A name is only taken where what FOLLOWS it says it is a declarator, which is a comma, a
+	 * semicolon, an initialiser or an array bracket. Reading the name alone is not enough, and a
+	 * parameter list is why: {@code TYPE_NAMES} carries no {@code const}, {@code in} or
+	 * {@code out}, so Bliss writing {@code float rayLength, const float steps} in a signature
+	 * ({@code lib/ROBOBO_sky.glsl:61}) offers {@code const} where a declarator would stand. What
+	 * follows it there is a type name and never one of the four, so it is refused.
+	 * <p>
+	 * Liveness is not consulted, here or anywhere else in this pass: a declaration is read whether
+	 * its branch is taken or not, and the tail of a list is read on the same terms as its head.
+	 * Making the pass live-aware would change what it answers for every declaration in the file
+	 * and belongs to a batch of its own.
+	 *
+	 * @param first the first declarator of the statement, the one the type stands in front of
+	 */
+	private List<String> continuationDeclarators(int first) {
+		int end = statementEnd(first);
+		if (end < 0) {
+			return List.of();
+		}
+
+		List<String> names = new ArrayList<>();
+		int depth = 0;
+		boolean expectName = false;
+
+		for (int index = significantAfter(first); index >= 0 && index <= end;
+				index = significantAfter(index)) {
+			Token token = this.tokens.get(index);
+			if (token.operator("(") || token.operator("[") || token.operator("{")) {
+				depth++;
+			} else if (token.operator(")") || token.operator("]") || token.operator("}")) {
+				if (depth == 0) {
+					return names;
+				}
+
+				depth--;
+			} else if (depth == 0 && token.operator(",")) {
+				expectName = true;
+			} else if (expectName) {
+				if (token.kind() != Kind.IDENTIFIER || !declaratorFollows(index)) {
+					return names;
+				}
+
+				names.add(token.text());
+				expectName = false;
+			}
+		}
+
+		return names;
+	}
+
+	/**
+	 * Whether the name at this position is followed by what only ever follows a declarator: the
+	 * comma before the next one, the semicolon that ends the declaration, an initialiser, or the
+	 * bracket of an array.
+	 */
+	private boolean declaratorFollows(int name) {
+		int next = significantAfter(name);
+		if (next < 0) {
+			return false;
+		}
+
+		Token token = this.tokens.get(next);
+
+		return token.operator(",") || token.operator(";") || token.operator("=")
+				|| token.operator("[");
 	}
 
 	/**
@@ -1498,9 +1576,15 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Whether the identifier at this position is being DECLARED rather than read, which is the same
-	 * test {@code collectDeclarations} makes: an identifier straight after a built-in type name is
-	 * being named, anywhere else it is being used.
+	 * Whether the identifier at this position is being DECLARED rather than read: an identifier
+	 * straight after a built-in type name is being named, anywhere else it is being used.
+	 * <p>
+	 * It answers for the head of a declaration and for nothing else, where
+	 * {@link #collectDeclarations} reads the whole list. A pack writing
+	 * {@code uniform mat4 gbufferModelView, modelViewMatrix} would be told the second name is a
+	 * use, and the injection below would land on the declarator. No pack of the corpus writes the
+	 * shape, and closing it is not this method's alone: {@code declaredUnderAType} makes the same
+	 * first-name-only test for the block, so the two move together or neither does.
 	 */
 	private boolean declaring(int index) {
 		int before = significantBefore(index);

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -1920,6 +1920,15 @@ public final class GlslTranslator {
 	 * An array size still needs a real constant, so a declaration whose initialiser is only literals
 	 * and type constructors is left alone. Parameters keep {@code const}: that spelling means
 	 * immutable, not compile-time, and the language allows it.
+	 * <p>
+	 * A name the unit {@code #define}s is left alone too, and it has to be: this pass reads tokens,
+	 * the macro is expanded later by the compiler, and what stands here is a name where a literal
+	 * will be. Mellow builds its outline offsets out of {@code OUTLINE_THICKNESS}, a constructor
+	 * multiplied by it four times over, and hands the array to {@code textureGatherOffsets}, which
+	 * takes nothing but a constant expression. Read as non-constant, the keyword came off a
+	 * declaration that was constant all along, one fullscreen pass of the pack would not compile,
+	 * and a pack one of whose passes does not compile draws nothing at all. What #157 was about is
+	 * a call and a uniform, neither of which a macro name is.
 	 */
 	private void demoteNonConstantInitialisers() {
 		int parens = 0;
@@ -1952,7 +1961,7 @@ public final class GlslTranslator {
 
 	/**
 	 * Whether this {@code const} declaration assigns something Vulkan will not take as a constant
-	 * expression: any identifier that is not a type constructor.
+	 * expression: any identifier that is neither a type constructor nor a macro this unit defines.
 	 */
 	private boolean nonConstantInitialiser(int keyword, int end) {
 		boolean seenEquals = false;
@@ -1967,7 +1976,8 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			if (!LegacyGlsl.TYPE_NAMES.contains(token.text())) {
+			if (!LegacyGlsl.TYPE_NAMES.contains(token.text())
+					&& !this.packMacros.contains(token.text())) {
 				return true;
 			}
 		}

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -237,6 +237,32 @@ final class ColorTargets {
 	private int screenWidth;
 	private int screenHeight;
 	private boolean clearOwed;
+
+	/**
+	 * Whether the full round of emptying a reallocation asks for is still owed, which is a different
+	 * question from {@link #clearOwed} and is why it is a field of its own.
+	 * <p>
+	 * A round is WRITTEN in one part and RECORDED in another, and the two are not finished at the
+	 * same moment. The constants, the noise field and the pack's own textures are written where the
+	 * round is decided, so they are done the instant {@link #clear} runs, and {@code clearOwed} is
+	 * all they need. The per target emptying is only recorded there and paid afterwards, by the
+	 * load-op of the first pass that attaches the surface or by the flush that takes what is left,
+	 * so it can be lost outright: the frame that recorded it may open no pass at all, and the next
+	 * one drops what it finds. This flag is what carries the recording across such a frame.
+	 * <p>
+	 * <strong>What it watches is the record, not the texels.</strong> It comes down when nothing is
+	 * left on the books, and an entry leaves them where a pass descriptor is BUILT rather than where
+	 * one opens. A frame that builds descriptors and opens none of them therefore clears the books
+	 * without emptying anything, and this comes down with them. That gap is older than this flag and
+	 * it is where the remaining hole is, not in the carrying.
+	 * <p>
+	 * Warm up is the case this exists for, and it is the ordinary road rather than an odd one: the
+	 * terrain opens the targets and hands the frame straight back, once per frame, for as long as
+	 * programs are still compiling. Carrying {@code clearOwed} itself across those frames would
+	 * rewrite every constant and re-upload every texture the pack ships on each one of them.
+	 */
+	private boolean fullDeferOwed;
+
 	private boolean broken;
 
 	/**
@@ -405,7 +431,14 @@ final class ColorTargets {
 	}
 
 	/**
-	 * Clears both halves of what the pack asked to have cleared, and pays any full clear owed.
+	 * Records the emptying that the main and the alternate surface of each target the pack asked to
+	 * have cleared are owed, and of every other target as well while a round is a full one.
+	 * <p>
+	 * A record is paid afterwards, by the load-op of the first pass that attaches the surface or by
+	 * the flush that takes whatever is left, and {@link #fullDeferOwed} is what carries it over a
+	 * frame that pays nothing. The rest of a full round is not a target at all, the constants, the
+	 * noise field and the textures the pack ships, and that part is written here and now on
+	 * {@link #clearOwed} alone, once per reallocation and never again while one is merely carried.
 	 * <p>
 	 * The shadow map is deliberately not in this list. It is drawn at the end of a frame for the
 	 * next one, so what it holds when the frame opens is exactly what the gbuffers are about to
@@ -417,9 +450,19 @@ final class ColorTargets {
 	 *            reflections, because the pack reads that channel as something of its own
 	 */
 	void clear(CommandEncoder encoder, Vector4fc fog) {
-		boolean full = this.clearOwed;
+		// Entries still standing are the last frame's, recorded and never paid, and the wipe below
+		// drops them without emptying a texel. So a full round that got no further than being
+		// recorded is owed again, and stays owed while anything of it is still on the books.
+		this.fullDeferOwed &= !this.pendingClears.isEmpty();
 
-		if (full) {
+		boolean full = this.clearOwed || this.fullDeferOwed;
+
+		// The written part, on the flag a reallocation raises and nothing carries forward. Hanging
+		// it off `full` instead would run all of this on every frame of a warm up, where the targets
+		// are opened and the frame handed back before any pass exists: four clears of their own, the
+		// noise field written out again, and every texture the pack ships uploaded again, once per
+		// frame for as long as programs are still compiling.
+		if (this.clearOwed) {
 			clear(encoder, this.black, OPAQUE_BLACK);
 			clear(encoder, this.white, OPAQUE_WHITE);
 			clear(encoder, this.grey, MID_GREY);
@@ -450,10 +493,14 @@ final class ColorTargets {
 			defer(this.altSide.get(index), colour);
 		}
 
-		// Last, so the debt is only ever paid off by a clear that got all the way through. Written
-		// off at the top, an upload that threw halfway - the noise field is the one that reads a file
-		// - left the pack sampling whatever the driver had put in a texture nobody had written, for
-		// the rest of the session and without a line to say so.
+		// Last, so a throw above leaves both flags standing. Written off at the top, an upload that
+		// threw halfway left the pack sampling whatever the driver had put in a texture nobody had
+		// written, for the rest of the session and without a line to say so.
+		//
+		// The written part is done by the time this line runs and is written off here. The record
+		// has only just been made, so it is owed from here until the check at the top of the next
+		// round finds the books clear.
+		this.fullDeferOwed = full;
 		this.clearOwed = false;
 	}
 

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -856,9 +856,14 @@ final class GeometryProgram {
 			return false;
 		}
 
-		if (this.compiled) {
-			return true;
-		}
+		// NOT short-circuited on the flag below, which only says shaderc has been paid once.
+		// Every resource reload empties the device cache under a running session, and what
+		// lowers that flag is the chain noticing its own head recompiled, which happens later in
+		// the frame than the sky, the first thing the world draws. A program trusting the flag
+		// hands back a pipeline the cache no longer holds, and setPipeline compiles it from the
+		// game's shader sources, which carry no line of this pack: an invalid pipeline, and the
+		// frame throws by name in the middle of the sky. The call below is a computeIfAbsent, so
+		// it costs a lookup for as long as the cache holds the key.
 
 		// What the worker finished is handed to the cache here, on the render thread, and the
 		// precompile below finds it as a lookup. A cache that already holds the key kept a copy

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -317,6 +317,14 @@ public final class PackChain {
 	private volatile int familiesReady;
 
 	/**
+	 * Guards the six family program maps against the one pair of threads that ever touches
+	 * them at once: the pack-load worker copying the family it has just read, and the render
+	 * thread emptying every family when the pack goes. A plain map read while another thread
+	 * clears it is undefined rather than merely unlucky, so neither side is left to chance.
+	 */
+	private final Object familyMaps = new Object();
+
+	/**
 	 * Raised by {@link #release()} and read by the pack-load worker between two programs, which is
 	 * what stops a worker still compiling for a chain nothing will ever draw again. Volatile for
 	 * that one cross-thread read; everything else about the release stays on the render thread.
@@ -2879,11 +2887,21 @@ public final class PackChain {
 			return;
 		}
 
+		// Copied here, on the thread that has just filled this family, and never walked live:
+		// the maps behind it are emptied on the render thread when the pack goes, and an
+		// iterator standing in one then throws under the worker even though the released flag
+		// it reads every step is already up. Under the lock, because the copy itself is a read
+		// of the live map and the emptying is what it races.
+		List<DumpedProgram> programs;
+		synchronized (this.familyMaps) {
+			programs = List.copyOf(familyPrograms(family));
+		}
+
 		// The plate grows before the task that will empty it exists, so the corner's count can
 		// only ever run behind the truth, never past it.
-		this.warmTotal.addAndGet(familyPrograms(family).size());
+		this.warmTotal.addAndGet(programs.size());
 		compiles.add(CompletableFuture.runAsync(
-				() -> warmFamily(family, device), COMPILE_POOL));
+				() -> warmFamily(programs, device), COMPILE_POOL));
 	}
 
 	/**
@@ -2895,9 +2913,9 @@ public final class PackChain {
 	 * {@code vitrail/keep-first-draw-compiles} beside the pack keeps the old first-draw path for
 	 * a measurement, the way {@code keep-redone-work} does.
 	 */
-	private void warmFamily(int family, VulkanDevice device) {
+	private void warmFamily(List<DumpedProgram> programs, VulkanDevice device) {
 		try (GlslCompiler compiler = new GlslCompiler()) {
-			for (DumpedProgram program : familyPrograms(family)) {
+			for (DumpedProgram program : programs) {
 				if (this.released || disabled) {
 					return;
 				}
@@ -3327,12 +3345,14 @@ public final class PackChain {
 		DhLods.handBack();
 
 		this.terrain.release();
-		this.sky.release();
-		this.entities.release();
-		this.clouds.release();
-		this.weather.release();
-		this.particles.release();
-		this.distant.release();
+		synchronized (this.familyMaps) {
+			this.sky.release();
+			this.entities.release();
+			this.clouds.release();
+			this.weather.release();
+			this.particles.release();
+			this.distant.release();
+		}
 
 		if (this.block != null) {
 			this.block.close();

--- a/common/src/main/java/dev/vitrail/screen/PackList.java
+++ b/common/src/main/java/dev/vitrail/screen/PackList.java
@@ -71,8 +71,15 @@ public final class PackList extends AbstractSelectionList<PackList.BaseEntry> {
 	/** The least alpha the separators are ever drawn at once they are drawn, also Iris's. */
 	private static final float FAINTEST = 0.01F;
 
-	/** Where a pack comes from when the folder is empty, and the page Iris points at from here. */
-	private static final String PACK_SITE = "https://modrinth.com/shaders";
+	/**
+	 * Where a pack comes from when the folder is empty. Iris sends people to Modrinth from here,
+	 * which is a store this mod is not on, so the address is the CurseForge search instead. It asks
+	 * for the shader class and nothing else: the same search filtered on a game version answers
+	 * with the packs whose author has uploaded a file tagged for it, which is close to none of them
+	 * in the weeks after a game release, exactly when somebody arrives here with an empty folder.
+	 */
+	private static final String PACK_SITE =
+			"https://www.curseforge.com/minecraft/search?class=shaders";
 
 	private static final int ROW_HEIGHT = 20;
 
@@ -333,7 +340,7 @@ public final class PackList extends AbstractSelectionList<PackList.BaseEntry> {
 	/**
 	 * Somewhere to get a pack, through the game's own "do you want to open this link" screen so that
 	 * nothing is opened without being asked for and the address is shown before it is followed. Iris
-	 * offers the same page from the same place.
+	 * offers a page of its own from the same place.
 	 */
 	private void openPackSite() {
 		Screen here = this.minecraft.gui.screen();

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.8.0-beta
+mod_version=0.8.1-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
<!--
The template for the ONE pull request that targets `main`. Open it with

    gh pr create --base main --head dev --template release.md

or by adding `?template=release.md` to the compare URL. Every other pull request targets `dev` and
uses the default template, which asks what a batch changes; this one asks nothing of the sort,
because a release changes nothing. Everything in it has already entered `dev` through a pull request
of its own, and been reviewed there.

**DO NOT PRESS A MERGE BUTTON ON THIS ONE.** All three rewrite, and `main` is already an ancestor of
`dev`, so replaying `dev` onto it hands `main` a second copy of every commit under a fresh hash.
What merges this is a fast-forward from a terminal,

    git push origin origin/dev:main

and the pull request closes itself as merged once its commits are on `main`. The tag goes on after
that and never before it, because the tag is what publishes.
-->

## What this publishes

<!--
One paragraph, for somebody reading the release later and not for the reviewer: what a player gets
that they did not have. Not a commit list, the changelog already is one.
-->

## The version

- Tag: `v`
- `mod_version` in `gradle.properties`:
- The changelog section is named after it, and `Unreleased` is gone or empty.

<!--
The tag and `mod_version` are one number written twice, and `release.yml` compares them before it
uploads anything. A disagreement stops the run, which is the one mistake that would otherwise ship a
jar under a version nothing inside it agrees with.
-->

## What the release carries that no changelog entry names

<!--
The question this template exists for. Read `git log origin/main..origin/dev` against the section
you just named, batch by batch. A batch that changed the picture and left no line here ships mute,
and the entity door did exactly that: three batches moved the mobs, the shine and the hand into the
pack's own images without a single line, and it was caught by looking at the range and not at the
last branch. "Nothing" is the answer you want, and it is worth having checked.
-->

## What proves it

<!--
- `gradlew build` green on `dev` at the commit being tagged, not on a branch before it.
- Anything looked at in the game since the last release, with the pack and the place.
- Say plainly what has NOT been looked at. A pre-release is allowed to carry that; a silent one is
  not.
-->

---

- [ ] `main` is an ancestor of `dev`, so this merges by fast-forward.
- [ ] `gradlew build` green locally on the commit being tagged.
- [ ] The changelog section is named after the tag, and the range was read against it.
- [ ] Merged by fast-forward from a terminal, and by no button.
- [ ] The tag is pushed only once its commits are on `main`, because the tag is what publishes.
