### PR TITLE
refactor(pack): fold three copied helpers onto their owners

### DIFF
--- a/common/src/main/java/dev/vitrail/pack/program/ProgramNames.java
+++ b/common/src/main/java/dev/vitrail/pack/program/ProgramNames.java
@@ -73,6 +73,26 @@ public final class ProgramNames {
 		};
 	}
 
+	/**
+	 * The order Iris folds directives in, from {@code ProgramSet.locateDirectives}. Setup programs
+	 * are not in it: they go to the compute list there and are only ever read for their work group
+	 * size, so they declare no format however they are written.
+	 * <p>
+	 * Kept beside {@link #frameRank} rather than beside either of its own readers, for the same
+	 * reason: two readers that disagree about where directives fold produce no error, only a wrong
+	 * answer in one place and not the other.
+	 */
+	public static int directiveRank(String family) {
+		return switch (family) {
+			case "shadowcomp" -> 0;
+			case "begin" -> 1;
+			case "prepare" -> 2;
+			case "deferred" -> 4;
+			case "composite" -> 5;
+			default -> 3;
+		};
+	}
+
 	/** A pass drawn over the world rather than over a quad, which never flips anything. */
 	public static boolean geometry(String family) {
 		return family.startsWith("gbuffers") || family.startsWith("dh_")

--- a/common/src/main/java/dev/vitrail/pack/program/ProgramSet.java
+++ b/common/src/main/java/dev/vitrail/pack/program/ProgramSet.java
@@ -6,10 +6,12 @@ import dev.vitrail.pack.source.ShaderPackSource;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.ToIntFunction;
 
 /**
  * The entry points a pack ships: one per file that is a program stage sitting where programs
@@ -111,6 +113,24 @@ public final class ProgramSet {
 	/** Directories under {@code shaders/} that were not walked into. */
 	public Map<String, Integer> skippedDirectories() {
 		return new TreeMap<>(this.skippedDirectories);
+	}
+
+	/** Every fragment entry point of one dimension. */
+	public List<ProgramKey> fragmentsOf(String place) {
+		return this.keys.stream()
+				.filter(key -> key.stage() == ProgramStage.FRAGMENT)
+				.filter(key -> key.dimension().equals(place))
+				.toList();
+	}
+
+	/** The same keys, ordered by family under the caller's rank, then by slot, then by file. */
+	public static List<ProgramKey> sorted(List<ProgramKey> entries, ToIntFunction<String> rank) {
+		return entries.stream()
+				.sorted(Comparator
+						.comparingInt((ProgramKey key) -> rank.applyAsInt(key.name().family()))
+						.thenComparingInt(key -> key.name().slot())
+						.thenComparing(ProgramKey::file))
+				.toList();
 	}
 
 	/** One entry point: where it lives, what it is, and which file holds it. */

--- a/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
+++ b/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
@@ -1,8 +1,8 @@
 package dev.vitrail.pack.target;
 
 import dev.vitrail.pack.option.SettingSet;
+import dev.vitrail.pack.program.ProgramNames;
 import dev.vitrail.pack.program.ProgramSet;
-import dev.vitrail.pack.program.ProgramStage;
 import dev.vitrail.pack.source.DimensionSet;
 import dev.vitrail.pack.source.IncludeExpander;
 import dev.vitrail.pack.source.ShaderPackSource;
@@ -12,7 +12,6 @@ import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -122,12 +121,12 @@ public final class PackDirectives {
 		boolean present = !dimension.equals(ProgramSet.ROOT)
 				&& source.topLevelDirectories().contains(dimension);
 		List<ProgramSet.ProgramKey> entries =
-				fragmentsOf(programs, present ? dimension : ProgramSet.ROOT);
+				programs.fragmentsOf(present ? dimension : ProgramSet.ROOT);
 
 		IncludeExpander expander = new IncludeExpander(source, settings);
 		Builder builder = builder();
 
-		for (ProgramSet.ProgramKey key : sorted(entries)) {
+		for (ProgramSet.ProgramKey key : ProgramSet.sorted(entries, ProgramNames::directiveRank)) {
 			Optional<Path> file = source.file(key.file());
 			if (file.isEmpty()) {
 				continue;
@@ -278,34 +277,6 @@ public final class PackDirectives {
 	/** Which {@code shadowcolor} buffers the pack named at all, which is not which ones exist. */
 	public Set<Integer> shadowColoursDeclared() {
 		return this.shadowColours.keySet();
-	}
-
-	private static List<ProgramSet.ProgramKey> fragmentsOf(ProgramSet programs, String place) {
-		return programs.keys().stream()
-				.filter(key -> key.stage() == ProgramStage.FRAGMENT)
-				.filter(key -> key.dimension().equals(place))
-				.toList();
-	}
-
-	private static List<ProgramSet.ProgramKey> sorted(List<ProgramSet.ProgramKey> entries) {
-		return entries.stream()
-				.sorted(Comparator
-						.comparingInt((ProgramSet.ProgramKey key) -> rank(key.name().family()))
-						.thenComparingInt(key -> key.name().slot())
-						.thenComparing(ProgramSet.ProgramKey::file))
-				.toList();
-	}
-
-	/** The order Iris folds directives in, the same one {@link TargetPlan} uses. */
-	private static int rank(String family) {
-		return switch (family) {
-			case "shadowcomp" -> 0;
-			case "begin" -> 1;
-			case "prepare" -> 2;
-			case "deferred" -> 4;
-			case "composite" -> 5;
-			default -> 3;
-		};
 	}
 
 	public static final class Builder {

--- a/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
@@ -364,7 +364,7 @@ public final class SamplerPlan {
 	 * gbuffers override stands for the whole frame however the targets have been flipped.
 	 */
 	private static Set<String> standing(TargetPlan plan, String program, Set<String> supplied) {
-		String bare = bareName(program);
+		String bare = TargetName.bareName(program);
 		String stage = stageOf(bare);
 		if (supplied.isEmpty() || stage == null) {
 			return supplied;
@@ -406,12 +406,6 @@ public final class SamplerPlan {
 			case "final" -> "composite";
 			default -> null;
 		};
-	}
-
-	private static String bareName(String program) {
-		int slash = program.lastIndexOf('/');
-
-		return slash < 0 ? program : program.substring(slash + 1);
 	}
 
 	/** In declaration order, one entry per name, never short. */

--- a/common/src/main/java/dev/vitrail/pack/target/TargetDirectives.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetDirectives.java
@@ -393,13 +393,9 @@ public final class TargetDirectives {
 		}
 	}
 
+	/** {@link TargetName#bareName}, with the file's own extension taken off besides its directory. */
 	private static String bareName(String program) {
-		String name = program;
-		int slash = name.lastIndexOf('/');
-		if (slash >= 0) {
-			name = name.substring(slash + 1);
-		}
-
+		String name = TargetName.bareName(program);
 		int dot = name.lastIndexOf('.');
 
 		return dot < 0 ? name : name.substring(0, dot);

--- a/common/src/main/java/dev/vitrail/pack/target/TargetName.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetName.java
@@ -5,7 +5,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 /**
- * The names a colour target answers to, and the index behind them.
+ * The names a colour target answers to, and the index behind them. Also, {@link #bareName}: not
+ * a target name at all, kept here because it is never called apart from one.
  * <p>
  * The eight names from before the format was numbered are not folklore. Five of the eight packs
  * sample a target through one of them, and not in a corner: Mellow reads {@code gaux1} in all of
@@ -90,5 +91,20 @@ public final class TargetName {
 	}
 
 	public record Suffixed(int index, String suffix) {
+	}
+
+	/**
+	 * A program is named here by itself, {@code composite1}, while the rest of the engine names it
+	 * by where it lives, {@code world0/composite1}. Both are accepted, so that neither side has to
+	 * remember which form the other one uses.
+	 * <p>
+	 * Not a target name, unlike the rest of this class: it strips a program's directory, not a
+	 * buffer's alias. Kept here anyway because every reader that calls it also reads a target name
+	 * in the same breath, matching a program's writes and samples against the targets above.
+	 */
+	public static String bareName(String program) {
+		int slash = program.lastIndexOf('/');
+
+		return slash < 0 ? program : program.substring(slash + 1);
 	}
 }

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -18,14 +18,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.ToIntFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -182,7 +180,7 @@ public final class TargetPlan {
 		draft.place = present ? dimension : ProgramSet.ROOT;
 		draft.properties = properties;
 
-		List<ProgramSet.ProgramKey> entries = fragmentsOf(programs, draft.place);
+		List<ProgramSet.ProgramKey> entries = programs.fragmentsOf(draft.place);
 
 		Map<String, String> defines = settings.globalDefines(options);
 		read(source, options, settings, properties, entries, draft);
@@ -252,7 +250,7 @@ public final class TargetPlan {
 		List<TargetSchedule.Step> steps = new ArrayList<>();
 		int rank = 0;
 
-		for (ProgramSet.ProgramKey key : sorted(entries, ProgramNames::frameRank)) {
+		for (ProgramSet.ProgramKey key : ProgramSet.sorted(entries, ProgramNames::frameRank)) {
 			String family = key.name().family();
 			String name = key.name().baseName();
 
@@ -390,7 +388,7 @@ public final class TargetPlan {
 		// Iris's order, from ProgramSet.locateDirectives, and the last live declaration wins. One
 		// unit is held at a time: the worst of the corpus expands to four hundred kilobytes and
 		// one dimension has up to forty six of them.
-		for (ProgramSet.ProgramKey key : sorted(entries, TargetPlan::directiveRank)) {
+		for (ProgramSet.ProgramKey key : ProgramSet.sorted(entries, ProgramNames::directiveRank)) {
 			Optional<Path> file = source.file(key.file());
 			if (file.isEmpty()) {
 				draft.unreadable.add(key.file());
@@ -568,7 +566,7 @@ public final class TargetPlan {
 
 	/** The draw buffers of one program after inference, by bare name. Empty for the final. */
 	public List<Integer> writes(String program) {
-		return this.writes.getOrDefault(bareName(program), List.of());
+		return this.writes.getOrDefault(TargetName.bareName(program), List.of());
 	}
 
 	/** Programs whose draw buffers nobody wrote down and that were sent to colortex0. */
@@ -581,7 +579,7 @@ public final class TargetPlan {
 	 * from a translation, so that the whole chain can be checked without compiling anything.
 	 */
 	public Set<Integer> samples(String program) {
-		return this.samples.getOrDefault(bareName(program), Set.of());
+		return this.samples.getOrDefault(TargetName.bareName(program), Set.of());
 	}
 
 	/**
@@ -797,7 +795,7 @@ public final class TargetPlan {
 			}
 
 			BlendMode.parse(directive.value())
-					.ifPresent(mode -> blend.put(bareName(directive.program()), mode));
+					.ifPresent(mode -> blend.put(TargetName.bareName(directive.program()), mode));
 		}
 
 		return Collections.unmodifiableMap(blend);
@@ -810,51 +808,7 @@ public final class TargetPlan {
 	 * @param program the bare name, {@code gbuffers_water}, not the file that ends up serving it
 	 */
 	public Optional<BlendMode> blend(String program) {
-		return Optional.ofNullable(this.blend.get(bareName(program)));
-	}
-
-	private static List<ProgramSet.ProgramKey> fragmentsOf(ProgramSet programs, String place) {
-		return programs.keys().stream()
-				.filter(key -> key.stage() == ProgramStage.FRAGMENT)
-				.filter(key -> key.dimension().equals(place))
-				.toList();
-	}
-
-	private static List<ProgramSet.ProgramKey> sorted(List<ProgramSet.ProgramKey> entries,
-			ToIntFunction<String> rank) {
-		return entries.stream()
-				.sorted(Comparator
-						.comparingInt((ProgramSet.ProgramKey key) -> rank.applyAsInt(key.name().family()))
-						.thenComparingInt(key -> key.name().slot())
-						.thenComparing(ProgramSet.ProgramKey::file))
-				.toList();
-	}
-
-	/**
-	 * The order Iris folds directives in, from {@code ProgramSet.locateDirectives}. Setup programs
-	 * are not in it: they go to the compute list there and are only ever read for their work group
-	 * size, so they declare no format however they are written.
-	 */
-	private static int directiveRank(String family) {
-		return switch (family) {
-			case "shadowcomp" -> 0;
-			case "begin" -> 1;
-			case "prepare" -> 2;
-			case "deferred" -> 4;
-			case "composite" -> 5;
-			default -> 3;
-		};
-	}
-
-	/**
-	 * A program is named here by itself, {@code composite1}, while the rest of the engine names
-	 * it by where it lives, {@code world0/composite1}. Both are accepted, as in the schedule, so
-	 * that neither side has to remember which form the other one uses.
-	 */
-	private static String bareName(String program) {
-		int slash = program.lastIndexOf('/');
-
-		return slash < 0 ? program : program.substring(slash + 1);
+		return Optional.ofNullable(this.blend.get(TargetName.bareName(program)));
 	}
 
 	private static final class Draft {

--- a/common/src/main/java/dev/vitrail/pack/target/TargetSchedule.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetSchedule.java
@@ -105,7 +105,8 @@ public final class TargetSchedule {
 		int opened = 0;
 
 		for (Step step : steps) {
-			int reached = ProgramNames.frameRank(ProgramNames.familyOf(bareName(step.program())));
+			int reached =
+					ProgramNames.frameRank(ProgramNames.familyOf(TargetName.bareName(step.program())));
 
 			// The snapshot is taken between the last deferred and the first thing after it, with
 			// the deferred stage opened and the composite one not. That is the moment Iris takes
@@ -138,7 +139,8 @@ public final class TargetSchedule {
 
 			doubled.addAll(step.writes());
 
-			Map<Integer, Boolean> here = forced.getOrDefault(bareName(step.program()), Map.of());
+			Map<Integer, Boolean> here =
+					forced.getOrDefault(TargetName.bareName(step.program()), Map.of());
 			for (int index : step.writes()) {
 				if (!Boolean.FALSE.equals(here.get(index))) {
 					flip(flipped, index);
@@ -208,9 +210,10 @@ public final class TargetSchedule {
 	}
 
 	public Optional<Bound> step(String program) {
-		String wanted = bareName(program);
+		String wanted = TargetName.bareName(program);
 
-		return this.steps.stream().filter(step -> bareName(step.program()).equals(wanted)).findFirst();
+		return this.steps.stream().filter(step -> TargetName.bareName(step.program()).equals(wanted))
+				.findFirst();
 	}
 
 	/**
@@ -275,11 +278,11 @@ public final class TargetSchedule {
 	 */
 	public Set<Integer> doubledFor(Set<String> programs) {
 		Set<String> wanted = new LinkedHashSet<>();
-		programs.forEach(program -> wanted.add(bareName(program)));
+		programs.forEach(program -> wanted.add(TargetName.bareName(program)));
 
 		Set<Integer> found = new TreeSet<>();
 		for (Bound step : this.steps) {
-			String name = bareName(step.program());
+			String name = TargetName.bareName(step.program());
 			if (!step.fullscreen() || !wanted.contains(name)) {
 				continue;
 			}
@@ -305,24 +308,14 @@ public final class TargetSchedule {
 		}
 	}
 
-	/**
-	 * A program is named here by itself, {@code composite1}, while the rest of the engine names
-	 * it by where it lives, {@code world0/composite1}. Both are accepted so that neither side has
-	 * to remember which form the other one uses.
-	 */
-	private static String bareName(String program) {
-		int slash = program.lastIndexOf('/');
-
-		return slash < 0 ? program : program.substring(slash + 1);
-	}
-
 	private static Map<String, Map<Integer, Boolean>> byProgram(
 			List<ShaderProperties.FlipDirective> explicit) {
 		Map<String, Map<Integer, Boolean>> forced = new LinkedHashMap<>();
 
 		for (ShaderProperties.FlipDirective directive : explicit) {
 			TargetName.index(directive.buffer()).ifPresent(index ->
-					forced.computeIfAbsent(bareName(directive.program()), _ -> new LinkedHashMap<>())
+					forced.computeIfAbsent(TargetName.bareName(directive.program()),
+							_ -> new LinkedHashMap<>())
 							.put(index, directive.value()));
 		}
 


### PR DESCRIPTION
## What changes

Three helpers that decide how a pack's directives are folded were carried in more than one copy,
and a change to any of them had to be made in every copy with nothing checking that they agreed.

`fragmentsOf` and the sort it feeds were identical in `TargetPlan` and `PackDirectives`, and the
rank behind them was a second copy of the same switch. They move to `ProgramSet`, which already
owns the key they walk, and to `ProgramNames`, beside the sibling rank whose own javadoc had
already said it was kept there rather than beside either of its two readers.

`bareName` was identical in three places. It moves to `TargetName`. A fourth copy, in
`TargetDirectives`, is NOT the same function: its input carries a file extension and it strips
one. That one now calls the shared version and adds only the stripping, so the two stop looking
alike while behaving differently, which is the shape that costs a reader the most.

No behaviour changes.

## How it differs from the reference, and for what obstacle

It does not. This is how this engine arranges its own code and Iris makes no claim on it.

## What proves it

- `gradlew build` green, after the rebase.
- The off-game harness: `Traduction` over the eight pack corpus emits 4548 files on 2369
  translated units, byte for byte identical to `dev`.
- The three folded copies were confirmed identical on `dev` before the move, and every call site
  that now reaches the shared version was calling one of them. The fourth was confirmed
  different, which is why it kept its own body around the shared call.

## What it leaves owing

`TargetSchedule.PRE_STAGES` is a related but distinct mechanism, a stage list read with a
different rank, and it stays where it is.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
