### PR TITLE
docs: make the pages agree with each other and with the javadoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,7 +345,7 @@ holds:
   ever reports annotations missing from a dependency's own jar, and the one asking for a
   `serialVersionUID` on exceptions nothing serialises
 - javadoc linting as errors, everything but the missing comments, so a broken reference, a
-  malformed tag or malformed HTML fails the build
+  malformed tag, malformed HTML and an accessibility fault all fail the build
 - Error Prone, contributing the checks it rates as errors, plus two of its warnings promoted to
   join them, `StringSplitter` and `OperatorPrecedence`
 - `checkText`, which covers the two things no compiler sees: a byte order mark, which PowerShell

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,12 +48,13 @@ the per-loader `vitrail-neoforge-*` and `vitrail-fabric-*` jars carry the same
 mod as the merged one, and a loader that finds it twice refuses to start.
 
 Shader packs go into the `shaderpacks/` folder at the root of the instance, the
-same folder OptiFine and Iris use, zipped or unpacked. The mod keeps two files of
-its own in a `vitrail/` folder next to `mods/`: `pack.txt`, which is which pack is
-loaded and whether shaders are on at all, and `options.txt`, which is the engine's
-own switches. A pack's own settings are not kept in either. They go beside the
-pack, in the file the reference engine reads and writes for the same pack, so they
-follow you from one engine to the other. What each of those files holds is in
+same folder OptiFine and Iris use, zipped or unpacked. Two files of the mod's own
+live in a `vitrail/` folder next to `mods/`. It writes `pack.txt` itself, which is
+which pack is loaded and whether shaders are on at all. It only ever reads
+`options.txt`, the engine's own switches, which is yours to write. A pack's own
+settings are kept in neither. They go beside the pack, in the file the reference
+engine reads and writes for the same pack, so they follow you from one engine to
+the other. What each of those files holds is in
 [the settings screen](docs/settings-screen.md).
 
 None of them has to exist, and without a pack picked nothing is drawn. The screen

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -13,7 +13,7 @@ quietly stale.
 
 | Pack | What I have seen |
 | --- | --- |
