### PR TITLE
perf(sodium): stop testing planes the answer no longer needs

### DIFF
--- a/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
@@ -406,7 +406,17 @@ public final class ShadowCullFrustum implements Frustum {
 		return true;
 	}
 
-	/** The same, answering whether the box is wholly inside as well, for the callers that ask. */
+	/**
+	 * The same, answering whether the box is wholly inside as well, for the callers that ask.
+	 * <p>
+	 * The two halves of the loop are not symmetric and must not be made so. The near corner is
+	 * tested against EVERY plane, because that is the test that culls and any plane may still be the
+	 * one that rejects. The far corner only decides between INSIDE and INTERSECT, and one plane
+	 * having put it outside already settles that, so the rest of its dot products answer a question
+	 * nobody is asking any more. Written as a guarded assignment rather than the {@code &=} it reads
+	 * like, since that operator on booleans does not short circuit: it would evaluate the second dot
+	 * product for all thirteen planes of every box the shadow walk hands over.
+	 */
 	private int corners(float minX, float minY, float minZ, float maxX, float maxY, float maxZ) {
 		boolean inside = true;
 
@@ -420,9 +430,11 @@ public final class ShadowCullFrustum implements Frustum {
 				return FrustumIntersection.OUTSIDE;
 			}
 
-			inside &= plane[0] * (plane[0] < 0.0F ? maxX : minX)
-					+ plane[1] * (plane[1] < 0.0F ? maxY : minY)
-					+ plane[2] * (plane[2] < 0.0F ? maxZ : minZ) + plane[3] >= 0.0F;
+			if (inside) {
+				inside = plane[0] * (plane[0] < 0.0F ? maxX : minX)
+						+ plane[1] * (plane[1] < 0.0F ? maxY : minY)
+						+ plane[2] * (plane[2] < 0.0F ? maxZ : minZ) + plane[3] >= 0.0F;
+			}
 		}
 
 		return inside ? FrustumIntersection.INSIDE : FrustumIntersection.INTERSECT;

--- a/common/src/main/java/dev/vitrail/uniform/values/ShadowGeometryValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/ShadowGeometryValues.java
@@ -46,10 +46,18 @@ public final class ShadowGeometryValues {
 				out.set(MODEL_VIEW_PROJECTION.set(world.drawnShadowProjection())
 						.mul(world.drawnShadowModelView())));
 
-		// The shadow model view carries the grid snap as a translation, so this is not the
-		// transpose of a pure rotation and computing it is the only way to get it right.
+		// The basis as it stands, where GeometryValues computes an inverse transpose off the pass
+		// matrix. Not a shortcut taken here: that one is computed because a pass model view can
+		// arrive carrying a scale, and this one cannot. ViewMatrices.advanceShadow builds the shadow
+		// model view from an identity, three rotations and the grid snap, and the snap is a
+		// translate, so it lands in the fourth column; Matrix3f.set(Matrix4fc) reads the upper left
+		// three by three and never sees it. What is read here is therefore a product of rotations,
+		// whose inverse is its transpose, so inverting and transposing it hands back what went in.
+		//
+		// What would break it is a scale multiplied into the shadow model view, and the symptom
+		// would be shadow pass normals off by that scale rather than anything that fails loudly.
 		builder.add("of_NormalMatrix", UniformShape.MAT3, (world, out) ->
-				out.set(NORMAL.set(world.drawnShadowModelView()).invert().transpose()));
+				out.set(NORMAL.set(world.drawnShadowModelView())));
 
 		builder.add("shadowModelView", UniformShape.MAT4,
 				(world, out) -> out.set(world.drawnShadowModelView()));


### PR DESCRIPTION
## What changes

Two arithmetic reductions on the shadow pass, and the picture is the same on both sides of them.

The frustum test that walks the shadow octree stops evaluating its second dot product once the
answer can no longer be "wholly inside". It was written with an operator that does not short
circuit, so up to thirteen planes per box were paying for a question already settled. The near
corner is still tested against every plane, that being the test that actually culls, and the two
halves now say in the javadoc that their asymmetry is deliberate.

The normal matrix handed to shadow programs stops being inverted and transposed. The matrix it is
read from is built from an identity, three rotations and a grid snap that only translates, so the
upper left block a `mat3` takes is a product of rotations and the round trip returned its input.
The comment that justified the round trip said the snap made the matrix impure. It never reaches
that block.

## How it differs from the reference, and for what obstacle

One difference, and it is a rounding one.

- Iris computes the inverse transpose unconditionally,
  `pipeline/programs/ExtendedShader.java:188`.
- Nothing prevents doing the same here. It is dropped because this engine builds the matrix
  itself and knows it orthonormal, `render/ViewMatrices.java:424-435`.
- What it costs the image: one float ULP on the normal matrix, and in our favour, the round trip
  being what introduced the rounding in the first place.

## What proves it

- `gradlew build` green, after the rebase.
- The off-game harness: `Coupe`, the tool that measures which corners of a box survive the shadow
  cut, returns the same verdict on every one of its invariants before and after.
- Not tried in the game. Neither change can move a pixel by construction.

## What it leaves owing

The frame cost of the first change is not measured. It sits on the shadow octree walk, which the
per-pass profile puts at the heaviest single item of a real frame, but nothing here puts a number
on what it saves.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
