### PR TITLE
Promote the documentation pass to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,18 @@ Interactions here are covered by the [code of conduct](CODE_OF_CONDUCT.md), and
 anything that looks exploitable goes through [SECURITY.md](SECURITY.md) rather
 than the issue tracker.
 
+## The short version
+
+Everything under it is the reference. What bites somebody who skips the page:
+
+- Branch from `dev`, name it `<type>/what-it-does`, and open the request **against `dev`**. A hook
+  refuses another name, and the base defaults to `main`.
+- One logical change per commit, and a conventional-commit subject of 72 columns or fewer.
+- A change a player would notice writes its `CHANGELOG.md` entry in the same commit.
+- Files are UTF-8 with no byte order mark, and line endings are LF. A BOM breaks anything that
+  feeds sources to a GLSL compiler.
+- `gradlew build` is the check and it fails on warnings. Run it before pushing, not after.
+
 ## Branches
 
 Two long-lived branches, and the difference between them is one question: has this been published?
@@ -22,134 +34,78 @@ Every other branch is a topic branch, and it is named for what it does:
 
 The type is one of the nine a commit subject uses, listed under [Commits](#commits), and it is
 whatever the branch mostly is. After the slash come two to five words in lower case joined by
-dashes, saying what the branch does rather than which class it opens. The two long-lived branches
-carry no prefix, being the only two that are not about one thing.
+dashes, saying what the branch does rather than which class it opens.
 
     feat/entity-color-from-overlay
     fix/hand-bob-frame
     ci/commit-and-branch-format
 
-`release/0.5.0-beta` is the one shape that departs from it, and the version is the whole of the
-name: such a branch carries the version bump and nothing else, so there is nothing else to say
-about it.
-
-Nothing in a name records who wrote the branch or when, and none of them carries an issue number
-either. That second one is a choice rather than an absence, now that there are issues to number: the
-commit that does the work names the issue it closes, and a name carrying the number would say the
-same thing in the one place nothing reads it back from. Commits says where that line goes and why it
-is not the request's body.
+`release/0.5.0-beta` is the one shape that departs from it, the version being the whole of the
+name: such a branch carries the version bump and nothing else. No name records who wrote the
+branch, or when, or which issue it answers. That last one is a choice rather than an absence: the
+commit that does the work names the issue it closes, and a branch name carrying the number would
+say it in the one place nothing reads it back from.
 
 **The history is linear and carries no merge commit anywhere, which is not a preference.** A tree
 that forks is a tree nobody reads once it is public, and this one is public. A topic branch is
 rebased onto `dev` and enters by a pull request, merged with the rebase button. If that button
 refuses, the rebase was not done, and the answer is to rebase rather than to merge.
 
-**`dev` reaches `main` by a fast-forward and NOT by that button**, and the difference is the whole
-of why `main` can be read as a prefix of `dev`. The rebase button always writes new commits: it
-re-applies each one under a fresh identity, which is what it is for on a topic branch and what makes
-it wrong here. `main` is already an ancestor of `dev`, so replaying `dev` onto it would give `main`
-a second copy of every commit under a different hash, and the two branches would then hold the same
-work under two histories. A pull request is still the right place to look at a release, for the
-record and for the checks it runs; what merges it is the fast-forward, and the pull request closes
-itself as merged once its commits are on `main`.
+**Rebase a topic branch as soon as `dev` moves under it, and read the whole of
+`git diff dev..HEAD` afterwards rather than only the hunks git marked.** Git follows a file that
+moved. What it does not follow is code that moved *between* classes, which comes back as a
+conflict whose two sides are about different files. And a fact may change on one side while the
+other side's prose still describes the old one, in a paragraph far from anything git touched: that
+compiles, reads well, and is simply false. Both happen because a fact is cited in more places than
+it lives in.
+
+**`dev` reaches `main` by a fast-forward and NOT by the merge button.** That button always writes
+new commits, and `main` is already an ancestor of `dev`, so replaying `dev` onto it would give
+`main` a second copy of every commit under a different hash. A pull request is still the right
+place to look at a release, for the record and for the checks it runs. What merges it is
 
     git push origin origin/dev:main
 
-**That pull request has a template of its own**, `.github/PULL_REQUEST_TEMPLATE/release.md`, opened
-with `gh pr create --base main --head dev --template release.md`. It asks nothing the default one
-asks: a release changes nothing by itself, everything in it having entered `dev` through a pull
-request of its own. What it asks instead is the version in both the places it is written, and one
-question no command can answer, whether the range about to be published carries a batch that changed
-the picture and left no changelog line. That is not hypothetical.
+and the request closes itself as merged once its commits are on `main`. That one has a template of
+its own, `.github/PULL_REQUEST_TEMPLATE/release.md`, opened with
+`gh pr create --base main --head dev --template release.md`. It asks the version in both the places
+it is written, and one question no command can answer: whether the range about to be published
+carries a batch that changed the picture and left no changelog line.
 
-**Nothing on GitHub can refuse the wrong press**, which is worth knowing rather than assuming: the
-merge buttons a repository offers are a repository-wide setting, and the rebase button this forbids
-here is the one a topic branch needs. So `prefix.yml` checks after the fact instead, on every push
-to `main`, that `main` is still contained in `dev`, and fails loudly within a minute when it is not.
-Recovering from it is a reset of `main` back onto `dev`, and it is cheap for exactly as long as
-nothing has been built on top.
+No repository setting can refuse the wrong press, so `prefix.yml` checks after the fact, on every
+push to `main`, that `main` is still contained in `dev`. Recovering is a reset of `main` back onto
+`dev`, cheap for exactly as long as nothing has been built on top.
 
-**Every batch enters that way, including one written by whoever owns the repository.** Folding a
+## Pull requests
+
+**Every batch enters by one, including one written by whoever owns the repository.** Folding a
 branch in locally skips the one thing the pull request is for: `build.yml` runs on `pull_request`,
 so a batch that goes in by hand is built only once it is already in `dev`, and a red build then
 lands on the branch everything else is opened from.
 
-### Rebase a topic branch as soon as `dev` moves under it
-
-A branch left standing while a large change lands on `dev` is not merely behind, and the cost is
-not the conflicts you are shown. Git follows a file that was moved or renamed, so a branch editing
-a class that has since changed module rebases onto the new path without a word. What it does not
-follow is code that moved *between* classes: a call the branch edited in one class, where `dev` has
-since moved that work into another, comes back as a conflict whose two sides are about different
-files, and the branch's half has to be written into its new home by hand.
-
-**Read the whole of `git diff dev..HEAD` after a rebase, not only the hunks git marked.** The
-conflicts it raises are the ones it could see; the ones that cost an afternoon are the two it could
-not. Two sides may add the same helper under one name in different places, which is a compile error
-and therefore cheap. Or a fact may change on one side while the other side's prose still describes
-the old one, in a paragraph far from anything git touched: that compiles, reads well, and is
-simply false. Both happen because a fact is cited in more places than it lives in.
-
-### A pull request merges one way, and the repository enforces it
-
 **"Rebase and merge", and neither of the other two buttons.** "Create a merge commit" forks a
-history the section above says never forks. "Squash and merge" collapses a branch into one commit
-and throws away the bodies, which is where the reasoning for each step lives; a branch is a
-sequence of logical changes here rather than a unit of work, and the sequence is the part worth
-keeping. A rebase button that refuses means the branch is behind `dev`: rebase it and force-push,
-rather than merging `dev` into it.
+history that never forks. "Squash and merge" collapses a branch into one commit and throws away the
+bodies, which is where the reasoning for each step lives: a branch is a sequence of logical changes
+here rather than a unit of work, and the sequence is the part worth keeping. A rebase button that
+refuses means the branch is behind `dev`: rebase it and force-push, rather than merging `dev` into
+it.
 
-None of that is left to memory, and it takes two settings because each one lets through what the
-other stops. The repository allows the rebase merge alone, so the other two buttons do not exist;
-and a ruleset requires a linear history on `main` and `dev`, which refuses a merge commit arriving
-by a direct push rather than through a request. **The second does not imply the first**, and that
-is the part worth knowing before changing either: a squash is linear, so the ruleset would take it
-happily, and it is the button setting that rules it out. The same ruleset refuses the deletion of
-either branch.
+That takes two settings, because each one lets through what the other stops. The repository allows
+the rebase merge alone, and a ruleset requires a linear history on `main` and `dev`. **The second
+does not imply the first**: a squash is linear, so the ruleset would take it happily, and it is the
+button setting that rules it out. The same ruleset refuses the deletion of either branch.
 
 Two more rulesets require status checks, and they are what turns a check into a refusal. On `dev`:
-`build`, `commits` and `label`, so a request from a branch outside the naming form above, or one
-whose subjects fail, cannot merge, and a commit pushed straight onto `dev` without having passed
-them is refused. On `main`: `build` and `main-from-dev`, the second being a workflow that fails
-every request not opened from `dev`, so what the fast-forward moves onto `main` is exactly what a
-green request from `dev` carried, and a commit pushed onto `main` from anywhere else is refused.
-Repairing either branch by hand therefore means switching its ruleset off for the length of the
-push, which is a deliberate act rather than a slip.
+`build`, `commits` and `label`. On `main`: `build` and `main-from-dev`, the second being a workflow
+that fails every request not opened from `dev`, so what the fast-forward moves onto `main` is
+exactly what a green request from `dev` carried. Repairing either branch by hand therefore means
+switching its ruleset off for the length of the push, which is a deliberate act rather than a slip.
 
 `.github/pull_request_template.md` is what a request opens with, and its four headings are the four
 questions this repository answers before anything lands. Three of them are ordinary. The one that
 is not is the second, "how it differs from the reference": packs are written against Iris, so a
 difference in behaviour is a pack rendering wrongly however good the reason sounds, and the answer
-is either "it does not" or the three parts a divergence owes. The final box is today's lesson
-rather than hygiene: a fact is cited in more places than it lives in, so changing it in the one
-place it lives leaves the rest standing and reading perfectly well.
-
-A tag is `v` followed by whatever `mod_version` in `gradle.properties` holds, and that line
-is where the version lives. Nothing derives one from the other: a human types the tag, and
-the release workflow refuses it when the two disagree rather than publishing a jar named
-after one and built from the other. The target Minecraft version is in the artifact name
-and comes from the same file.
-
-A tag is pushed on `main` and on nothing else, which is what keeps the sentence above true.
-
-A version is three numbers, and after them either `-alpha`, or `-beta`, or nothing at all. Those
-three are one version reached in order: `0.5.0-alpha`, then `0.5.0-beta`, then `0.5.0`. Nothing
-follows the word, and a counter least of all, so `0.5.0-beta.1` is not a version here. What that
-costs is worth saying, because it is the whole of the rule: there is no second beta of a version.
-A beta that needs a fix is a new version and the patch number moves, `0.5.1-beta`, which is also
-what a reader of the two numbers would have assumed. The hook refuses a release branch named
-otherwise, and the release workflow refuses such a tag before it builds anything.
-
-## Changelog
-
-`CHANGELOG.md` carries an `Unreleased` section, and a change a player would notice is written into
-it in the same commit that makes the change, not gathered from the log afterwards. Gathering
-afterwards is how a subject line ends up standing in for an entry, and the two are not the same
-thing: a subject says what the commit did to the tree, an entry says what the version does
-differently to somebody running it. A refactor that changes nothing a player sees gets no entry.
-
-Raising `mod_version` is what closes the section: `Unreleased` becomes that number, and the section
-is what the release body and both stores are handed.
+is either "it does not" or the three parts a divergence owes.
 
 ## Commits
 
@@ -158,8 +114,7 @@ commit:
 
     <type>(<scope>)!: what the commit does
 
-That form is worth more here than it is in most repositories, because of how a branch lands. The
-rebase button replays every subject verbatim into the public history instead of collapsing them
+The rebase button replays every subject verbatim into the public history instead of collapsing them
 into the request's title, so a subject is not a note to a reviewer: it is the line somebody reads
 two years later, in a log where `git log --oneline` is the only thing they will look at.
 
@@ -181,28 +136,23 @@ out where the type already says everything, which `docs` and `ci` usually do.
 
 The subject is imperative and therefore starts on a verb, in lower case, and it carries no full
 stop. The whole line is 72 columns or fewer with the prefix counted in, and the prefix is not free:
-`feat(render): ` is fourteen of them. What used to fit in a subject running to a hundred columns
-goes in the body now, which is where it reads better anyway. A body is for the reason, when the
-reason is not in the diff, and a blank line separates it from the subject.
+`feat(render): ` is fourteen of them. A body is for the reason, when the reason is not in the diff,
+and a blank line separates it from the subject.
 
 A `!` before the colon marks a change that breaks a pack or a configuration that used to work. What
 breaks is written in the body, and there is no `BREAKING CHANGE:` footer: the changelog is written
-by hand and the version typed by a human, so nothing here would read one. The `Closes` line below is
-the single exception, and what reads it is GitHub rather than anything in this repository.
+by hand and the version typed by a human, so nothing here would read one.
 
 **An issue is closed from the COMMIT that closes it and never from the pull request**, on a line of
 its own at the foot of the body:
 
     Closes #30
 
-That is the shape of this repository rather than a taste. A closing keyword fires when the request
-it is written in merges into the DEFAULT branch, which here is `main`, and every request here merges
-into `dev`: written in a request's body it links the issue and then leaves it open for good. Written
-on the commit it travels with the commit, and it lands on `main` the day `dev` does.
-
-**Check the issue really closed once `dev` has landed on `main`, and close it by hand if it did
-not.** This is the one rule in this file whose far end is a service rather than a script, so it is
-the one that can quietly stop being true without anything here changing.
+A closing keyword fires when the request it is written in merges into the DEFAULT branch, which
+here is `main`, and every request here merges into `dev`: written in a request's body it links the
+issue and then leaves it open for good. Written on the commit it travels with it and lands on
+`main` the day `dev` does. **Check it really closed once `dev` has landed**, this being the one
+rule here whose far end is a service rather than a script.
 
 ```
 feat(render): read entityColor off the entity mesh overlay
@@ -215,20 +165,10 @@ A commit that changes a mechanism and the paragraph describing it is one commit 
 the mechanism rather than two, since a changelog entry and a doc line belong with the change that
 made them true. `docs` is for the batch that is documentation and nothing else.
 
-None of this is retroactive, and what was written before the convention is left as it was. Rewriting
-a public history to tidy the shape of its subjects would cost every reference anybody holds to it
-and buy a uniformity nobody reads for.
-
-The line falls at what LANDS, and not at what was written. A subject already in `dev` or `main` is
-history and stays as it is, for the reason just given. A branch that was opened before this page and
-has not landed yet is not history: it owes a rebase before it can enter at all, since `dev` has moved
-under it, and a subject is amended in that same gesture. It conforms.
-
-One branch escaped that, on the evening this was written. The branch carrying the settings screen
-held fourteen subjects from before the convention, needed nothing else, and entered `dev` while the
-check had never run on a request. So the log holds fourteen lines this page would refuse, in the days
-just after it. They are left where they are, and this paragraph is what a reader finds instead of
-concluding that the rule was ignored from the start.
+None of this is retroactive, and the line falls at what LANDS rather than at what was written. A
+subject already in `dev` or `main` is history and stays as it is. A branch opened before the
+convention and not yet landed is not history: it owes a rebase anyway, since `dev` has moved under
+it, and its subjects are amended in that same gesture.
 
 ### Both ends of the rule are one file
 
@@ -243,43 +183,31 @@ file: a workflow rewriting the same expression would be a second home for the ru
 would agree only until one of them changed.
 
 `.githooks/prepare-commit-msg` sits one step earlier and takes a `Co-authored-by`, `Made-with` or
-`Generated-by` line out of the message before it is stored. Nothing here forbids saying which tools
-built this project, and the readme says so plainly; what the log keeps is the reasoning for a
-change, and a trailer naming an editor is not that. The refusal in `commit-msg` stays either way,
-so a message that reaches it with one is still turned back.
+`Generated-by` line out of the message before it is stored. What the log keeps is the reasoning for
+a change, and a trailer naming an editor is not that.
 
-Catch it at the commit rather than at the request. A subject is amended in one gesture while it is
-still the last one, and rebuilt by hand once nine commits stand on top of it.
-
-The hook reads the name of the branch you are standing on, so a branch opened before this page
-refuses its next commit until it is renamed, wherever that commit was going. Renaming is one command
-and there is nothing to reinstall: `git branch -m <type>/what-it-does`, and the request it was
-already pushed to is replaced by one on the new name, GitHub having no way to move a request from
-one branch to another. `main` and `dev` are exempt from the name, and so is a detached HEAD, which
-is why a rebase replays a branch without ever asking.
+Catch it at the commit rather than at the request: a subject is amended in one gesture while it is
+still the last one, and rebuilt by hand once nine commits stand on top of it. The hook reads the
+branch you are standing on too, so a name outside the form refuses the next commit wherever it was
+going, until `git branch -m <type>/what-it-does` renames it and the request it was pushed to is
+replaced by one on the new name. `main`, `dev` and a detached HEAD are exempt, which is why a
+rebase replays a branch without ever asking.
 
 ## Labels
 
 Everything carries one, requests and issues alike, and neither set is decoration: a list of a dozen
 open things has to say what each one is before any of them is opened.
 
-**A pull request carries the type of its branch, and only that.** The nine are the ones in the table
-above, so the label is not a second opinion about the change: it is the word already in the branch
-name and at the head of every subject the branch carries. `docs/correct-a-page` is labelled `docs`,
-and a branch whose commits are mostly `fix` with a `refactor` among them is labelled `fix`, the same
-way its name was settled.
+**A pull request carries the type of its branch, and only that**, so the label is not a second
+opinion about the change: it is the word already in the branch name and at the head of every
+subject the branch carries. **The repository poses it itself**, off the
+branch name and at the moment the request is opened (`.github/workflows/label.yml`), a label
+derived rather than decided having no reason to be asked of anybody. Where it posts nothing, the
+branch opened on a word this convention does not know, and `commits.yml` is what says so.
 
-**The repository poses that one itself**, off the branch name and at the moment the request is
-opened (`.github/workflows/label.yml`). A label derived rather than decided has no reason to be
-asked of anybody, and this one held only for as long as it was remembered: of the requests opened
-before the workflow existed, nine of the first eighty-eight carry it and none of the twenty-seven
-that followed do. Where it posts nothing, the branch opens on a word this convention does not know,
-and `commits.yml` is what says so.
-
-**A release request carries `release` and no type**, posed by that same workflow. Two requests carry
-it: `release/<version>` into `dev`, which lands the bump, and `dev` into `main`, which records the
-fast-forward. Neither is a change of the kind the nine words classify, the first carrying a number
-and the second nothing that did not enter `dev` under a label of its own.
+**A release request carries `release` and no type**, posed by that same workflow. Two requests
+carry it: `release/<version>` into `dev`, which lands the bump, and `dev` into `main`, which
+records the fast-forward.
 
 **An issue carries what it is about instead**, being a report rather than a change:
 
@@ -290,13 +218,52 @@ and the second nothing that did not enter `dev` under a label of its own.
 | `upstream` | the cause is in another project or in the backend, and nothing here closes it |
 
 beside GitHub's own `bug`, `enhancement` and `question`, which the issue forms set themselves. The
-two sets do not overlap and are not meant to: a type says what a change does, and these say what a
-report is about.
+two sets do not overlap: a type says what a change does, and these say what a report is about. A
+known limitation is open as an issue rather than living in a file for that reason, so that a branch
+can point at one.
 
-**A request that closes an issue says so in its body**, `Closes #31` on a line of its own, so that
-the issue goes with the merge rather than being noticed weeks later. That is the whole reason the
-known limitations are open as issues rather than living in a file somewhere: a branch can point at
-one, and a reader can see that somebody is on it.
+## Changelog
+
+`CHANGELOG.md` carries an `Unreleased` section, and a change a player would notice is written into
+it in the same commit that makes the change, not gathered from the log afterwards. Gathering
+afterwards is how a subject line ends up standing in for an entry, and the two are not the same
+thing: a subject says what the commit did to the tree, an entry says what the version does
+differently to somebody running it. A refactor that changes nothing a player sees gets no entry.
+
+Raising `mod_version` is what closes the section: `Unreleased` becomes that number, and the section
+is what the release body and both stores are handed.
+
+## Versions and releasing
+
+A version is three numbers, and after them either `-alpha`, or `-beta`, or nothing at all. Those
+three are one version reached in order: `0.5.0-alpha`, then `0.5.0-beta`, then `0.5.0`. Nothing
+follows the word, and a counter least of all, so `0.5.0-beta.1` is not a version here. There is no
+second beta of a version: a beta that needs a fix is a new version whose patch number moves,
+`0.5.1-beta`. The hook refuses a release branch named otherwise, and the release workflow refuses
+such a tag before it builds anything.
+
+The version lives on one line, `mod_version` in `gradle.properties`, and a tag is `v` followed by
+what that line holds. Nothing derives one from the other: a human types the tag, and the release
+workflow refuses it when the two disagree rather than publishing a jar named after one and built
+from the other. The target Minecraft version is in the artifact name and comes from the same file.
+A tag is pushed on `main` and on nothing else, which is what keeps that sentence true.
+
+Publishing, in order: rewrite the pack table at the head of
+[docs/compatibility.md](docs/compatibility.md) against whatever has been seen since the last one,
+bump `mod_version`, land those commits on `main` the way every other commit lands, push `main`,
+then tag that commit `v` plus the same version and push the tag. The order matters, a tag push
+carrying its own objects and nothing else: tagging before the branch is pushed publishes a commit
+that is on no branch.
+
+**Pushing the tag is what publishes.** `.github/workflows/release.yml` runs the same
+`gradlew build` anyone runs, creates a GitHub release under the tag's own name, attaches the jar
+that build produced, and mirrors it to CurseForge and to Modrinth from the same job. Those three
+are the only places a build goes. A version carrying `-alpha` or `-beta` is published as a
+pre-release, one carrying neither as a release. The body both stores are handed is this version's
+entry in `CHANGELOG.md`, read back off the release page at the moment the run reaches it, and the
+run refuses the tag when that entry is missing rather than publishing an empty one. A body
+corrected by hand afterwards reaches the stores by running the workflow again on that tag, and by
+no other road.
 
 ## Encoding and text
 
@@ -318,34 +285,29 @@ arrive at it. What is not wanted is the other kind, the comment that restates th
 below it.
 
 Two more go with that one. A comment says what holds now and not how the code got there, so
-"this used to read", "for a while" and the story of the batch that changed it belong to the
-history, which keeps them better and keeps them out of the way. And a mechanism has one home
-in `docs/`, so a comment that explains one a second time is a copy that will drift out of
-step with the page: point at the page, and keep only the trap the page does not carry.
-
-## Verifying a change
-
-Where a change lands decides how it can be checked, and the split is worth knowing before
-writing anything.
-
-`pack/`, `glsl/` and `uniform/` use no Minecraft class at all. That is deliberate: it lets
-them be compiled and run on their own, outside the game, against a corpus of real packs, which is
-how a translation regression is caught in seconds instead of in a play session. Keep the property. A
-Minecraft import in one of those three packages costs more than it looks.
-
-There is exactly one exception, and it is worth knowing before you try the standalone compile: a
-single file reaches out of the three trees for the logger, and the out-of-game build drops that file
-rather than dragging the rest in behind it.
-
-`render/` has no equivalent and cannot have one: it exists only inside a frame. A change
-there is argued from the code and from the log it produces, and it is worth saying which
-of the two a claim rests on rather than leaving it implied.
+"this used to read" and the story of the batch that changed it belong to the history. And a
+mechanism has one home in `docs/`, so a comment that explains one a second time is a copy that
+will drift: point at the page, and keep only the trap the page does not carry.
 
 One rule is not negotiable, because a pack is downloaded content: a path a pack writes
 never leaves the pack. `customTexture.x = ../../../secret.png` served an arbitrary PNG of
 the disk to a shader until c1c50c0 confined it, the way an include was already confined.
 Anything new that turns text from a pack into a file on disk goes through the same
 confinement.
+
+## Verifying a change
+
+`pack/`, `glsl/` and `uniform/` use no Minecraft class at all. That is deliberate: it lets them be
+compiled and run on their own, outside the game, against a corpus of real packs, which is how a
+translation regression is caught in seconds instead of in a play session. Keep the property. A
+Minecraft import in one of those three packages costs more than it looks.
+
+`render/` has no equivalent and cannot have one, since it exists only inside a frame. A change
+there is argued from the code and from the log it produces, and it is worth saying which of the two
+a claim rests on rather than leaving it implied.
+
+What each check covers, and what a clone cannot run at all because shader packs are not
+redistributable, is in [developing](docs/developing.md).
 
 ## Building
 
@@ -376,99 +338,28 @@ gradlew.bat :neoforge:runClient
 
 ## What the build refuses
 
-`gradlew build` is also the check, and it fails on warnings rather than printing them. Not on
-all of them: four categories are off. Deprecation, because Minecraft and NeoForge deprecate faster
-than a mod can follow and the noise would bury everything else; annotation processing, which reports
-which processor claimed what and is a property of how the build is wired; the category that only
-ever reports annotations missing from a dependency's own jar; and the one that asks for a
-serialVersionUID on exceptions nothing serialises.
+`gradlew build` is also the check, and it fails on warnings rather than printing them. What it
+holds:
 
-Javadoc is linted for everything but missing comments, so broken references, malformed tags,
-malformed HTML and accessibility all fail the build. That matters more here than it would elsewhere.
-The javadoc carries the design, so a reference that no longer resolves is a piece of the design lost,
-and nothing says so until someone goes looking.
+- compiler warnings, minus four categories: deprecation, annotation processing, the one that only
+  ever reports annotations missing from a dependency's own jar, and the one asking for a
+  `serialVersionUID` on exceptions nothing serialises
+- javadoc linting as errors, everything but the missing comments, so a broken reference, a
+  malformed tag or malformed HTML fails the build
+- Error Prone, contributing the checks it rates as errors, plus two of its warnings promoted to
+  join them, `StringSplitter` and `OperatorPrecedence`
+- `checkText`, which covers the two things no compiler sees: a byte order mark, which PowerShell
+  writes unless told not to, and typographic punctuation
 
-Error Prone runs alongside javac and contributes the checks it rates as errors, the part of its
-catalogue meant to be a bug rather than a preference. Two of its warnings are promoted to join them,
-`StringSplitter` and `OperatorPrecedence`; the rest are worth reading and not worth blocking on, so
-`gradlew build -PlintReport` prints them and lets the build through.
+`gradlew build -PlintReport` prints the remaining Error Prone warnings and every compiler warning
+with them, since it drops `-Werror`. A run under it is a listing rather than a check, and the build
+says so on the way past. What it cannot let through is anything javac calls an error, which is the
+javadoc lint and the two promotions.
 
-That flag lets those remaining warnings through and every compiler warning with them, since it drops
-`-Werror`. A run under it is a listing, not a check, and the build says so on the way past. What it
-cannot let through is anything javac calls an error, which is the javadoc lint and the two
-promotions.
+The vendored stareval sources under `uniform/expr/kroppeb/` are left out of the javadoc lint and out
+of the static analyser, promotions included, so that borrowed code stays as its author wrote it.
+Nothing guards that package, so a change made there is worth reading twice.
 
-The first of the two is why every `split` here passes a limit: given a pattern and nothing else the
-call cannot say which of two readings of an empty field it wants. Which reading each of the two
-limits is, why either check was promoted, and what neither of them covers, are in
-[developing](docs/developing.md).
-
-`checkText` covers the two things no compiler sees: a byte order mark, which PowerShell writes
-unless told not to, and typographic punctuation. Why each of those is a gate, and what the second
-one really catches, is in [developing](docs/developing.md).
-
-The vendored stareval sources under `uniform/expr/kroppeb/` are left out of the javadoc lint and
-out of the static analyser, promotions included. The code is its author's, and bending borrowed
-code to this project's taste only makes the next comparison with upstream harder to read. Nothing
-guards that package, so a change made there is worth reading twice.
-
-Run it before pushing rather than after. `main` staying buildable is a promise kept by whoever
-pushes.
-
-## Publishing
-
-Pushing a tag is what publishes. Rewrite the pack table at the head of
-[docs/compatibility.md](docs/compatibility.md) against whatever has been seen since the
-last one, bump `mod_version` in `gradle.properties`, land those commits on `main` the way
-every other commit lands, push `main`, then tag that commit `v` plus the same version and
-push the tag. The order matters: a tag push carries its own objects and nothing else, so
-tagging before the branch is pushed publishes a commit that is on no branch.
-
-`.github/workflows/release.yml` takes it from there. It runs the same `gradlew build`
-anyone runs, then creates a GitHub release under the tag's own name and attaches the jar
-that build produced, so what is downloaded is what this history compiles rather than what
-a machine had lying in `build/libs`.
-
-The same job then mirrors it to CurseForge and to Modrinth, which is why there is no second
-workflow: a release this one creates is authored by the token it runs under, and such a
-release starts no further workflow, so a file listening for it would never wake. The mirror
-needs a pair per store set in the repository settings, `CURSEFORGE_ID` with
-`CURSEFORGE_TOKEN` and `MODRINTH_ID` with `MODRINTH_TOKEN`, and a store whose pair is
-incomplete is passed over with a notice rather than failing the release over it. Neither id
-is a secret in any real sense (both are on the project's own page): the CurseForge one lives
-in the secrets tab only so that both halves of the same configuration are found in the same
-place, and the Modrinth one is read from the variables tab as well.
-
-The release body is what both stores are given as the changelog, read back at the moment the
-run reaches it. A body written by hand after the tag went out therefore reaches them by
-running the workflow again on that tag, from the Actions tab, and by no other road.
-
-**Run it once for a given tag.** A second run rebuilds the same tag, and the archives here
-are built to be reproducible, so it offers CurseForge a file whose hash it already holds;
-CurseForge rejects a duplicate at processing while the run itself still ends green, which
-means a changelog corrected on the second attempt quietly never lands. On the GitHub side
-the same run replaces the asset rather than adding one, which resets what the old asset had
-counted.
-
-CurseForge holds a fresh file under review before it is public, and an app looking for updates
-does not see a file that is not approved yet. An instance reading the list inside that window
-keeps the release before this one as the newest it knows and offers it as an update, which is a
-downgrade: what it compares is which file is installed against which file is newest, and no
-version number anywhere. Nothing is wrong with the release and there is nothing to repair, the
-instance settling by itself the next time it looks. It is whoever published who meets this,
-having installed the jar minutes after the tag while everybody else arrives once the review is
-over.
-
-A version carrying `-alpha` or `-beta` is published as a pre-release. One carrying neither is
-published as a release.
-
-The release body is this version's entry in `CHANGELOG.md`, and the run refuses the tag when that
-entry is missing rather than publishing an empty one. It was GitHub's own generated notes until
-`06d5f53`, and they came out empty: those notes list merged pull requests and new contributors,
-and a history that is rebased and fast-forwarded has neither to show, so the body arrived as a
-comparison link under a heading. A body corrected by hand on the release page afterwards reaches
-both stores by dispatching the workflow again on the same tag, since what the stores are handed is
-read back off the page rather than rebuilt.
-
-GitHub, CurseForge and Modrinth are the three places a build goes, and nothing else is
-automated.
+Why each of those gates exists, what the two promotions are really about and what none of them
+covers is in [developing](docs/developing.md). Run the build before pushing rather than after:
+`main` staying buildable is a promise kept by whoever pushes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -357,8 +357,9 @@ says so on the way past. What it cannot let through is anything javac calls an e
 javadoc lint and the two promotions.
 
 The vendored stareval sources under `uniform/expr/kroppeb/` are left out of the javadoc lint and out
-of the static analyser, promotions included, so that borrowed code stays as its author wrote it.
-Nothing guards that package, so a change made there is worth reading twice.
+of the static analyser, promotions included, so that borrowed code stays as its author wrote it. The
+analyser is pointed away from `vitrail/mixin/` as well. Nothing guards either package, so a change
+made in one is worth reading twice.
 
 Why each of those gates exists, what the two promotions are really about and what none of them
 covers is in [developing](docs/developing.md). Run the build before pushing rather than after:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,7 +354,25 @@ gradlew.bat build
 ```
 
 The JDK it wants is pinned in `gradle.properties`, along with the Minecraft and loader versions.
-Artifacts land in `build/libs`.
+The first build decompiles Minecraft and takes a couple of minutes. After that it is a few seconds.
+
+Three jars land in `build/libs`, named for the version in `gradle.properties` and the Minecraft
+version beside it. The first is the one a release ships and runs on either loader; the other two are
+the slices it is merged from, one per loader, kept beside it for whoever wants only theirs:
+
+```
+build/libs/vitrail-<version>+mc<minecraft>.jar
+build/libs/vitrail-<loader>-<version>+mc<minecraft>.jar
+```
+
+`gradlew.bat :neoforge:build` builds the NeoForge slice alone, into that module's own
+`neoforge/build/libs`, and `:fabric:build` the other; only the full build refreshes `build/libs`.
+
+To run the mod in a development client instead of installing it:
+
+```
+gradlew.bat :neoforge:runClient
+```
 
 ## What the build refuses
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,7 +345,7 @@ holds:
   ever reports annotations missing from a dependency's own jar, and the one asking for a
   `serialVersionUID` on exceptions nothing serialises
 - javadoc linting as errors, everything but the missing comments, so a broken reference, a
-  malformed tag or malformed HTML fails the build
+  malformed tag, malformed HTML and an accessibility fault all fail the build
 - Error Prone, contributing the checks it rates as errors, plus two of its warnings promoted to
   join them, `StringSplitter` and `OperatorPrecedence`
 - `checkText`, which covers the two things no compiler sees: a byte order mark, which PowerShell

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,8 +10,8 @@ one per tag, built by the tag itself rather than uploaded by hand, and mirrored 
 [CurseForge](https://www.curseforge.com/minecraft/mc-mods/vitrail-shaders) by that
 same run, so whichever of the two places you take it from serves the same file. A version
 carrying an identifier after a dash is marked as a pre-release, which is what it
-is. Building from source is below and gives the same thing for whatever commit you
-are on.
+is. Building it yourself gives the same thing for whatever commit you are on, and
+[CONTRIBUTING.md](CONTRIBUTING.md) says how.
 
 ## Requirements
 
@@ -33,118 +33,6 @@ Sodium is declared as a required dependency, so the game will refuse to start
 without it. Do not update it past 0.9.x: it has no stable API for what a shader
 engine needs from it.
 
-Chloride is no longer required. One thing was behind that requirement:
-NeoForge opens a loading window of its own before the game exists, that window
-carries an OpenGL context, and the game takes it over instead of making one, so
-the Vulkan surface is asked for on a window built for OpenGL and the boot fails
-with `GLFW error 65540 ... requires the window to have the client API set to
-GLFW_NO_API`. Vitrail refuses that window itself when the backend is Vulkan,
-takes it off FML's hands at the end of mod loading, and closes it once the game
-has drawn a first frame of its own, which is the whole of what Chloride was
-load bearing for here. Fabric opens no such window and never needed the help.
-Chloride remains worth installing, and running it alongside changes nothing:
-the two refusals nest, so exactly one of them ends up owning the window left
-over, and the other stands down.
-
-Worth knowing because the failure hides itself, and it hides itself twice over.
-Asked for Vulkan and unable to bring it up, the game falls back to OpenGL within
-the same run and keeps your setting, so `options.txt` goes on saying `vulkan`
-while the session is not on it: the file cannot answer the question. And a game
-that dies before it reaches the title screen leaves a mark that the *next* start
-reads, which sets `preferredGraphicsBackend` back to `default` and saves over
-whatever you had written. Either way Vitrail loads, reads the pack and draws
-nothing of it: the game keeps its own image. It says which backend it came up on
-at startup, says it as an error when that backend is not Vulkan, and says it once
-more in chat the first time a world is shown, naming the setting to change, so a
-picture that did not change is answered on the screen rather than by the file.
-
-If you do run it, some of Chloride's own settings decide what reaches this
-engine, in `config/chloride-client.toml`, and they are entries inside its tables
-rather than keys of their own. `tileEntities`, `entities` and `monsters`, under
-`[culling]`, decide on their own which block entities, which mobs and which other
-entities are drawn at all, by distance: what they take out is never handed to the
-pack, so a chest, a sign, a boat or a mob that is not there is those settings
-rather than anything the pack does.
-`chests` and `beds`, under `[fastBlocks]`, draw those blocks by a path this
-engine's final pass then covers over, so they go invisible with no other symptom.
-Which of the five a given Chloride writes on is its own business and changes with
-its versions, which is why none of them is described here as on or off.
-
-There is nothing to go looking for by hand: with Chloride installed, Vitrail
-reads that file at startup and, in the log, names each of them that is on with
-what it costs and what to set it to, names any it could not find, and says so
-when the file itself is not there.
-
-## Other mods
-
-Vitrail hooks the frame through public NeoForge events where the game offers
-them, and through mixins where it does not, which on Fabric is everywhere: the
-points a NeoForge event is posted at are reached there by a mixin on the very
-line that posts it, so both loaders run the same ordered work. The load-bearing
-ones: the matrices
-the world is really drawn with, which are never stored anywhere the camera
-exposes; the game's sky renderer, which opens a pass of its own per sky element
-and is handed the pack's program for that element, the colour targets the pack
-sends it to, and the pack's word on whether that element is drawn at all; and
-Sodium's chunk renderer, which is handed the pack's terrain programs, one extra
-vertex element carrying the block id, and the render pass its draw buffers need.
-Sodium has no API for any of that, which is why its version is pinned above.
-Every family drawn since takes one or two more, and the whole list is the mixin
-config shipped in the jar rather than anything summarised here.
-
-Which Distant Horizons build works depends on the loader. On Fabric, 3.2.0-b
-installs from the launcher like any other mod and runs beside Vitrail, with a
-pack drawn and without one. On NeoForge that same build unwraps a GPU texture
-into an OpenGL handle as the lightmap renders, its NeoForge wrapper alone doing
-so, and dies on the first frame of a world with a `ClassCastException` naming
-`VulkanGpuTexture`: there the [patched build][dh-build] below is still the one
-to install, by hand and with no other Distant Horizons jar beside it. That build
-reports itself as `3.2.1-b-dev`, the same string an upstream development build
-carries, so bug reports made with it belong on this tracker and not with the
-Distant Horizons team. While a pack
-is up, Vitrail hands its far terrain to the pack's own programs, `dh_terrain`
-and `dh_water` for the picture, and `dh_shadow` for the shadow map where the
-pack ships one and has not switched it off, and serves its depth beside the
-world's, which is the arrangement packs are written against. The changelog says
-what that changes and what it does not reach, and the log names each far
-terrain pass as the pack takes it over.
-
-With shaders off, that mod draws its far terrain itself and this engine is not
-involved. Beyond the NeoForge death above, the patched build changes one more
-thing: how that mod's own fog and ambient occlusion read a reverse depth
-buffer, a divergence seen in its code, reachable only while no pack is drawn,
-and never yet seen in a picture. On Fabric it is optional and that is all it
-would buy.
-
-[dh-build]: https://gitlab.com/avpbynf/distant-horizons/-/releases/vitrail-26.2-1
-
-## Building
-
-```
-gradlew.bat build
-```
-
-The first build decompiles Minecraft and takes a couple of minutes. After that it
-is a few seconds. Three jars land in `build/libs`, named for the version in
-`gradle.properties` and the Minecraft version beside it. The first is the one a
-release ships and runs on either loader; the other two are the slices it is
-merged from, one per loader, kept beside it for whoever wants only theirs:
-
-```
-build/libs/vitrail-<version>+mc<minecraft>.jar
-build/libs/vitrail-<loader>-<version>+mc<minecraft>.jar
-```
-
-`gradlew.bat :neoforge:build` builds the NeoForge slice alone, into that
-module's own `neoforge/build/libs`, and `:fabric:build` the other; only the
-full build refreshes `build/libs`.
-
-To run the mod in a development client instead of installing it:
-
-```
-gradlew.bat :neoforge:runClient
-```
-
 ## Installing into an instance
 
 Copy the jar into the `mods` folder of a NeoForge or Fabric 26.2 instance, next
@@ -160,97 +48,21 @@ the per-loader `vitrail-neoforge-*` and `vitrail-fabric-*` jars carry the same
 mod as the merged one, and a loader that finds it twice refuses to start.
 
 Shader packs go into the `shaderpacks/` folder at the root of the instance, the
-same folder OptiFine and Iris use, zipped or unpacked. The mod keeps its own
-files in a `vitrail/` folder next to `mods/`:
+same folder OptiFine and Iris use, zipped or unpacked. The mod keeps two files of
+its own in a `vitrail/` folder next to `mods/`: `pack.txt`, which is which pack is
+loaded and whether shaders are on at all, and `options.txt`, which is the engine's
+own switches. A pack's own settings are not kept in either. They go beside the
+pack, in the file the reference engine reads and writes for the same pack, so they
+follow you from one engine to the other. What each of those files holds is in
+[the settings screen](docs/settings-screen.md).
 
-```
-pack.txt       pack=  which pack of the folder to load, by whole or partial
-                      name, or none to load nothing at all
-               enabled=  false to switch shaders off without forgetting which
-                      pack was picked
-               shadowdistance=  how far the shadow map reaches, in chunks, 0 to
-                      32; the Max Shadow Distance slider writes this line
-options.txt    engine switches, one NAME=value per line; wins over the settings
-```
-
-A `pack.txt` holding one bare word, which is what earlier versions wrote, still
-reads as that pack, and one holding `none` still reads as shaders off.
-
-What you change in a pack's own settings screen is not kept there. It goes beside
-the pack, in `shaderpacks/<pack file name>.txt`, which is the file Iris reads and
-writes for the same pack: one file per pack, shared, so settings follow you from
-one engine to the other.
-
-Earlier versions kept those settings in `vitrail/settings/` instead. The first time
-a pack is loaded after the move its old file is read, written out beside the pack,
-and renamed to `.txt.migrated` on the spot. Nothing is asked of you, and a profile
-you had chosen comes over too: the old file stored only what differed from it, so
-the profile is turned back into the values it names on the way.
-
-Two cases leave your old file exactly where it is, both named in the log. One is a
-file naming a profile the pack no longer declares, because what it stored is only
-the difference from a set of values nothing can rebuild; the log gives the profile
-name. The other is a file that could not be read or written at all, usually a folder
-this game cannot write to. Neither loses anything, and both are tried again at the
-next load.
-
-None of these files has to exist, and without them nothing is drawn: a pack is
-loaded once one is picked, in the screen or in `pack.txt`, and never before.
-What is picked is then drawn whole. `options.txt` is there to take a stage back
-out again, which is how a wrong picture is bisected without a rebuild. The names
-it reads:
-
-```
-terrain=off      hands the chunk passes back to the game's own shader
-shadow=off       stops the second pass over the world from the light
-sky=off          hands the sky back to the game's own shaders
-clouds=off       hands the clouds back too, and with them the pack's own
-                 clouds directive, which most packs use to remove them
-weather=off      hands the rain and the snow back to the game's own shader,
-                 and with them the pack's own weather directive
-particles=off    hands the quad particles back too, both halves of them
-entities=off     hands the mobs and the block entities back, lit by the game
-                 and carried in flat by the scene seed, and with them the glint
-                 an enchantment puts over anything they hold or wear
-hand=off         leaves the player's own hand where the game draws it, after
-                 the whole chain has run, and the glint over what it holds
-                 with it
-chain=off        stops the composites and the final from drawing at all
-seed=off         stops the game's finished frame being painted in under the chain
-passes=N         cuts the chain to its first N passes, or to a list of names
-dump=NAME        prints the values one program was handed, decoded
-screen=settings  opens the settings screen on the pack rather than on the list
-```
-
-Every one of those that is a yes or a no is on until it is taken out: what this
-engine can serve it serves, and only a disabling is written down. The last three
-are values rather than switches and do nothing unless written.
-
-One more name is held back rather than handed to the pack as a setting:
-`profile=NAME` picks a whole profile the pack declares, and the settings screen
-greys its own profile selector out for as long as that line is there. Everything
-else in the file is a setting of the pack, by its own name.
-
-Each of the switches is a stage that can be taken in or out on its own, which
-is what tells a wrong gbuffer from a wrong composite. `dump=` is the one that
-answers what no picture can, since a value can be non zero, plausible and wrong.
-
-A settings screen covers all of it in game: the video settings, where it sits
-under Vitrail in the list of pages, the I key, or, on NeoForge, the Config button
-in the mod list. It is the screen of the engine packs are written against, ported rather
-than approximated, so it looks and behaves like that one. It opens on the pack
-list and reads each pack's own menu layout. The row at the head of the list turns shaders off
-altogether and leaves the game drawing its own image. Clicking a pack only selects it: Apply writes what
-you changed and reads the pack again without closing, Done does both and closes,
-and Cancel throws the changes away. A program that fails to compile is reported
-in the log and the game keeps its own rendering rather than crashing.
-
-The pack folder is watched, so a pack dropped into it turns up in the list on its
-own. Nothing inside a pack is watched, and neither is `vitrail/`: edit either by
-hand while the game runs, then press `R` and the pack is read again from disk,
-whole. From inside the settings screen, where no key reaches, the same thing is
-the small circular arrow at the bottom left, which like the eye beside it is
-there in a world only. The jar never needs rebuilding for any of it.
+None of them has to exist, and without a pack picked nothing is drawn. The screen
+that picks one is in the video settings, under Vitrail in the list of pages, on the
+`I` key, or, on NeoForge, behind the Config button in the mod list. The pack folder
+is watched, so a pack dropped into it turns up in the list on its own. Nothing
+inside a pack is watched: edit a shader by hand while the game runs, press `R`, and
+the pack is read again from disk, whole. The jar never needs rebuilding for any of
+it.
 
 ## Switching the graphics backend to Vulkan
 
@@ -265,6 +77,57 @@ The same setting is reachable in game under Options, Video Settings, where it is
 called Graphics API and the entry to pick reads "Prefer Vulkan (Experimental)".
 Either way the change only takes effect on the next start, which the game says
 itself when you pick it.
+
+**A game that came up on the wrong backend hides it, twice over.** Asked for
+Vulkan and unable to bring it up, the game falls back to OpenGL within the same
+run and keeps your setting, so `options.txt` goes on saying `vulkan` while the
+session is not on it: the file cannot answer the question. And a game that dies
+before it reaches the title screen leaves a mark that the *next* start reads,
+which sets `preferredGraphicsBackend` back to `default` and saves over whatever
+you had written. Either way Vitrail loads, reads the pack and draws nothing of
+it: the game keeps its own image. So the answer is on the screen rather than in
+the file. The mod says which backend the game came up on at startup, says it as
+an error when that backend is not Vulkan, and says it once more in chat the first
+time a world is shown, naming the setting to change.
+
+## Other mods
+
+Vitrail hooks the frame through public NeoForge events where the game offers
+them, and through mixins where it does not, which on Fabric is everywhere: the
+points a NeoForge event is posted at are reached there by a mixin on the very
+line that posts it, so both loaders run the same ordered work. Sodium's chunk
+renderer is one of those hooks and has no API for any of it, which is why its
+version is pinned above. The whole list is the mixin config shipped in the jar.
+
+**Chloride** is no longer required. What it was load bearing for, the OpenGL
+loading window NeoForge opens before the game exists, Vitrail refuses on its own
+now, and the two refusals nest if you run both. What Chloride does change is what
+reaches this engine: five entries of `config/chloride-client.toml` decide it.
+`tileEntities`, `entities` and `monsters`, under `[culling]`, take block entities,
+mobs and other entities out by distance before the pack is ever asked, so a chest,
+a sign, a boat or a mob that is not there is those settings rather than anything
+the pack does.
+`chests` and `beds`, under `[fastBlocks]`, draw those blocks by a path this
+engine's final pass then covers over, so they go invisible with no other symptom.
+Which of the five a given Chloride writes on is its own business and changes with
+its versions, which is why none of them is described here as on or off: with
+Chloride installed, Vitrail reads that file at startup and names in the log each
+one that is on, with what it costs and what to set it to.
+
+**Distant Horizons** works, and which build depends on the loader. On Fabric,
+3.2.0-b installs from the launcher like any other mod. On NeoForge that same build
+unwraps a GPU texture into an OpenGL handle as the lightmap renders, its NeoForge
+wrapper alone doing so, and dies on the first frame of a world with a
+`ClassCastException` naming `VulkanGpuTexture`: there the [patched build][dh-build]
+is the one to install, by hand and with no other Distant Horizons jar beside it.
+It reports itself as `3.2.1-b-dev`, the same string an upstream development build
+carries, so bug reports made with it belong on this tracker and not with the
+Distant Horizons team. While a pack is up, Vitrail hands its far terrain to the
+pack's own programs, and serves its depth beside the world's, which is the
+arrangement packs are written against. With shaders off, that mod draws its far
+terrain itself and this engine is not involved.
+
+[dh-build]: https://gitlab.com/avpbynf/distant-horizons/-/releases/vitrail-26.2-1
 
 ## Going back
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,12 +48,13 @@ the per-loader `vitrail-neoforge-*` and `vitrail-fabric-*` jars carry the same
 mod as the merged one, and a loader that finds it twice refuses to start.
 
 Shader packs go into the `shaderpacks/` folder at the root of the instance, the
-same folder OptiFine and Iris use, zipped or unpacked. The mod keeps two files of
-its own in a `vitrail/` folder next to `mods/`: `pack.txt`, which is which pack is
-loaded and whether shaders are on at all, and `options.txt`, which is the engine's
-own switches. A pack's own settings are not kept in either. They go beside the
-pack, in the file the reference engine reads and writes for the same pack, so they
-follow you from one engine to the other. What each of those files holds is in
+same folder OptiFine and Iris use, zipped or unpacked. Two files of the mod's own
+live in a `vitrail/` folder next to `mods/`. It writes `pack.txt` itself, which is
+which pack is loaded and whether shaders are on at all. It only ever reads
+`options.txt`, the engine's own switches, which is yours to write. A pack's own
+settings are kept in neither. They go beside the pack, in the file the reference
+engine reads and writes for the same pack, so they follow you from one engine to
+the other. What each of those files holds is in
 [the settings screen](docs/settings-screen.md).
 
 None of them has to exist, and without a pack picked nothing is drawn. The screen

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ experimental by the game itself.
   own settings screen.
 
 [INSTALL.md](INSTALL.md) has the versions this needs, the Chloride settings that
-have to come off, and how to build from source.
+decide what reaches your pack, and what a game that came up on the wrong backend
+looks like.
 
 ## What goes through your pack
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ is the reference this engine is checked against.
 
 Open an issue before writing anything substantial. I order the work by risk, and
 code that lands ahead of what can be verified is hard to accept however good it
-is. [CONTRIBUTING.md](CONTRIBUTING.md) is short, and two of its rules bite people
-who skip it: files are UTF-8 without a BOM, because a BOM breaks anything that
-feeds sources to a GLSL compiler, and line endings are LF.
+is.
+
+[CONTRIBUTING.md](CONTRIBUTING.md) opens on the short version, what refuses a first
+push, and carries the rest.
 
 ## Licence
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -13,7 +13,7 @@ quietly stale.
 
 | Pack | What I have seen |
 | --- | --- |
-| BSL v10.1.3 | Drawn whole, and the one watched most closely. Terrain, water, shadow map, sky, clouds, weather, particles, mobs and the held hand all go through it. |
+| BSL v10.1.3 | Drawn whole, and the one watched most closely. Terrain, water, shadow map, sky, clouds, weather, particles, mobs, block entities and the held hand all go through it. |
 | Complementary Unbound r5.8.1 | Drawn whole, and watched as closely. Its colour targets, its deferred chain and its shadow map all come up; the log prints how many targets it allocated and at what size. Its two top profiles are the exception, and the pack announces it itself: see [the pack asks for Iris](#the-pack-asks-for-iris). |
 | Complementary Reimagined r5.8.1 | Drawn whole, seen beside Unbound, and visually as close to it as the two packs are to each other. Same top-profile exception as Unbound. |
 | Bliss v2.1.2 | Drawn, water included. The flat wrong colours its mobs and its held arm used to come out in are gone: that was this engine sending their first output through a target of the game's, eight bits to a channel where the pack stacks two values in sixteen, and both now write the pack's own. It is the pack that reads the light map raw where BSL and Complementary multiply the matrix in, which is why the far terrain's pair is served normalised. |
@@ -27,7 +27,7 @@ rather than guess.
 
 | What you see | Go to |
 | --- | --- |
-| Nothing of the pack is drawn, the world looks vanilla | [The pack was refused](#the-pack-was-refused) |
+| Nothing of the pack is drawn, the world looks vanilla | [The pack was refused](#the-pack-was-refused), or a game that came up on OpenGL, which [INSTALL](../INSTALL.md#switching-the-graphics-backend-to-vulkan) answers |
 | A red full-screen message tells you to install Iris | [The pack asks for Iris](#the-pack-asks-for-iris) |
 | An effect does nothing at all | [The effect never ran](#the-effect-never-ran) |
 | Blocks have no relief, however smooth the pack promises | [Everything is flat](#everything-is-flat) |

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -71,7 +71,8 @@ buffer parity is checked outside the game rather than judged on screen.
 
 **A target a pack keeps across frames is not a fault.** Packs use one for temporal accumulation:
 the clear skips it, so the first frame of a session reads the clear and every later frame reads
-what the previous frame left. The engine reports such a read as historical rather than flagging it.
+what the previous frame left. Nothing flags such a read, in the engine or in the checks outside
+the game.
 
 Targets belong to a **place** (the root, or a dimension directory) and never to a pack as a
 whole. A pack can declare its format table in one dimension folder only, and then other dimensions

--- a/docs/internals/entities.md
+++ b/docs/internals/entities.md
@@ -135,9 +135,17 @@ one answer bound by a pipeline compiled under the other, which is the wrong stri
 So there is one answer in force and one call that moves it. Its instant is the head of the chunk
 renderer being built again from nothing, which is reached from the extract that consumes the world
 rebuild: after the previous frame was submitted and presented, and before this one has bound a single
-pipeline, so emptying the compiled pipelines there has nothing in flight to tear down. Emptying them
-is owed only where the answer really moved, and it is owed: the game precompiles every static
-pipeline at every resource load and caches it by identity, so the entity ones standing at that
+pipeline. What happens there is that the entity pipelines leave the lookup map, which is map work,
+safe anywhere, and enough on its own: what no lookup can answer with, no new draw binds.
+
+**Nothing is destroyed there, and that is not an omission.** This backend records continuously, so
+at any instant of a running session something already recorded still names what a purge would free.
+Freed at this one, on a pack load in a running world, the device was lost seconds later with nothing
+in the log. The compiled pipelines wait aside for the game's own cache clear, which quiesces first,
+and the recompile happens at once rather than lazily at the next bind.
+
+Dropping them is owed only where the answer really moved, and it is owed: the game precompiles every
+static pipeline at every resource load and caches it by identity, so the entity ones standing at that
 moment were compiled under the other answer.
 
 **Asking is all a switch does.** Moving one raises the same world rebuild F3+A raises and lets the

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -164,10 +164,10 @@ the game's texture-backed target type is public and instantiable, so owning targ
 and its textures are created with usages that allow the same texture to be a colour attachment in
 one pass and a sampled input in the next without being recreated.
 
-## Coordinates keep the OpenGL convention end to end
+## The screen's two axes keep the OpenGL convention end to end
 
-This is the question every port of an OpenGL-era renderer asks, and the answer is that there is
-nothing to flip.
+This is the question every port of an OpenGL-era renderer asks, and for X and Y the answer is that
+there is nothing to flip. Depth is the other story, and it is at the foot of this section.
 
 The Vulkan viewport the game sets is **not** inverted: it starts at zero and has a positive height.
 The flip happens once, at the very last moment, in the blit to the swapchain, where the destination
@@ -176,8 +176,13 @@ any target a mod owns) keeps the OpenGL orientation, origin at the bottom left.
 
 So a full-screen shader that maps a corner to both its texture coordinate and its clip position
 sees texture coordinate zero at the bottom left of the screen, which is exactly the convention
-OptiFine-format packs are written against. No coordinate flip is needed for them anywhere, and one
+OptiFine-format packs are written against. No flip of those two axes is needed anywhere, and one
 added "to be safe" is a defect.
+
+**Depth does not keep it, and that is the one to remember.** The game rasterises with a reversed Z
+where a pack is written for the OpenGL volume, so a formula that is correct in a pack becomes false
+here with no word of it misquoted. The translator converts at three fixed sites rather than leaving
+it to the pack, and [translation](../translation.md) names them.
 
 ## Samplers and uniform blocks are paired by reflection
 

--- a/docs/internals/pack-loading.md
+++ b/docs/internals/pack-loading.md
@@ -162,9 +162,10 @@ constant is the one that enters only while it is true, because an `#ifdef` on on
 has to read false whatever text the declaration carries.
 
 The table a source file starts with carries **the engine's symbols and nothing else**. The pack's own
-settings enter as the expander walks past their declarations, in file order, exactly as a
-preprocessor would. A file that tests a setting above the line declaring it has to see it undefined,
-because that is what the compiler will see later.
+defines enter as the expander walks past their declarations, in file order, exactly as a preprocessor
+would, and its constants never do: there is nothing in one for a preprocessor to test. A file that
+tests a define above the line declaring it has to see it undefined, because that is what the compiler
+will see later.
 
 A chosen name the pack declares nowhere therefore reaches no unit at all. It has no declaration to
 rewrite, and writing it into the head of the unit instead is the one thing that must not happen: a

--- a/docs/internals/pack-loading.md
+++ b/docs/internals/pack-loading.md
@@ -45,11 +45,13 @@ are split on all three endings including a lone carriage return: a file with cla
 read as one long line loses every directive in it. A pack that ships one file in the wrong encoding
 should lose that file's accented comments, not fail to load.
 
-## One sorted walk, over a closed set of extensions
+## The sorted walk, over a closed set of extensions
 
-Only a fixed list of extensions is read. Widening it is not free: packs ship JSON meant for other
-mods that contains lines beginning with an include directive, and scanning those changes every
-number the loader reports. The extension list is the only filter.
+Only a fixed list of extensions is read as source. Widening it is not free: packs ship JSON meant
+for other mods that contains lines beginning with an include directive, and scanning those changes
+every number the loader reports. The extension list is the only filter on what becomes source, and
+everything it leaves out is still reachable: proving that a name is mentioned nowhere in a pack
+means reading those files too, by a second walk that filters on the size ceiling instead.
 
 The walk is then **sorted by pack-relative path**, and that sort is part of the contract. The
 settings index keeps the first declaration of a name and drops later ones, and packs do declare the
@@ -84,8 +86,9 @@ hits are counted so a pack that depends on it can be named rather than merely to
 
 ## The settings index
 
-Two patterns, tried in order per line: a define that may itself be commented out, and a typed
-constant of a scalar type. The first declaration of a name wins.
+Three patterns run over each line: a define that may itself be commented out, a typed constant of
+a scalar type, and an `#ifdef` or `#ifndef` naming one symbol and nothing else, which records that
+something tests that name. The first declaration of a name wins.
 
 **The kind of a setting is decided by whether the rest of the line is empty** once the trailing
 comment is stripped, not by whether a list of allowed values is present. Empty is a switch; anything
@@ -133,6 +136,11 @@ The rewrite rules are asymmetric on purpose:
   as an expression rather than tested for existence, so commenting it out would leave the name
   undeclared where it is used, and skipping it would drop the player's choice silently.
 
+**Those last two reach a closed list of names and no others.** A `const` the reference does not
+configure is a plain constant, whatever its type, and no choice ever rewrites it. So is one the
+index refuses for a reason of its own: a `uint`, a number shipped without a list of values to
+cycle through, or a boolean nothing tests.
+
 A name the pack declares **nowhere** is not applied at all, and nothing is emitted for it in the
 unit's header. There is nowhere to apply it: the section below carries why that is the answer rather
 than an omission.
@@ -149,7 +157,9 @@ Reading a pack produces two tables of defines. Unifying them makes one of the tw
 
 The table used for `shaders.properties` carries the engine's symbols, the default of every setting
 the pack does not ship commented out, and the player's choices on top. That file may test any
-setting, so every setting has to be present before the first line is read.
+setting, so every setting the index offers is present before the first line is read. A boolean
+constant is the one that enters only while it is true, because an `#ifdef` on one declared false
+has to read false whatever text the declaration carries.
 
 The table a source file starts with carries **the engine's symbols and nothing else**. The pack's own
 settings enter as the expander walks past their declarations, in file order, exactly as a
@@ -186,13 +196,18 @@ device at all, which is what the out-of-game checks in [Developing](../developin
 The table is ordered, and its order is preserved, because it is emitted in order: an ordered emission
 is one a person can diff against the previous run.
 
-What it holds are the symbols packs branch on to decide what they are allowed to use: the game
-version in the packed form the format specifies, the GL and GLSL levels, one symbol each for the
-operating system, the vendor and the renderer, quality and hand-depth scalars, the render stage
+What it holds are the symbols packs branch on to decide what they are allowed to use: the
+reference's own name and version, which a pack tests to know it is on an engine that speaks this
+format at all, the game version in the packed form the format specifies, the GL and GLSL levels,
+the colour buffer ceiling, the two symbols saying the normal and specular maps are served, one
+symbol each for the operating system, the vendor and the renderer, quality and hand-depth
+scalars, the render stage
 constants taken straight off the engine's own enumeration so the number a pack compares against and
 the number a draw carries cannot part company, the block kinds and precipitation kinds packs read
 without declaring, and the biome and biome-category symbols, which stay empty until a caller has a
-registry to walk. **A missing symbol does not fail loudly.** It quietly sends the pack down a
+registry to walk. Two more are posted only while they hold: the far terrain symbol while that mod
+is drawing, and the custom images capability while it is served. **A missing symbol does not fail
+loudly.** It quietly sends the pack down a
 fallback path written for a renderer from a decade ago, which is why classifying a vendor string into
 the wrong bucket is worse than not classifying it.
 

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -121,7 +121,8 @@ wrong resolution.
 
 A scaled target also cannot join the game's colour target inside one render pass, because a pass
 has a single render area and every attachment has to match the first (see below), and attachment
-zero is the game's target at screen size. A pack that scales a target its geometry writes therefore
+zero is the game's own target, at whatever size the render scale has left it rather than at any
+size a pack chose. A pack that scales a target its geometry writes therefore
 has that pass fall back to the game's target alone: the attachments the pack named for it are
 dropped as a set rather than one by one, so every draw buffer of that pass is written nowhere. The
 log names the program and says exactly that, which is the point of dropping them at load: the

--- a/docs/internals/uniforms.md
+++ b/docs/internals/uniforms.md
@@ -94,9 +94,12 @@ integrates over and an unquantised one puts all of them slightly off the referen
 reason. The running time a pack reads accumulates those frame durations rather than sampling a wall
 clock, so it stops while the game is paused, which is what a pack driving noise from it expects.
 
-A handful of values are properties of the **pass** rather than of the frame: the depth convention
-of the target being drawn into, the model view the pass draws with, the colour it modulates by, and
-which stage of the frame it is. Those are set beside each block write and never carried over. Left
+A handful of values are properties of the **pass** rather than of the frame: the depth convention of
+the target being drawn into, the model view the pass draws with and the projection it draws under,
+the colour it modulates by, and which stage of the frame it is. Those are set beside each block
+write and dropped rather than carried over, though not in the same place: the frame boundary drops
+the model view, the projection and the colour, and the chain drops the render stage before it
+writes its own blocks, being the only reader left that could hold a stale one. Left
 standing from the pass before, the render stage would tell every full-screen pass of the frame that
 it was drawing the moon, because that value sits in the same table a full-screen pass shares with a
 geometry one.
@@ -119,8 +122,10 @@ Three details decide the result and none of them is obvious:
   fall is a constant here, and the pack cannot change it, because both of the directive names it
   would write (the one that reads as the rise and the one that reads as the fall) are registered
   against the rise, so the second one it writes only overwrites the first. That is the reference's
-  behaviour, reproduced on purpose: honouring the pack's own fall directive instead would dry the
-  ground several times too fast on every pack of the corpus that declares both.
+  behaviour, reproduced on purpose. Honouring the pack's own fall directive instead would be the
+  more sensible reading, and it would change the look of the three packs of the corpus that declare
+  one, in opposite directions: BSL asks for 5 deciseconds against this 200, and both Complementary
+  for 300.
 - There is no smoothing at all on the first value, which is set outright. Otherwise a fresh
   accumulator would spend its first seconds climbing out of zero.
 - A half-life of zero gives an infinite decay constant, hence a factor of one, hence no smoothing.
@@ -285,11 +290,13 @@ could not be read back (`glGetUniformfv` is there for it). It is that reading th
 the second walk the paragraph above rules out. Holding them costs one class rather than a redesign.
 
 It names one program at a time, since the point is to read the file rather than to search it, and
-not because two programs of one frame would say the same thing. They do not. The depth convention,
-the model view the pass draws with, the colour it modulates by and the render stage are properties
-of the pass, so a terrain program and a composite answer differently on exactly the members that
-have to be told apart: one carries the world's model view where the other carries the identity.
-Taking the reading under one program and then under the other is how that pair gets compared at all.
+not because two programs of one frame would say the same thing. They do not, on everything the named
+program itself decides. What they do NOT tell apart is what a pass sets beside its block write. The
+dump is taken as the frame opens, before any pass has written one, so the pass model view reads back
+as the camera's, the modulating colour as white, and the render stage as whatever the last block of
+the frame before left there, which is not the chain's own. The eight pieces of the sky dump alike on
+exactly those. Taking the reading under one program and then under the other is how the rest gets
+compared at all.
 It is rewritten whole rather
 than appended, roughly once a second rather than once a frame, so what is in it is always now: a
 curve is taken by reading it repeatedly, which is exactly how a half-life is measured.

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -101,9 +101,10 @@ swallowed the commented-out block underneath when the rule was written the other
 
 The recognised families include profiles, per-program enable flags, custom uniform and variable
 declarations, the settings screen and its pages, blending, alpha test and sliders, and also the
-buffer sizes, the sky toggles, the shadow caster directives, the noise and custom texture keys, the
-images and the per-program flip directives described further down. Patterns are anchored and tried
-in a fixed order, first match wins.
+buffer sizes, the sky toggles, the shadow caster directives, the noise and custom texture keys and
+the images, all described further down, and the per-program flip directives, whose one home is
+[render targets](internals/render-targets.md#the-flip-convention-one-set-and-one-place-allowed-to-consult-it).
+Patterns are anchored and tried in a fixed order, first match wins.
 
 **A value is cut on SPACES, and a tab never separates two words.** The lists, which are the screen
 and its pages, the two feature lines, the sliders and the profile bodies, take a run of spaces as
@@ -192,7 +193,8 @@ default is the tightest of them rather than the loosest.
   `voxelDistance` that is kept whatever the sweep says of it, for a pack that samples its map from
   places the sweep knows nothing about.
 
-A word this cannot read leaves the default standing, which is what the reference does with it.
+A word this cannot read leaves the default standing rather than the answer a valid line above it
+gave, which is what the reference does with it.
 
 **The safe zone's box can have a width now, where for most of the corpus it could not.** The width
 comes from a `const float voxelDistance`, and it only counts where it sits on a line that survives
@@ -240,8 +242,11 @@ per-buffer spellings Iris configures and nothing else, and the list is necessary
 sufficient: a `const bool` also needs an `#ifdef` testing its name, a constant holding a number
 needs its bracketed list, and a `uint` never qualifies, the reference reading only `int`, `float`
 and `bool` as configurable. Every other `const` is a plain constant of the program, whatever its
-comment offers: it appears on no screen, no settings file line can rewrite it, and conditionals
-read its name exactly as they read a name the pack never declared. Through those bars, a
+comment offers: it appears on no screen, and conditionals read its name exactly as they read a name
+the pack never declared. One case escapes on the way out. A name that IS on the closed list and was
+refused only for want of a value list or of anything testing it still takes a hand-written value
+from the settings file, the rewriter reading a line at a time with the list as the whole of its
+gate. No screen offers that name, so only a hand can write it. Through those bars, a
 `const bool` is a toggle like a bare define, and a numeric constant cycles through its bracketed
 values. The same two demands hold for the defines: a bare toggle is only a setting while an
 `#ifdef` or `#ifndef` somewhere tests it, and a define carrying a value is only one with a

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -196,7 +196,8 @@ per line, because the reference has no key for a profile name at all: writing th
 hand it a file carrying none of the eight settings a profile like BSL's ULTRA decides.
 
 A file this engine wrote before the settings moved is carried over at the first load of that pack,
-in one go: it is read, written out to the shared file, and renamed aside. It is not read for as long
+in one go: it is read, written out to the shared file, and renamed aside to `.txt.migrated`. It is
+not read for as long
 as the shared file happens to be missing, and the difference matters three times over. The screen's
 Apply rebases on the shared file, so a first Apply after a lazy carry-over would write the one
 setting just clicked and drop the rest. An Apply with nothing pending writes nothing, so a pack the
@@ -217,7 +218,8 @@ declared and simply no longer be on a page.
 
 **Which pack was chosen, and whether shaders are on at all, are two separate lines** of
 `vitrail/pack.txt`. They have to be: a single line cannot switch shaders off and still remember which
-pack to come back to. A file holding one bare word is still read the way it always was.
+pack to come back to. A file holding one bare word is still read the way it always was, and one
+holding `none` still reads as shaders off.
 
 Two more lines of that same file are not this screen's at all, and both are written by the video
 settings: `shadowdistance=` is how far the shadow map reaches, in chunks, from the Max Shadow
@@ -228,6 +230,43 @@ which is where the reference keeps its own distance. Every writer reads the file
 it, so none drops another's line.
 
 `vitrail/options.txt` keeps its own job and is never written by this screen.
+
+## The switches that file holds
+
+One `NAME=value` per line, and what it says wins over the screen. Every one of them that is a yes
+or a no is on until it is taken out: what this engine can serve it serves, and only a disabling is
+written down. The last three are values rather than switches and do nothing unless written.
+
+```
+terrain=off      hands the chunk passes back to the game's own shader
+shadow=off       stops the second pass over the world from the light
+sky=off          hands the sky back to the game's own shaders
+clouds=off       hands the clouds back too, and with them the pack's own
+                 clouds directive, which most packs use to remove them
+weather=off      hands the rain and the snow back to the game's own shader,
+                 and with them the pack's own weather directive
+particles=off    hands the quad particles back too, both halves of them
+entities=off     hands the mobs and the block entities back, lit by the game
+                 and carried in flat by the scene seed, and with them the glint
+                 an enchantment puts over anything they hold or wear
+hand=off         leaves the player's own hand where the game draws it, after
+                 the whole chain has run, and the glint over what it holds
+                 with it
+chain=off        stops the composites and the final from drawing at all
+seed=off         stops the game's finished frame being painted in under the chain
+passes=N         cuts the chain to its first N passes, or to a list of names
+dump=NAME        prints the values one program was handed, decoded
+screen=settings  opens the settings screen on the pack rather than on the list
+```
+
+Each of the switches is a stage that can be taken in or out on its own, which is what tells a
+wrong gbuffer from a wrong composite, and it is how a wrong picture is bisected without a
+rebuild. `dump=` is the one that answers what no picture can, since a value can be non zero,
+plausible and wrong.
+
+One more name is held back rather than handed to the pack as a setting: `profile=NAME` picks a
+whole profile the pack declares, and this screen greys its own profile selector out for as long as
+that line is there. Everything else in the file is a setting of the pack, by its own name.
 
 ## The layers
 

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -256,9 +256,10 @@ plane from `n` out to `2nf / (n + f)`. And the planes come out in camera-relativ
 than in the light's clip space, which is also the space the boxes arrive in, so no further conversion
 is owed anywhere: the light's own volume never enters the cull at all.
 
-What this buys has to be read off the log rather than off the screen, and the shadow stage prints it:
-how many sections the light walked, how many the camera walked, and which shape was used. The picture
-is the place it will NOT show, because keeping a section too many costs a draw and not a pixel.
+What this buys is read off the log, where the shadow stage prints how many sections the light walked,
+how many the camera walked and which shape was used, or off the debug screen, which carries the shape
+and the count that survived it. The picture is the place it will NOT show, because keeping a section
+too many costs a draw and not a pixel.
 
 All of the above is about the terrain. What moves is culled separately, and there is an open
 divergence there worth stating plainly, because it is a gap and not a workaround. A caster is

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -69,8 +69,9 @@ function that disagree about them are a real conflict.
 **`const` on a variable whose initialiser is not a constant expression is stripped.** Vulkan
 refuses a global `const mat3` initialised from `transpose(...)`, or from a uniform, which OpenGL
 drivers took as merely immutable. The keyword comes off and the value stays. A declaration whose
-initialiser is only literals and type constructors is left alone, because an array size still
-needs a real constant. Parameters keep `const`: that spelling means immutable, not compile-time.
+initialiser is only literals, type constructors and names the unit itself defines is left alone,
+because an array size still needs a real constant. Parameters keep `const`: that spelling means
+immutable, not compile-time.
 
 **Names that collide with newer builtins are renamed.** A function a pack defines can collide with
 a builtin introduced after the version the pack targets, and the error does not name the collision:

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,16 +1,17 @@
 # Why this exists
 
-Minecraft renders through Vulkan now, and not one shader pack that exists today runs on it. Two
-choices follow from that, and this page is the reasoning behind both: keeping the OptiFine format
-rather than inventing one, and writing an engine at all when others are already in the area.
+Minecraft ships a Vulkan renderer now, and not one of the shader packs written over the last decade
+ran on it. Two choices follow from that, and this page is the reasoning behind both: keeping the
+OptiFine format rather than inventing one, and writing an engine at all when others are already in
+the area.
 
 ## Why the OptiFine format
 
 Not because it is elegant, but because that is where the work is. Packs have been written against
 the OptiFine conventions for more than a decade, by a lot of people, and that is still where nearly
 all of the community writes today. Minecraft moving to Vulkan does not make any of that work worse.
-It just makes it unrunnable, and asking every author to port to a new format is asking them to throw
-it away.
+It just makes it unrunnable there, and asking every author to port to a new format is asking them
+to throw it away.
 
 So inventing a format was the obvious alternative, and it was rejected on purpose. Following
 conventions that have held for ten years means the specification already exists, there is a corpus


### PR DESCRIPTION
## What this publishes

Nothing to install. The range is four documentation commits and no engine code, so the jar `main`
builds is byte for byte the one `v0.8.1-beta` already names. What changes is what somebody reads
before installing: the install guide is half its length, the contributing page opens on a short
version, and twenty-six sentences across the documentation now say what the code does rather than
what it did when they were written.

Two of those twenty-six are the reason this is worth moving rather than waiting for the next
release. The entity internals page described pipelines being destroyed at an instant where the code
destroys none, which is exactly the thing that cost a device once. And the graphics API page
concluded that no coordinate flip is needed anywhere, while its own body only argues the two screen
axes and the depth convention is reversed here.

## The version

- Tag: none. `v0.8.1-beta` sits on `ba192326` and stays there.
- `mod_version` in `gradle.properties`: `0.8.1-beta`, untouched by this range.
- The changelog is untouched. Its top section is `0.8.1-beta`, already published, and documentation
  owes it no entry.

## What the release carries that no changelog entry names

Nothing a player sees. `git log origin/main..origin/dev` is four `docs` commits, no behaviour
changes with them, and the pages they touch are read rather than run.

## What proves it

`gradlew build` green locally on this tree, and green again on each of the requests that landed the
four commits in `dev`. Every correction in the range was read in the source before it was written,
and four of them are settled by the javadoc of the class the sentence is about.

Nothing was looked at in the game, and nothing needed to be: no engine code is in this range.

---

- [x] `main` is an ancestor of `dev`, so this merges by fast-forward.
- [x] `gradlew build` green locally on the commit being promoted.
- [x] The changelog section is named after the tag, and the range was read against it. Read, and it
      owes nothing: the range is documentation.
- [ ] Merged by fast-forward from a terminal, and by no button.
- [x] The tag is pushed only once its commits are on `main`. There is no tag here, `v0.8.1-beta`
      staying on the commit it already names.
