### PR TITLE
docs: correct the claims the code no longer supports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -357,8 +357,9 @@ says so on the way past. What it cannot let through is anything javac calls an e
 javadoc lint and the two promotions.
 
 The vendored stareval sources under `uniform/expr/kroppeb/` are left out of the javadoc lint and out
-of the static analyser, promotions included, so that borrowed code stays as its author wrote it.
-Nothing guards that package, so a change made there is worth reading twice.
+of the static analyser, promotions included, so that borrowed code stays as its author wrote it. The
+analyser is pointed away from `vitrail/mixin/` as well. Nothing guards either package, so a change
+made in one is worth reading twice.
 
 Why each of those gates exists, what the two promotions are really about and what none of them
 covers is in [developing](docs/developing.md). Run the build before pushing rather than after:

--- a/docs/internals/pack-loading.md
+++ b/docs/internals/pack-loading.md
@@ -45,11 +45,13 @@ are split on all three endings including a lone carriage return: a file with cla
 read as one long line loses every directive in it. A pack that ships one file in the wrong encoding
 should lose that file's accented comments, not fail to load.
 
-## One sorted walk, over a closed set of extensions
+## The sorted walk, over a closed set of extensions
 
-Only a fixed list of extensions is read. Widening it is not free: packs ship JSON meant for other
-mods that contains lines beginning with an include directive, and scanning those changes every
-number the loader reports. The extension list is the only filter.
+Only a fixed list of extensions is read as source. Widening it is not free: packs ship JSON meant
+for other mods that contains lines beginning with an include directive, and scanning those changes
+every number the loader reports. The extension list is the only filter on what becomes source, and
+everything it leaves out is still reachable: proving that a name is mentioned nowhere in a pack
+means reading those files too, by a second walk that filters on the size ceiling instead.
 
 The walk is then **sorted by pack-relative path**, and that sort is part of the contract. The
 settings index keeps the first declaration of a name and drops later ones, and packs do declare the
@@ -84,8 +86,9 @@ hits are counted so a pack that depends on it can be named rather than merely to
 
 ## The settings index
 
-Two patterns, tried in order per line: a define that may itself be commented out, and a typed
-constant of a scalar type. The first declaration of a name wins.
+Three patterns run over each line: a define that may itself be commented out, a typed constant of
+a scalar type, and an `#ifdef` or `#ifndef` naming one symbol and nothing else, which records that
+something tests that name. The first declaration of a name wins.
 
 **The kind of a setting is decided by whether the rest of the line is empty** once the trailing
 comment is stripped, not by whether a list of allowed values is present. Empty is a switch; anything
@@ -133,6 +136,11 @@ The rewrite rules are asymmetric on purpose:
   as an expression rather than tested for existence, so commenting it out would leave the name
   undeclared where it is used, and skipping it would drop the player's choice silently.
 
+**Those last two reach a closed list of names and no others.** A `const` the reference does not
+configure is a plain constant, whatever its type, and no choice ever rewrites it. So is one the
+index refuses for a reason of its own: a `uint`, a number shipped without a list of values to
+cycle through, or a boolean nothing tests.
+
 A name the pack declares **nowhere** is not applied at all, and nothing is emitted for it in the
 unit's header. There is nowhere to apply it: the section below carries why that is the answer rather
 than an omission.
@@ -149,7 +157,9 @@ Reading a pack produces two tables of defines. Unifying them makes one of the tw
 
 The table used for `shaders.properties` carries the engine's symbols, the default of every setting
 the pack does not ship commented out, and the player's choices on top. That file may test any
-setting, so every setting has to be present before the first line is read.
+setting, so every setting the index offers is present before the first line is read. A boolean
+constant is the one that enters only while it is true, because an `#ifdef` on one declared false
+has to read false whatever text the declaration carries.
 
 The table a source file starts with carries **the engine's symbols and nothing else**. The pack's own
 settings enter as the expander walks past their declarations, in file order, exactly as a
