### PR TITLE
feat(uniform): publish the biome's humidity as rainfall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Fixed
+
+- **A pack that changes with how humid a biome is no longer sees a desert everywhere.** The
+  `rainfall` value handed to shaders was always nought, so puddles, wetness and fog that
+  scale with humidity stayed at their driest in a swamp and a jungle alike.
+
 ## 0.8.1-beta
 
 ### Changed

--- a/common/src/main/java/dev/vitrail/mixin/BiomeClimateAccessor.java
+++ b/common/src/main/java/dev/vitrail/mixin/BiomeClimateAccessor.java
@@ -1,0 +1,22 @@
+package dev.vitrail.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * The downfall of a biome's climate record, without naming the record type.
+ * <p>
+ * The type cannot be named: 26.2 compiles {@code Biome.ClimateSettings} as a package-private
+ * member of {@code Biome}, so javac refuses it from any other package even though its own {@code downfall()}
+ * is public. Naming it in a target string sidesteps that, the string never being a type to javac,
+ * and the field the accessor reads is a plain float that both sides can write down.
+ * <p>
+ * Iris does not need this hop, its {@code mixin/MixinBiome.java:11-30} shadowing the record type
+ * directly, which is what 26.1 still allowed. The value read is the same field either way.
+ */
+@Mixin(targets = "net.minecraft.world.level.biome.Biome$ClimateSettings")
+public interface BiomeClimateAccessor {
+
+	@Accessor("downfall")
+	float vitrail$downfall();
+}

