### PR TITLE
perf(render): spare two pieces of per-frame card work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ what the next one holds.
   surface lit by the wrong program, with nothing in the log pointing at it. The failure now names
   itself at launch. The one exception is the line this mod adds to the F3 overlay, which is
   allowed to go missing because nothing on screen depends on it.
+- **Two pieces of per-frame work on the graphics card are gone, and the picture is the same.**
+  The far terrain's own depth image is emptied by the pass that draws into it rather than by a
+  command of its own, which also spares the full stop of the card that such a command carries.
+  The voxel volumes that follow the camera now copy only the part of themselves that survives
+  the move, where they used to copy the whole volume. Neither has been measured, so this says
+  work removed and not frames gained.
 
 ### Fixed
 

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -54,6 +54,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.Set;
 
 /**
@@ -811,10 +812,36 @@ public final class DistantDraw {
 		// keyed on the opaque half: a half that refused, or a pack that serves only the other one,
 		// would otherwise leave the image holding the frame before it, and the takes would hand the
 		// pack last frame's far terrain in a world that has moved on.
+		//
+		// Nought is DH's own clear and the far plane of a reversed Z, so an untouched pixel reads as
+		// nothing drawn, which converts to the far plane the pack tests for.
+		//
+		// Paid as the load-op of the pass that is about to attach the image, and not as a command of
+		// its own: an encoder clear is a vkCmdClearDepthStencilImage plus the full pipeline drain the
+		// backend appends to every clear it performs, where a load-op costs the pass nothing it was
+		// not already paying. That drain is not what ordered the emptying against the draws before it,
+		// though: every pass already ends on the same ALL_COMMANDS barrier the clear posted
+		// (VulkanCommandEncoder.submitRenderPass), so what the drain added was a second one. Nothing
+		// reads the image in between either: it leaves this class through served()
+		// alone, which answers null until drew is set, and drew is set below this pass. A half that
+		// gives up between here and the pass therefore leaves the image as the last frame left it,
+		// which the same guard keeps out of the pack's hands.
+		OptionalDouble clear = OptionalDouble.empty();
 		if (!this.drew) {
-			// Nought is DH's own clear and the far plane of a reversed Z, so an untouched pixel reads
-			// as nothing drawn, which converts to the far plane the pack tests for.
-			encoder.clearDepthTexture(this.depth, 0.0);
+			if (into == this.depthView && coversDepth(descriptor)) {
+				clear = OptionalDouble.of(0.0);
+
+				// The hold is ended first because a joined pass applies no load-op, which
+				// GeometryHold.open says out loud, and the emptying would go silently missing. This
+				// costs nothing that was not already spent: the encoder clear standing here ended
+				// the hold too, through the door CommandEncoderMixin holds open for every clear.
+				GeometryHold.flush(() -> "the far terrain's depth being emptied");
+				if (descriptor != null) {
+					descriptor.withDepthAttachment(into, clear);
+				}
+			} else {
+				encoder.clearDepthTexture(this.depth, 0.0);
+			}
 		}
 
 		// The camera is the game's own and not DH's copy of it, although DH hands one in: everything
@@ -830,8 +857,7 @@ public final class DistantDraw {
 
 		try (RenderPass pass = descriptor == null
 				? encoder.createRenderPass(() -> "Vitrail " + element.element(),
-						main.getColorTextureView(), Optional.empty(), into,
-						java.util.OptionalDouble.empty())
+						main.getColorTextureView(), Optional.empty(), into, clear)
 				: GeometryHold.open(encoder, descriptor)) {
 			pass.setPipeline(pipeline);
 			program.bind(pass);
@@ -871,6 +897,31 @@ public final class DistantDraw {
 	}
 
 	/**
+	 * Whether a pass built from this descriptor covers the depth image whole, which is what decides
+	 * that the frame's emptying may be paid as that pass's load-op.
+	 * <p>
+	 * A load-op empties the render area and not one texel outside it, where {@code clearDepthTexture}
+	 * empties the image. The two agree while the area is the screen and the image is the screen's
+	 * size, which holds because {@link ColorTargets#ensure} and {@link #ensureDepth} both read it off
+	 * {@code mainRenderTarget()} rather than off each other, the two being reached frames apart on
+	 * some roads; a frame where they disagree keeps the standalone clear rather than
+	 * leaving a margin of the last frame's far terrain for the window takes to sample.
+	 *
+	 * @param descriptor the pack's own descriptor, or null where the pass is built here instead from
+	 *                   the game's colour view, which is the image's own size by construction
+	 */
+	private boolean coversDepth(RenderPassDescriptor descriptor) {
+		if (descriptor == null) {
+			return true;
+		}
+
+		RenderPass.RenderArea area = descriptor.renderArea;
+
+		return area != null && area.x() == 0 && area.y() == 0
+				&& area.width() >= this.depthWidth && area.height() >= this.depthHeight;
+	}
+
+	/**
 	 * Makes the far terrain's own depth image, or remakes it after a resize.
 	 *
 	 * @return whether there is one to draw into
@@ -888,10 +939,11 @@ public final class DistantDraw {
 		}
 
 		// Three usages and every one of them is asked for by name somewhere: drawn into as an
-		// attachment, sampled by the window takes, and emptied at the head of the frame. The clear is
-		// the one that is not obvious: an encoder refuses to clear a depth image that was not also
-		// made a copy destination (CommandEncoder.verifyDepthTexture), a clear being a write it
-		// performs itself rather than a load the pass does.
+		// attachment, sampled by the window takes, and emptied by the encoder here at birth and on
+		// the frames the pass's own load-op cannot pay for. That last one is not obvious: an encoder
+		// refuses to clear a depth image that was not also made a copy destination
+		// (CommandEncoder.verifyDepthTexture), a clear being a write it performs itself rather than a
+		// load the pass does.
 		this.depth = device.createTexture(() -> "Vitrail far terrain depth",
 				GpuTexture.USAGE_RENDER_ATTACHMENT | GpuTexture.USAGE_TEXTURE_BINDING
 						| GpuTexture.USAGE_COPY_DST,

--- a/common/src/main/java/dev/vitrail/render/StorageImages.java
+++ b/common/src/main/java/dev/vitrail/render/StorageImages.java
@@ -344,27 +344,43 @@ public final class StorageImages implements AutoCloseable {
 	 * The move itself, in two copies through the image's own scratch because Vulkan leaves a copy
 	 * whose source and destination regions overlap undefined, and a shift of one plane overlaps
 	 * everywhere.
+	 * <p>
+	 * Both copies carry the SAME region, the one the second reads, and the scratch keeps whatever an
+	 * earlier move left outside it: no reader of any kind ever names the scratch, so a texel there
+	 * that the second copy will not read is a texel the first one has no reason to write. That is
+	 * {@code |d|} planes an axis, a plane at a walking pace and a large part of the volume at speed.
 	 */
 	private static void move(VkCommandBuffer commands, MemoryStack stack, Allocated image,
 			int dx, int dy, int dz) {
-		VkImageCopy.Buffer whole = VkImageCopy.calloc(1, stack);
-		layers(whole.get(0));
-		whole.get(0).extent().set(image.width, image.height, image.depth);
+		// The reader wants index p to hold what index p + d holds, d being the blocks the camera has
+		// crossed since the write: so the source starts d planes in where the camera moved forward,
+		// and the destination does where it moved back. Written once and used by both copies, which
+		// is what makes the pair agree by construction rather than by two readings of the same
+		// arithmetic.
+		int fromX = Math.max(dx, 0);
+		int fromY = Math.max(dy, 0);
+		int fromZ = Math.max(dz, 0);
+		int spanX = image.width - Math.abs(dx);
+		int spanY = image.height - Math.abs(dy);
+		int spanZ = image.depth - Math.abs(dz);
+
+		VkImageCopy.Buffer kept = VkImageCopy.calloc(1, stack);
+		VkImageCopy carried = kept.get(0);
+		layers(carried);
+		carried.srcOffset().set(fromX, fromY, fromZ);
+		carried.dstOffset().set(fromX, fromY, fromZ);
+		carried.extent().set(spanX, spanY, spanZ);
 		VK12.vkCmdCopyImage(commands, image.image, VK12.VK_IMAGE_LAYOUT_GENERAL,
-				image.scratch, VK12.VK_IMAGE_LAYOUT_GENERAL, whole);
+				image.scratch, VK12.VK_IMAGE_LAYOUT_GENERAL, kept);
 
 		GpuRecording.betweenTransfers(commands, stack);
 
