### PR TITLE
perf(render): stop rebinding what a pass already holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ what the next one holds.
   numbers that had not moved in between. They are kept and reused until something they are
   built from actually changes. The values handed over are the same ones, to the bit, and this
   has not been measured either, so again it is work removed rather than frames gained.
+- **The same picture with less repeated work inside the frame.** A pack's geometry program
+  re-bound every texture it declares for every chunk region, mob piece and particle batch it
+  drew, where only the two to four that follow the image in hand can change inside one pass;
+  the rest are now written once, when the pass opens. Beside it: the far terrain's sections are
+  collected into a list sized from the count Distant Horizons gives rather than grown into one,
+  and handed on without a copy; a vertex format is searched for this engine's own elements only
+  until the first one it has not got; and a pass is asked for its name only once everything
+  cheaper about it has already matched. Whether the frame rate moves is a machine's to measure.
 
 ### Fixed
 

--- a/common/src/main/java/dev/vitrail/dh/DhLods.java
+++ b/common/src/main/java/dev/vitrail/dh/DhLods.java
@@ -544,14 +544,18 @@ public final class DhLods {
 	/** One half of one pass, out of DH's objects and into this engine's. */
 	private static List<Section> sections(Object set, boolean opaque)
 			throws ReflectiveOperationException {
-		List<Section> sections = new ArrayList<>();
+		int count = (Integer) setSize.invoke(set);
+
+		// Given the width DH just answered with rather than grown into it. A far view hands out
+		// thousands of sections twice a frame, and a list that starts at ten reaches that by
+		// allocating a longer array and copying the old one into it a dozen times over.
+		List<Section> sections = new ArrayList<>(count);
 
 		// One list refilled section by section rather than one built per section: the record copies
 		// what it is handed, so nothing downstream can be holding this one, and a far view hands out
 		// thousands of sections twice a frame.
 		List<Piece> pieces = new ArrayList<>();
 
-		int count = (Integer) setSize.invoke(set);
 		for (int index = 0; index < count; index++) {
 			Object one = setGet.invoke(set, index);
 			Object[] wrappers =
@@ -562,8 +566,15 @@ public final class DhLods {
 
 			pieces.clear();
 			for (Object wrapper : wrappers) {
-				if (wrapper == null || !uploadedField.getBoolean(wrapper)
-						|| vertexCountField.getInt(wrapper) <= 0) {
+				if (wrapper == null || !uploadedField.getBoolean(wrapper)) {
+					continue;
+				}
+
+				// Asked once and kept: the read below it is reflective like every other here, and it
+				// answered the same number twice for every buffer of every section of every frame so
+				// that one check could have it on the one frame a session where it looks.
+				int written = vertexCountField.getInt(wrapper);
+				if (written <= 0) {
 					continue;
 				}
 
@@ -572,7 +583,7 @@ public final class DhLods {
 				if (vertices instanceof GpuBuffer vertexBuffer
 						&& indices instanceof GpuBuffer indexBuffer
 						&& !vertexBuffer.isClosed()) {
-					checkStride(vertexBuffer, vertexCountField.getInt(wrapper));
+					checkStride(vertexBuffer, written);
 					pieces.add(new Piece(vertexBuffer, indexBuffer, indexCountField.getInt(wrapper)));
 				}
 			}
@@ -590,7 +601,11 @@ public final class DhLods {
 		// anybody argues about whether the reflection under it is worth removing.
 		PassTimings.censusFarSections(sections.size());
 
-		return List.copyOf(sections);
+		// Handed over as it stands rather than copied. The copy was one more array as wide as the far
+		// view, twice a frame, and it bought nothing: this list is built here, is not the reused one
+		// above it, and the only thing that holds it afterwards is {@code DistantDraw}, which reads
+		// it and drops it.
+		return sections;
 	}
 
 	/** Says once what the far terrain really holds, which is what tells a reader it is reachable. */

--- a/common/src/main/java/dev/vitrail/mixin/BufferBuilderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/BufferBuilderMixin.java
@@ -127,7 +127,18 @@ public abstract class BufferBuilderMixin {
 	@Inject(method = "<init>", at = @At("RETURN"), require = 1)
 	private void vitrail$findElements(ByteBufferBuilder buffer, PrimitiveTopology topology,
 			VertexFormat format, CallbackInfo callback) {
+		this.vitrail$identifiers = -1;
+		// Asked on its own and ahead of the others, because asking is a WALK. A format keeps its
+		// elements in an array map sixteen slots wide (VertexFormat's own elements field, a fastutil
+		// Object2ObjectArrayMap), so a name is compared against every element the format has until it
+		// matches or runs out, and a name that is not there is that walk paid in full. This is the one
+		// name no format but this engine's carries, and the game builds one of these per render type
+		// change, so the five below are five walks an ordinary builder no longer takes.
 		int identifiers = vitrail$offsetOf(EntityVertex.IDENTIFIERS);
+		if (identifiers < 0) {
+			return;
+		}
+
 		int midTexCoord = vitrail$offsetOf(EntityVertex.MID_TEX_COORD);
 		int tangent = vitrail$offsetOf(EntityVertex.TANGENT);
 		int position = vitrail$offsetOf("Position");
@@ -137,10 +148,7 @@ public abstract class BufferBuilderMixin {
 		// carrying the first without the rest is not a state this engine can build. Answering it the
 		// way a builder of any other format is answered is what keeps a constructor the game runs
 		// thousands of times a frame from being a place anything can be thrown out of.
-		if (identifiers < 0 || midTexCoord < 0 || tangent < 0 || position < 0 || texCoord < 0
-				|| normal < 0) {
-			this.vitrail$identifiers = -1;
-
+		if (midTexCoord < 0 || tangent < 0 || position < 0 || texCoord < 0 || normal < 0) {
 			return;
 		}
 

--- a/common/src/main/java/dev/vitrail/render/GeometryHold.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryHold.java
@@ -118,8 +118,14 @@ public final class GeometryHold {
 	 * @return the held pass, or {@code null} to let the encoder open a new one
 	 */
 	public static RenderPass leftover(RenderPassDescriptor descriptor) {
-		if (opening || current == null || clears(descriptor) || !leftoverLabel(descriptor)
-				|| fit(descriptor) != JOINS) {
+		// The NAME is asked last, and that order is what keeps this on the path every pass of the
+		// frame takes: the encoder sends every createRenderPass through here, and reading a
+		// descriptor's name means running the supplier that builds it, which for the game's own
+		// immediate draws concatenates the pipeline it is drawing with into a string that is thrown
+		// away one comparison later. Everything ahead of it compares pointers and numbers, so the
+		// string is now only built for a pass that already writes the held images at the held area.
+		if (opening || current == null || clears(descriptor) || fit(descriptor) != JOINS
+				|| !leftoverLabel(descriptor)) {
 			return null;
 		}
 

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -205,6 +205,35 @@ final class GeometryProgram {
 	 */
 	private static final String OVERLAY = LegacyGlsl.OVERLAY_SAMPLER;
 
+	/**
+	 * The pass the answers that do NOT follow the draw's image are currently standing in, and the
+	 * program that put them there.
+	 * <p>
+	 * A bind writes a name into a map the pass keeps until it closes, allocating the pair it stores,
+	 * so a name whose answer cannot move inside a pass only has to be written once. Two things can
+	 * undo that writing, and both are held here rather than on the program: {@link #resolve} moving
+	 * the answers, which drops the pair below, and another program binding ITS names over them,
+	 * which one pass sees often since {@link GeometryHold} carries several families through one and
+	 * the entity family alone hands its pass twenty pieces.
+	 * <p>
+	 * Nothing outside this class writes one of these names into a geometry pass, and that is a fact
+	 * about today's naming rather than a guarantee. A composite, a copy or a clear ends the hold
+	 * before it records anything, but {@link GeometryHold#leftover} deliberately does not: it
+	 * adopts the game's remaining immediate draws and Distant Horizons' generic object renderer
+	 * into a hold that is already open. What keeps them apart is only that none of their names
+	 * collides: the game binds {@code Sampler0} and its siblings, Sodium {@code u_BlockTex} and
+	 * {@code u_LightTex}, Distant Horizons {@code uLightMap} alone, and a pack's names are the
+	 * lower case ones a pack writes. The translation never compares a name a pack declared
+	 * against any of those, so nothing enforces it.
+	 * <p>
+	 * <strong>Settling raises what a collision would cost.</strong> A foreign write over one of
+	 * these names used to be undone by the next bind of the same program; it now stands for the
+	 * rest of the pass.
+	 */
+	private static RenderPass settledIn;
+
+	private static GeometryProgram settled;
+
 	/** Where one colour attachment of a world pass takes its image from. */
 	private enum Bound {
 
@@ -1017,7 +1046,14 @@ final class GeometryProgram {
 	 * <strong>Only the names that follow the draw's own image are worked out here.</strong> The rest
 	 * were settled by {@link #resolve}, at the one point of a pass that stands outside it, and this
 	 * walks them in order out of an array rather than asking for each of them by name.
+	 * <p>
+	 * <strong>And only those are WRITTEN here, past the first bind of a pass.</strong> A pack's
+	 * geometry program declares ten to twenty five names of which two to four move with the draw,
+	 * and the pass holds what it was told until it closes, so the rest were a pair allocated and a
+	 * map entry replaced by its own value, once for every draw of the frame. {@link #settledIn}
+	 * carries what makes that safe.
 	 */
+	@SuppressWarnings("ReferenceEquality")
 	void bind(RenderPass pass) {
 		// Once, and it is the one thing that tells a pass that draws from a pass that only compiled:
 		// announce() says a program was prepared, which happens whether or not the renderer goes on
@@ -1039,10 +1075,17 @@ final class GeometryProgram {
 		pass.setUniform(UNIFORM_BLOCK, blockSlice());
 		StorageBuffers.bind(pass, this.storage);
 
+		// The rest are already standing in this pass, put there by this program's own last bind into
+		// it, and writing them again would allocate a pair and put back what the map already holds.
+		// {@link #settledIn} says what can undo that and why nothing else can.
+		boolean settle = settledIn != pass || settled != this;
+		settledIn = pass;
+		settled = this;
+
 		for (Sampled one : this.bound) {
 			if (one.followsTheImage()) {
 				pass.bindTexture(one.name, imageView(one), imageSampler(one));
-			} else {
+			} else if (settle) {
 				pass.bindTexture(one.name, one.view, one.state);
 			}
 		}
@@ -1068,6 +1111,12 @@ final class GeometryProgram {
 	 * pipeline draws every mob on screen and each of them brings its own skin.
 	 */
 	private void resolve() {
+		// Whatever this program left standing in a pass is no longer what it would write now, so the
+		// next bind writes the lot again. release() clears the same two, and not because a released
+		// program is unreachable: TerrainDraw is the one family that keeps its program map across a
+		// release, so its static bind can reach a program that has never come back through here.
+		settledIn = null;
+		settled = null;
 		boolean labPbr = PbrAtlases.labPbr();
 		for (Sampled one : this.bound) {
 			one.interpolates = one.material != null && one.material.interpolates(labPbr);
@@ -1487,6 +1536,15 @@ final class GeometryProgram {
 		for (Sampled one : this.bound) {
 			one.view = null;
 			one.state = null;
+		}
+
+		// Let go of the pass and the program the same way, and for the same reason as the views
+		// above: these two are the one place a closed RenderPass and a released program stay
+		// reachable, and they would otherwise stand until some program's next bind. Only when it
+		// is this program standing there, another one's settling being none of our business.
+		if (settled == this) {
+			settled = null;
+			settledIn = null;
 		}
 	}
 


### PR DESCRIPTION
## What changes

A pack's geometry program declares ten to twenty five texture names, and only the two to four
that follow the image in hand can change while a pass is open. All of them were written into the
pass at every draw, and a bind writes a name into a map the pass keeps until it closes, allocating
the pair it stores: once per chunk region, mob piece and particle batch of the frame, most of it
replacing an entry by its own value. The settled ones are now written when the program first binds
into a pass, and again only where something can have undone them, which is the answers moving or
another program binding its own names over them. A release lets go of the pass and the program it
settled through, those two being the one place a closed pass and a released program would
otherwise stay reachable.

Three smaller ones beside it. The far terrain's sections go into a list sized from the count
Distant Horizons gives rather than grown into one, and are handed on without a copy, that copy
being another array as wide as the far view twice a frame. A vertex format is asked for this
engine's own identifier first and abandoned if it is absent, a name that is not there costing a
full walk of a sixteen slot array map, and the game builds one of these per render type change.
And a pass descriptor is asked for its name only once everything cheaper about it has matched,
reading a name meaning running the supplier that builds it.

## How it differs from the reference, and for what obstacle

It does not. Iris binds its samplers against an OpenGL program object rather than into a pass that
remembers them, so there is no per-draw map write there to spare.

## What proves it

- `gradlew build` green, after the rebase.
- The pass held in a static field cannot be confused with a later one: `createRenderPass` builds a
  new object per call, and the field holds a strong reference, so no address is reused under it.
- What may write one of these names into a geometry pass was walked by hand. The game binds
  `Sampler0` and its siblings, Sodium `u_BlockTex` and `u_LightTex`, Distant Horizons `uLightMap`
  alone, and none collides with the lower case names a pack writes. That is a fact about today's
  naming and not a guarantee, and the javadoc now says so along with what a collision would cost.
- Not tried in the game. A name left standing wrongly would show as a texture from another family
  on a whole draw, which the corpus would make obvious.

## What it leaves owing

The gain is not measured.

`TerrainDraw` is the one family that keeps its program map across a release, so its static bind
can reach a program that has not been prepared again. No route to a defect is proven, and it would
need a release falling between two binds of one open pass, but that family is the reason a release
now clears the settling rather than leaving it to the next prepare.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
