### PR TITLE
feat(glsl): put the driver's own sine back behind a switch

### DIFF
--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Turns one flattened pack unit into GLSL a Vulkan compiler will take.
@@ -178,11 +179,64 @@ public final class GlslTranslator {
 	 * <p>
 	 * The goldberg hash {@code fract(sin(dot(p, K)) * 43758.5453)} is not sent through this helper.
 	 * See {@link #HASH}.
+	 * <p>
+	 * The substitution can be taken off for a measurement, which leaves the driver's own two in
+	 * place and emits neither of these. See {@code reduceTrig} below, which is on wherever nobody
+	 * has said otherwise.
 	 */
 	private static final String REDUCED_SIN = "ofReducedSin";
 
 	/** See {@link #REDUCED_SIN}. */
 	private static final String REDUCED_COS = "ofReducedCos";
+
+	/**
+	 * Whether a pack's {@code sin} and {@code cos} are sent through {@link #REDUCED_SIN} at all.
+	 * On, which is what a player gets and what every reading taken so far was taken under.
+	 * <p>
+	 * <strong>It is an instrument, and not a preference anybody is meant to keep.</strong> The
+	 * substitution above is unconditional: it does not look at the argument, so a call on a small
+	 * one pays the reduction and the polynomial for a value the driver's own sine would have got
+	 * right, and one pack of the corpus writes a hundred and thirty six of them in its text,
+	 * multiplied by every stage whose includes pull them in. What that costs a
+	 * frame has never been measured, and it cannot be measured across two jars: a rate read on one
+	 * build and set beside a rate read on another carries every difference between the two runs and
+	 * not this one. Both states in one jar, a pack load apart, is what makes the number mean
+	 * something.
+	 * <p>
+	 * What turning it off gives up is the whole reason the helper exists. Packs feed these two
+	 * whole world coordinates, and a single fp32 two-pi sheds the low bits of a large argument long
+	 * before anybody watching can say where the shimmer came from. {@code DriverTrig} carries how
+	 * it is armed, and the line it writes to the log in both directions at every pack load.
+	 */
+	private static volatile boolean reduceTrig = true;
+
+	/**
+	 * The call sites matched since the switch was last set, added up over every unit translated.
+	 * <p>
+	 * Matched and not substituted, which is the point of it: a reading taken with the driver's own
+	 * sine in place still has to be able to say the pack had something for the substitution to bite
+	 * on, and a count that only rose in one of the two states would say nothing at all there.
+	 * <p>
+	 * One window makes it a tally and not an exact figure: a family of the chain that has just
+	 * been released finishes translating on its worker (the prefetch only tests for release
+	 * between families), and its sites land here after the reset. Nothing of that reaches a live
+	 * program, the released chain is never active again; it moves this count and no more.
+	 */
+	private static final AtomicInteger TRIG_SITES = new AtomicInteger();
+
+	/**
+	 * Set at the head of a pack load, before a program of it is translated, and it empties the
+	 * count with it: a tally belongs to the load whose state it was taken under.
+	 */
+	public static void reduceTrig(boolean on) {
+		reduceTrig = on;
+		TRIG_SITES.set(0);
+	}
+
+	/** How many {@code sin} and {@code cos} call sites have been matched since that call. */
+	public static int trigSites() {
+		return TRIG_SITES.get();
+	}
 
 	/**
 	 * What the goldberg hash idiom becomes.
@@ -375,6 +429,13 @@ public final class GlslTranslator {
 	/** Calls to {@code sin} or {@code cos} sent through the reduced-argument helpers. */
 	private int trigCalls;
 
+	/**
+	 * Call sites to those two this unit matched, whether or not they were substituted. The same
+	 * number as {@link #trigCalls} wherever {@code reduceTrig} is on, which is everywhere a player
+	 * is, and the only one of the two that says anything at all when it is off.
+	 */
+	private int trigSites;
+
 	/** Goldberg hash idioms rewritten onto {@link #HASH} instead of through a sine. */
 	private int hashCalls;
 
@@ -565,7 +626,8 @@ public final class GlslTranslator {
 		dropVersionAndExtensions();
 		rewriteIdentifiers();
 		// After the identifiers, because the goldberg idiom's sine has become ofReducedSin by then
-		// and that is how the site is recognised. Taking it earlier would leave the sine standing
+		// and that is one of the two names the site is recognised under, the other being the plain
+		// sin that reduceTrig off leaves standing. Taking it earlier would leave the sine standing
 		// and the helper below would wrap a call this pass was about to erase.
 		rewriteGoldbergHash();
 		// After the identifiers and before the depth, and both halves of that matter: the legacy
@@ -605,6 +667,11 @@ public final class GlslTranslator {
 
 		this.used = usedNames();
 		this.declaredAfter = declaredUnderAType();
+		// Once per unit and only here, after the goldberg rewrite has taken its own sites back off.
+		// The families translate on a worker while the chain is already read, so a counter each of
+		// them walked up and down itself would be read mid-flight; one addition at the end of a
+		// unit is the whole of what crosses a thread.
+		TRIG_SITES.addAndGet(this.trigSites);
 	}
 
 	/**
@@ -1198,11 +1265,19 @@ public final class GlslTranslator {
 			// Calls only, and never a name the pack declared for itself: a unit shipping its own
 			// sin has already said what it means by it. See REDUCED_SIN for why the builtin cannot
 			// be left to take the argument raw.
+			//
+			// The site is counted before the switch is asked and not after, so that a load running
+			// on the driver's own two can still say what the substitution would have had to bite
+			// on. With the switch off nothing is replaced and the token falls through to the
+			// readings below, exactly as any other name the pack calls does.
 			if ((name.equals("sin") || name.equals("cos")) && callOpener(index) >= 0
 					&& !this.declaredNames.contains(name)) {
-				replace(index, name.equals("sin") ? REDUCED_SIN : REDUCED_COS);
-				this.trigCalls++;
-				continue;
+				this.trigSites++;
+				if (reduceTrig) {
+					replace(index, name.equals("sin") ? REDUCED_SIN : REDUCED_COS);
+					this.trigCalls++;
+					continue;
+				}
 			}
 
 			if (directive != null) {
@@ -1297,6 +1372,12 @@ public final class GlslTranslator {
 			String argument = tokenText(argStart, argEnd);
 			blankRange(index, fractClose);
 			inject(index, HASH + "(" + argument + ")");
+			// Off both counts, and the site comes off whichever name its sine still went under: the
+			// idiom is erased here, so it is not a call either helper was ever going to take.
+			if (this.trigSites > 0) {
+				this.trigSites--;
+			}
+
 			if (reduced && this.trigCalls > 0) {
 				this.trigCalls--;
 			}
@@ -1306,8 +1387,12 @@ public final class GlslTranslator {
 	}
 
 	private boolean goldbergSine(Token token) {
+		// The plain arm carries BOTH exclusions the substitution itself applies, the pack macro
+		// one included: a pack that defines sin for itself keeps its idiom whatever the switch
+		// says, exactly as it kept it before the switch existed.
 		return token.identifier(REDUCED_SIN)
-				|| (token.identifier("sin") && !this.declaredNames.contains("sin"));
+				|| (token.identifier("sin") && !this.declaredNames.contains("sin")
+						&& !this.packMacros.contains("sin"));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/DriverTrig.java
+++ b/common/src/main/java/dev/vitrail/render/DriverTrig.java
@@ -1,0 +1,84 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+import dev.vitrail.glsl.GlslTranslator;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Whether a pack's {@code sin} and {@code cos} are left to the driver instead of going through the
+ * translation's own reduced-argument helpers.
+ * <p>
+ * <strong>It exists so that a cost can be MEASURED rather than assumed.</strong> Every call to
+ * either builtin, in every program of every pack, is replaced at load time by an odd polynomial
+ * behind a two constant argument reduction, and the replacement never looks at the argument: one
+ * pack of the corpus writes a hundred and thirty six of them in its text, and the shared includes
+ * multiply that by every stage that pulls them in. The reason written down for it concerns large
+ * arguments, where a single fp32 two-pi sheds the low bits a pack fed whole world coordinates
+ * depends on. What the substitution costs a frame has never been read off anything.
+ * <p>
+ * It cannot be read off two jars either. A frame rate taken on one build and set beside a frame
+ * rate taken on another carries the whole difference between the two runs, and the one variable
+ * under test is the smallest part of it. So both states are in this jar, a pack load apart, and a
+ * measurement is two readings in one world with one thing between them.
+ * <p>
+ * A file {@code vitrail/driver-trig} in the game directory, or {@code -Dvitrail.driverTrig=true}.
+ * Read again at every pack load, so the reload key is the whole gesture, and the state is written
+ * to the log BOTH WAYS at every load that installs a chain: a switch that says nothing when it is
+ * off leaves every reading taken without a line unable to name the state it belongs to, and that
+ * has already cost a morning of readings here. A load the engine refuses prints its refusal
+ * instead, and no reading is taken under one of those anyway. The line carries the call sites the
+ * chain and its terrain had matched when it prints, which is what says whether the switch had
+ * anything to bite on in that pack at all; the other families translate on a worker after the
+ * line and add to the tally it was read from, not to the line.
+ * <p>
+ * It is not a setting anybody should keep. Armed, a pack asking for a sine of the world position
+ * gets whatever the driver makes of an argument in the hundreds of thousands, which is the defect
+ * the substitution was written against.
+ */
+public final class DriverTrig {
+
+	private static final boolean PROPERTY = Boolean.getBoolean("vitrail.driverTrig");
+
+	private static final String ARM_FILE = "driver-trig";
+
+	private static boolean armed;
+
+	private DriverTrig() {
+	}
+
+	/**
+	 * Read at the head of a pack load, before one program of it has been translated, since what it
+	 * decides is what the translation emits and nothing re-emits a unit afterwards.
+	 * <p>
+	 * The game directory is handed in rather than asked of the game: this is settled once per load
+	 * and the load already knows where it is reading from.
+	 */
+	public static void read(Path gameDirectory) {
+		armed = PROPERTY
+				|| Files.isRegularFile(gameDirectory.resolve(Vitrail.MOD_ID).resolve(ARM_FILE));
+		GlslTranslator.reduceTrig(!armed);
+	}
+
+	/**
+	 * Said once per installed chain and said BOTH WAYS, which is the rule this switch exists
+	 * under. A line that only appeared in one of the two states would make every load without one
+	 * ambiguous, and a reading taken under an ambiguous load is worth nothing at all.
+	 */
+	public static void announce() {
+		int sites = GlslTranslator.trigSites();
+		if (armed) {
+			Vitrail.logger().warn("Every sin and cos of this pack is left to the DRIVER, asked for "
+					+ "by vitrail/{} or by -Dvitrail.driverTrig, over {} call sites. A large "
+					+ "argument sheds its low bits there, which is what the engine's own reduction "
+					+ "was written against; remove it to go back", ARM_FILE, sites);
+			return;
+		}
+
+		Vitrail.logger().info("Every sin and cos of this pack goes through the engine's own "
+				+ "reduced-argument helper, over {} call sites, which is the default. vitrail/{} "
+				+ "would leave the driver's own two in place, and this line is said either way so "
+				+ "that a reading can name the state it was taken under", sites, ARM_FILE);
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -601,6 +601,9 @@ public final class PackChain {
 	 */
 	public static void load(Path gameDirectory) {
 		PassTimings.resetCensus();
+		// Here and not lower down: it decides what the translation emits, and every road
+		// below this point that reads a pack translates one.
+		DriverTrig.read(gameDirectory);
 		// The storage blocks the translator files away, emptied at the head of a load and NOT beside
 		// the CustomImages line in release(), though the two are installed on the same line.
 		//
@@ -881,6 +884,10 @@ public final class PackChain {
 				// for a shader. The other families then translate on a worker, so Complementary
 				// Unbound's entities overlap the composite compiles and never sit on the render thread.
 				active.terrain.read(opened);
+				// After the two reads this thread makes and before the worker starts on the rest,
+				// so the count on the line is a number rather than a snapshot of a tally still
+				// moving.
+				DriverTrig.announce();
 				// The count, so that what a load costs is a figure in the log rather than a feeling.
 				// It covers the whole of this method, the report and the settings reading included,
 				// and the families are deliberately outside it: they translate on a worker, off the

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -262,6 +262,17 @@ game's full memory barrier and sends the mip chain back to a pass per level. It 
 cannot be the cause of a wrong image, so it is the first thing to ask of a machine that draws one
 this one does not.
 
+**The sine substitution can be taken off.** Every `sin` and `cos` a pack writes is replaced at load
+time by a reduced-argument helper of the translation's own, whatever the argument. An empty file
+`vitrail/driver-trig` in the instance, or `-Dvitrail.driverTrig=true` among the JVM arguments,
+leaves the driver's own two in place instead, so what the replacement costs a frame can be read as
+two measurements in one world rather than across two builds. The state is written to the log in
+both directions at every load that installs a chain, with the call sites matched by the time the
+line prints, so a reading always names the state it belongs to and says whether the pack had
+anything for the switch to bite on. It is an instrument and not a setting to keep: without the
+replacement a pack feeding whole world coordinates to a sine gets whatever the driver makes of
+them.
+
 **The card's time per pass is in the log on request.** Started with `-Dvitrail.passTimings=N`
 among the JVM arguments, the game prints every N seconds a table of GPU time per render pass
 label, the game's and Sodium's passes beside the pack's, sorted by cost, with the share of the pass


### PR DESCRIPTION
## What changes

Every `sin` and `cos` a pack writes is replaced at load time by a reduced-argument helper of the
translation's own, whatever the argument. This branch puts the driver's own two back behind a
switch: an empty file `vitrail/driver-trig` in the instance, or `-Dvitrail.driverTrig=true`,
leaves the builtins untouched, so what the replacement costs a frame can be read as two
measurements in one world, a pack load apart, instead of across two builds carrying every other
difference between the runs. The state is written to the log in both directions at every load
that installs a chain, with the count of call sites matched by the time the line prints, so a
reading always names the state it was taken under. Alongside it, the goldberg hash rewrite gains
the same pack-macro exclusion the substitution itself applies: a pack that defines `sin` for
itself keeps its idiom in both states.

## How it differs from the reference, and for what obstacle

The standing divergence is the substitution itself, documented at `glsl/GlslTranslator.java:169`:
Iris leaves both builtins to the driver, and a pack feeding whole world coordinates to a sine
then loses its low bits to a single fp32 two-pi. The switch adds nothing to that divergence; armed
it does exactly what Iris does, which is what makes the cost of the divergence measurable at all.
It is an instrument, not a setting to keep, and the log line says so when it is armed.

## What proves it

- `gradlew build` green locally, after the rebase.
- The out-of-game harness: `Traduction` over the eight-pack corpus, built once from `dev` and
  once from this branch, renders a byte-identical translated tree with the switch at its default.
  The only differing line in the detail TSV is the absolute path of the work directory inside two
  compiler error messages.
- In game, Fabric bench, ComplementaryUnbound r5.8.1 on a frozen world, alternating the two
  states over three pack-load pairs: the substitution reads at about 0.13 ms of GPU passes per
  frame against the driver's own sine (5.15 against 5.02 ms of passes), about half of it in the
  terrain pass, with the log naming the state on each side of every toggle.

## What it leaves owing

The announced count covers the chain and its terrain at the moment the line prints; the other
families translate on a worker after it and add to the tally the next load resets, so the figure
is a tally that says whether the switch had something to bite on, not an exact census. Armed, a
pack that depends on the reduction draws with whatever the driver makes of a large argument,
which is the defect the substitution exists to prevent; that is the point of the instrument and
the log warns about it.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
