### PR TITLE
fix(glsl): keep a macro name recognised after an insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack written with the old shadow lookups could be translated wrong, without a word.**
+  Wrapping those lookups shifted the translator's own note of which words are macro names,
+  which could rename one of them or leave a local variable reading a global value instead.
+  Nothing in the tested packs reached it.
 - **A pack that changes with how humid a biome is no longer sees a desert everywhere.** The
   `rainfall` value handed to shaders was always nought, so puddles, wetness and fog that
   scale with humidity stayed at their driest in a swamp and a jungle alike.

--- a/common/src/main/java/dev/vitrail/glsl/GlslLexer.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslLexer.java
@@ -38,10 +38,20 @@ public final class GlslLexer {
 	 *
 	 * @param directive the preprocessor keyword of the line this token sits on, {@code null} when
 	 *                  the token is ordinary code. A {@code #} on its own gives an empty string.
+	 * @param macroName whether this token is the name a naming directive gives rather than a use of
+	 *                  one, which is what keeps it from being renamed. It rides on the token and not
+	 *                  on its position because the translator inserts tokens, and an insertion moves
+	 *                  every index after it: a position recorded before one names somebody else's
+	 *                  token afterwards, and nothing on the way out says so
 	 */
-	public record Token(Kind kind, String text, String directive) {
+	public record Token(Kind kind, String text, String directive, boolean macroName) {
 
 		public static final Token BLANK = new Token(Kind.SPACE, "", null);
+
+		/** A token of ordinary source, which is what everything the lexer produces starts as. */
+		public Token(Kind kind, String text, String directive) {
+			this(kind, text, directive, false);
+		}
 
 		public boolean trivia() {
 			return this.kind == Kind.SPACE || this.kind == Kind.COMMENT;
@@ -56,7 +66,12 @@ public final class GlslLexer {
 		}
 
 		public Token as(String replacement) {
-			return new Token(this.kind, replacement, this.directive);
+			return new Token(this.kind, replacement, this.directive, this.macroName);
+		}
+
+		/** The same token, marked as the name its directive gives. */
+		public Token naming() {
+			return new Token(this.kind, this.text, this.directive, true);
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -278,9 +278,6 @@ public final class GlslTranslator {
 	/** Names the pack defines as macros. Their uses belong to the preprocessor, not to us. */
 	private final Set<String> packMacros = new HashSet<>();
 
-	/** Token positions that name a macro rather than use one, and so are never renamed. */
-	private final Set<Integer> macroNamePositions = new HashSet<>();
-
 	/** Names the unit declares under a built-in type, which is how a declaration is told apart. */
 	private final Set<String> declaredNames = new HashSet<>();
 
@@ -851,7 +848,7 @@ public final class GlslTranslator {
 			Token token = this.tokens.get(index);
 			boolean rename = token.kind() == Kind.IDENTIFIER
 					&& shadowed.contains(token.text())
-					&& !this.macroNamePositions.contains(index)
+					&& !token.macroName()
 					&& (token.directive() == null
 							|| !LegacyGlsl.OPAQUE_DIRECTIVES.contains(token.directive()));
 
@@ -923,6 +920,17 @@ public final class GlslTranslator {
 	}
 
 
+	/**
+	 * Marks the name each naming directive gives, so that later passes leave it spelled as the
+	 * preprocessor needs it.
+	 * <p>
+	 * The mark goes on the token and not into a set of positions, and that is the whole point of
+	 * {@link Token#macroName()}. This runs first, before anything inserts, and two passes do insert:
+	 * {@link #rewriteIdentifiers} closes the legacy shadow lookups it wrapped and {@link #convertDepth}
+	 * closes the depth writes it wrapped. Each insertion moves every index after it, so a position
+	 * taken here would name a different token by the time {@link #body(Set)} reads it, and rename a
+	 * macro name or leave a shadowed read on the block value with nothing logged either way.
+	 */
 	private void collectMacroNames() {
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
@@ -935,7 +943,7 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			this.macroNamePositions.add(name);
+			this.tokens.set(name, this.tokens.get(name).naming());
 			if (token.directive().equals("define")) {
 				this.packMacros.add(this.tokens.get(name).text());
 			}
@@ -1095,7 +1103,7 @@ public final class GlslTranslator {
 
 			String directive = token.directive();
 			if (directive != null
-					&& (LegacyGlsl.OPAQUE_DIRECTIVES.contains(directive) || this.macroNamePositions.contains(index))) {
+					&& (LegacyGlsl.OPAQUE_DIRECTIVES.contains(directive) || token.macroName())) {
 				continue;
 			}
 
@@ -1220,7 +1228,11 @@ public final class GlslTranslator {
 			}
 		}
 
-		// Inserting shifts every index after it, so the last insertion is made first.
+		// Inserting shifts every index after it, so the last insertion is made first. It also ends
+		// every position taken before it: this loop and insertClosings are the only two places that
+		// move a token, so anything a later pass still has to know about a token is carried on the
+		// token, as Token#macroName is. A position kept across here would be read against somebody
+		// else's token, and the reading pass has no way to notice.
 		closings.sort(Comparator.reverseOrder());
 		for (int at : closings) {
 			this.tokens.add(at, new Token(Kind.RAW, ")", null));
@@ -1678,7 +1690,7 @@ public final class GlslTranslator {
 
 			String directive = token.directive();
 			if (directive != null
-					&& (LegacyGlsl.OPAQUE_DIRECTIVES.contains(directive) || this.macroNamePositions.contains(index))) {
+					&& (LegacyGlsl.OPAQUE_DIRECTIVES.contains(directive) || token.macroName())) {
 				continue;
 			}
 
@@ -1874,7 +1886,15 @@ public final class GlslTranslator {
 		this.fragDepthWrites++;
 	}
 
-	/** Inserting shifts every index after it, so the last insertion is made first. */
+	/**
+	 * Inserting shifts every index after it, so the last insertion is made first.
+	 * <p>
+	 * This and the closing loop at the end of {@link #rewriteIdentifiers} are the only two places
+	 * that move a token, and so the only two that can make a position stale. What a later pass has
+	 * to know about a token is carried on the token for that reason, as {@link Token#macroName()}
+	 * is: a position kept across either of them would be read against somebody else's token, and
+	 * nothing downstream can tell.
+	 */
 	private void insertClosings(List<Closing> closings) {
 		closings.sort(Comparator.comparingInt(Closing::at).reversed());
 		for (Closing closing : closings) {


### PR DESCRIPTION
## What changes

A pack's macro names could stop being recognised part way through translation. The translator
noted which tokens name a macro by remembering their POSITION in the token list, and two later
passes insert tokens into that same list, one of them every time it wraps an old-style
`shadow2D` lookup. Every position after an insertion shifts by one, and nothing updated the
notes.

Two reads happen after that shift. The one that matters runs at output time and decides whether
an identifier shadowing a block member is renamed out of the way. With shifted positions it
could rename a macro name, or leave a shadowed read on the block value instead of the local one.
Neither says anything in the log.

The fact now rides on the token itself, so an insertion carries it along. That closes the whole
family rather than this one case, and the two insertion sites now say in their comments that
they are the only two places able to make a position stale.

## How it differs from the reference, and for what obstacle

It does not. Iris runs its equivalent rewrite over a tree built after the preprocessor has
already resolved the file, so the question does not arise there in this shape. Nothing a pack
sees moves relative to it.

## What proves it

- `gradlew build` green, after the rebase.
- The off-game harness: `Traduction` over the eight-pack corpus emits 4548 files, byte for byte
  identical before and after. Nothing regressed.
- **And the corpus cannot see this defect at all.** Disabling the mark outright, over the same
  corpus, also leaves the output byte for byte identical. The three conditions the defect needs,
  an insertion and a shadowed name and a colliding position, are not lined up by any of the
  eight packs, so nothing here demonstrates a repair. The argument for the change is the reading
  of the code, not this measurement.
- Not tried in the game.

## What it leaves owing

A pack that reaches the defect. None of the current corpus does, so the gate that would catch a
regression here is blind, and a small pack built to line the three conditions up would turn the
argument into a measurement.

One path stays uncovered on purpose. The helper that replaces a token with raw text of the
engine's own builds a fresh token and drops the mark. Every read skips a marked token before
that helper can reach one, and the output pass renames identifiers only, so it cannot bite
today. It is the one place a future pass could lose the mark.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