--- a/common/src/main/java/dev/vitrail/mixin/BiomeMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/BiomeMixin.java
@@ -1,0 +1,59 @@
+package dev.vitrail.mixin;
+
+import dev.vitrail.render.BiomeHumidity;
+
+import net.minecraft.world.attribute.EnvironmentAttributeMap;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeGenerationSettings;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import net.minecraft.world.level.biome.MobSpawnSettings;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Carries the biome's downfall out to {@link BiomeHumidity}, which is what a pack reads as
+ * {@code rainfall}.
+ * <p>
+ * <strong>Taken in the constructor rather than read on demand, because the record type cannot be
+ * named here.</strong> An accessor answers with the field's own type, and 26.2 compiles
+ * {@code Biome.ClimateSettings} as a package-private member, so no method in this package can be
+ * declared to return it. What CAN cross the boundary is a parameter widened to {@code Object}, which is
+ * what {@code @Coerce} is for, and the constructor is the one place the record arrives as a
+ * parameter. It runs once per biome at registry load and the field is final, so nothing is being
+ * cached that could go stale.
+ * <p>
+ * Iris reaches the same field with a plain shadow ({@code mixin/MixinBiome.java:11-30}), which is
+ * what 26.1 allowed and 26.2 does not. The number handed to a pack is the same either way, with one
+ * exception worth writing down: NeoForge redirects every read of that field to a copy its biome
+ * modifiers may have rewritten, and a constructor parameter is the original. So a pack running
+ * under a mod that edits biome humidity would read Iris' rewritten number and our unrewritten one.
+ * Reaching the rewritten copy means naming a method that exists on one loader only, which this
+ * module cannot do; what it costs is one uniform, on one loader, with such a mod installed.
+ * <p>
+ * The other four parameters are named because an injector's signature has to match its target's,
+ * and they are all public types. {@code require = 1} against this config's {@code defaultRequire}
+ * of nought, for the reason {@code BiomesMixin} gives: a silently missed injection here would leave
+ * every biome answering nought, which is exactly the desert this exists to stop being published.
+ */
+@Mixin(Biome.class)
+public abstract class BiomeMixin implements BiomeHumidity {
+
+	@Unique
+	private float vitrail$downfall;
+
+	@Inject(method = "<init>", at = @At("RETURN"), require = 1)
+	private void vitrail$readDownfall(@Coerce Object climate, EnvironmentAttributeMap attributes,
+			BiomeSpecialEffects effects, BiomeGenerationSettings generation,
+			MobSpawnSettings spawns, CallbackInfo callback) {
+		this.vitrail$downfall = ((BiomeClimateAccessor) climate).vitrail$downfall();
+	}
+
+	@Override
+	public float vitrail$downfall() {
+		return this.vitrail$downfall;
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/BiomeHumidity.java
+++ b/common/src/main/java/dev/vitrail/render/BiomeHumidity.java
@@ -1,0 +1,20 @@
+package dev.vitrail.render;
+
+/**
+ * A biome's downfall, which is what a pack reads as {@code rainfall}: the constant a swamp and a
+ * desert differ by, and not whether it is raining.
+ * <p>
+ * <strong>It exists because 26.2 hands the number out through nothing at all.</strong> The biome
+ * keeps its climate in a record whose {@code downfall} component is exactly this value, and it
+ * publishes {@code getBaseTemperature} for the component beside it and no getter whatever for this
+ * one. Every public path that touches it comes back out as a grass or foliage colour, which is a
+ * lookup and not an inverse.
+ * <p>
+ * Outside the mixin package on purpose, for the reason {@link BlockEntityOrigin} already gives: a
+ * class in there is read as a mixin, and this is a plain interface the mixin implements and its
+ * caller casts to.
+ */
+public interface BiomeHumidity {
+
+	float vitrail$downfall();
+}

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -924,6 +924,7 @@ public final class FrameState implements WorldState {
 					case RAIN -> 1;
 					case SNOW -> 2;
 				};
+		this.rainfall = ((BiomeHumidity) (Object) holder.value()).vitrail$downfall();
 		this.temperature = holder.value().getBaseTemperature();
 	}
 
@@ -1225,12 +1226,18 @@ public final class FrameState implements WorldState {
 	}
 
 	/**
-	 * Zero, and it stays zero here. Vanilla has no accessor at all: {@code Biome.climateSettings}
-	 * is private and there is no {@code getDownfall}. The only public route is NeoForge's
-	 * modifiable copy of the biome, and this module compiles against vanilla alone on purpose, so
-	 * that the Fabric module can reuse it as it stands. Answering it means moving the read to the
-	 * loader side, which is a piece of plumbing rather than a question, and not inventing a getter
-	 * that does not exist.
+	 * The biome's own humidity, and not the weather: {@code rainStrength} and {@code wetness} carry
+	 * whether it is raining, this one is the constant a desert and a swamp differ by. Iris publishes
+	 * the same field ({@code uniforms/BiomeUniforms.java:50-51}), off the same biome at the player's
+	 * block, so a pack reads one number on both engines.
+	 * <p>
+	 * There is still no getter, and there never was one to wait for: the value comes through
+	 * {@link BiomeHumidity}, which the biome answers because a mixin puts it there. That this module
+	 * compiles against vanilla alone was never what blocked it, and saying so here is what kept the
+	 * gap alive: a mixin onto a vanilla class is available here like any other, {@code BiomesMixin}
+	 * having stood beside this one doing exactly that the whole time. What the belief cost is a
+	 * nought that arrived through a registered source, which reads as measured rather than missing,
+	 * and told any pack scaling puddles or fog by humidity that the whole world was a desert.
 	 */
 	@Override
 	public float rainfall() {

--- a/common/src/main/java/dev/vitrail/uniform/UniformGaps.java
+++ b/common/src/main/java/dev/vitrail/uniform/UniformGaps.java
@@ -105,8 +105,6 @@ public final class UniformGaps {
 		reasons.put("currentColorSpace", "there is no settings screen to choose it from, which is "
 				+ "also what Iris answers outside the mode concerned");
 
-		reasons.put("rainfall",
-				"vanilla has no accessor for it and this module compiles against vanilla alone");
 		reasons.put("constantMood", "Iris reads it through an interface it mixes into the player");
 
 		return Map.copyOf(reasons);

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -8,6 +8,8 @@
 	},
 	"client": [
 		"ArenaAggregatorMixin",
+		"BiomeClimateAccessor",
+		"BiomeMixin",
 		"BiomesMixin",
 		"BlockEntityRenderDispatcherMixin",
 		"BlockEntityRenderStateAccessor",


### PR DESCRIPTION
## What changes

`rainfall`, the biome humidity a pack reads to scale puddles, wetness and fog, was declared and
never assigned, so every program reading it got nought. Twenty-six translated units of Bliss read
the name in the current test corpus, and all of them were being told the world is a desert. It now
carries the biome's own downfall, read at the player's block beside `temperature`, which is the
moment and the biome Iris reads it at.

The two texts that explained the gap said this module compiles against vanilla alone and so could
not reach the value. That was never what blocked it, a mixin onto a vanilla class being available
here like any other, and saying so is what kept the gap alive. Both now say what is true.

## How it differs from the reference, and for what obstacle

The value matches Iris. The route to it does not, and that is a workaround rather than a
preference.

- Iris shadows the biome's climate record type directly, `mixin/MixinBiome.java:11-30`, and reads
  the field off it.
- 26.2 compiles `Biome.ClimateSettings` package private in the jar this module builds against, so
  no class outside that package can name the type and no accessor can be declared to return it.
  The number is taken from the biome constructor instead, the one place it arrives as a
  parameter, `common/src/main/java/dev/vitrail/mixin/BiomeMixin.java`.
- What it costs the image: nothing under Fabric. Under NeoForge, biome modifiers rewrite a copy
  of that record and redirect field reads to it, while a constructor parameter is the original.
  A world running a mod that edits biome humidity would read Iris' rewritten number and this
  engine's unrewritten one.

## What proves it

- `gradlew build` green, after the rebase.
- The off-game harness: the uniform gate runs clean and its tables are unchanged, which says the
  catalogue stayed consistent and nothing more. It cannot reach a mixin.
- Not tried in the game. What would settle it is Bliss in a swamp against Bliss in a desert.

## What it leaves owing

Nothing proves at build time that the injector matches its target. Mixin's annotation processor
is not wired into this build, so a wrong signature fails at startup rather than at compile, which
is loud but late.

`constantMood`, the other name in the stand-in list with a similar shape, is not served by this.
Vanilla carries no such value at all and Iris synthesises it from an ambient sound handler, which
is a different piece of work and its texts stay true.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
