### PR TITLE
fix(mixin): require every patch the picture depends on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ what the next one holds.
 
 ## Unreleased
 
+### Changed
+
+- **A patch of this mod that stops fitting the game now refuses to start it, instead of drawing a
+  wrong picture.** Those patches used to be dropped without a word when a game or Sodium update
+  moved what they attach to, and what reached the screen was an effect quietly missing or a
+  surface lit by the wrong program, with nothing in the log pointing at it. The failure now names
+  itself at launch. The one exception is the line this mod adds to the F3 overlay, which is
+  allowed to go missing because nothing on screen depends on it.
+
 ### Fixed
 
 - **A pack written with the old shadow lookups could be translated wrong, without a word.**

--- a/build.gradle
+++ b/build.gradle
@@ -97,8 +97,11 @@ subprojects {
 		// one of them reads as unused. Measured before deciding, on the report of 6 August: sixty
 		// of the hundred and sixty four findings were UnusedMethod or UnusedVariable and ALL sixty
 		// were in this one package, none of them dead. Acting on a single one would have deleted a
-		// handler the game calls, and with the defaultRequire this config carries it would have
-		// failed in silence, which is the trap DefaultFluidRendererMixin already documents.
+		// handler the game calls, and neither half of that is caught here. Dropping a parameter
+		// leaves a descriptor that no longer matches its target, which the required injections turn
+		// into a refusal to start, and that is the trap DefaultFluidRendererMixin documents.
+		// Dropping the whole method takes its injector with it, and nothing counts an injector that
+		// is not there: that half fails in silence whatever the configuration says.
 		//
 		// Only this analyser steps back. The javac warnings still apply here and are still errors,
 		// and they are the ones that catch a real mistake in a mixin.

--- a/common/src/main/java/dev/vitrail/mixin/BiomeMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/BiomeMixin.java
@@ -35,9 +35,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * module cannot do; what it costs is one uniform, on one loader, with such a mod installed.
  * <p>
  * The other four parameters are named because an injector's signature has to match its target's,
- * and they are all public types. {@code require = 1} against this config's {@code defaultRequire}
- * of nought, for the reason {@code BiomesMixin} gives: a silently missed injection here would leave
- * every biome answering nought, which is exactly the desert this exists to stop being published.
+ * and they are all public types. {@code require = 1}, written out where this config already
+ * defaults to it, for the reason {@code BiomesMixin} gives: a silently missed injection here would
+ * leave every biome answering nought, which is exactly the desert this exists to stop being
+ * published.
  */
 @Mixin(Biome.class)
 public abstract class BiomeMixin implements BiomeHumidity {

--- a/common/src/main/java/dev/vitrail/mixin/BiomesMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/BiomesMixin.java
@@ -29,7 +29,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(Biomes.class)
 public abstract class BiomesMixin {
 
-	// require = 1 against this config's defaultRequire of nought: a silently missed injection
+	// require = 1, written out where this config now defaults to it: a silently missed injection
 	// here would number every biome nought and write no BIOME_* define at all, which a pack
 	// swallows without a word.
 	@Inject(method = "register", at = @At("TAIL"), require = 1)

--- a/common/src/main/java/dev/vitrail/mixin/DebugScreenEntriesMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/DebugScreenEntriesMixin.java
@@ -25,7 +25,14 @@ public abstract class DebugScreenEntriesMixin {
 		throw new AssertionError();
 	}
 
-	@Inject(method = "<clinit>", at = @At("RETURN"))
+	// require = 0 against this config's default of one, and what it tolerates is precisely the
+	// target going away: RETURN cannot fail to match inside a class initializer that exists, so the
+	// only thing left for the guard to catch is the game losing this class or its initializer. The
+	// two places in this package where that is worth tolerating are this one and the status beside
+	// it: what is lost is a line of the F3 overlay, the picture is drawn exactly the same without
+	// it, and the absence is plain to whoever opens the screen. Refusing to start the game over a
+	// debug entry would cost more than the entry.
+	@Inject(method = "<clinit>", at = @At("RETURN"), require = 0)
 	private static void vitrail$register(CallbackInfo ci) {
 		register(VitrailDebugEntry.ID, new VitrailDebugEntry());
 	}

--- a/common/src/main/java/dev/vitrail/mixin/DebugScreenEntryListMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/DebugScreenEntryListMixin.java
@@ -28,7 +28,11 @@ public abstract class DebugScreenEntryListMixin {
 	@Final
 	private Map<Identifier, DebugScreenEntryStatus> allStatuses;
 
-	@Inject(method = "rebuildCurrentList", at = @At("HEAD"))
+	// require = 0 for the same reason as the registration in DebugScreenEntriesMixin, and for less:
+	// HEAD cannot fail to match either, so this too only tolerates the method going away, and what
+	// it costs then is smaller still. The entry stays registered and merely switched off, so a
+	// player who wants the line turns it on from the F3 configuration screen.
+	@Inject(method = "rebuildCurrentList", at = @At("HEAD"), require = 0)
 	private void vitrail$showByDefault(CallbackInfo ci) {
 		this.allStatuses.putIfAbsent(VitrailDebugEntry.ID, DebugScreenEntryStatus.IN_OVERLAY);
 	}

--- a/common/src/main/java/dev/vitrail/mixin/DefaultFluidRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/DefaultFluidRendererMixin.java
@@ -68,8 +68,8 @@ public abstract class DefaultFluidRendererMixin {
 	 * reading the third. Writing {@code Object} for one of them compiles and matches nothing at all.
 	 * <p>
 	 * {@code require = 1} is what makes the next Sodium release say so at load rather than at
-	 * leisure: with the {@code defaultRequire: 0} this config carries, a descriptor that stops
-	 * matching fails in silence and shows up as water that is no longer water.
+	 * leisure: unrequired, a descriptor that stops matching fails in silence and shows up as water
+	 * that is no longer water. It says out loud what this config now defaults to.
 	 */
 	@Inject(method = "render", at = @At("HEAD"), require = 1)
 	private void vitrail$take(LevelSlice level, BlockState blockState, FluidState fluidState,

--- a/common/src/main/java/dev/vitrail/mixin/GameRendererHandMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GameRendererHandMixin.java
@@ -35,11 +35,11 @@ public abstract class GameRendererHandMixin {
 	/**
 	 * Skips the game's own submission exactly when this engine has already made one.
 	 * <p>
-	 * <strong>Required, where most of this package is not.</strong> The configuration sets
-	 * {@code defaultRequire} to nought, so a handler that stopped matching would be dropped in
-	 * silence; here that leaves both submissions standing and the hand is drawn twice, once inside
-	 * the level under the pack's programs and once over the finished image under the game's. Two arms
-	 * a frame apart is a picture nothing else in the engine would explain.
+	 * <strong>Required, and written out rather than left to the configuration's default.</strong> A
+	 * handler that stopped matching and was dropped in silence would leave both submissions standing
+	 * and the hand drawn twice, once inside the level under the pack's programs and once over the
+	 * finished image under the game's. Two arms a frame apart is a picture nothing else in the
+	 * engine would explain.
 	 * <p>
 	 * {@link HandDraw#diverted()} is the same question both halves ask before they draw anything, so
 	 * the two cannot disagree and leave the hand submitted twice or not at all.

--- a/common/src/main/java/dev/vitrail/mixin/GameRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GameRendererMixin.java
@@ -37,7 +37,13 @@ public abstract class GameRendererMixin {
 		return original.call(projection, bob);
 	}
 
-	@WrapOperation(method = "renderLevel",
+	/**
+	 * {@code require = 2} because the rotation and the rotation back are two calls of the same
+	 * signature in the same method, and Mixin counts an injector's matches as one total: at one, the
+	 * turn back could stop matching on its own and be dropped without a word, which would leave the
+	 * copy holding a spin the game undid.
+	 */
+	@WrapOperation(method = "renderLevel", require = 2,
 			at = @At(value = "INVOKE", target = "Lorg/joml/Matrix4f;rotate(FLorg/joml/Vector3fc;)Lorg/joml/Matrix4f;"))
 	private Matrix4f vitrail$spin(Matrix4f projection, float angle, Vector3fc axis,
 			Operation<Matrix4f> original) {

--- a/common/src/main/java/dev/vitrail/mixin/ItemInHandRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/ItemInHandRendererMixin.java
@@ -34,11 +34,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class ItemInHandRendererMixin {
 
 	/**
-	 * <strong>Required, where most of this package is not.</strong> Dropped in silence, both arms
-	 * would be drawn in both passes: the whole hand would be drawn twice per frame, the second time
-	 * with the water program over the first, and a pack that tints its translucent hand would tint
-	 * the sword as well. That is a plausible picture and a wrong one, which is the failure this
-	 * engine refuses.
+	 * <strong>Required, and written out rather than left to the configuration's default.</strong>
+	 * Dropped in silence, both arms would be drawn in both passes: the whole hand would be drawn
+	 * twice per frame, the second time with the water program over the first, and a pack that tints
+	 * its translucent hand would tint the sword as well. That is a plausible picture and a wrong
+	 * one, which is the failure this engine refuses.
 	 */
 	@Inject(method = "submitArmWithItem", at = @At("HEAD"), cancellable = true, require = 1)
 	private void vitrail$oneHalfAtATime(AbstractClientPlayer player, float frameInterp, float xRot,

--- a/common/src/main/java/dev/vitrail/mixin/LevelRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/LevelRendererMixin.java
@@ -33,11 +33,10 @@ import org.spongepowered.asm.mixin.injection.At;
 public abstract class LevelRendererMixin {
 
 	/**
-	 * The only wrap in this package to carry {@code require}, because it is the only one whose
-	 * failure to bind gives back exactly the picture it was written against: under the
-	 * {@code defaultRequire: 0} the config carries, a descriptor that stopped matching would leave
-	 * {@code depthtex0} reading the far plane again, in silence and with nothing on screen to tell
-	 * the two apart.
+	 * {@code require} written out where the config already defaults to it, because this is the wrap
+	 * whose failure to bind gives back exactly the picture it was written against: unrequired, a
+	 * descriptor that stopped matching would leave {@code depthtex0} reading the far plane again, in
+	 * silence and with nothing on screen to tell the two apart.
 	 */
 	@WrapOperation(method = "addAlwaysOnTopPass",
 			at = @At(value = "INVOKE",

--- a/common/src/main/java/dev/vitrail/mixin/MixinDefaultChunkRenderer.java
+++ b/common/src/main/java/dev/vitrail/mixin/MixinDefaultChunkRenderer.java
@@ -76,9 +76,14 @@ public abstract class MixinDefaultChunkRenderer {
 	 * <p>
 	 * What comes back is thrown away. The descriptor below replaces the whole pass, so this only has
 	 * to be something that exists.
+	 * <p>
+	 * {@code require = 2} because the method asks twice, and Mixin counts an injector's matches as
+	 * one total: at one, either call could stop matching on its own and be dropped without a word,
+	 * and the one left unwrapped throws from inside Sodium the first time a shadow map is drawn.
 	 */
 	@WrapOperation(
 			method = "render",
+			require = 2,
 			at = @At(value = "INVOKE",
 					target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/terrain/TerrainRenderPass;"
 							+ "getTarget()Lcom/mojang/blaze3d/pipeline/RenderTarget;"))

--- a/common/src/main/java/dev/vitrail/mixin/QuadParticleFeatureRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/QuadParticleFeatureRendererMixin.java
@@ -38,11 +38,11 @@ import java.util.function.Supplier;
  * game reads the same field to decide which layers go into the group and which target they go to, so
  * taking it from anywhere else would be a second answer to a question already asked.
  * <p>
- * <strong>All four handlers are required</strong>, which the rest of this package is not. The pass
- * and the pipeline are a pair, and half of them applying binds a pipeline carrying eight colour
- * states into a pass carrying one, which throws by name. The other two each leave a picture with
- * nothing in the log: particles drawn with the block of the group before, or a group that kept this
- * engine's program after the one that opened it was forgotten.
+ * <strong>All four handlers are required</strong>, and say so rather than lean on the
+ * configuration's default. The pass and the pipeline are a pair, and half of them applying binds a
+ * pipeline carrying eight colour states into a pass carrying one, which throws by name. The other
+ * two each leave a picture with nothing in the log: particles drawn with the block of the group
+ * before, or a group that kept this engine's program after the one that opened it was forgotten.
  */
 @Mixin(QuadParticleFeatureRenderer.class)
 public abstract class QuadParticleFeatureRendererMixin {

--- a/common/src/main/java/dev/vitrail/mixin/RenderTypeFeatureRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/RenderTypeFeatureRendererMixin.java
@@ -36,13 +36,14 @@ import java.util.List;
  * left a pass open, deliberately: the next draw of the group usually wants the same one, and it is
  * closed by the first draw this engine does not serve or by the handler below.
  * <p>
- * <strong>All three handlers are required, which the rest of this package is not.</strong> The mixin
- * configuration sets {@code defaultRequire} to nought, so an injection that stops matching is
- * normally dropped in silence. The two that open and close are a pair, and half of them applying is
- * a render pass left standing over whatever the game draws next. The third, which says where a draw
- * came from, fails more quietly and worse: every chest in the world would be lit as a mob, and
- * nothing on screen or in the log would say why. Refusing to start is the better half of both
- * bargains, and it is the only failure of the three that names itself.
+ * <strong>All three handlers are required, and say so rather than lean on the configuration's
+ * default.</strong> Writing the count out is what keeps it right when a handler moves or a target
+ * gains a call, since the default is one whatever the injector really binds. The two
+ * that open and close are a pair, and half of them applying is a render pass left standing over
+ * whatever the game draws next. The third, which says where a draw came from, fails more quietly
+ * and worse: every chest in the world would be lit as a mob, and nothing on screen or in the log
+ * would say why. Refusing to start is the better half of both bargains, and it is the only failure
+ * of the three that names itself.
  */
 @Mixin(RenderTypeFeatureRenderer.class)
 public abstract class RenderTypeFeatureRendererMixin {

--- a/common/src/main/java/dev/vitrail/mixin/SkyRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/SkyRendererMixin.java
@@ -52,6 +52,12 @@ import java.util.function.Supplier;
  * place under the End's skybox reaches two of these methods and a place under any other reaches the
  * remaining six, and the ones a place never calls cost it nothing.
  * <p>
+ * <strong>Each wrap states how many calls it has to bind, and the number is not decoration.</strong>
+ * Mixin counts an injector's matches as one total over every method it names, so a wrap listing
+ * eight methods and requiring one is satisfied by one of the eight and lets the other seven die
+ * without a word. The counts written below are what the game's bytecode holds, one call in each
+ * method named, so a method that loses its call refuses the launch instead of the picture.
+ * <p>
  * <strong>One of the pack's answers is not a shader at all.</strong> Two of these pieces, the sun
  * and the moon, can be refused outright in {@code shaders.properties}, and a refusal is cancelled at
  * the head of the method rather than served with a program of ours, because the pack has drawn that
@@ -152,6 +158,7 @@ public abstract class SkyRendererMixin {
 	@WrapOperation(
 			method = {"renderSkyDisc", "renderDarkDisc", "renderStars", "renderSunriseAndSunset", "renderSun",
 					"renderMoon", "renderEndFlash"},
+			require = 7,
 			at = @At(value = "INVOKE",
 					target = "Lnet/minecraft/client/renderer/DynamicUniforms;writeTransform("
 							+ "Lorg/joml/Matrix4f;"
@@ -191,6 +198,7 @@ public abstract class SkyRendererMixin {
 	@WrapOperation(
 			method = {"renderSkyDisc", "renderDarkDisc", "renderStars", "renderSunriseAndSunset", "renderSun",
 					"renderMoon", "renderEndSky", "renderEndFlash"},
+			require = 8,
 			at = @At(value = "INVOKE",
 					target = "Lcom/mojang/blaze3d/systems/CommandEncoder;createRenderPass("
 							+ "Ljava/util/function/Supplier;"
@@ -216,6 +224,7 @@ public abstract class SkyRendererMixin {
 	@WrapOperation(
 			method = {"renderSkyDisc", "renderDarkDisc", "renderStars", "renderSunriseAndSunset", "renderSun",
 					"renderMoon", "renderEndSky", "renderEndFlash"},
+			require = 8,
 			at = @At(value = "INVOKE",
 					target = "Lcom/mojang/blaze3d/systems/RenderPass;setPipeline("
 							+ "Lcom/mojang/blaze3d/pipeline/RenderPipeline;)V"))
@@ -236,6 +245,7 @@ public abstract class SkyRendererMixin {
 	 */
 	@WrapOperation(
 			method = {"renderSun", "renderMoon", "renderEndSky", "renderEndFlash"},
+			require = 4,
 			at = @At(value = "INVOKE",
 					target = "Lcom/mojang/blaze3d/systems/RenderPass;bindTexture("
 							+ "Ljava/lang/String;"
@@ -283,6 +293,7 @@ public abstract class SkyRendererMixin {
 	@WrapOperation(
 			method = {"renderSkyDisc", "renderDarkDisc", "renderStars", "renderSunriseAndSunset", "renderSun",
 					"renderMoon", "renderEndSky", "renderEndFlash"},
+			require = 8,
 			at = @At(value = "INVOKE",
 					target = "Lcom/mojang/blaze3d/systems/RenderPass;setVertexBuffer("
 							+ "ILcom/mojang/blaze3d/buffers/GpuBufferSlice;)V"))

--- a/common/src/main/java/dev/vitrail/mixin/WeatherEffectRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/WeatherEffectRendererMixin.java
@@ -48,13 +48,14 @@ import java.util.function.Supplier;
  * is the texture, so it is handed over as the game binds it and the block is bound again before each
  * of the two draws.
  * <p>
- * <strong>All five handlers are required</strong>, which the rest of this package is not: the
- * configuration sets {@code defaultRequire} to nought, so an injection that stops matching is
- * normally dropped in silence, and not one of these five can afford that. The pass and the pipeline
- * are a pair, and half of them applying binds a pipeline carrying eight colour states into a pass
- * carrying one, which throws by name in the middle of a rainstorm. The other three each turn into a
- * picture with nothing in the log: the curtain drawn twice, the curtain drawn with the wrong image,
- * or a pack's {@code rain.depth} quietly unread.
+ * <strong>All five handlers are required</strong>, and say so rather than lean on the
+ * configuration's default, which is one whatever the injector really binds: writing the count out
+ * is what keeps it right when a handler moves or a target gains a call.
+ * The pass and the pipeline are a pair, and half of them
+ * applying binds a pipeline carrying eight colour states into a pass carrying one, which throws by
+ * name in the middle of a rainstorm. The other three each turn into a picture with nothing in the
+ * log: the curtain drawn twice, the curtain drawn with the wrong image, or a pack's
+ * {@code rain.depth} quietly unread.
  */
 @Mixin(WeatherEffectRenderer.class)
 public abstract class WeatherEffectRendererMixin {

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -4,7 +4,7 @@
 	"package": "dev.vitrail.mixin",
 	"compatibilityLevel": "JAVA_21",
 	"injectors": {
-		"defaultRequire": 0
+		"defaultRequire": 1
 	},
 	"client": [
 		"ArenaAggregatorMixin",

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -373,8 +373,8 @@ inside the game's own matrices instead. Doing it that way then forces the held i
 by hand, since it is drawn with the same model-view and has to stay put. Keeping the change inside
 the published uniforms means that problem never arises. It also means the reference's fourth
 interception has no counterpart here, which is just as well: the method it wraps has a different
-shape in this version of the game, and a patch descriptor that no longer matches its target fails
-silently when injectors are not required.
+shape in this version of the game, and this engine's injectors are required, so a patch descriptor
+that no longer matched its target would refuse to load rather than quietly do nothing.
 
 One family is not placed by that matrix and therefore does not read it: the player's own hand, which
 is drawn under a projection the engine builds rather than under the level's. The game builds the


### PR DESCRIPTION
## What changes

A patch of this mod that stops fitting the game now refuses to start it instead of drawing a
wrong picture. The common mixin configuration set `defaultRequire` to nought, so an injection
whose anchor point had moved was dropped without a word: twenty-nine of the hundred and
twenty-one carried no explicit count and were free to vanish, which is what a game or a Sodium
update does by moving a descriptor. What reaches the screen then is an effect quietly missing or
a surface lit by the wrong program, with nothing in the log pointing at it. The default is now
one, and the failure names itself at launch.

One handler is exempt and says so: the line this mod adds to the F3 overlay, which nothing on
screen depends on.

A count is also written out wherever an injector names several methods. Mixin counts matches as
one total over all of them, so a wrap listing eight methods and requiring one is satisfied by a
single match and lets the other seven die. The counts written are what the game's bytecode
holds, one call in each method named.

## How it differs from the reference, and for what obstacle

It does not. Iris requires its injections too. This was a configuration of ours that no obstacle
justified.

## What proves it

- `gradlew build` green, after the rebase.
- The mixin service applies the whole configuration at launch on both loaders, so a count that
  did not match what the bytecode holds would refuse the game rather than pass quietly. That is
  the same check the change installs.
- Not tried in the game.

## What it leaves owing

Nothing this branch introduces, and one half of the trap it names stays open by construction. A
patch method deleted outright takes its injector with it, and nothing counts an injector that is
not there, whatever the configuration says. The note in `build.gradle` that lets the static
analyser step back over the mixin package used to state that trap as the requirement's job; it
now says which half the requirement catches and which half nothing does.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
