### PR TITLE
fix(sodium): name the road that left the chunk mesh alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ what the next one holds.
   at all, which is how one of those forms switches a pass off, now dispatches nothing rather
   than one tile, and a program whose size cannot be read at all is left out with a line in
   the log naming it, rather than guessed at.
+- **The log says why a pack is drawing the world with the game's own terrain shader.**
+  When nothing of the pack reaches the chunk mesh, three quite different things can have
+  happened: the pack was read and asks for none of the extra vertex data, or its load never
+  got as far as its chunk programs, or the mesh was built before the pack had been read. All
+  three used to share one line that named none of them, and the third only showed itself a
+  world later, as an error about two lists of attributes that said nothing about the order
+  that made them differ. Each now says which one it was, where it happened.
 
 ## 0.8.1-beta
 

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -207,6 +207,18 @@ public final class TerrainDraw {
 	 * format would be settled from the pack before it and every section would be meshed at a stride
 	 * these programs do not declare.
 	 * <p>
+	 * <strong>This is one half of a contract, and {@code TerrainMesh.settle} is the other.</strong>
+	 * That method reads what this publishes and decides the layout out of it, at the head of Sodium's
+	 * {@code initRenderer}; it cannot check that this has run, and nothing between the two makes them
+	 * agree by construction. What keeps them in order is where each is reached from and not a test:
+	 * this runs from {@code PackChain.load}, at client setup before any level exists and afterwards
+	 * on the render thread, and Sodium reaches {@code initRenderer} only with a level and only on
+	 * that same thread. Reversed with a pack in force, the mesh answers with Sodium's own twenty
+	 * bytes for a pack that declares more, and what the player is left with is a pack put away a
+	 * world later, over the two lists {@code TerrainProgram.carries} prints rather than over the
+	 * order that parted them. A dimension change does reverse them, harmlessly and for one frame,
+	 * and {@code TerrainMesh.settle} is where that road is written out.
+	 * <p>
 	 * Nothing here touches the device, so it runs wherever the load runs, off the render thread while
 	 * the client starts up. What it costs a place that never draws a chunk is those six translations;
 	 * what the laziness bought was exactly that, and it cannot be had at the same time as a format

--- a/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
+++ b/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
@@ -76,7 +76,14 @@ public final class TerrainMesh implements ChunkVertexType {
 	private static boolean broken;
 
 	/**
-	 * What the log last announced, and null until the first settle of a run.
+	 * What the pack had published the last time the log announced anything, and null until the first
+	 * settle of a run.
+	 * <p>
+	 * What the pack published and not what {@link #settle()} decided out of it, because the two part
+	 * on the road where a pack's programs declare Sodium's own elements and none of ours. The
+	 * decision is empty there, and it is empty again where no pack wants the terrain at all, so a key
+	 * taken from the decision would let one of those two roads follow the other without a word. They
+	 * are different lines and one of them is the answer to a question a log has to be able to answer.
 	 * <p>
 	 * Null and not the empty list, because the two would otherwise share their value: without the
 	 * difference, the first settle of a game nobody picked a pack in would find nothing changed and
@@ -210,11 +217,41 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * the pack's chunk programs far enough to know, and has already asked for the world to be rebuilt
 	 * if the answer moved. Nothing is decided here beyond turning that list into a layout.
 	 * <p>
+	 * <strong>"Already" is an ORDER, and it is a contract with {@code TerrainDraw.read} that nothing
+	 * in this class can enforce.</strong> That method is what fills the answer in, and it runs where
+	 * the pack is loaded; this runs where Sodium builds its chunk renderer. Read first, the mesh
+	 * follows the pack. Settled first, {@code TerrainDraw.carried} answers empty, the mesh stays at
+	 * Sodium's own twenty bytes, and the pack is not put away here but a world later: the first chunk
+	 * pass compares the format it was handed against what the programs declare, in
+	 * {@code TerrainProgram.carries}, and puts the whole pack away with an error naming two lists and
+	 * not the order that made them differ. That is why the empty branch below names the order among
+	 * its causes rather than leaving the log to be read backwards from the error.
+	 * <p>
+	 * What holds the order is two facts and neither is a check. The first load runs at client setup,
+	 * before any level exists, and Sodium reaches {@code initRenderer} only with a level. A reload
+	 * asked for by the settings screen or by the key runs on the render thread and asks for the
+	 * rebuild through {@code allChanged} rather than performing it, so the reading has returned
+	 * before the rebuild begins.
+	 * <p>
+	 * <strong>A dimension change runs the two the other way round, and what saves it is the second
+	 * rebuild.</strong> {@code Minecraft.setLevel} reaches {@code LevelExtractor.setLevel}, which
+	 * calls {@code allChanged} itself, so the next {@code extract} invalidates the compiled geometry
+	 * and this settles before that frame's level is drawn; the pack of the new dimension is not read
+	 * until {@code PackChain.draw} reaches {@code reloadIfTheWorldMoved}, at the end of that same
+	 * frame. Nothing is bound wrongly in between, and the reason is that the reversal is complete:
+	 * the pack in force is still the previous dimension's, and its programs declare exactly the list
+	 * this settled from. When the new reading moves the list, {@code carries} asks for a rebuild of
+	 * its own and this runs again on the frame after, which is the hitch at the portal.
+	 * <p>
 	 * Built here rather than in a static field so that a mesh this cannot extend leaves the game
 	 * running on Sodium's own instead of failing to load a class in the middle of a world.
 	 */
 	public static synchronized void settle() {
-		List<String> carried = broken ? List.of() : TerrainDraw.carried();
+		// What the pack published, kept apart from what is decided out of it: a list that arrives
+		// empty is a pack with nothing to say, and one emptied below is a pack that asked for none of
+		// ours. The two decide the same layout and are not the same event, and the log parts them.
+		List<String> asked = broken ? List.of() : TerrainDraw.carried();
+		List<String> carried = asked;
 		// Sodium's own four and nothing of ours is the same layout Sodium already binds, so it is
 		// answered with Sodium's own rather than with a copy of it. No pack of the corpus is here,
 		// every one of them reading at least the block id, but a pack that read none of the five
@@ -238,19 +275,62 @@ public final class TerrainMesh implements ChunkVertexType {
 			built = null;
 		}
 
-		if (carried.equals(said)) {
+		if (asked.equals(said)) {
 			return;
 		}
 
-		said = carried;
+		said = asked;
 		if (carried.isEmpty()) {
+			if (broken) {
+				// Nothing, and before the roads below rather than among them. The error above has
+				// named the one cause this road has, and every line below it would be a guess at a
+				// question already answered: the pack is still wanted and still published its
+				// elements, so both of them would read as true and neither would be.
+				return;
+			}
+
+			List<String> ours = Arrays.stream(Extra.values()).map(Extra::attribute).toList();
+			if (!asked.isEmpty()) {
+				// The pack was read and wants none of the five, so Sodium's own layout is what its
+				// programs were translated against and there is nothing to append. A normal event
+				// and not a failure, which is why it is said at this level; it is said at all
+				// because it decides the stride of every vertex in the world and would otherwise be
+				// indistinguishable in the log from the pack below that decides the same stride.
+				Vitrail.logger().info("This pack's chunk programs read none of {}, so nothing is "
+						+ "appended and they draw from the format Sodium gave the mesh", ours);
+
+				return;
+			}
+
+			if (TerrainDraw.asked()) {
+				// THREE roads share this one and nothing here can part them, so all three are named
+				// rather than the likeliest one guessed at. The commonest by far is a load that
+				// never reached the pack's chunk programs at all: PackChain raises this flag off the
+				// options and only opens the pack afterwards, so a required flag it does not serve,
+				// a chain with no final, a refusal and an archive that will not open all leave the
+				// flag standing with nothing behind it. Then a pack that was read and serves no
+				// chunk program, where the world keeps the game's own shader and the pack's sky and
+				// chain go on being drawn. Then this having run before TerrainDraw.read published
+				// anything, which is the order this method depends on and cannot check.
+				//
+				// Said at this level and not louder because the first road is the one that arrives,
+				// and every way into it has already said what went wrong in its own words. What this
+				// adds is the consequence for the mesh, which none of them mentions.
+				Vitrail.logger().info("The pack's own terrain program is wanted and nothing has been "
+						+ "published for it, so the mesh keeps the format Sodium gave it and carries "
+						+ "none of {}. Either this pack's load never reached its chunk programs, or "
+						+ "it serves none of its own, or they had not been read when the chunk "
+						+ "renderer was built", ours);
+
+				return;
+			}
+
 			// Said out loud, this being the branch that would otherwise be silent. Without naming a
 			// cause, because there are three and this cannot tell them apart: a terrain= line, no
 			// pack chosen yet, which is every first launch of a fresh instance, and a terrain
 			// program that threw.
 			Vitrail.logger().info("The pack's own terrain program is not wanted, so the mesh keeps the "
-					+ "format Sodium gave it and carries none of {}",
-					Arrays.stream(Extra.values()).map(Extra::attribute).toList());
+					+ "format Sodium gave it and carries none of {}", ours);
 
 			return;
 		}


### PR DESCRIPTION
## What changes

The chunk mesh keeps Sodium's own twenty bytes a vertex whenever the pack has published nothing
for it, and three roads reached that branch with a single line between them. One of those roads
is an order: the mesh layout is settled from what the pack's terrain read published, and settled
first it answers empty, so the mesh stays at Sodium's format and the pack is not put away there
but a world later, by the first chunk pass, over an error naming two lists of attributes and not
the order that made them differ. That is a log read backwards. The three roads now say which one
was taken, at the point they part.

A pack that was read and asks for none of the five appended elements is also said out loud. It
decides the stride of every vertex in the world, and it was indistinguishable in the log from
the pack that decides the same stride for the opposite reason.

## How it differs from the reference, and for what obstacle

It does not. This is our own chunk mesh extension, and Iris settles its vertex format from the
same kind of reading; nothing here changes what is decided, only what is said about it.

## What proves it

- `gradlew build` green, after the rebase.
- Nothing in the decision changed, so no pack of the corpus draws differently. What changed is
  which of three branches writes a line and what that line says.
- Not tried in the game. The branch that gains the most is the one reached by an order this
  machine has never produced.

## What it leaves owing

The order itself is still held by where each side is reached from and not by a check, and both
sides now write that down: the first load runs at client setup before any level exists and
Sodium builds its chunk renderer only with a level, while a reload asks for the rebuild rather
than performing it. A dimension change does run the two the other way round, for one frame, and
what saves it is the second rebuild. Nothing here makes them agree by construction.

A reporter seeing a pack put away for want of a widened mesh can now be told which of the three
roads their log took, which is what this was written for.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