-		// The reader wants index p to hold what index p + d holds, d being the blocks the camera
-		// has crossed since the write: so the source starts d planes in where the camera moved
-		// forward, and the destination does where it moved back.
 		VkImageCopy.Buffer shifted = VkImageCopy.calloc(1, stack);
 		VkImageCopy region = shifted.get(0);
 		layers(region);
-		region.srcOffset().set(Math.max(dx, 0), Math.max(dy, 0), Math.max(dz, 0));
+		region.srcOffset().set(fromX, fromY, fromZ);
 		region.dstOffset().set(Math.max(-dx, 0), Math.max(-dy, 0), Math.max(-dz, 0));
-		region.extent().set(image.width - Math.abs(dx), image.height - Math.abs(dy),
-				image.depth - Math.abs(dz));
+		region.extent().set(spanX, spanY, spanZ);
 		VK12.vkCmdCopyImage(commands, image.scratch, VK12.VK_IMAGE_LAYOUT_GENERAL,
 				image.image, VK12.VK_IMAGE_LAYOUT_GENERAL, shifted);
 	}


### PR DESCRIPTION
## What changes

Two pieces of per-frame work on the graphics card go away, and the picture is the same on both
sides of them.

The far terrain's own depth image is emptied by the load-op of the pass that is about to attach
it, instead of by a clear command of its own. An encoder clear is a `vkCmdClearDepthStencilImage`
plus the full pipeline drain the backend appends to every clear it performs, where a load-op
costs the pass nothing it was not already paying. Dropping that drain leaves nothing unordered:
every render pass already ends on the same `ALL_COMMANDS` barrier the clear posted
(`VulkanCommandEncoder.submitRenderPass`), so what the drain added was a second one. The
standalone clear is kept for the frames where the pass does not cover the image whole, a load-op
emptying the render area and not one texel outside it.

The voxel volumes that follow the camera no longer copy the whole volume into their scratch when
only the region the second copy reads is ever read back. Nothing else in the engine names that
scratch.

## How it differs from the reference, and for what obstacle

It does not. Neither piece exists in Iris: it runs against an OpenGL volume with no load-op to
pay a clear with, and its voxel volumes are not moved this way.

## What proves it

- `gradlew build` green, after the rebase.
- Read against the decompiled backend: `submitRenderPass` ends on the same barrier
  `clearDepthTexture` posts, `withDepthAttachment` overwrites its field rather than accumulating,
  and `record()` is never reached with a shadow element, so the descriptor always carries the
  screen area and never the shadow map's square.
- Not tried in the game. Both changes need Distant Horizons to be reached at all.

## What it leaves owing

The gain is not measured. Both are removals of work on a path the per-pass profile does not
break out, so nothing here puts a number on what they save.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