@@ -186,13 +196,18 @@ device at all, which is what the out-of-game checks in [Developing](../developin
 The table is ordered, and its order is preserved, because it is emitted in order: an ordered emission
 is one a person can diff against the previous run.
 
-What it holds are the symbols packs branch on to decide what they are allowed to use: the game
-version in the packed form the format specifies, the GL and GLSL levels, one symbol each for the
-operating system, the vendor and the renderer, quality and hand-depth scalars, the render stage
+What it holds are the symbols packs branch on to decide what they are allowed to use: the
+reference's own name and version, which a pack tests to know it is on an engine that speaks this
+format at all, the game version in the packed form the format specifies, the GL and GLSL levels,
+the colour buffer ceiling, the two symbols saying the normal and specular maps are served, one
+symbol each for the operating system, the vendor and the renderer, quality and hand-depth
+scalars, the render stage
 constants taken straight off the engine's own enumeration so the number a pack compares against and
 the number a draw carries cannot part company, the block kinds and precipitation kinds packs read
 without declaring, and the biome and biome-category symbols, which stay empty until a caller has a
-registry to walk. **A missing symbol does not fail loudly.** It quietly sends the pack down a
+registry to walk. Two more are posted only while they hold: the far terrain symbol while that mod
+is drawing, and the custom images capability while it is served. **A missing symbol does not fail
+loudly.** It quietly sends the pack down a
 fallback path written for a renderer from a decade ago, which is why classifying a vendor string into
 the wrong bucket is worse than not classifying it.
 

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -121,7 +121,8 @@ wrong resolution.
 
 A scaled target also cannot join the game's colour target inside one render pass, because a pass
 has a single render area and every attachment has to match the first (see below), and attachment
-zero is the game's target at screen size. A pack that scales a target its geometry writes therefore
+zero is the game's own target, at whatever size the render scale has left it rather than at any
+size a pack chose. A pack that scales a target its geometry writes therefore
 has that pass fall back to the game's target alone: the attachments the pack named for it are
 dropped as a set rather than one by one, so every draw buffer of that pass is written nowhere. The
 log names the program and says exactly that, which is the point of dropping them at load: the

--- a/docs/internals/uniforms.md
+++ b/docs/internals/uniforms.md
@@ -94,9 +94,12 @@ integrates over and an unquantised one puts all of them slightly off the referen
 reason. The running time a pack reads accumulates those frame durations rather than sampling a wall
 clock, so it stops while the game is paused, which is what a pack driving noise from it expects.
 
-A handful of values are properties of the **pass** rather than of the frame: the depth convention
-of the target being drawn into, the model view the pass draws with, the colour it modulates by, and
-which stage of the frame it is. Those are set beside each block write and never carried over. Left
+A handful of values are properties of the **pass** rather than of the frame: the depth convention of
+the target being drawn into, the model view the pass draws with and the projection it draws under,
+the colour it modulates by, and which stage of the frame it is. Those are set beside each block
+write and dropped rather than carried over, though not in the same place: the frame boundary drops
+the model view, the projection and the colour, and the chain drops the render stage before it
+writes its own blocks, being the only reader left that could hold a stale one. Left
 standing from the pass before, the render stage would tell every full-screen pass of the frame that
 it was drawing the moon, because that value sits in the same table a full-screen pass shares with a
 geometry one.
@@ -119,8 +122,10 @@ Three details decide the result and none of them is obvious:
   fall is a constant here, and the pack cannot change it, because both of the directive names it
   would write (the one that reads as the rise and the one that reads as the fall) are registered
   against the rise, so the second one it writes only overwrites the first. That is the reference's
-  behaviour, reproduced on purpose: honouring the pack's own fall directive instead would dry the
-  ground several times too fast on every pack of the corpus that declares both.
+  behaviour, reproduced on purpose. Honouring the pack's own fall directive instead would be the
+  more sensible reading, and it would change the look of the three packs of the corpus that declare
+  one, in opposite directions: BSL asks for 5 deciseconds against this 200, and both Complementary
+  for 300.
 - There is no smoothing at all on the first value, which is set outright. Otherwise a fresh
   accumulator would spend its first seconds climbing out of zero.
 - A half-life of zero gives an infinite decay constant, hence a factor of one, hence no smoothing.
@@ -285,11 +290,13 @@ could not be read back (`glGetUniformfv` is there for it). It is that reading th
 the second walk the paragraph above rules out. Holding them costs one class rather than a redesign.
 
 It names one program at a time, since the point is to read the file rather than to search it, and
-not because two programs of one frame would say the same thing. They do not. The depth convention,
-the model view the pass draws with, the colour it modulates by and the render stage are properties
-of the pass, so a terrain program and a composite answer differently on exactly the members that
-have to be told apart: one carries the world's model view where the other carries the identity.
-Taking the reading under one program and then under the other is how that pair gets compared at all.
+not because two programs of one frame would say the same thing. They do not, on everything the named
+program itself decides. What they do NOT tell apart is what a pass sets beside its block write. The
+dump is taken as the frame opens, before any pass has written one, so the pass model view reads back
+as the camera's, the modulating colour as white, and the render stage as whatever the last block of
+the frame before left there, which is not the chain's own. The eight pieces of the sky dump alike on
+exactly those. Taking the reading under one program and then under the other is how the rest gets
+compared at all.
 It is rewritten whole rather
 than appended, roughly once a second rather than once a frame, so what is in it is always now: a
 curve is taken by reading it repeatedly, which is exactly how a half-life is measured.

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -256,9 +256,10 @@ plane from `n` out to `2nf / (n + f)`. And the planes come out in camera-relativ
 than in the light's clip space, which is also the space the boxes arrive in, so no further conversion
 is owed anywhere: the light's own volume never enters the cull at all.
 
-What this buys has to be read off the log rather than off the screen, and the shadow stage prints it:
-how many sections the light walked, how many the camera walked, and which shape was used. The picture
-is the place it will NOT show, because keeping a section too many costs a draw and not a pixel.
+What this buys is read off the log, where the shadow stage prints how many sections the light walked,
+how many the camera walked and which shape was used, or off the debug screen, which carries the shape
+and the count that survived it. The picture is the place it will NOT show, because keeping a section
+too many costs a draw and not a pixel.
 
 All of the above is about the terrain. What moves is culled separately, and there is an open
 divergence there worth stating plainly, because it is a gap and not a workaround. A caster is

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -69,8 +69,9 @@ function that disagree about them are a real conflict.
 **`const` on a variable whose initialiser is not a constant expression is stripped.** Vulkan
 refuses a global `const mat3` initialised from `transpose(...)`, or from a uniform, which OpenGL
 drivers took as merely immutable. The keyword comes off and the value stays. A declaration whose
-initialiser is only literals and type constructors is left alone, because an array size still
-needs a real constant. Parameters keep `const`: that spelling means immutable, not compile-time.
+initialiser is only literals, type constructors and names the unit itself defines is left alone,
+because an array size still needs a real constant. Parameters keep `const`: that spelling means
+immutable, not compile-time.
 
 **Names that collide with newer builtins are renamed.** A function a pack defines can collide with
 a builtin introduced after the version the pack targets, and the error does not name the collision:

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,16 +1,17 @@
 # Why this exists
 
-Minecraft renders through Vulkan now, and not one shader pack that exists today runs on it. Two
-choices follow from that, and this page is the reasoning behind both: keeping the OptiFine format
-rather than inventing one, and writing an engine at all when others are already in the area.
+Minecraft ships a Vulkan renderer now, and not one of the shader packs written over the last decade
+ran on it. Two choices follow from that, and this page is the reasoning behind both: keeping the
+OptiFine format rather than inventing one, and writing an engine at all when others are already in
+the area.
 
 ## Why the OptiFine format
 
 Not because it is elegant, but because that is where the work is. Packs have been written against
 the OptiFine conventions for more than a decade, by a lot of people, and that is still where nearly
 all of the community writes today. Minecraft moving to Vulkan does not make any of that work worse.
-It just makes it unrunnable, and asking every author to port to a new format is asking them to throw
-it away.
+It just makes it unrunnable there, and asking every author to port to a new format is asking them
+to throw it away.
 
 So inventing a format was the obvious alternative, and it was rejected on purpose. Following
 conventions that have held for ten years means the specification already exists, there is a corpus


### PR DESCRIPTION
## What changes

Nothing in the engine. Fifteen sentences across seven pages said something the code stopped doing,
and each one now says what the code does. They were found by reading each page against the commits
that landed under it since it was last touched, so they are all the same kind of defect: a change
that updated the page it was about and left the page that cited it standing.

The two that a reader would have acted on. The pack loading page said the two `const` rewrite rules
applied to any constant, when they reach a closed list of names and nothing else, and it said every
setting is in the table a `shaders.properties` reads, when a boolean constant enters only while it
is true. The uniforms page said a decoded dump tells two programs apart on the values a pass sets,
when the dump is taken before any pass has written a block, so those read back the same under every
program: somebody bisecting a wrong picture with that file would have concluded from a difference
that is not there.

The rest are narrower. The shadow cull counts are on the debug screen as well as in the log.
Attachment zero is the size the render scale left it rather than the window's. A `const` survives an
initialiser that names a macro the unit defines. The static analyser is pointed away from two
packages and the gate list named one. The settings index runs a third pattern per line. The engine
define table carries the reference's own identity and two symbols posted only while they hold. The
wetness fall constant is not what the corpus asks for in one direction: the three packs that declare
one disagree with it in both.

`docs/why.md` opened on "not one shader pack that exists today runs on it", which the same page then
contradicts two sections down by naming an engine that was already running them.

## How it differs from the reference, and for what obstacle

It does not. No code is touched.

## What proves it

Every correction was verified against the source before it was written, not taken from the reading
that raised it: four of them are settled by a javadoc in the very class the sentence is about, which
says in full what the page had half of. `gradlew build` green locally.

Two claims were left alone deliberately. The pack table of `docs/compatibility.md` cannot be settled
without launching the game, and the FSR render scale is missing from that page and from the
documentation index, which is an omission rather than a false sentence, and it has a home already.

## What it leaves owing

The pages were read against the code, not against each other. A fact cited in two pages that agree
with each other and disagree with the code would have been caught; two pages that disagree about
something neither cites in code would not.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
