### PR TITLE
docs: merge from the terminal rather than leave a button

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -10,7 +10,10 @@ of its own, and been reviewed there.
 
 **DO NOT PRESS A MERGE BUTTON ON THIS ONE.** All three rewrite, and `main` is already an ancestor of
 `dev`, so replaying `dev` onto it hands `main` a second copy of every commit under a fresh hash.
-What merges this is a fast-forward from a terminal,
+That has happened once, and the repository said so within the minute: `prefix` went red on `main`.
+
+What merges this is a fast-forward, run from a terminal by whoever opened the request as soon as
+the checks are green, rather than left on the page for somebody to find:
 
     git push origin origin/dev:main
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,9 @@ say it in the one place nothing reads it back from.
 
 **The history is linear and carries no merge commit anywhere, which is not a preference.** A tree
 that forks is a tree nobody reads once it is public, and this one is public. A topic branch is
-rebased onto `dev` and enters by a pull request, merged with the rebase button. If that button
-refuses, the rebase was not done, and the answer is to rebase rather than to merge.
+rebased onto `dev` and enters by a pull request, merged by rebase and by nothing else, which is
+`gh pr merge --rebase` from a terminal or the one button that does the same. If either refuses, the
+rebase was not done, and the answer is to rebase rather than to merge.
 
 **Rebase a topic branch as soon as `dev` moves under it, and read the whole of
 `git diff dev..HEAD` afterwards rather than only the hunks git marked.** Git follows a file that
@@ -62,7 +63,9 @@ it lives in.
 **`dev` reaches `main` by a fast-forward and NOT by the merge button.** That button always writes
 new commits, and `main` is already an ancestor of `dev`, so replaying `dev` onto it would give
 `main` a second copy of every commit under a different hash. A pull request is still the right
-place to look at a release, for the record and for the checks it runs. What merges it is
+place to look at a release, for the record and for the checks it runs. What merges it is a command,
+run by whoever opened the request as soon as its checks are green, so that nobody is ever left
+looking at that page with a button on it:
 
     git push origin origin/dev:main
 


### PR DESCRIPTION
## What changes

Nothing in the engine. Two pages described merging as pressing a button, and the one request where
a button is wrong carried its warning at the top of a body nobody reads again at the moment of
clicking. So the warning sat in the one place the reader is not, and a promotion went in through the
rebase button: four commits landed on `main` under fresh hashes, `main` stopped being an exact
prefix of `dev`, and the `prefix` check went red within the minute, which is what it is there for.

The rule itself was right and its shape was not. A merge is now written as what it is, a command run
by whoever opened the request as soon as the checks are green: `gh pr merge --rebase` for a topic
branch, `git push origin origin/dev:main` for the promotion. That leaves nobody looking at a page
with a button on it. The button stays named, because a repository cannot hide it and because it
stays the thing that breaks the promotion.

## How it differs from the reference, and for what obstacle

It does not. No code is touched.

## What proves it

`gradlew build` green locally. The promotion push was tried before this was written, so the claim
that it is not a forbidden push is measured rather than assumed: `main` refuses a force push, a
deletion and a non-linear history, and a fast-forward carrying commits already green through a
request is none of the three.

## What it leaves owing

`dev` and `main` hold the same content under two histories until `dev` is replayed onto `main`, and
that replay needs a force push on `dev`, which its own ruleset refuses. Nothing a reader sees is
wrong meanwhile: the two trees are identical file for file.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