-| BSL v10.1.3 | Drawn whole, and the one watched most closely. Terrain, water, shadow map, sky, clouds, weather, particles, mobs and the held hand all go through it. |
+| BSL v10.1.3 | Drawn whole, and the one watched most closely. Terrain, water, shadow map, sky, clouds, weather, particles, mobs, block entities and the held hand all go through it. |
 | Complementary Unbound r5.8.1 | Drawn whole, and watched as closely. Its colour targets, its deferred chain and its shadow map all come up; the log prints how many targets it allocated and at what size. Its two top profiles are the exception, and the pack announces it itself: see [the pack asks for Iris](#the-pack-asks-for-iris). |
 | Complementary Reimagined r5.8.1 | Drawn whole, seen beside Unbound, and visually as close to it as the two packs are to each other. Same top-profile exception as Unbound. |
 | Bliss v2.1.2 | Drawn, water included. The flat wrong colours its mobs and its held arm used to come out in are gone: that was this engine sending their first output through a target of the game's, eight bits to a channel where the pack stacks two values in sixteen, and both now write the pack's own. It is the pack that reads the light map raw where BSL and Complementary multiply the matrix in, which is why the far terrain's pair is served normalised. |
@@ -27,7 +27,7 @@ rather than guess.
 
 | What you see | Go to |
 | --- | --- |
-| Nothing of the pack is drawn, the world looks vanilla | [The pack was refused](#the-pack-was-refused) |
+| Nothing of the pack is drawn, the world looks vanilla | [The pack was refused](#the-pack-was-refused), or a game that came up on OpenGL, which [INSTALL](../INSTALL.md#switching-the-graphics-backend-to-vulkan) answers |
 | A red full-screen message tells you to install Iris | [The pack asks for Iris](#the-pack-asks-for-iris) |
 | An effect does nothing at all | [The effect never ran](#the-effect-never-ran) |
 | Blocks have no relief, however smooth the pack promises | [Everything is flat](#everything-is-flat) |

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -71,7 +71,8 @@ buffer parity is checked outside the game rather than judged on screen.
 
 **A target a pack keeps across frames is not a fault.** Packs use one for temporal accumulation:
 the clear skips it, so the first frame of a session reads the clear and every later frame reads
-what the previous frame left. The engine reports such a read as historical rather than flagging it.
+what the previous frame left. Nothing flags such a read, in the engine or in the checks outside
+the game.
 
 Targets belong to a **place** (the root, or a dimension directory) and never to a pack as a
 whole. A pack can declare its format table in one dimension folder only, and then other dimensions

--- a/docs/internals/entities.md
+++ b/docs/internals/entities.md
@@ -135,9 +135,17 @@ one answer bound by a pipeline compiled under the other, which is the wrong stri
 So there is one answer in force and one call that moves it. Its instant is the head of the chunk
 renderer being built again from nothing, which is reached from the extract that consumes the world
 rebuild: after the previous frame was submitted and presented, and before this one has bound a single
-pipeline, so emptying the compiled pipelines there has nothing in flight to tear down. Emptying them
-is owed only where the answer really moved, and it is owed: the game precompiles every static
-pipeline at every resource load and caches it by identity, so the entity ones standing at that
+pipeline. What happens there is that the entity pipelines leave the lookup map, which is map work,
+safe anywhere, and enough on its own: what no lookup can answer with, no new draw binds.
+
+**Nothing is destroyed there, and that is not an omission.** This backend records continuously, so
+at any instant of a running session something already recorded still names what a purge would free.
+Freed at this one, on a pack load in a running world, the device was lost seconds later with nothing
+in the log. The compiled pipelines wait aside for the game's own cache clear, which quiesces first,
+and the recompile happens at once rather than lazily at the next bind.
+
+Dropping them is owed only where the answer really moved, and it is owed: the game precompiles every
+static pipeline at every resource load and caches it by identity, so the entity ones standing at that
 moment were compiled under the other answer.
 
 **Asking is all a switch does.** Moving one raises the same world rebuild F3+A raises and lets the

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -164,10 +164,10 @@ the game's texture-backed target type is public and instantiable, so owning targ
 and its textures are created with usages that allow the same texture to be a colour attachment in
 one pass and a sampled input in the next without being recreated.
 
-## Coordinates keep the OpenGL convention end to end
+## The screen's two axes keep the OpenGL convention end to end
 
-This is the question every port of an OpenGL-era renderer asks, and the answer is that there is
-nothing to flip.
+This is the question every port of an OpenGL-era renderer asks, and for X and Y the answer is that
+there is nothing to flip. Depth is the other story, and it is at the foot of this section.
 
 The Vulkan viewport the game sets is **not** inverted: it starts at zero and has a positive height.
 The flip happens once, at the very last moment, in the blit to the swapchain, where the destination
@@ -176,8 +176,13 @@ any target a mod owns) keeps the OpenGL orientation, origin at the bottom left.
 
 So a full-screen shader that maps a corner to both its texture coordinate and its clip position
 sees texture coordinate zero at the bottom left of the screen, which is exactly the convention
-OptiFine-format packs are written against. No coordinate flip is needed for them anywhere, and one
+OptiFine-format packs are written against. No flip of those two axes is needed anywhere, and one
 added "to be safe" is a defect.
+
+**Depth does not keep it, and that is the one to remember.** The game rasterises with a reversed Z
+where a pack is written for the OpenGL volume, so a formula that is correct in a pack becomes false
+here with no word of it misquoted. The translator converts at three fixed sites rather than leaving
+it to the pack, and [translation](../translation.md) names them.
 
 ## Samplers and uniform blocks are paired by reflection
 

--- a/docs/internals/pack-loading.md
+++ b/docs/internals/pack-loading.md
@@ -162,9 +162,10 @@ constant is the one that enters only while it is true, because an `#ifdef` on on
 has to read false whatever text the declaration carries.
 
 The table a source file starts with carries **the engine's symbols and nothing else**. The pack's own
-settings enter as the expander walks past their declarations, in file order, exactly as a
-preprocessor would. A file that tests a setting above the line declaring it has to see it undefined,
-because that is what the compiler will see later.
+defines enter as the expander walks past their declarations, in file order, exactly as a preprocessor
+would, and its constants never do: there is nothing in one for a preprocessor to test. A file that
+tests a define above the line declaring it has to see it undefined, because that is what the compiler
+will see later.
 
 A chosen name the pack declares nowhere therefore reaches no unit at all. It has no declaration to
 rewrite, and writing it into the head of the unit instead is the one thing that must not happen: a

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -101,9 +101,10 @@ swallowed the commented-out block underneath when the rule was written the other
 
 The recognised families include profiles, per-program enable flags, custom uniform and variable
 declarations, the settings screen and its pages, blending, alpha test and sliders, and also the
-buffer sizes, the sky toggles, the shadow caster directives, the noise and custom texture keys, the
-images and the per-program flip directives described further down. Patterns are anchored and tried
-in a fixed order, first match wins.
+buffer sizes, the sky toggles, the shadow caster directives, the noise and custom texture keys and
+the images, all described further down, and the per-program flip directives, whose one home is
+[render targets](internals/render-targets.md#the-flip-convention-one-set-and-one-place-allowed-to-consult-it).
+Patterns are anchored and tried in a fixed order, first match wins.
 
 **A value is cut on SPACES, and a tab never separates two words.** The lists, which are the screen
 and its pages, the two feature lines, the sliders and the profile bodies, take a run of spaces as
@@ -192,7 +193,8 @@ default is the tightest of them rather than the loosest.
   `voxelDistance` that is kept whatever the sweep says of it, for a pack that samples its map from
   places the sweep knows nothing about.
 
-A word this cannot read leaves the default standing, which is what the reference does with it.
+A word this cannot read leaves the default standing rather than the answer a valid line above it
+gave, which is what the reference does with it.
 
 **The safe zone's box can have a width now, where for most of the corpus it could not.** The width
 comes from a `const float voxelDistance`, and it only counts where it sits on a line that survives
@@ -240,8 +242,11 @@ per-buffer spellings Iris configures and nothing else, and the list is necessary
 sufficient: a `const bool` also needs an `#ifdef` testing its name, a constant holding a number
 needs its bracketed list, and a `uint` never qualifies, the reference reading only `int`, `float`
 and `bool` as configurable. Every other `const` is a plain constant of the program, whatever its
-comment offers: it appears on no screen, no settings file line can rewrite it, and conditionals
-read its name exactly as they read a name the pack never declared. Through those bars, a
+comment offers: it appears on no screen, and conditionals read its name exactly as they read a name
+the pack never declared. One case escapes on the way out. A name that IS on the closed list and was
+refused only for want of a value list or of anything testing it still takes a hand-written value
+from the settings file, the rewriter reading a line at a time with the list as the whole of its
+gate. No screen offers that name, so only a hand can write it. Through those bars, a
 `const bool` is a toggle like a bare define, and a numeric constant cycles through its bracketed
 values. The same two demands hold for the defines: a bare toggle is only a setting while an
 `#ifdef` or `#ifndef` somewhere tests it, and a define carrying a value is only one with a


### PR DESCRIPTION
## What changes

Nothing in the engine. Eleven sentences across eight pages. The pages had been read against the
code before this, and never against each other or against the javadoc of the class they describe,
which is where these were hiding.

**Two of them described a mechanism the code deliberately does not have.** The entity page said the
compiled pipelines are emptied at the settle instant because nothing is in flight there. Nothing is
destroyed there at all, and that is the design: this backend records continuously, so a purge frees
what already recorded work still names, and doing it on a pack load in a running world cost the
device seconds later with nothing in the log. What happens at that instant is a drop from the lookup
map, and the pipelines wait aside for the game's own cache clear. And the graphics API page was
titled for coordinates keeping the OpenGL convention end to end, concluding that no flip is needed
anywhere and that one added to be safe is a defect, while its body only ever argues the two screen
axes. Depth does not keep the convention, the translator converts at three fixed sites, and a
formula that is right in a pack is wrong here without a word of it misquoted.

The rest, each a page disagreeing with another page or with a javadoc: a symptom index sending a
player to the pack when the cause may be a game that came up on OpenGL, a table row listing what
goes through a pack without the block entities the same page grants two hundred lines down, a
per-unit define table said to take settings when a constant never enters one, a constant the index
refused that a hand-written settings file still rewrites, a page promising flip directives further
down where the subject lives on another page, an unreadable culling word resetting to the default
rather than to the valid line above it, the install guide reading as though the mod writes both of
its files when it only writes one, and a build gate list naming three javadoc lint categories where
the build enables four.

One promise was withdrawn rather than corrected: the frame page said the engine reports a kept
target's read as historical, and no such report exists, in the engine or in the checks outside the
game.

## How it differs from the reference, and for what obstacle

It does not. No code is touched.

## What proves it

Every correction was read in the source before it was written. Four are settled by the javadoc of
the class the sentence is about, one by the log strings that do not exist, and one by the build
script.

Two candidates were dropped after reading rather than applied. A page saying the seed carries the
opaque particles in does not contradict another saying they go through the pack's own programs: the
first is buffer routing, and the code logs as much. And a refusal described as naming the pipeline
does not contradict a message that does not name the formats.

## What it leaves owing

One count could not be settled here: the entity page says two of the game's four output targets
exist only while its improved transparency is on, and the game's own source is not in this tree.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
