### PR TITLE
perf: spare the draw loop what it rebuilt every frame

### DIFF
--- a/common/src/main/java/dev/vitrail/glsl/TangentFrame.java
+++ b/common/src/main/java/dev/vitrail/glsl/TangentFrame.java
@@ -64,6 +64,13 @@ public final class TangentFrame {
 	 */
 	private static final float FLAT = 1.0E-20F;
 
+	/**
+	 * The three floats {@link #pack} decodes its own normal into, one array per thread: packing
+	 * runs on every builder thread of the world, and the decoded copy lives no longer than the
+	 * call that made it.
+	 */
+	private static final ThreadLocal<float[]> DECODED = ThreadLocal.withInitial(() -> new float[3]);
+
 	private TangentFrame() {
 	}
 
@@ -87,7 +94,7 @@ public final class TangentFrame {
 	 */
 	public static int pack(float[] frame) {
 		int normal = packNormal(frame[0], frame[1], frame[2]);
-		float[] decoded = normal(normal);
+		float[] decoded = normal(normal, DECODED.get());
 
 		return normal | (frame[6] >= 0.0F ? 1 << 23 : 0)
 				| (packTangent(decoded, frame[3], frame[4], frame[5]) << 24);
@@ -99,16 +106,26 @@ public final class TangentFrame {
 	 * comes out of here and the prologue reads it in a basis built from its own copy.
 	 */
 	public static float[] normal(int word) {
+		return normal(word, new float[3]);
+	}
+
+	/** The same, into an array the caller keeps, which is what lets a hot path bring its own. */
+	public static float[] normal(int word, float[] into) {
 		float x = (word << 20 >> 20) / (float) X_MAX;
 		float y = (word << 9 >> 21) / (float) Y_MAX;
 		float z = 1.0F - Math.abs(x) - Math.abs(y);
-		float[] normal = z >= 0.0F
-				? new float[] {x, y, z}
-				: new float[] {(1.0F - Math.abs(y)) * sideOf(x),
-						(1.0F - Math.abs(x)) * sideOf(y), z};
-		normalise(normal);
+		if (z >= 0.0F) {
+			into[0] = x;
+			into[1] = y;
+		} else {
+			into[0] = (1.0F - Math.abs(y)) * sideOf(x);
+			into[1] = (1.0F - Math.abs(x)) * sideOf(y);
+		}
 
-		return normal;
+		into[2] = z;
+		normalise(into);
+
+		return into;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -1156,6 +1156,13 @@ public final class EntityDraw {
 	/** The reasons a draw has already been handed back to the game. One line each, not one a frame. */
 	private final Set<String> refused = new LinkedHashSet<>();
 
+	/**
+	 * The pipelines whose casters have already been reported dropped, which is the same "once each"
+	 * as {@link #refused} and is kept apart from it: the pipeline itself is the key there, where a
+	 * name built from it was a string composed at every draw the light's walk gives up on.
+	 */
+	private final Set<RenderPipeline> droppedPipelines = new LinkedHashSet<>();
+
 	/** The pass a run of draws is being recorded into, or null between runs. */
 	private RenderPass open;
 
@@ -1737,7 +1744,7 @@ public final class EntityDraw {
 	 */
 	@SuppressWarnings("ReferenceEquality")
 	private void dropped(RenderPipeline pipeline) {
-		if (!this.refused.add("shadow:" + pipeline.getLocation())) {
+		if (!this.droppedPipelines.add(pipeline)) {
 			return;
 		}
 
@@ -2232,6 +2239,7 @@ public final class EntityDraw {
 		// this can refuse again, for the same reason or for another, and a reader watching a portal
 		// would see the first reading's lines and nothing after them.
 		this.refused.clear();
+		this.droppedPipelines.clear();
 		this.read = false;
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -1452,10 +1452,11 @@ public final class EntityDraw {
 					+ prepared.outputTarget(), true, "the game sends it to "
 					+ prepared.outputTarget() + ", which it composes itself afterwards, and the pack's "
 					+ "colour targets cannot be attached beside a picture this engine has not got. It "
-					+ "is the game's improved transparency that allocates those targets, and Iris "
-					+ "never meets this: it turns improved transparency OFF as soon as shaders are "
-					+ "enabled (mixin/fabulous/MixinDisableFabulousGraphics.java:37-40), which this "
-					+ "engine does not do. Turning improved transparency off gives it back");
+					+ "is the game's improved transparency that allocates those targets, and this "
+					+ "engine turns that option off when the pack is loaded, as Iris does when shaders "
+					+ "are enabled (mixin/fabulous/MixinDisableFabulousGraphics.java:37-40). Reaching "
+					+ "this line means it was turned back on afterwards, and turning it off again "
+					+ "gives the draw back");
 		}
 
 		try {

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -459,7 +459,6 @@ final class GeometryProgram {
 
 	/** Reused while a descriptor is built: Sodium asks for one per region, not once a frame. */
 	private final List<GpuTextureView> attachedViews = new ArrayList<>();
-	private final List<GpuTextureView> writtenViews = new ArrayList<>();
 	private final List<GpuTextureView> shadowViews = new ArrayList<>();
 
 	/**
@@ -1395,14 +1394,12 @@ final class GeometryProgram {
 		}
 
 		RenderPassDescriptor descriptor = RenderPassDescriptor.create(this.passLabel);
-		this.writtenViews.clear();
 		for (GpuTextureView view : this.attachedViews) {
 			if (view == null) {
 				descriptor.withUnusedColorAttachment();
 				continue;
 			}
 
-			this.writtenViews.add(view);
 			descriptor.withColorAttachment(view, this.targets.takeClear(view));
 		}
 

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -460,6 +460,21 @@ final class GeometryProgram {
 	/** Reused while a descriptor is built: Sodium asks for one per region, not once a frame. */
 	private final List<GpuTextureView> attachedViews = new ArrayList<>();
 	private final List<GpuTextureView> writtenViews = new ArrayList<>();
+	private final List<GpuTextureView> shadowViews = new ArrayList<>();
+
+	/**
+	 * The area of the last descriptor built, and the size it was built for.
+	 * <p>
+	 * Held for the same reason the view lists above are: one is asked for per region and the value
+	 * moves only when the window does. The size is carried beside it rather than the area being
+	 * dropped on a resize, because nothing here is told of one; the map's own is a square and moves
+	 * when the player scales it.
+	 */
+	private RenderPass.RenderArea area;
+	private int areaWidth;
+	private int areaHeight;
+	private RenderPass.RenderArea shadowArea;
+	private int shadowAreaSize;
 
 	GeometryProgram(Pass pass, PackProgram.Loaded loaded, PackValues values, int load,
 			VertexFormat format, List<ChainPlan.Attachment> writes, ColorTargets targets,
@@ -1399,8 +1414,7 @@ final class GeometryProgram {
 		// at the first draw rather than at load time. The size is the screen's, and stays the
 		// screen's now that attachment nought may be a target of the pack's: a scaled colour target
 		// is dropped before it gets here, and the game's depth is attached whatever else is.
-		descriptor.withRenderArea(new RenderPass.RenderArea(0, 0,
-				this.targets.screenWidth(), this.targets.screenHeight()));
+		descriptor.withRenderArea(area(this.targets.screenWidth(), this.targets.screenHeight()));
 
 		return depth == null ? descriptor : descriptor.withDepthAttachment(depth);
 	}
@@ -1458,7 +1472,7 @@ final class GeometryProgram {
 			return null;
 		}
 
-		List<GpuTextureView> colours = new ArrayList<>(this.shadowColours.size());
+		this.shadowViews.clear();
 		for (int index : this.shadowColours) {
 			// One attachment per state the pipeline carries, and in the same order. The images are
 			// allocated together with the depth, so this is null only where the depth above is, and
@@ -1470,21 +1484,47 @@ final class GeometryProgram {
 				return null;
 			}
 
-			colours.add(colour);
+			this.shadowViews.add(colour);
 		}
 
 		RenderPassDescriptor descriptor = RenderPassDescriptor.create(this.shadowLabel);
 		int at = 0;
 		for (int index : this.shadowColours) {
-			descriptor.withColorAttachment(colours.get(at), this.shadow.takeColourClear(index));
+			descriptor.withColorAttachment(this.shadowViews.get(at), this.shadow.takeColourClear(index));
 			at++;
 		}
 
 		descriptor.withDepthAttachment(depth, this.shadow.takeDepthClear())
-				.withRenderArea(new RenderPass.RenderArea(0, 0, this.shadow.resolution(),
-						this.shadow.resolution()));
+				.withRenderArea(shadowArea());
 		this.shadow.flushPending(RenderSystem.getDevice().createCommandEncoder());
 		return descriptor;
+	}
+
+	/**
+	 * The area a descriptor covers, built again only where the window has moved since the last one.
+	 * <p>
+	 * The value is the same on every region of a frame and on every frame between two resizes, and
+	 * the object is read by the descriptor and kept by nobody else.
+	 */
+	private RenderPass.RenderArea area(int width, int height) {
+		if (this.area == null || width != this.areaWidth || height != this.areaHeight) {
+			this.areaWidth = width;
+			this.areaHeight = height;
+			this.area = new RenderPass.RenderArea(0, 0, width, height);
+		}
+
+		return this.area;
+	}
+
+	/** The same for the map's own square, which moves when the player scales it and not otherwise. */
+	private RenderPass.RenderArea shadowArea() {
+		int size = this.shadow.resolution();
+		if (this.shadowArea == null || size != this.shadowAreaSize) {
+			this.shadowAreaSize = size;
+			this.shadowArea = new RenderPass.RenderArea(0, 0, size, size);
+		}
+
+		return this.shadowArea;
 	}
 
 	/** Rotates the ring buffer. Called once the frame's terrain draw has been recorded. */

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -113,6 +113,16 @@ final class PackPass {
 	private final PackValues values;
 	private final PackUniforms uniforms;
 	private final List<String> samplers;
+
+	/**
+	 * The plan's answer for each of {@link #samplers}, in that order.
+	 * <p>
+	 * Taken here because the plan is settled when the pack is read and the names never move: asked at
+	 * the binding it was a lookup by name per sampler, per pass and per frame, and a name nothing
+	 * serves built its answer afresh on every one of them.
+	 */
+	private final List<SamplerPlan.Binding> samplerBindings;
+
 	private final List<String> storage;
 	private final List<LodRead> lodReads;
 
@@ -124,6 +134,15 @@ final class PackPass {
 	private final Supplier<String> label;
 	private final List<String> notes = new ArrayList<>();
 	private final List<GpuTextureView> attachedViews = new ArrayList<>();
+
+	/**
+	 * The area of the last descriptor built and the screen it was built for. This program's own size
+	 * follows the screen and nothing else, so the value moves on a resize and never between two.
+	 */
+	private RenderPass.RenderArea area;
+	private int areaWidth;
+	private int areaHeight;
+
 	private final int outputs;
 	private final int offset;
 	private final boolean last;
@@ -158,6 +177,7 @@ final class PackPass {
 		this.values = values;
 		this.uniforms = new PackUniforms(loaded.program().uniforms(), values.catalog());
 		this.samplers = loaded.program().samplers().stream().map(TranslatedUnit.Uniform::name).toList();
+		this.samplerBindings = this.samplers.stream().map(loaded.samplers()::binding).toList();
 		this.storage = loaded.storageBlocks().stream()
 				.distinct()
 				.filter(StorageBuffers::named)
@@ -445,8 +465,7 @@ final class PackPass {
 			descriptor.withUnusedColorAttachment();
 		}
 
-		descriptor.withRenderArea(new RenderPass.RenderArea(0, 0,
-				this.pass.size().width(screenWidth), this.pass.size().height(screenHeight)));
+		descriptor.withRenderArea(area(screenWidth, screenHeight));
 
 		if (targets.hasPendingClears()) {
 			targets.flushPending(encoder);
@@ -455,6 +474,21 @@ final class PackPass {
 		try (RenderPass pass = encoder.createRenderPass(descriptor)) {
 			record(pass, targets, depthView, distantView, quad, uniforms);
 		}
+	}
+
+	/**
+	 * The area this program is drawn over, built again only where the screen has moved since the last
+	 * one. The record is read by the descriptor and kept by nobody else.
+	 */
+	private RenderPass.RenderArea area(int screenWidth, int screenHeight) {
+		if (this.area == null || screenWidth != this.areaWidth || screenHeight != this.areaHeight) {
+			this.areaWidth = screenWidth;
+			this.areaHeight = screenHeight;
+			this.area = new RenderPass.RenderArea(0, 0, this.pass.size().width(screenWidth),
+					this.pass.size().height(screenHeight));
+		}
+
+		return this.area;
 	}
 
 	/**
@@ -500,8 +534,9 @@ final class PackPass {
 	 */
 	private void bindSamplers(RenderPass pass, ColorTargets targets, GpuTextureView depthView,
 			GpuTextureView distantView) {
-		for (String sampler : this.samplers) {
-			SamplerPlan.Binding binding = this.loaded.samplers().binding(sampler);
+		for (int at = 0; at < this.samplers.size(); at++) {
+			String sampler = this.samplers.get(at);
+			SamplerPlan.Binding binding = this.samplerBindings.get(at);
 
 			// A texture the pack ships answers all three questions at once, and they are one
 			// answer: which image, how it is filtered, and how it is addressed outside zero to one

--- a/common/src/main/java/dev/vitrail/render/ParticleDraw.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleDraw.java
@@ -391,10 +391,10 @@ public final class ParticleDraw {
 		if (element.afterDeferred() && minecraft.levelRenderer.particlesTarget() != null) {
 			return refuse("fabulous", "the game's improved transparency is on, so it draws its "
 					+ "translucent particles into a target of its own that it composes afterwards, "
-					+ "and the pack's colour targets cannot be attached beside it. Iris never meets "
-					+ "this: it turns improved transparency OFF as soon as shaders are enabled, which "
-					+ "this engine does not do, so that half is the game's here where it would be the "
-					+ "pack's there. Turning improved transparency off gives it back");
+					+ "and the pack's colour targets cannot be attached beside it. This engine turns "
+					+ "that option off when the pack is loaded, as Iris does when shaders are enabled, "
+					+ "so reaching this line means it was turned back on afterwards. Turning it off "
+					+ "again gives that half back to the pack");
 		}
 
 		this.owner.beginFrame();

--- a/common/src/main/java/dev/vitrail/render/WeatherDraw.java
+++ b/common/src/main/java/dev/vitrail/render/WeatherDraw.java
@@ -351,10 +351,10 @@ public final class WeatherDraw {
 
 			return refuse("fabulous", "the game's improved transparency is on, so it draws its "
 					+ "weather into a target of its own that it composes afterwards, and the pack's "
-					+ "colour targets cannot be attached beside it. Iris never meets this: it turns "
-					+ "improved transparency OFF as soon as shaders are enabled, which this engine "
-					+ "does not do, so the rain is the game's here where it would be the pack's "
-					+ "there. Turning improved transparency off gives the pack's rain back");
+					+ "colour targets cannot be attached beside it. This engine turns that option off "
+					+ "when the pack is loaded, as Iris does when shaders are enabled, so reaching "
+					+ "this line means it was turned back on afterwards. Turning it off again gives "
+					+ "the pack's rain back");
 		}
 
 		// The same two calls the sky and the terrain make, and for the same reasons. This is never the

--- a/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
+++ b/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
@@ -129,6 +129,17 @@ public final class TerrainMesh implements ChunkVertexType {
 	 */
 	private static final float FLATTENED = 1.0E-20F;
 
+	/**
+	 * The seven floats {@link #frame} works in, one array per thread.
+	 * <p>
+	 * A quad's frame is read by {@link TangentFrame#pack} and kept by nobody, so one array serves
+	 * every quad a thread ever meshes rather than one per quad. Per THREAD and not per instance:
+	 * this class is remade whenever the carried list moves, the workers outlive any one of it, and
+	 * Sodium meshes on as many of them as it was given, so an array of the instance would still be
+	 * four builders writing seven floats over each other.
+	 */
+	private static final ThreadLocal<float[]> FRAMES = ThreadLocal.withInitial(() -> new float[7]);
+
 	private final ChunkVertexType inner = ChunkMeshFormats.COMPACT;
 	private final ChunkVertexEncoder innerEncoder = this.inner.getEncoder();
 	private final ChunkVertexEncoder encoder = this::encode;
@@ -575,7 +586,14 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * reads, and normalising a zero puts a NaN in the colour.
 	 */
 	private static float[] frame(ChunkVertexEncoder.Vertex[] vertices) {
-		float[] frame = new float[7];
+		float[] frame = FRAMES.get();
+
+		// Emptied rather than allocated, and only the three Newell sums into: the tangent's three are
+		// written outright on every road out of here, the last of them being perpendicular's, and the
+		// handedness on the line below.
+		frame[0] = 0.0F;
+		frame[1] = 0.0F;
+		frame[2] = 0.0F;
 
 		// The answer for a quad no triangle of which has an area to measure. A triangle that has one
 		// overwrites it below, whether or not it goes on to yield a direction.

--- a/common/src/main/java/dev/vitrail/uniform/Val.java
+++ b/common/src/main/java/dev/vitrail/uniform/Val.java
@@ -33,6 +33,16 @@ public final class Val {
 	private int rank;
 	private boolean integral;
 
+	/**
+	 * Whether {@link #floats} already holds what the value holds, which a matrix leaves false.
+	 * <p>
+	 * A matrix is written out of {@link #mat3()} or {@link #mat4()} on every road but one, a pack
+	 * declaring a mat4 name as a mat3 or the other way round, and that road reads it component by
+	 * component through {@link #f(int)}. Copying the sixteen floats at the set was paying for that
+	 * road on every matrix of every block of every frame, so it is paid where it is taken instead.
+	 */
+	private boolean flattened;
+
 	public Val set(float x) {
 		return scalars(1, false, x, 0.0F, 0.0F, 0.0F);
 	}
@@ -83,18 +93,18 @@ public final class Val {
 
 	public Val set(Matrix3fc m) {
 		this.mat3.set(m);
-		this.mat3.get(this.floats);
 		this.rank = 9;
 		this.integral = false;
+		this.flattened = false;
 
 		return this;
 	}
 
 	public Val set(Matrix4fc m) {
 		this.mat4.set(m);
-		this.mat4.get(this.floats);
 		this.rank = 16;
 		this.integral = false;
+		this.flattened = false;
 
 		return this;
 	}
@@ -112,6 +122,7 @@ public final class Val {
 		this.floats[7] = scale;
 		this.rank = 8;
 		this.integral = false;
+		this.flattened = true;
 
 		return this;
 	}
@@ -126,7 +137,13 @@ public final class Val {
 	}
 
 	public float f(int component) {
-		return component < this.rank ? this.floats[component] : 0.0F;
+		if (component >= this.rank) {
+			return 0.0F;
+		}
+
+		flatten();
+
+		return this.floats[component];
 	}
 
 	public int i(int component) {
@@ -134,9 +151,13 @@ public final class Val {
 			return 0;
 		}
 
-		return this.integral && component < this.ints.length
-				? this.ints[component]
-				: (int) this.floats[component];
+		if (this.integral && component < this.ints.length) {
+			return this.ints[component];
+		}
+
+		flatten();
+
+		return (int) this.floats[component];
 	}
 
 	/** Only meaningful at rank 16. */
@@ -149,6 +170,24 @@ public final class Val {
 		return this.mat3;
 	}
 
+	/**
+	 * The matrix into the flat array, on the one road that reads it there and never before: the
+	 * columns of a mat3 are three long and those of a mat4 are four, and both land where the
+	 * component readers above expect them.
+	 */
+	private void flatten() {
+		if (this.flattened) {
+			return;
+		}
+
+		this.flattened = true;
+		if (this.rank == 9) {
+			this.mat3.get(this.floats);
+		} else {
+			this.mat4.get(this.floats);
+		}
+	}
+
 	private Val scalars(int rank, boolean integral, float x, float y, float z, float w) {
 		this.floats[0] = x;
 		this.floats[1] = y;
@@ -156,6 +195,7 @@ public final class Val {
 		this.floats[3] = w;
 		this.rank = rank;
 		this.integral = integral;
+		this.flattened = true;
 
 		return this;
 	}

--- a/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/GeometryValues.java
@@ -10,8 +10,6 @@ import dev.vitrail.uniform.WorldState;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 
-import java.util.Set;
-
 /**
  * The fixed function state of a pass drawn over the world rather than over a quad, and the one
  * name outside it whose answer depends on which of the two a program is.
@@ -74,7 +72,9 @@ public final class GeometryValues {
 	 * write {@code [1]}. It is written down rather than fixed because fixing it belongs to the chunk
 	 * prologue, which is where the aliasing is missing.
 	 */
-	private static final Set<Integer> LIGHTMAP_UNITS = Set.of(1, 2);
+	private static boolean lightmapUnit(int element) {
+		return element == 1 || element == 2;
+	}
 
 	/**
 	 * What {@code gl_TextureMatrix[1]} held when the game still had a fixed function pipeline, and
@@ -254,7 +254,7 @@ public final class GeometryValues {
 
 			@Override
 			public void read(WorldState world, Val out, int element) {
-				out.set(LIGHTMAP_UNITS.contains(element) ? LIGHTMAP_TEXTURE_MATRIX : IDENTITY);
+				out.set(lightmapUnit(element) ? LIGHTMAP_TEXTURE_MATRIX : IDENTITY);
 			}
 		});
 	}

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -105,7 +105,7 @@ texture is used as a colour attachment is the same as the one passed when it is 
 per-texture layout tracking anywhere, so there is nothing that can drift out of step from one frame
 to the next.
 
-On top of that, submitting a render pass ends it with a **full memory barrier**: all commands to
+On top of that, closing a render pass ends it with a **full memory barrier**: all commands to
 all commands, memory read and memory write. The other operations that touch textures (clearing,
 copying, uploading) end the same way. That is still what the game does for its own passes.
 
@@ -130,7 +130,8 @@ has named the synchronisation rather than the pass that shows it.
 
 The practical consequence is that reading in pass N+1 what pass N wrote still requires no
 synchronisation code of our own: close, open, bind. But the barrier exists only if the pass is
-genuinely closed, since it is closing that submits. A pass left open by an early return or an
+genuinely closed, closing being what records it: `vkCmdEndRenderingKHR` and then the barrier, on the
+command buffer the frame submits once at its end. A pass left open by an early return or an
 exception path skips its barrier and stays open besides, so passes belong in try-with-resources
 without exception.
 


### PR DESCRIPTION
## What changes

Per-frame work that rebuilt the same values on every draw is settled once. A composite pass
resolved every sampler name through a map on every frame and rebuilt its render area on every
descriptor; both are now taken at construction and cached against the sizes they depend on. The
geometry descriptor's shadow half allocated a list per region and rebuilt its area the same way;
it reuses fields like the camera half, and a second list the camera half filled without ever
reading it back is gone. The chunk mesher allocated two small arrays per quad on every builder
thread, for a frame nothing keeps past the packing that reads it; each thread now carries its own
scratch. Setting a matrix uniform copied it twice, once into the matrix and once into a flat
array only read when a pack declares a mat4 name as a mat3 or the reverse; the copy is taken on
that road only. The light-map test asked a hash set a question two integer comparisons answer,
and the key that names a dropped shadow caster was rebuilt as a string on every refused draw.

Three refusal messages also told the player to lower a setting the engine had already lowered:
the engine turns improved transparency off at pack load, so reaching those refusals means the
option came back on afterwards, and the messages now say so. One page of the internals
documentation said that closing a render pass submits to the queue; it records the end of the
pass and a barrier, and the frame submits once, which the page now states.

## How it differs from the reference, and for what obstacle

It does not. The values handed on are the same ones, in the same order.

## What proves it

`gradlew build` green. The changes replace recomputation with values cached against exactly what
they were derived from (the sampler table frozen at load, the screen and shadow map sizes, the
thread); no figure is claimed, so nothing was measured in game.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
