### PR TITLE
perf(pack): open a pack once for a load, not a dozen times

### DIFF
--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -12,6 +12,7 @@ import dev.vitrail.pack.program.TerrainPass;
 import dev.vitrail.pack.source.DimensionSet;
 import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
 import dev.vitrail.pack.source.IncludeExpander;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.source.ShaderPackSource;
 import dev.vitrail.pack.source.SourceMentions;
 import dev.vitrail.pack.source.ShaderProperties;
@@ -389,37 +390,36 @@ public final class PackProgram {
 
 	/**
 	 * One {@code .csh} entry point, translated on its own. Empty when the pack does not ship it.
+	 * <p>
+	 * Reads the opening the caller already holds rather than one of its own, and this is the entry
+	 * point where that matters most: a pack's shadow computes are read in a loop, so an opening
+	 * apiece meant mounting the archive and rebuilding the whole settings index once per compute
+	 * program rather than once for the load.
 	 */
-	public static Optional<Compute> loadCompute(Path packPath, String path,
-			Map<String, OptionValue> chosen, String profile) throws IOException {
-		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
-			OptionIndex options = OptionIndex.build(source);
-			ShaderProperties properties = ShaderProperties.parse(source);
-			Map<String, OptionValue> fromProfile = profile.isEmpty()
-					? Map.of()
-					: properties.expandProfile(profile);
-			SettingSet settings = SettingSet.resolve(fromProfile, chosen,
-					profile.isEmpty() ? "chosen" : profile);
-			IncludeExpander expander = new IncludeExpander(source, settings);
-			Optional<Path> file = source.file(path + "." + ProgramStage.COMPUTE.extension());
-			if (file.isEmpty()) {
-				return Optional.empty();
-			}
-
-			ExpandedUnit unit = expander.expand(file.get());
-			TargetPlan targets = TargetPlan.build(source, options, settings, properties,
-					dimensionOf(path));
-			PackTextures textures = textures(source, properties, options, settings);
-			Map<ProgramStage, ExpandedUnit> units = new LinkedHashMap<>();
-			units.put(ProgramStage.COMPUTE, unit);
-			ProgramTranslator.TranslatedProgram program = ProgramTranslator.translate(units,
-					VertexInputs.FULLSCREEN, VertexInputs.FULLSCREEN.elements(), AlphaTest.OFF, false,
-					programOf(path), textures.volumes());
-			int[] groups = workGroupsOf(unit);
-			return Optional.of(new Compute(
-					bind(source.packName(), path, program, targets, AlphaTest.OFF, textures),
-					groups[0], groups[1], groups[2]));
+	public static Optional<Compute> loadCompute(OpenedPack pack, String path) throws IOException {
+		ShaderPackSource source = pack.source();
+		OptionIndex options = pack.options();
+		ShaderProperties properties = pack.properties();
+		SettingSet settings = pack.settings();
+		IncludeExpander expander = new IncludeExpander(source, settings);
+		Optional<Path> file = source.file(path + "." + ProgramStage.COMPUTE.extension());
+		if (file.isEmpty()) {
+			return Optional.empty();
 		}
+
+		ExpandedUnit unit = expander.expand(file.get());
+		TargetPlan targets = TargetPlan.build(source, options, settings, properties,
+				dimensionOf(path));
+		PackTextures textures = textures(source, properties, options, settings);
+		Map<ProgramStage, ExpandedUnit> units = new LinkedHashMap<>();
+		units.put(ProgramStage.COMPUTE, unit);
+		ProgramTranslator.TranslatedProgram program = ProgramTranslator.translate(units,
+				VertexInputs.FULLSCREEN, VertexInputs.FULLSCREEN.elements(), AlphaTest.OFF, false,
+				programOf(path), textures.volumes());
+		int[] groups = workGroupsOf(unit);
+		return Optional.of(new Compute(
+				bind(source.packName(), path, program, targets, AlphaTest.OFF, textures),
+				groups[0], groups[1], groups[2]));
 	}
 
 	/**
@@ -483,90 +483,98 @@ public final class PackProgram {
 	public static Terrain loadTerrain(Path packPath, String place,
 			Map<String, OptionValue> chosen, String profile, VertexInputs inputs)
 			throws IOException {
+		try (OpenedPack pack = OpenedPack.open(packPath, chosen, profile)) {
+			return loadTerrain(pack, place, inputs);
+		}
+	}
+
+	/**
+	 * The same, reading an opening the caller already holds, which is the road the engine takes:
+	 * the chunk programs are read where the pack is loaded, beside the chain and the computes, and
+	 * the three of them share one reading of the archive.
+	 */
+	public static Terrain loadTerrain(OpenedPack pack, String place, VertexInputs inputs)
+			throws IOException {
 		if (!inputs.terrain()) {
 			throw new IllegalArgumentException("The chunk passes are drawn from Sodium's own mesh, so "
 					+ inputs + " is not one of the contracts they may be written against");
 		}
 
-		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
-			OptionIndex options = OptionIndex.build(source);
-			ShaderProperties properties = ShaderProperties.parse(source);
-			Map<String, OptionValue> fromProfile = profile.isEmpty()
-					? Map.of()
-					: properties.expandProfile(profile);
-			SettingSet settings = SettingSet.resolve(fromProfile, chosen, profile.isEmpty() ? "chosen" : profile);
-			IncludeExpander expander = new IncludeExpander(source, settings);
-			TargetPlan targets = TargetPlan.build(source, options, settings, properties, place);
-			PackTextures textures = textures(source, properties, options, settings);
+		ShaderPackSource source = pack.source();
+		OptionIndex options = pack.options();
+		ShaderProperties properties = pack.properties();
+		SettingSet settings = pack.settings();
+		IncludeExpander expander = new IncludeExpander(source, settings);
+		TargetPlan targets = TargetPlan.build(source, options, settings, properties, place);
+		PackTextures textures = textures(source, properties, options, settings);
 
-			DimensionSet dimensions = DimensionSet.discover(source);
-			ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
-					dimensions);
+		DimensionSet dimensions = DimensionSet.discover(source);
+		ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
+				dimensions);
 
-			Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
-			// The pack's own switch comes before its programs: the reference nulls its whole
-			// shadow renderer on shadow.enabled=false, however many shadow programs the pack
-			// ships, and only an explicit false moves anything.
-			boolean shadowOff =
-					properties.shadowEnabled(settings.globalDefines(options)).equals(Optional.of(false));
+		Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
+		// The pack's own switch comes before its programs: the reference nulls its whole
+		// shadow renderer on shadow.enabled=false, however many shadow programs the pack
+		// ships, and only an explicit false moves anything.
+		boolean shadowOff =
+				properties.shadowEnabled(settings.globalDefines(options)).equals(Optional.of(false));
 
-			// What each pass is served by, read once and kept, because the passes are walked twice:
-			// the mesh is built out of what ALL of them ask for, and every one of them then declares
-			// that whole mesh. Expanding the includes a second time would be the same files read
-			// again for the same answer.
-			record Served(String path, Map<ProgramStage, ExpandedUnit> units, AlphaTest alphaTest) {
-			}
-
-			Map<TerrainPass, Served> served = new LinkedHashMap<>();
-			Set<String> reads = new LinkedHashSet<>();
-			for (TerrainPass pass : TerrainPass.values()) {
-				if (pass.shadow() && shadowOff) {
-					continue;
-				}
-
-				Optional<ProgramResolver.Resolution> resolution = resolver.lookup(place, pass.program());
-				if (resolution.isEmpty()) {
-					continue;
-				}
-
-				// The name the override is written under is the file that really serves the pass and
-				// not the one the pass asked for, which is how Iris looks it up: a pack shipping one
-				// gbuffers_terrain moves both halves of the chunk pass with one line.
-				String servedBy = resolution.get().servedBy();
-				String path = pathOf(place, servedBy);
-				Map<ProgramStage, ExpandedUnit> units = read(source, expander, path);
-				if (!units.containsKey(ProgramStage.VERTEX) || !units.containsKey(ProgramStage.FRAGMENT)) {
-					continue;
-				}
-
-				AlphaTest alphaTest = pass.alphaTest(overrides, servedBy);
-				served.put(pass, new Served(path, units, alphaTest));
-				reads.addAll(ProgramTranslator.reads(units.get(ProgramStage.VERTEX), inputs,
-						alphaTest, pass.covers(), pass.program(), textures.volumes()));
-			}
-
-			// Nothing to draw and therefore nothing to carry, which is not the same answer as a mesh
-			// whose pack reads none of the six: the caller leaves Sodium's own format alone either
-			// way, and this is the road where it also has no program to leave it alone for.
-			if (served.isEmpty()) {
-				return new Terrain(Map.of(), List.of());
-			}
-
-			List<String> carried = SodiumVertex.carried(reads);
-			Map<TerrainPass, Loaded> loaded = new LinkedHashMap<>();
-			for (Map.Entry<TerrainPass, Served> entry : served.entrySet()) {
-				TerrainPass pass = entry.getKey();
-				Served one = entry.getValue();
-				// The pass's own program and not the file that serves it, for the reason the alpha
-				// test is taken that way: what the engine supplies belongs to what is being drawn.
-				loaded.put(pass, bind(source.packName(), one.path(),
-						ProgramTranslator.translate(one.units(), inputs, carried, one.alphaTest(),
-								pass.covers(), pass.program(), textures.volumes()),
-						targets, one.alphaTest(), textures));
-			}
-
-			return new Terrain(loaded, carried);
+		// What each pass is served by, read once and kept, because the passes are walked twice:
+		// the mesh is built out of what ALL of them ask for, and every one of them then declares
+		// that whole mesh. Expanding the includes a second time would be the same files read
+		// again for the same answer.
+		record Served(String path, Map<ProgramStage, ExpandedUnit> units, AlphaTest alphaTest) {
 		}
+
+		Map<TerrainPass, Served> served = new LinkedHashMap<>();
+		Set<String> reads = new LinkedHashSet<>();
+		for (TerrainPass pass : TerrainPass.values()) {
+			if (pass.shadow() && shadowOff) {
+				continue;
+			}
+
+			Optional<ProgramResolver.Resolution> resolution = resolver.lookup(place, pass.program());
+			if (resolution.isEmpty()) {
+				continue;
+			}
+
+			// The name the override is written under is the file that really serves the pass and
+			// not the one the pass asked for, which is how Iris looks it up: a pack shipping one
+			// gbuffers_terrain moves both halves of the chunk pass with one line.
+			String servedBy = resolution.get().servedBy();
+			String path = pathOf(place, servedBy);
+			Map<ProgramStage, ExpandedUnit> units = read(source, expander, path);
+			if (!units.containsKey(ProgramStage.VERTEX) || !units.containsKey(ProgramStage.FRAGMENT)) {
+				continue;
+			}
+
+			AlphaTest alphaTest = pass.alphaTest(overrides, servedBy);
+			served.put(pass, new Served(path, units, alphaTest));
+			reads.addAll(ProgramTranslator.reads(units.get(ProgramStage.VERTEX), inputs,
+					alphaTest, pass.covers(), pass.program(), textures.volumes()));
+		}
+
+		// Nothing to draw and therefore nothing to carry, which is not the same answer as a mesh
+		// whose pack reads none of the six: the caller leaves Sodium's own format alone either
+		// way, and this is the road where it also has no program to leave it alone for.
+		if (served.isEmpty()) {
+			return new Terrain(Map.of(), List.of());
+		}
+
+		List<String> carried = SodiumVertex.carried(reads);
+		Map<TerrainPass, Loaded> loaded = new LinkedHashMap<>();
+		for (Map.Entry<TerrainPass, Served> entry : served.entrySet()) {
+			TerrainPass pass = entry.getKey();
+			Served one = entry.getValue();
+			// The pass's own program and not the file that serves it, for the reason the alpha
+			// test is taken that way: what the engine supplies belongs to what is being drawn.
+			loaded.put(pass, bind(source.packName(), one.path(),
+					ProgramTranslator.translate(one.units(), inputs, carried, one.alphaTest(),
+							pass.covers(), pass.program(), textures.volumes()),
+					targets, one.alphaTest(), textures));
+		}
+
+		return new Terrain(loaded, carried);
 	}
 
 	/**
@@ -1065,79 +1073,87 @@ public final class PackProgram {
 	public static Optional<Chain> loadChain(Path packPath, String dimension,
 			Map<String, OptionValue> chosen, String profile, ChainFilter filter,
 			ChainPlan.Families families) throws IOException {
-		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
-			OptionIndex options = OptionIndex.build(source);
-			ShaderProperties properties = ShaderProperties.parse(source);
-			Map<String, OptionValue> fromProfile = profile.isEmpty()
-					? Map.of()
-					: properties.expandProfile(profile);
-			SettingSet settings = SettingSet.resolve(fromProfile, chosen, profile.isEmpty() ? "chosen" : profile);
-			IncludeExpander expander = new IncludeExpander(source, settings);
-
-			TargetPlan targets = TargetPlan.build(source, options, settings, properties, dimension, filter);
-			String place = targets.place();
-
-			// Asked before anything is expanded. A place that serves no final draws nothing at all,
-			// and finding that out after nine programs have been read is nine wasted seconds.
-			if (!targets.running().contains(FINAL) || !serves(source, pathOf(place, FINAL))) {
-				return Optional.empty();
-			}
-
-			PackTextures textures = textures(source, properties, options, settings);
-
-			// Inside the same opening as everything else, for the reason the other readings give: a
-			// zip closed behind us invalidates every path taken from it.
-			SourceMentions mentions = SourceMentions.of(source, SETTLED_EARLY);
-			Map<String, ProgramTranslator.TranslatedProgram> translated = new LinkedHashMap<>();
-			for (String name : targets.running()) {
-				String path = pathOf(place, name);
-				Map<ProgramStage, ExpandedUnit> units = read(source, expander, path);
-				if (!units.containsKey(ProgramStage.VERTEX) || !units.containsKey(ProgramStage.FRAGMENT)) {
-					throw new IOException(path + " is meant to run and " + source.packName()
-							+ " does not serve both of its stages");
-				}
-
-				translated.put(name, translate(path, units, textures.volumes()));
-			}
-
-			Map<String, Refusal> refused =
-					unbindable(translated, properties.imageSamplers(settings.globalDefines(options)));
-			List<String> refusals = new ArrayList<>();
-			if (refused.containsKey(FINAL)) {
-				// A final is never offered to a filter and cannot be: with it gone nothing of the
-				// chain reaches the screen, so there is nothing left to salvage and the whole pack
-				// is refused instead. Mellow and Reverie are both this case as they ship.
-				refusals.add(refusal(source.packName(), pathOf(place, FINAL), refused));
-			} else if (!refused.isEmpty()) {
-				targets = TargetPlan.build(source, options, settings, properties, dimension,
-						filter.without(refused.keySet()));
-			}
-
-			DimensionSet dimensions = DimensionSet.discover(source);
-			ProgramSet programs = ProgramSet.enumerate(source, dimensions);
-			ChainPlan chain = ChainPlan.of(targets, ProgramResolver.resolve(programs, dimensions),
-					refusals, families);
-
-			Map<String, Loaded> loaded = new LinkedHashMap<>();
-			for (String name : targets.running()) {
-				ProgramTranslator.TranslatedProgram program = translated.get(name);
-				if (program == null) {
-					// The second walk reads the same files with the same ranks and only ever takes
-					// programs away, so a name appearing that the first one never had is this class
-					// contradicting itself rather than anything a pack can cause.
-					throw new IllegalStateException(name + " is in the rebuilt chain of "
-							+ source.packName() + " and was never translated");
-				}
-
-					// A full screen pass has no alpha test. The fixed function one was for geometry, and
-				// nothing in the format lets a composite ask for it.
-				loaded.put(name, bind(source.packName(), pathOf(place, name), program, targets,
-						AlphaTest.OFF, textures));
-			}
-
-			return Optional.of(
-					new Chain(source.packName(), place, targets, chain, loaded, refused, mentions));
+		try (OpenedPack pack = OpenedPack.open(packPath, chosen, profile)) {
+			return loadChain(pack, dimension, filter, families);
 		}
+	}
+
+	/**
+	 * The same, reading an opening the caller already holds, which is the road the engine takes:
+	 * the chain, the chunk programs and the shadow computes are all read at the load and share one
+	 * reading of the archive between them.
+	 */
+	public static Optional<Chain> loadChain(OpenedPack pack, String dimension, ChainFilter filter,
+			ChainPlan.Families families) throws IOException {
+		ShaderPackSource source = pack.source();
+		OptionIndex options = pack.options();
+		ShaderProperties properties = pack.properties();
+		SettingSet settings = pack.settings();
+		IncludeExpander expander = new IncludeExpander(source, settings);
+
+		TargetPlan targets = TargetPlan.build(source, options, settings, properties, dimension, filter);
+		String place = targets.place();
+
+		// Asked before anything is expanded. A place that serves no final draws nothing at all,
+		// and finding that out after nine programs have been read is nine wasted seconds.
+		if (!targets.running().contains(FINAL) || !serves(source, pathOf(place, FINAL))) {
+			return Optional.empty();
+		}
+
+		PackTextures textures = textures(source, properties, options, settings);
+
+		// Inside the same opening as everything else, for the reason the other readings give: a
+		// zip closed behind us invalidates every path taken from it.
+		SourceMentions mentions = SourceMentions.of(source, SETTLED_EARLY);
+		Map<String, ProgramTranslator.TranslatedProgram> translated = new LinkedHashMap<>();
+		for (String name : targets.running()) {
+			String path = pathOf(place, name);
+			Map<ProgramStage, ExpandedUnit> units = read(source, expander, path);
+			if (!units.containsKey(ProgramStage.VERTEX) || !units.containsKey(ProgramStage.FRAGMENT)) {
+				throw new IOException(path + " is meant to run and " + source.packName()
+						+ " does not serve both of its stages");
+			}
+
+			translated.put(name, translate(path, units, textures.volumes()));
+		}
+
+		Map<String, Refusal> refused =
+				unbindable(translated, properties.imageSamplers(settings.globalDefines(options)));
+		List<String> refusals = new ArrayList<>();
+		if (refused.containsKey(FINAL)) {
+			// A final is never offered to a filter and cannot be: with it gone nothing of the
+			// chain reaches the screen, so there is nothing left to salvage and the whole pack
+			// is refused instead. Mellow and Reverie are both this case as they ship.
+			refusals.add(refusal(source.packName(), pathOf(place, FINAL), refused));
+		} else if (!refused.isEmpty()) {
+			targets = TargetPlan.build(source, options, settings, properties, dimension,
+					filter.without(refused.keySet()));
+		}
+
+		DimensionSet dimensions = DimensionSet.discover(source);
+		ProgramSet programs = ProgramSet.enumerate(source, dimensions);
+		ChainPlan chain = ChainPlan.of(targets, ProgramResolver.resolve(programs, dimensions),
+				refusals, families);
+
+		Map<String, Loaded> loaded = new LinkedHashMap<>();
+		for (String name : targets.running()) {
+			ProgramTranslator.TranslatedProgram program = translated.get(name);
+			if (program == null) {
+				// The second walk reads the same files with the same ranks and only ever takes
+				// programs away, so a name appearing that the first one never had is this class
+				// contradicting itself rather than anything a pack can cause.
+				throw new IllegalStateException(name + " is in the rebuilt chain of "
+						+ source.packName() + " and was never translated");
+			}
+
+				// A full screen pass has no alpha test. The fixed function one was for geometry, and
+			// nothing in the format lets a composite ask for it.
+			loaded.put(name, bind(source.packName(), pathOf(place, name), program, targets,
+					AlphaTest.OFF, textures));
+		}
+
+		return Optional.of(
+				new Chain(source.packName(), place, targets, chain, loaded, refused, mentions));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/pack/source/OpenedPack.java
+++ b/common/src/main/java/dev/vitrail/pack/source/OpenedPack.java
@@ -1,0 +1,64 @@
+package dev.vitrail.pack.source;
+
+import dev.vitrail.pack.option.OptionIndex;
+import dev.vitrail.pack.option.OptionValue;
+import dev.vitrail.pack.option.SettingSet;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * A pack opened once, with the three answers every reading of it starts from already in hand.
+ * <p>
+ * <strong>This exists because those answers were being derived once per reading and there are a
+ * dozen readings in one load.</strong> Every one of them opened the pack again, which for a zip
+ * mounts the archive as a filesystem, and then walked every source file of it line by line to
+ * rebuild the same {@link OptionIndex}. A dozen identical answers, each paid for in full, on the
+ * thread that draws; that is the freeze a player sees after picking a pack. Carried instead, the
+ * place, the values, the chain, the chunk programs and every shadow compute of a load share one.
+ * <p>
+ * The settings are part of it and not a fourth thing derived beside it, because the profile is
+ * expanded out of the properties: two readings that resolved it apart would be two answers about
+ * which branch of the pack compiles, and nothing would say which of them the picture came from.
+ * <p>
+ * <strong>Nothing taken from this may outlive {@link #close()}</strong>, which is
+ * {@link ShaderPackSource}'s own rule and reaches everything held here: the index and the
+ * properties hold strings and are safe, and the {@code Path} the source hands out is not.
+ *
+ * @param packPath what was opened, kept so that a line about it names the file the player sees
+ *                 rather than the pack's own name, which is not always the same word
+ */
+public record OpenedPack(Path packPath, ShaderPackSource source, OptionIndex options,
+		ShaderProperties properties, SettingSet settings) implements AutoCloseable {
+
+	/**
+	 * @param chosen  settings to override, by the name the pack declares them under
+	 * @param profile a profile the pack declares, applied underneath {@code chosen} so that a single
+	 *                setting can still be overridden on top of it, or the empty string
+	 */
+	public static OpenedPack open(Path packPath, Map<String, OptionValue> chosen, String profile)
+			throws IOException {
+		ShaderPackSource source = ShaderPackSource.open(packPath);
+		try {
+			OptionIndex options = OptionIndex.build(source);
+			ShaderProperties properties = ShaderProperties.parse(source);
+			Map<String, OptionValue> fromProfile =
+					profile.isEmpty() ? Map.of() : properties.expandProfile(profile);
+			SettingSet settings =
+					SettingSet.resolve(fromProfile, chosen, profile.isEmpty() ? "chosen" : profile);
+
+			return new OpenedPack(packPath, source, options, properties, settings);
+		} catch (IOException | RuntimeException e) {
+			// The archive is ours the moment it opened, so a failure below has to give it back.
+			// Left to the caller it would leak a mounted filesystem per pack that cannot be read.
+			source.close();
+			throw e;
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		this.source.close();
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 /**
@@ -51,6 +52,18 @@ public final class ShaderPackSource implements AutoCloseable {
 
 	/** How much of a file is read before it is allowed to be called binary. */
 	private static final int BINARY_PROBE = 4096;
+
+	/**
+	 * How many packs have been opened since the game started, which a load reports the difference
+	 * of.
+	 * <p>
+	 * Counted here because this is the one door, and because the number is the shape of what a load
+	 * costs: opening a zip mounts the archive as a filesystem, and everything above this class then
+	 * walks every source file of the pack again to rebuild what it needs. A load that opens the same
+	 * pack half a dozen times is doing all of that half a dozen times, and the difference between
+	 * "it should be faster" and a figure is this one increment.
+	 */
+	private static final AtomicInteger OPENINGS = new AtomicInteger();
 
 	private final String packName;
 	private final Path shadersRoot;
@@ -90,7 +103,13 @@ public final class ShaderPackSource implements AutoCloseable {
 		return text.substring(0, text.length() - 4);
 	}
 
+	/** How many packs have been opened so far, which a load takes a before and an after of. */
+	public static int openings() {
+		return OPENINGS.get();
+	}
+
 	public static ShaderPackSource open(Path packPath) throws IOException {
+		OPENINGS.incrementAndGet();
 		if (Files.isDirectory(packPath)) {
 			return new ShaderPackSource(nameOf(packPath), findShadersRoot(packPath), null);
 		}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -6,6 +6,7 @@ import dev.vitrail.mixin.GpuDeviceAccessor;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.program.TerrainPass;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.source.PackLoader;
 import dev.vitrail.pack.source.PackReport;
 import dev.vitrail.pack.source.ShaderPackSource;
@@ -383,7 +384,7 @@ public final class PackChain {
 	private boolean redirected;
 
 	private PackChain(PackProgram.Chain chain, PackValues values, String world, boolean seedEnabled,
-			Path packPath, Map<String, OptionValue> chosen, String profile) {
+			OpenedPack opened, Path packPath, Map<String, OptionValue> chosen, String profile) {
 		this.chain = chain;
 		this.values = values;
 		this.world = world;
@@ -420,7 +421,7 @@ public final class PackChain {
 		// say a word. Whether the chain runs travels with them, because a translucent pass that
 		// takes draw buffer nought for the pack is drawing for a final: without one, the water
 		// would leave the screen and reach nothing.
-		this.terrain = new TerrainDraw(this, packPath, chain.place(), chosen, profile, values,
+		this.terrain = new TerrainDraw(this, packPath, chain.place(), values,
 				this.load, chain.chain(), chain.targets(), chainWanted, this.targets);
 		// The same plan and the same schedule again, and for the same reason. The sky is read on
 		// demand too, since the game builds its meshes once at startup and a place that never draws
@@ -457,8 +458,8 @@ public final class PackChain {
 		// on the frames DH really draws a far terrain.
 		this.distant = new DistantDraw(this, packPath, chain.place(), chosen, profile, values,
 				this.load, chain.chain(), chain.targets(), chainWanted, this.targets);
-		this.compute = PackCompute.load(packPath, chain.place(), chosen, profile,
-				chain.targets().computes(), this.load, values.shadowGeometryCatalog());
+		this.compute = PackCompute.load(opened, chain.place(), chain.targets().computes(), this.load,
+				values.shadowGeometryCatalog());
 	}
 
 	/**
@@ -596,6 +597,9 @@ public final class PackChain {
 	 */
 	public static void load(Path gameDirectory) {
 		PassTimings.resetCensus();
+		// Taken before anything reads the folder, so that the count printed at the end of the load
+		// covers every opening the load made and not only the translation's.
+		int openings = ShaderPackSource.openings();
 		session = null;
 		lastError = null;
 		removed = List.of();
@@ -774,54 +778,73 @@ public final class PackChain {
 				return;
 			}
 
-			// The world decides the directory, and the pack decides which world that is: a folder
-			// may be named anything and mapped in dimension.properties, so the name is read from
-			// the pack rather than composed from the dimension.
-			String place = PackPlace.place(pack);
-			String world = PackPlace.world();
+			// ONE opening of the archive for everything below, and it is what a player feels. The
+			// place, the values, the chain, the chunk programs and every shadow compute used to
+			// open the pack for themselves: for a zip that mounts the archive again each time, and
+			// each of them then walked every source file of the pack line by line to rebuild the
+			// same index of the same settings. Half a dozen identical readings and one more per
+			// compute program, on the thread that draws, is the freeze after picking a pack.
+			//
+			// Nothing below may keep a path taken from it. ShaderPackSource says why: closing the
+			// zip invalidates every path out of it, and what that leaves is a
+			// ClosedFileSystemException on an unrelated read much later.
+			try (OpenedPack opened = OpenedPack.open(pack, chosen, settings.profile())) {
+				// The world decides the directory, and the pack decides which world that is: a folder
+				// may be named anything and mapped in dimension.properties, so the name is read from
+				// the pack rather than composed from the dimension.
+				String place = PackPlace.place(opened.source());
+				String world = PackPlace.world();
 
-			// Before the translation and not after: this is what installs the machine's own
-			// symbols, and the biome ones among them decide which branch of the pack compiles.
-			PackValues values = PackValues.read(pack, place, chosen, settings.profile());
+				// Before the translation and not after: this is what installs the machine's own
+				// symbols, and the biome ones among them decide which branch of the pack compiles.
+				PackValues values = PackValues.read(opened, place);
 
-			long began = System.nanoTime();
-			Optional<PackProgram.Chain> read = PackProgram.loadChain(pack, place, chosen,
-					settings.profile(), engine.passes(), engine.families());
-			if (read.isEmpty()) {
-				String where = place.isEmpty() ? "at its root" : "in " + place + " or at its root";
-				String named = ShaderPackSource.nameOf(pack);
-				lastError = named + " serves no final with both stages " + where;
-				Vitrail.logger().warn("{} serves no final with both stages {}, nothing to draw",
-						named, where);
-				return;
+				long began = System.nanoTime();
+				Optional<PackProgram.Chain> read =
+						PackProgram.loadChain(opened, place, engine.passes(), engine.families());
+				if (read.isEmpty()) {
+					String where = place.isEmpty() ? "at its root" : "in " + place + " or at its root";
+					String named = ShaderPackSource.nameOf(pack);
+					lastError = named + " serves no final with both stages " + where;
+					Vitrail.logger().warn("{} serves no final with both stages {}, nothing to draw",
+							named, where);
+					return;
+				}
+
+				PackProgram.Chain chain = read.get();
+				Vitrail.logger().info("Read {} programs of {} in {} ms", chain.programs().size(),
+						chain.packName(), (System.nanoTime() - began) / 1_000_000L);
+
+				// A refusal is a rule of the API this engine cannot bend, named with the program that
+				// broke it. Dropping that program instead would move the half every later pass reads.
+				List<String> refusals = chain.chain().refusals();
+				if (!refusals.isEmpty()) {
+					disabled = true;
+					refusals.forEach(refusal -> Vitrail.logger().error("{}", refusal));
+					// The first one, in the pack's own terms, so that the screen says why nothing is
+					// drawn rather than sending the reader to the log for all of them.
+					lastError = chain.packName() + " cannot be drawn as it stands: " + refusals.get(0);
+					Vitrail.logger().error("{} cannot be drawn as it stands, nothing will be drawn",
+							chain.packName());
+					return;
+				}
+
+				announceRemoved(chain);
+				active = new PackChain(chain, values, world, engine.seed(), opened, pack, chosen,
+						settings.profile());
+				// Terrain first, and it finishes before the other families start: two readers on one
+				// zip at once is a race, and Sodium takes the mesh format here before any pass asks
+				// for a shader. The other families then translate on a worker, so Complementary
+				// Unbound's entities overlap the composite compiles and never sit on the render thread.
+				active.terrain.read(opened);
+				// The count, so that what a load costs is a figure in the log rather than a feeling.
+				// It covers the whole of this method, the report and the settings reading included,
+				// and the families are deliberately outside it: they translate on a worker, off the
+				// thread the player is waiting on, and each opens the pack for itself.
+				Vitrail.logger().info("Opened {} {} times to load it", chain.packName(),
+						ShaderPackSource.openings() - openings);
 			}
 
-			PackProgram.Chain chain = read.get();
-			Vitrail.logger().info("Read {} programs of {} in {} ms", chain.programs().size(),
-					chain.packName(), (System.nanoTime() - began) / 1_000_000L);
-
-			// A refusal is a rule of the API this engine cannot bend, named with the program that
-			// broke it. Dropping that program instead would move the half every later pass reads.
-			List<String> refusals = chain.chain().refusals();
-			if (!refusals.isEmpty()) {
-				disabled = true;
-				refusals.forEach(refusal -> Vitrail.logger().error("{}", refusal));
-				// The first one, in the pack's own terms, so that the screen says why nothing is
-				// drawn rather than sending the reader to the log for all of them.
-				lastError = chain.packName() + " cannot be drawn as it stands: " + refusals.get(0);
-				Vitrail.logger().error("{} cannot be drawn as it stands, nothing will be drawn",
-						chain.packName());
-				return;
-			}
-
-			announceRemoved(chain);
-			active = new PackChain(chain, values, world, engine.seed(), pack, chosen,
-					settings.profile());
-			// Terrain first, and it finishes before the other families start: two readers on one
-			// zip at once is a race, and Sodium takes the mesh format here before any pass asks
-			// for a shader. The other families then translate on a worker, so Complementary
-			// Unbound's entities overlap the composite compiles and never sit on the render thread.
-			active.terrain.read();
 			active.startFamilyPrefetch();
 			turnOffImprovedTransparency();
 			if (!chainWanted) {

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -5,10 +5,10 @@ import dev.vitrail.glsl.TranslatedUnit;
 import dev.vitrail.mixin.CommandEncoderAccessor;
 import dev.vitrail.mixin.GpuDeviceAccessor;
 import dev.vitrail.mixin.VulkanCommandEncoderAccessor;
-import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.ProgramNames;
 import dev.vitrail.pack.program.ProgramStage;
 import dev.vitrail.pack.program.RenderStage;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.texture.CustomImages;
 import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.UniformCatalog;
@@ -53,11 +53,9 @@ import org.lwjgl.vulkan.VkWriteDescriptorSet;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -99,8 +97,16 @@ final class PackCompute implements AutoCloseable {
 		return new PackCompute(List.of());
 	}
 
-	static PackCompute load(Path packPath, String place, Map<String, OptionValue> chosen,
-			String profile, List<String> computes, int load, UniformCatalog catalog) {
+	/**
+	 * Reads every shadow compute the pack ships, out of the opening the load already holds.
+	 * <p>
+	 * The opening is handed in and not taken here, and this loop is why it matters: read a program
+	 * at a time from a pack path, each turn mounted the archive again and walked every source file
+	 * of it to rebuild the same index of the same settings, so a pack with four shadow computes
+	 * paid for four whole readings of itself to translate four files.
+	 */
+	static PackCompute load(OpenedPack pack, String place, List<String> computes, int load,
+			UniformCatalog catalog) {
 		List<Pass> passes = new ArrayList<>();
 		for (String name : computes) {
 			if (!ProgramNames.shadowComposite(ProgramNames.familyOf(name))) {
@@ -109,8 +115,7 @@ final class PackCompute implements AutoCloseable {
 
 			String path = place.isEmpty() ? name : place + "/" + name;
 			try {
-				Optional<PackProgram.Compute> compute = PackProgram.loadCompute(packPath, path, chosen,
-						profile);
+				Optional<PackProgram.Compute> compute = PackProgram.loadCompute(pack, path);
 				if (compute.isEmpty()) {
 					continue;
 				}

--- a/common/src/main/java/dev/vitrail/render/PackPlace.java
+++ b/common/src/main/java/dev/vitrail/render/PackPlace.java
@@ -8,7 +8,6 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.world.level.dimension.DimensionType;
 
 import java.io.IOException;
-import java.nio.file.Path;
 
 /**
  * Which world the player is in, in the terms a pack is written in, and which of the pack's
@@ -62,14 +61,13 @@ public final class PackPlace {
 	 * Reads the pack's own map of worlds to folders and answers where this world's programs live,
 	 * the empty string for the root.
 	 * <p>
-	 * One more opening of the pack per load, which is two files and a directory listing against the
-	 * second the load itself costs. The map is kept afterwards because {@link #world()} needs it
-	 * every second and must not touch the disk to get it.
+	 * Read from the opening the load already holds rather than one of its own, which is two files
+	 * and a directory listing off the load and, for a zipped pack, one archive mount fewer. The map
+	 * is kept afterwards because {@link #world()} needs it every second and must not touch the disk
+	 * to get it.
 	 */
-	public static String place(Path packPath) throws IOException {
-		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
-			known = DimensionSet.discover(source);
-		}
+	public static String place(ShaderPackSource source) throws IOException {
+		known = DimensionSet.discover(source);
 
 		return known.place(world());
 	}

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -3,9 +3,9 @@ package dev.vitrail.render;
 import dev.vitrail.pack.id.BlockIds;
 import dev.vitrail.pack.id.NameIds;
 import dev.vitrail.pack.option.OptionIndex;
-import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.option.SettingSet;
 import dev.vitrail.pack.program.RenderStage;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.source.ShaderPackSource;
 import dev.vitrail.pack.source.ShaderProperties;
 import dev.vitrail.pack.source.ShadowCasters;
@@ -113,50 +113,47 @@ public final class PackValues {
 	 * {@code shaders.properties} is live and which branch of the GLSL compiles, so they have to be
 	 * in the table before either is read.
 	 *
+	 * @param pack      the pack, already opened and already read for its settings. Handed in rather
+	 *                  than opened here because the load reads it half a dozen times over, and
+	 *                  every one of those readings walked the whole archive to rebuild the same
+	 *                  index of the same settings
 	 * @param dimension which set of programs the directives are folded from, {@code world0} for the
 	 *                  overworld
-	 * @param chosen    the settings forced on the pack, by the name the pack declares them under
-	 * @param profile   a profile the pack declares, or the empty string
 	 */
-	public static PackValues read(Path packPath, String dimension, Map<String, OptionValue> chosen,
-			String profile) throws IOException {
+	public static PackValues read(OpenedPack pack, String dimension) throws IOException {
 		PackValues values = new PackValues();
 		PackDefines.install();
 
-		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
-			OptionIndex options = OptionIndex.build(source);
-			ShaderProperties properties = ShaderProperties.parse(source);
-			Map<String, OptionValue> fromProfile =
-					profile.isEmpty() ? Map.of() : properties.expandProfile(profile);
-			SettingSet settings =
-					SettingSet.resolve(fromProfile, chosen, profile.isEmpty() ? "chosen" : profile);
+		ShaderPackSource source = pack.source();
+		OptionIndex options = pack.options();
+		ShaderProperties properties = pack.properties();
+		SettingSet settings = pack.settings();
 
-			values.state.directives(PackDirectives.read(source, settings, dimension));
-			values.state.endFlashShadows(properties.endFlashShadows());
-			values.skyElements = properties.skyElements(settings.globalDefines(options));
-			values.weather = properties.weather(settings.globalDefines(options));
-			values.rainDepth = properties.rainDepth(settings.globalDefines(options));
-			values.shadowCasters = properties.shadowCasters(settings.globalDefines(options));
-			values.dhShadow = properties.dhShadow(settings.globalDefines(options));
-			values.shadowCull = properties.shadowCull(settings.globalDefines(options));
-			values.separateAo = properties.separateAo(settings.globalDefines(options));
-			values.particleOrdering = properties.particleOrdering(settings.globalDefines(options));
-			values.declare(properties, settings.globalDefines(options));
-			values.readNoise(properties, source, settings.globalDefines(options));
-			values.packImages =
-					PackImages.read(properties, settings.globalDefines(options), source);
-			values.storageImages = properties.imageDirectives(settings.globalDefines(options));
-			values.bufferObjects = properties.bufferObjects(settings.globalDefines(options));
-			CustomStorage.install(values.bufferObjects);
+		values.state.directives(PackDirectives.read(source, settings, dimension));
+		values.state.endFlashShadows(properties.endFlashShadows());
+		values.skyElements = properties.skyElements(settings.globalDefines(options));
+		values.weather = properties.weather(settings.globalDefines(options));
+		values.rainDepth = properties.rainDepth(settings.globalDefines(options));
+		values.shadowCasters = properties.shadowCasters(settings.globalDefines(options));
+		values.dhShadow = properties.dhShadow(settings.globalDefines(options));
+		values.shadowCull = properties.shadowCull(settings.globalDefines(options));
+		values.separateAo = properties.separateAo(settings.globalDefines(options));
+		values.particleOrdering = properties.particleOrdering(settings.globalDefines(options));
+		values.declare(properties, settings.globalDefines(options));
+		values.readNoise(properties, source, settings.globalDefines(options));
+		values.packImages =
+				PackImages.read(properties, settings.globalDefines(options), source);
+		values.storageImages = properties.imageDirectives(settings.globalDefines(options));
+		values.bufferObjects = properties.bufferObjects(settings.globalDefines(options));
+		CustomStorage.install(values.bufferObjects);
 
-			// Read against the same settings as everything above, which is not a formality: BSL wraps
-			// all its declarations in one conditional and keeps a fifth of them under the #else, so a
-			// reading with an empty table measures a different pack.
-			BlockStateIds.install(BlockIds.read(source, settings.globalDefines(options)));
-			PackNameIds.install(
-					NameIds.read(source, settings.globalDefines(options), NameIds.Kind.ENTITY),
-					NameIds.read(source, settings.globalDefines(options), NameIds.Kind.ITEM));
-		}
+		// Read against the same settings as everything above, which is not a formality: BSL wraps
+		// all its declarations in one conditional and keeps a fifth of them under the #else, so a
+		// reading with an empty table measures a different pack.
+		BlockStateIds.install(BlockIds.read(source, settings.globalDefines(options)));
+		PackNameIds.install(
+				NameIds.read(source, settings.globalDefines(options), NameIds.Kind.ENTITY),
+				NameIds.read(source, settings.globalDefines(options), NameIds.Kind.ITEM));
 
 		return values;
 	}

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -1,8 +1,8 @@
 package dev.vitrail.render;
 
 import dev.vitrail.glsl.PackProgram;
-import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.TerrainPass;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.source.ShadowCasters;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
@@ -112,8 +112,6 @@ public final class TerrainDraw {
 	private final PackChain owner;
 	private final Path packPath;
 	private final String place;
-	private final Map<String, OptionValue> chosen;
-	private final String profile;
 	private final PackValues values;
 	private final int load;
 	private final ChainPlan plan;
@@ -138,14 +136,11 @@ public final class TerrainDraw {
 	private TerrainProgram lastOwner;
 	private boolean read;
 
-	TerrainDraw(PackChain owner, Path packPath, String place, Map<String, OptionValue> chosen,
-			String profile, PackValues values, int load, ChainPlan plan, TargetPlan chainTargets,
-			boolean chainRuns, ColorTargets targets) {
+	TerrainDraw(PackChain owner, Path packPath, String place, PackValues values, int load,
+			ChainPlan plan, TargetPlan chainTargets, boolean chainRuns, ColorTargets targets) {
 		this.owner = owner;
 		this.packPath = packPath;
 		this.place = place;
-		this.chosen = Map.copyOf(chosen);
-		this.profile = profile;
 		this.values = values;
 		this.load = load;
 		this.plan = plan;
@@ -163,7 +158,7 @@ public final class TerrainDraw {
 	 * that does not describe them. What that costs when it is skipped is a world drawn by the game
 	 * while the sky is drawn by the pack, which reads as the sky being in front of the world rather
 	 * than as a terrain program that never ran. Switched on it empties nothing and settles nothing:
-	 * {@link #read()} is what fills the answer in, once the pack's own programs have been read.
+	 * {@link #read(OpenedPack)} is what fills the answer in, once the pack's own programs have been read.
 	 * <p>
 	 * The door is the one F3+A uses, {@code LevelExtractor.allChanged}, and it raises a flag the next
 	 * extract consumes rather than tearing sections down inside a frame. That extract calls
@@ -220,15 +215,18 @@ public final class TerrainDraw {
 	 * A reading that throws takes the terrain down rather than the pack: the sky and the entities are
 	 * read from the same archive and have their own answer about it, and a world drawn by the game
 	 * under a pack's sky is what this would otherwise leave behind.
+	 *
+	 * @param pack the opening the load holds, which stays open for exactly as long as this call. The
+	 *             six programs are read from it rather than from an opening of this class's own,
+	 *             which is why nothing here may keep a {@code Path} taken from the pack
 	 */
-	void read() {
+	void read(OpenedPack pack) {
 		if (!wanted) {
 			return;
 		}
 
 		try {
-			PackProgram.Terrain read = TerrainProgram.read(this.packPath, this.place, this.chosen,
-					this.profile, this.values);
+			PackProgram.Terrain read = TerrainProgram.read(pack, this.place, this.values);
 			this.loaded = read.programs();
 			this.declares = read.carried();
 		} catch (IOException | RuntimeException e) {

--- a/common/src/main/java/dev/vitrail/render/TerrainProgram.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainProgram.java
@@ -3,8 +3,8 @@ package dev.vitrail.render;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.glsl.SodiumVertex;
 import dev.vitrail.glsl.VertexInputs;
-import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.TerrainPass;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.target.TargetSize;
@@ -25,7 +25,6 @@ import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
@@ -117,17 +116,18 @@ public final class TerrainProgram implements DumpedProgram {
 	 * were written against. A pass the pack ships nothing for is absent, and keeps the game's own
 	 * shader.
 	 * <p>
-	 * A second reading of the pack, which costs one plan build for all six. The chain's own reading
-	 * translates what the chain runs, and a gbuffers program is not in it: folding this into that
-	 * walk would make every place pay for programs only this step uses.
+	 * A second walk of the pack's programs, inside the opening the load already holds, and it costs
+	 * one plan build for all six. The chain's own reading translates what the chain runs, and a
+	 * gbuffers program is not in it: folding this into that walk would make every place pay for
+	 * programs only this step uses.
 	 * <p>
 	 * <strong>Read where the pack is loaded and not where a chunk pass first asks.</strong> What the
 	 * mesh carries is the union of what these six read, and the mesh has to be settled before Sodium
 	 * builds the chunk renderer that meshes with it. The device is not touched here: the pipelines
 	 * are built by {@link #build}, at the first draw and against the format the renderer hands over.
 	 */
-	static PackProgram.Terrain read(Path packPath, String place, Map<String, OptionValue> chosen,
-			String profile, PackValues values) throws IOException {
+	static PackProgram.Terrain read(OpenedPack pack, String place, PackValues values)
+			throws IOException {
 		// Which of the two colours the six vertex stages read, settled here because this is where
 		// the pack's own reading of separateAo is held. Two shapes for one word Sodium already
 		// writes, so it decides both which element a stage reads and whether the mesh carries the
@@ -135,10 +135,10 @@ public final class TerrainProgram implements DumpedProgram {
 		VertexInputs inputs = values.separateAo()
 				? VertexInputs.TERRAIN_SEPARATE_AO
 				: VertexInputs.TERRAIN;
-		PackProgram.Terrain read = PackProgram.loadTerrain(packPath, place, chosen, profile, inputs);
+		PackProgram.Terrain read = PackProgram.loadTerrain(pack, place, inputs);
 		if (read.programs().isEmpty()) {
 			Vitrail.logger().warn("{} serves no terrain program with both stages in {}, so the "
-					+ "world keeps the game's own shader", packPath.getFileName(),
+					+ "world keeps the game's own shader", pack.packPath().getFileName(),
 					place.isEmpty() ? "its root" : place);
 		}
 


### PR DESCRIPTION
## What changes

Loading a pack opened it and walked every one of its source files again at twelve places. Each
of those mounted the archive afresh and matched two expressions per line to build the same
option index, and one of them sat inside a loop over the pack's compute programs.

One record now carries the live source, its option index, its properties and the resolved
settings, built once and handed on. The render thread's road goes from six openings plus one per
shadow compute, and five index walks, down to three openings and one walk.

Nothing about what is read, in what order or against which settings changes. The resolve was
repeated verbatim at every site and every log string is preserved.

## How it differs from the reference, and for what obstacle

It does not. This is how the engine reads its own input and Iris makes no claim on it.

## What proves it

- `gradlew build` green, after the rebase.
- The off-game harness: `Traduction` over the eight pack corpus emits 4548 files, byte for byte
  identical before and after, on 2369 translated units. The harness also compiles against this
  branch unchanged, which is what says no signature it uses moved.
- In the game, on the Fabric bench with Complementary and Bliss: **the clock did not resolve
  it.** Bliss read its zip in 984, 1079 and 1040 ms here against 1363 ms before, Complementary in
  1305 and 1387 ms against 1327 ms. One pack moved, the other did not, and the two comparisons
  cross different launches.

## What it leaves owing

**The gain is not measured, and this branch does not claim one.** The work removed is certain by
reading, eleven walks of five hundred odd files. What that is worth on the clock is not, and the
likeliest reason is that the first walk pulls the archive into the operating system's file cache
and the rest read memory. No changelog entry for that reason: there is nothing here to promise
somebody running the mod.

Three roads still open the pack for themselves and could not share this record as it stands,
because they run before the chosen settings and the profile are known: the pack report, the
settings menu, and the required feature check. Splitting the record into a settings free half
plus a `with(chosen, profile)` would fold them in.

The six family prefetch still opens once per family. It runs on a worker rather than in the
freeze, which is why it was left.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
