### PR TITLE
fix(pack): forget the storage blocks when a pack goes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ what the next one holds.
 - **A pack that changes with how humid a biome is no longer sees a desert everywhere.** The
   `rainfall` value handed to shaders was always nought, so puddles, wetness and fog that
   scale with humidity stayed at their driest in a swamp and a jungle alike.
+- **Changing shaderpack without restarting no longer leaves the buffers of the pack before it
+  in play.** The names a pack gives its `bufferObject` blocks were remembered for the whole
+  session rather than for the pack that wrote them, so a pack loaded after another could have a
+  block bound to a buffer the earlier one had declared, at whatever size and contents that one
+  asked for, or keep a program running against a block nothing binds at all. Complementary
+  Ultra with world-space reflections on is the pack that declares such a block, and quitting
+  the game between two packs was the only thing that cleared it.
 
 ## 0.8.1-beta
 

--- a/common/src/main/java/dev/vitrail/pack/texture/CustomStorage.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/CustomStorage.java
@@ -16,6 +16,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class CustomStorage {
 
 	private static volatile BufferObject.Reading declared = BufferObject.Reading.empty();
+
+	/**
+	 * The block names the translator saw, which is the one half of this class that does not replace
+	 * itself. {@link #install} hands the whole of {@link #declared} over at each load, while this is
+	 * filled a name at a time and would otherwise carry every name of every pack read this session.
+	 * Emptied by {@link #clear} at the head of a load, and the answers below say what that buys.
+	 */
 	private static final Map<String, Integer> bindings = new ConcurrentHashMap<>();
 
 	private CustomStorage() {
@@ -26,6 +33,15 @@ public final class CustomStorage {
 		declared = reading;
 	}
 
+	/**
+	 * Forgets the pack that was read before, both halves of it.
+	 * <p>
+	 * Called at the head of a load and not with the chain that is going. The two answers below sit
+	 * on either side of one descriptor type decision, the bind group layout and the descriptor
+	 * write, and a layout outlives a release in the pipeline cache. A road that releases a chain
+	 * without replacing it would then draw a frame with the two disagreeing, and
+	 * {@code PackChain.load} carries the whole of why.
+	 */
 	public static void clear() {
 		declared = BufferObject.Reading.empty();
 		bindings.clear();

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -16,6 +16,7 @@ import dev.vitrail.pack.target.TargetDirectives;
 import dev.vitrail.pack.target.TargetName;
 import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.texture.CustomImages;
+import dev.vitrail.pack.texture.CustomStorage;
 import dev.vitrail.settings.PackFile;
 import dev.vitrail.settings.PackSession;
 import dev.vitrail.settings.SettingsFile;
@@ -326,9 +327,11 @@ public final class PackChain {
 	private final Object familyMaps = new Object();
 
 	/**
-	 * Raised by {@link #release()} and read by the pack-load worker between two programs, which is
-	 * what stops a worker still compiling for a chain nothing will ever draw again. Volatile for
-	 * that one cross-thread read; everything else about the release stays on the render thread.
+	 * Raised by {@link #release()} and read by the pack-load worker on both of its stages, which is
+	 * what stops a worker still working for a chain nothing will ever draw again:
+	 * {@link #warmFamily} reads it between two programs and {@link #prefetchFamily} between two
+	 * families. Volatile for those cross-thread reads; everything else about the release stays on
+	 * the render thread.
 	 */
 	private volatile boolean released;
 
@@ -597,6 +600,28 @@ public final class PackChain {
 	 */
 	public static void load(Path gameDirectory) {
 		PassTimings.resetCensus();
+		// The storage blocks the translator files away, emptied at the head of a load and NOT beside
+		// the CustomImages line in release(), though the two are installed on the same line.
+		//
+		// What parts them is not when they are asked. VulkanBindGroupLayoutMixin asks both in the
+		// same method, while the layout is built. It is that only this one is asked again on the
+		// OTHER side of the same decision: the layout takes VK_DESCRIPTOR_TYPE_STORAGE_BUFFER from
+		// StorageBuffers.named and the descriptor write takes it from StorageBuffers.bound, and both
+		// of those come back here. A layout is cached with its pipeline and a release does not empty
+		// that cache, so emptying this between the two makes the write go in as a uniform buffer
+		// against a slot the layout already declared storage. The image half cannot do that: the
+		// write side reads StorageImages.bound, which walks an allocation of its own and never asks
+		// CustomImages, so an empty table there costs a filter mode for a frame and no more. And the
+		// road that would reach it is real: leaving a world releases the chain and does NOT replace
+		// it, so the first frame of the next world is drawn by that same chain before draw() gets to
+		// reloadIfTheWorldMoved.
+		//
+		// What emptying here buys is bounded, not absolute. The pack-load worker of the chain that
+		// has just gone translates on a background thread and every program it reads reinstalls what
+		// ITS pack declared, so it can put the outgoing answers back after this line. prefetchFamily
+		// stops between two families once the chain is released, which leaves the one family already
+		// under way, and that is the whole of what can still land here.
+		CustomStorage.clear();
 		// Taken before anything reads the folder, so that the count printed at the end of the load
 		// covers every opening the load made and not only the translation's.
 		int openings = ShaderPackSource.openings();
@@ -2951,7 +2976,26 @@ public final class PackChain {
 		}
 	}
 
+	/**
+	 * One family read ahead, and the translation half of what {@link #released} stops.
+	 * <p>
+	 * {@link #warmFamily} read that flag between two programs and this did not, so a chain nothing
+	 * would ever draw again went on translating its remaining families. That is wasted work, and it
+	 * is also the one thing that writes to state no chain owns: every {@code PackProgram.load}
+	 * reinstalls the {@code bufferObject} lines of the pack it is reading and the translator files
+	 * its storage block names away as it goes, so a worker outliving its pack can put the outgoing
+	 * pack's answers back after the next load has emptied them.
+	 * <p>
+	 * Read once per family rather than per program, which is what the counter below can express: it
+	 * is a prefix bound, and skipping the rest without raising it leaves exactly the families that
+	 * were really filled walkable. So a translation already under way still finishes and can still
+	 * write, and that one family is the window this narrows the race to rather than closes it.
+	 */
 	private void prefetchFamily(Runnable prefetch) {
+		if (this.released || disabled) {
+			return;
+		}
+
 		try {
 			prefetch.run();
 		} catch (RuntimeException e) {


### PR DESCRIPTION
## What changes

Changing shaderpack without restarting the game no longer leaves the buffer blocks of the pack
before it in play. The table that maps a `bufferObject` block name to its binding was filled a
name at a time and never emptied, so it held every block of every pack read in the session. A
pack loaded after another could resolve one of its blocks to a buffer the earlier pack had
declared, at that pack's size and contents, or run a program against a block nothing binds at
all. Complementary Ultra with world-space reflections on is the pack of the corpus that declares
such a block, and quitting the game was the only thing that cleared it.

The pack-load worker also stops between two families once its chain is released. It read that
flag between two programs only, so a chain nothing would ever draw again went on translating its
remaining families, and every program it read reinstalled the block names of the pack that had
just gone.

## How it differs from the reference, and for what obstacle

It does not. Iris rebuilds its buffer objects per pack with the pipeline that owns them, so the
question of a table outliving a pack does not arise there.

## What proves it

- `gradlew build` green, after the rebase.
- Not tried in the game. Reaching it needs two packs in one session where the first declares a
  `bufferObject` block, and what it produces is a program reading a buffer at the wrong size
  rather than an error.

## What it leaves owing

Two things about where the emptying is placed, both deliberate and both bounded.

It is done at the head of a load rather than in `release()`, where the images half sits, because
the bind group layout and the descriptor write read this same answer on either side of one
descriptor type decision, and a layout outlives a release in the pipeline cache: emptying
between the two would write a uniform buffer into a slot already declared storage.

And the window it closes is narrowed, not shut. The outgoing pack's worker stops between two
families, which leaves the one family already under way free to finish and to reinstall what it
read. `CustomImages.clear()` in `release()` has the same shape of exposure and is untouched here.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
