### PR TITLE
perf(uniform): rebuild a value only when its inputs move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ what the next one holds.
   the move, where they used to copy the whole volume. Neither has been measured, so this says
   work removed and not frames gained.
 
+- **A handful of values handed to shaders are worked out once a frame instead of once for
+  every program that asks for them.** Where the sun and the moon are, which way is up, the
+  End's flash, and the two matrices a pack multiplies its vertices by were all rebuilt from
+  scratch each time a shader asked, which for a large pack is dozens of times a frame out of
+  numbers that had not moved in between. They are kept and reused until something they are
+  built from actually changes. The values handed over are the same ones, to the bit, and this
+  has not been measured either, so again it is work removed rather than frames gained.
+
 ### Fixed
 
 - **A pack written with the old shadow lookups could be translated wrong, without a word.**

--- a/common/src/main/java/dev/vitrail/uniform/values/CelestialValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/CelestialValues.java
@@ -44,6 +44,27 @@ public final class CelestialValues {
 	private static final Matrix4f SCRATCH = new Matrix4f();
 	private static final Vector4f POSITION = new Vector4f();
 
+	/**
+	 * The four eye space answers as they were last built, each beside the inputs it was built from.
+	 * <p>
+	 * A name is asked for once per program that declares it and a pack has many programs, so the
+	 * rotations below were built again and again inside one frame out of numbers that had not moved
+	 * between two of the asks. {@link Settled} carries what the key is and why it is the inputs
+	 * rather than the frame. What belongs here is that these four do not move together, so they do
+	 * not share one: {@code upPosition} turns on the camera alone and settles again the instant the
+	 * head stops turning, the sun and the moon each carry an angle of their own, and the flash
+	 * carries two angles nothing else reads.
+	 */
+	private static final Settled SUN = new Settled();
+	private static final Settled MOON = new Settled();
+	private static final Settled UP = new Settled();
+	private static final Settled FLASH = new Settled();
+
+	private static final Vector3f SUN_POSITION = new Vector3f();
+	private static final Vector3f MOON_POSITION = new Vector3f();
+	private static final Vector3f UP_POSITION = new Vector3f();
+	private static final Vector3f FLASH_POSITION = new Vector3f();
+
 	private CelestialValues() {
 	}
 
@@ -55,14 +76,7 @@ public final class CelestialValues {
 
 		builder.add("sunPosition", UniformShape.VEC3, (world, out) -> celestial(world, true, out));
 		builder.add("moonPosition", UniformShape.VEC3, (world, out) -> celestial(world, false, out));
-		builder.add("upPosition", UniformShape.VEC3, (world, out) -> {
-			// The same fixed quarter turn as the sky, and deliberately not the sky angle: this one
-			// is where up is, not where the sun is.
-			SCRATCH.set(world.gbufferModelView()).rotateY((float) Math.toRadians(-90.0F));
-			POSITION.set(0.0F, 100.0F, 0.0F, 0.0F);
-			SCRATCH.transform(POSITION);
-			out.set(POSITION.x, POSITION.y, POSITION.z);
-		});
+		builder.add("upPosition", UniformShape.VEC3, CelestialValues::up);
 
 		// The pack has to have opted in for this one, and not for the position below it. Where the
 		// light comes from is something a pack is written around; where the flash is is a fact.
@@ -152,29 +166,60 @@ public final class CelestialValues {
 	}
 
 	/**
+	 * The same fixed quarter turn as the sky, and deliberately not the sky angle: this one is where
+	 * up is, not where the sun is. The camera is the whole of what it turns on.
+	 */
+	private static void up(WorldState world, Val out) {
+		if (!UP.holds(world.gbufferModelView())) {
+			SCRATCH.set(world.gbufferModelView()).rotateY((float) Math.toRadians(-90.0F));
+			POSITION.set(0.0F, 100.0F, 0.0F, 0.0F);
+			SCRATCH.transform(POSITION);
+			UP_POSITION.set(POSITION.x, POSITION.y, POSITION.z);
+		}
+
+		out.set(UP_POSITION);
+	}
+
+	/**
 	 * The transformation the sky renderer applies, moved forward so that a pack can read the result
 	 * before vanilla performs it. The angle is the <b>raw</b> attribute, not the wrapped one the
 	 * {@code sunAngle} uniform carries.
+	 * <p>
+	 * Built again only when the camera or one of the two angles has moved, which is the whole of
+	 * what it is a function of.
 	 */
 	private static void celestial(WorldState world, boolean sun, Val out) {
-		SCRATCH.set(world.gbufferModelView())
-				.rotateY((float) Math.toRadians(-90.0F))
-				.rotateZ((float) Math.toRadians(world.sunPathRotation()))
-				.rotateX((float) Math.toRadians(
-						sun ? world.sunAngleDegrees() : world.moonAngleDegrees()));
+		Settled settled = sun ? SUN : MOON;
+		Vector3f held = sun ? SUN_POSITION : MOON_POSITION;
+		float angle = sun ? world.sunAngleDegrees() : world.moonAngleDegrees();
 
-		POSITION.set(0.0F, 100.0F, 0.0F, 1.0F);
-		SCRATCH.transform(POSITION);
-		out.set(POSITION.x, POSITION.y, POSITION.z);
+		if (!settled.holds(world.gbufferModelView(), world.sunPathRotation(), angle)) {
+			SCRATCH.set(world.gbufferModelView())
+					.rotateY((float) Math.toRadians(-90.0F))
+					.rotateZ((float) Math.toRadians(world.sunPathRotation()))
+					.rotateX((float) Math.toRadians(angle));
+
+			POSITION.set(0.0F, 100.0F, 0.0F, 1.0F);
+			SCRATCH.transform(POSITION);
+			held.set(POSITION.x, POSITION.y, POSITION.z);
+		}
+
+		out.set(held);
 	}
 
+	/** The camera and the two flash angles, on the same terms as {@link #celestial}. */
 	private static void endFlash(WorldState world, Val out) {
-		SCRATCH.set(world.gbufferModelView())
-				.rotateY((float) Math.toRadians(180.0F - world.endFlashYAngleDegrees()))
-				.rotateX((float) Math.toRadians(-90.0F - world.endFlashXAngleDegrees()));
+		if (!FLASH.holds(world.gbufferModelView(),
+				world.endFlashXAngleDegrees(), world.endFlashYAngleDegrees())) {
+			SCRATCH.set(world.gbufferModelView())
+					.rotateY((float) Math.toRadians(180.0F - world.endFlashYAngleDegrees()))
+					.rotateX((float) Math.toRadians(-90.0F - world.endFlashXAngleDegrees()));
 
-		POSITION.set(0.0F, 100.0F, 0.0F, 0.0F);
-		SCRATCH.transform(POSITION);
-		out.set(POSITION.x, POSITION.y, POSITION.z);
+			POSITION.set(0.0F, 100.0F, 0.0F, 0.0F);
+			SCRATCH.transform(POSITION);
+			FLASH_POSITION.set(POSITION.x, POSITION.y, POSITION.z);
+		}
+
+		out.set(FLASH_POSITION);
 	}
 }

--- a/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
@@ -112,8 +112,25 @@ public final class GeometryValues {
 
 	/** The six units that are not the light map's, which the fixed function pipeline left alone. */
 	private static final Matrix4f IDENTITY = new Matrix4f();
+
+	/**
+	 * The two matrices this class composes, as they were last built, each beside the matrices it was
+	 * built from. A name is asked for once per program that declares it and a pack has many
+	 * programs, so the product and the inverse were formed again and again inside one frame out of
+	 * matrices that had not moved between two of the asks.
+	 * <p>
+	 * <strong>What settles them is the PASS's pair and never the frame, which is why
+	 * {@link Settled} asks about inputs and not about a frame number.</strong> The sky, the hand and
+	 * the entities each set a matrix of their own, so both of these really do change several times
+	 * inside one frame. Settled for the frame instead, they would answer the sky and the hand with
+	 * whichever pass reached them first: a sky vertex would be placed by the camera's product rather
+	 * than by the one the game drew it with, and a pack's {@code ftransform()} would stop being the
+	 * matrix its own {@code gl_ProjectionMatrix * gl_ModelViewMatrix} is.
+	 */
 	private static final Matrix4f MODEL_VIEW_PROJECTION = new Matrix4f();
+	private static final Settled MODEL_VIEW_PROJECTION_INPUTS = new Settled();
 	private static final Matrix3f NORMAL = new Matrix3f();
+	private static final Settled NORMAL_INPUTS = new Settled();
 
 	private GeometryValues() {
 	}
@@ -185,15 +202,25 @@ public final class GeometryValues {
 		// only reader. Left to right, so that the pack's own gl_ProjectionMatrix * gl_ModelViewMatrix
 		// and its ftransform() are the same matrix, which is why this reads the pass's projection and
 		// not the frame's: the two factors have to be the two the pack would have multiplied.
-		builder.add("of_ModelViewProjectionMatrix", UniformShape.MAT4, (world, out) ->
-				out.set(MODEL_VIEW_PROJECTION.set(world.passProjection()).mul(world.passModelView())));
+		builder.add("of_ModelViewProjectionMatrix", UniformShape.MAT4, (world, out) -> {
+			if (!MODEL_VIEW_PROJECTION_INPUTS.holds(world.passProjection(), world.passModelView())) {
+				MODEL_VIEW_PROJECTION.set(world.passProjection()).mul(world.passModelView());
+			}
+
+			out.set(MODEL_VIEW_PROJECTION);
+		});
 
 		// The inverse transpose of the model view's rotation. The level's model view is a pure
 		// rotation, so this is its transpose, but it is computed rather than assumed: a shadow pass
 		// or a pack directive could put a scale in it, and normalising a normal afterwards hides
 		// the difference exactly until it does not.
-		builder.add("of_NormalMatrix", UniformShape.MAT3, (world, out) ->
-				out.set(NORMAL.set(world.passModelView()).invert().transpose()));
+		builder.add("of_NormalMatrix", UniformShape.MAT3, (world, out) -> {
+			if (!NORMAL_INPUTS.holds(world.passModelView())) {
+				NORMAL.set(world.passModelView()).invert().transpose();
+			}
+
+			out.set(NORMAL);
+		});
 
 		// Six identities and the light map's twice, where the engine table answers eight identities.
 		// That is the whole of the difference between a pass drawn over the world and one drawn over a

--- a/common/src/main/java/dev/vitrail/uniform/values/Settled.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/Settled.java
@@ -1,0 +1,113 @@
+package dev.vitrail.uniform.values;
+
+import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
+
+/**
+ * Whether the answer a value handed out last time is still the answer, decided on what that answer
+ * was built from rather than on a clock.
+ * <p>
+ * The catalogue is asked once per PROGRAM that declares a name, and a pack has many programs, so a
+ * name like {@code sunPosition} is asked for many times over inside one frame and every ask
+ * rebuilds the same rotations out of the same numbers. Iris pays that same bill: its celestial
+ * names are PER_FRAME uniforms ({@code uniforms/CelestialUniforms.java:80-91}) held on a
+ * {@code ProgramUniforms} that belongs to one program and steps its own frame counter
+ * ({@code gl/program/ProgramUniforms.java:231-234}), so there too the work is done once per program
+ * and not once per frame. Nothing here is a divergence in either direction: what a pack reads is
+ * the value that would have been rebuilt, and only the rebuilding goes.
+ * <p>
+ * <strong>Keyed on the inputs, and deliberately not on the frame number that
+ * {@link FrameSmoothed} is keyed on.</strong> That class holds an accumulator which has to step
+ * once per frame however many passes read it, so the frame IS its question. There is no
+ * accumulator here: the answer is a pure function of a few matrices and angles, so asking whether
+ * those moved is both the cheaper question and the one that cannot go stale. It needs no case for
+ * a pack reload, a dimension change or a world leave, because none of those reaches a value except
+ * through an input that moved. And it is right about the one boundary a frame key would have been
+ * wrong about: the model view and the projection a PASS reads are that pass's own and change
+ * several times inside a frame, the sky and the hand each setting theirs
+ * ({@link dev.vitrail.uniform.ViewSource#passModelView()}).
+ * <p>
+ * This does remember between calls, which {@link dev.vitrail.uniform.UniformSource} tells a source
+ * not to, and it keeps the rule that prohibition exists for: nothing here advances with time, so
+ * two passes of one frame are handed the same number for the same reason they always were. It is
+ * held statically like the scratch of the classes that use it, on the same single caller they
+ * already assume.
+ * <p>
+ * One of these belongs to one call site. Each site uses the single overload whose shape is its own,
+ * and the fields the other shapes use are never touched.
+ */
+final class Settled {
+
+	private final Matrix4f first = new Matrix4f();
+	private final Matrix4f second = new Matrix4f();
+
+	private float a;
+	private float b;
+
+	/**
+	 * False until a call has recorded a key. Not redundant: a matrix nothing has written yet is the
+	 * identity, and the identity is a matrix a pass really does hand in.
+	 */
+	private boolean valid;
+
+	/**
+	 * @return whether the answer built last time still stands. A false also RECORDS what was handed
+	 *         in, so a caller that gets one rebuilds and the call after it compares against these
+	 */
+	boolean holds(Matrix4fc matrix) {
+		if (this.valid && same(this.first, matrix)) {
+			return true;
+		}
+
+		this.first.set(matrix);
+		this.valid = true;
+
+		return false;
+	}
+
+	/**
+	 * The same, for an answer that also turns on two numbers.
+	 *
+	 * @see #holds(Matrix4fc)
+	 */
+	boolean holds(Matrix4fc matrix, float a, float b) {
+		if (this.valid && this.a == a && this.b == b && same(this.first, matrix)) {
+			return true;
+		}
+
+		this.first.set(matrix);
+		this.a = a;
+		this.b = b;
+		this.valid = true;
+
+		return false;
+	}
+
+	/**
+	 * The same, for an answer built out of two matrices.
+	 *
+	 * @see #holds(Matrix4fc)
+	 */
+	boolean holds(Matrix4fc first, Matrix4fc second) {
+		if (this.valid && same(this.first, first) && same(this.second, second)) {
+			return true;
+		}
+
+		this.first.set(first);
+		this.second.set(second);
+		this.valid = true;
+
+		return false;
+	}
+
+	/**
+	 * Exact, and it has to be. JOML's delta comparison tests the bits of each element first and
+	 * falls through to {@code |a - b| <= delta}, so a delta of nought admits nothing a plain
+	 * {@code ==} would not, and a NaN matches the NaN it was built from rather than forcing a
+	 * rebuild for ever. Any tolerance at all would hand a pack the answer to a slightly different
+	 * question, which is a changed image however small the tolerance is.
+	 */
+	private static boolean same(Matrix4f held, Matrix4fc matrix) {
+		return held.equals(matrix, 0.0F);
+	}
+}


### PR DESCRIPTION
## What changes

Six composed uniform values stop being rebuilt for every program that asks for them. The
catalogue is asked for a name once per program that declares it, and a pack has many programs, so
`sunPosition`, `moonPosition`, `upPosition`, the End flash, `of_ModelViewProjectionMatrix` and
`of_NormalMatrix` formed the same rotations and the same matrix product dozens of times inside
one frame out of numbers that had not moved between two of the asks. Each now holds its last
answer beside the inputs it was built from, and rebuilds only when one of them differs. What a
pack reads is the same value, to the bit: the comparison is exact, a delta of nought, because any
tolerance would hand a pack the answer to a slightly different question.

The key is the inputs and deliberately not a frame number, which would be wrong at the one
boundary that matters: the model view and the projection a pass reads are that pass's own, and
the sky, the hand and the entities each set theirs. A frame key would hand a sky vertex the
camera's product and stop a pack's `ftransform()` being its own
`gl_ProjectionMatrix * gl_ModelViewMatrix`.

## How it differs from the reference, and for what obstacle

It does not, and Iris pays the same bill. Its celestial names are `PER_FRAME` uniforms
(`uniforms/CelestialUniforms.java:80-91`) held on a `ProgramUniforms` that belongs to one program
and steps its own frame counter (`gl/program/ProgramUniforms.java:231-234`), so there too the work
is done once per program rather than once per frame. Nothing changes in either direction about
what a pack is handed.

## What proves it

- `gradlew build` green.
- Each of the six was walked against what its body reads, and the key of each is the complete set
  of those inputs. Nothing here accumulates over time, so two passes of one frame are handed the
  same number for the same reason they always were.
- The comparison is JOML's `Matrix4f.equals(Matrix4fc, float)` at a delta of nought. Read at the
  bytecode on the jar the game actually installs, `joml-1.10.8`, where it walks the elements
  through the `Matrix4fc` interface. The `instanceof Matrix4f` guard that would have made it
  answer false for a non-`Matrix4f` argument exists in 1.10.2 and is gone by 1.10.8.
- Not tried in the game. A wrong answer here would move the sun, so the corpus would show it
  immediately.

## What it leaves owing

The gain is not measured, and this removes work rather than claiming frames.

Three overloads of the holder share their fields, so one holder belongs to one call site and
nothing enforces that. Each site uses the single overload whose shape is its own.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
