### PR TITLE
perf(render): fill a mip chain once per writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ what the next one holds.
   surface lit by the wrong program, with nothing in the log pointing at it. The failure now names
   itself at launch. The one exception is the line this mod adds to the F3 overlay, which is
   allowed to go missing because nothing on screen depends on it.
+- **A texture's chain of shrunken copies is rebuilt only when its base has changed.** Packs that
+  blur or expose through those copies asked for the whole chain to be rebuilt before every pass
+  that reads one, even when nothing had touched the image in between; two readers in a row now
+  pay one rebuild instead of two. The copies read are the same ones. Not measured, so this says
+  work removed and not frames gained.
 - **Two pieces of per-frame work on the graphics card are gone, and the picture is the same.**
   The far terrain's own depth image is emptied by the pass that draws into it rather than by a
   command of its own, which also spares the full stop of the card that such a command carries.

--- a/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
  * backend: scaled copies on the same command buffer, not a render pass per level. A pass per level
  * was the only public path, and each one ends with a full memory barrier. Iris pays one driver
  * call. The blit loop is that call: transfer barriers between levels so each read sees the write
- * below it, then the encoder's own full barrier once so the rest of the frame can sample the chain.
+ * below it, then one barrier naming what a filled chain owes the rest of the frame.
  * <p>
  * Closing a pass still runs the encoder's full barrier. Our own labels start with {@code Vitrail}
  * and get a write-then-sample barrier instead, the rest of the frame keeping the original wait.
@@ -207,7 +207,7 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 				}
 			}
 
-			VulkanCommandEncoder.memoryBarrier(commands, stack);
+			vitrail$chainTailBarrier(commands, stack);
 			return true;
 		} catch (RuntimeException e) {
 			Vitrail.logger().error("Blit mipmaps failed on {}, falling back to a pass per level",
@@ -245,6 +245,39 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 		VkDependencyInfo info = VkDependencyInfo.calloc(stack)
 				.sType$Default()
 				.pImageMemoryBarriers(barrier);
+		KHRSynchronization2.vkCmdPipelineBarrier2KHR(commands, info);
+	}
+
+	/**
+	 * What the filled chain owes the rest of the frame, named instead of the whole of memory. The
+	 * only writes standing unsynchronised at this point are the blits themselves: the pass that
+	 * wrote the base has already closed on its own barrier, and that is also what ordered the
+	 * first blit's read. What can touch the chain next is a sampled read from any shader stage, a
+	 * pass writing the base again, or another transfer; the image is a colour target, so no depth
+	 * stage ever meets it. The wide wait never reaches here: {@code vitrail$generateMipmaps}
+	 * refuses while it is armed, and the caller then pays a pass per level, each closing on the
+	 * game's own barrier.
+	 */
+	@Unique
+	private static void vitrail$chainTailBarrier(VkCommandBuffer commands, MemoryStack stack) {
+		VkMemoryBarrier2.Buffer barrier = VkMemoryBarrier2.calloc(1, stack)
+				.sType$Default()
+				.srcStageMask(KHRSynchronization2.VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR)
+				.srcAccessMask(KHRSynchronization2.VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR)
+				.dstStageMask(KHRSynchronization2.VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR
+						| KHRSynchronization2.VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR
+						| KHRSynchronization2.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR
+						| KHRSynchronization2.VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR
+						| KHRSynchronization2.VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR)
+				.dstAccessMask(KHRSynchronization2.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_SHADER_STORAGE_READ_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_TRANSFER_READ_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR);
+		VkDependencyInfo info = VkDependencyInfo.calloc(stack)
+				.sType$Default()
+				.pMemoryBarriers(barrier);
 		KHRSynchronization2.vkCmdPipelineBarrier2KHR(commands, info);
 	}
 

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -707,9 +707,10 @@ final class ColorTargets {
 	 * Which targets one program reads at a lod, narrowed to those that carry a chain.
 	 * <p>
 	 * Per program and not the union, because this is what decides when a chain is rebuilt. A chain
-	 * is only valid until something writes level nought again, so it is refilled before each program
-	 * that reads one; taking the union here would rebuild every chain before every program that
-	 * happens to sample the target, which is ten render passes apiece for a result nothing reads.
+	 * is only valid until something writes level nought again, so it is refilled before the next
+	 * program that reads one after such a write; taking the union here would rebuild every chain
+	 * before every program that happens to sample the target, which is ten render passes apiece
+	 * for a result nothing reads.
 	 */
 	Set<Integer> lodReads(String program) {
 		return this.plan.directives().mipmapRequests().getOrDefault(program, Set.of()).stream()

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -66,6 +66,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -282,6 +283,16 @@ public final class PackChain {
 
 	/** Fills the mip chains of the targets the programs of this place read at a lod. */
 	private final MipmapReduction mipmaps = new MipmapReduction();
+
+	/**
+	 * The chains {@link #drawRange} has filled and nothing has written over since. Held by the
+	 * surface itself and never by target and side, because the two spellings do not name surfaces
+	 * one to one: a target nobody doubles answers its main surface for either side, and a write
+	 * filed under one spelling has to evict what the other spelling filled. One object for the
+	 * frame rather than one per range, cleared where the walk says so: what it remembers is only
+	 * ever true inside one walk.
+	 */
+	private final Set<TargetSurface> currentChains = new HashSet<>();
 
 	/** What colortex0 is emptied to, refilled once a frame. One object, because a clear is a frame. */
 	private final Vector4f fogClear = new Vector4f(0.0F, 0.0F, 0.0F, 1.0F);
@@ -2171,22 +2182,35 @@ public final class PackChain {
 		// it short of knowing which passes do not overlap.
 		CommandEncoder encoder = device.createCommandEncoder();
 		GpuBuffer buffer = this.block.currentBuffer();
+		// The chains this walk has filled and nothing has written over since, by target and side.
+		// Emptied at the head because the range starts after geometry the plan does not see, and
+		// again wherever a write this loop cannot place lands: the seed paints targets of its own
+		// list, and the deferred emptying inside a draw clears every target still owed one.
+		this.currentChains.clear();
 		for (int at = from; at < to; at++) {
 			if (!this.seeded && at == seedAt) {
 				paintSeed(encoder, ready);
+				this.currentChains.clear();
 			}
 
 			PackPass pass = this.programs.get(at);
 
-			// Right before the program that reads them, and no earlier: a chain is only true of the
-			// level nought it was built from, and every pass between the two may have written it.
-			// The reduction opens render passes of its own, which is why this is here rather than
-			// inside the draw: a pass cannot be opened while another is recording.
+			// Right before the first program that reads them after a write: a chain is only true
+			// of the level nought it was built from, and every pass between the two may have
+			// written it. The reduction opens render passes of its own, which is why this is here
+			// rather than inside the draw: a pass cannot be opened while another is recording. A
+			// chain filled for an earlier reader and written over by nothing since is still true,
+			// so it is not refilled: two readers in a row used to pay two whole chains for one
+			// image.
 			for (PackPass.LodRead read : pass.lodReads()) {
-				this.mipmaps.generate(encoder, device, this.quad,
-						this.targets.surface(read.target(), read.side()));
+				TargetSurface surface = this.targets.surface(read.target(), read.side());
+				if (surface != null && !this.currentChains.contains(surface)
+						&& this.mipmaps.generate(encoder, device, this.quad, surface)) {
+					this.currentChains.add(surface);
+				}
 			}
 
+			boolean emptying = this.targets.hasPendingClears();
 			GpuBufferSlice uniforms = buffer.slice(pass.uniformOffset(), pass.uniformSize());
 			if (pass == this.last) {
 				pass.drawFinal(encoder, ready.mainView(), this.targets, depth, distant, this.quad,
@@ -2194,6 +2218,15 @@ public final class PackChain {
 			} else {
 				pass.draw(encoder, this.targets, depth, distant, this.quad, uniforms,
 						ready.main().width, ready.main().height);
+			}
+
+			if (emptying) {
+				this.currentChains.clear();
+			} else {
+				for (ChainPlan.Attachment attachment : pass.attachments()) {
+					this.currentChains.remove(
+							this.targets.surface(attachment.target(), attachment.side()));
+				}
 			}
 		}
 

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -300,6 +300,14 @@ final class PackPass {
 	}
 
 	/**
+	 * The colour targets this program draws into, with the half of each, which is what lets the
+	 * caller know a chain it filled is no longer true of its base once this program has run.
+	 */
+	List<ChainPlan.Attachment> attachments() {
+		return this.attachments;
+	}
+
+	/**
 	 * Whether this program declares the sampler the smoothed centre depth was moved onto, which is
 	 * what decides that the pass drawing that texel is worth running at all.
 	 * <p>

--- a/common/src/main/java/dev/vitrail/render/TargetSurface.java
+++ b/common/src/main/java/dev/vitrail/render/TargetSurface.java
@@ -59,8 +59,9 @@ final class TargetSurface implements AutoCloseable {
 	 * the driver left there, so a sampler allowed to climb the chain before the reduction has run
 	 * once serves undefined memory rather than a coarser image, which is the defect 4d52d20 closed
 	 * for the shadow map. Stale is a different matter and not a danger: a chain built two passes ago
-	 * is a real image of the target, only an older one, and the reduction runs immediately before
-	 * each program that reads one.
+	 * is a real image of the target, only an older one, and the walk that fills chains runs the
+	 * reduction before any program that reads one where something has written the base since the
+	 * last fill.
 	 */
 	private boolean chainWritten;
 


### PR DESCRIPTION
## What changes

The mip chains a pack reads through `mipmapEnabled` are filled only when their base image has
changed. The walk over the fullscreen chain remembers, by the surface itself, which chains it has
filled, and forgets one wherever a write it can place lands: the pass that attaches the target,
the scene seed painting its own list, and the deferred emptying that clears every target still
owed one. Two readers in a row used to pay two whole chains for one image, a third of the target
read and written again, and the second fill also cut the geometry-hold pass fusion for nothing.

Beside it, the blits that fill a chain no longer close on the game's full memory barrier. The
only writes standing unsynchronised at that point are the blits themselves, so the tail now names
them and their consumers: sampled reads from any shader stage, a pass writing the base again, or
another transfer.

## How it differs from the reference, and for what obstacle

Iris rebuilds the chain before every reader, unconditionally
(`CompositeRenderer.setupMipmapping`, called per pass at `CompositeRenderer.java:311`, and
`FinalPassRenderer.java:240`). Nothing prevents doing the same here; it is repeated work, not a
behaviour. A chain rebuilt from an unchanged base is bit-identical to the one already standing,
so skipping the rebuild costs the image nothing.

## What proves it

`gradlew build` green after the rebase. The invalidation points were checked against every road
that writes a chained colour target inside the walk's window: composite attachments and deferred
clears pass through the walk itself, the seed empties the memo, the pack's compute dispatches at
the head of the frame, geometry runs between the two halves where the memo starts empty, and
target reallocation is locked out mid-frame. The memo keys on the surface instance because a
target nobody doubles answers its main surface for either side, so a spelling key would let a
write under one spelling survive a fill under the other. Not tried in game; the picture to check
is any pack that blurs or exposes through lods (BSL composite3 to composite7).

## What it leaves owing

On the pass where deferred clears run, the chain is still filled before those clears land, so
that reader sees a chain of the pre-clear image over a post-clear base. That is the order the
engine always had; the memo forgets the chain afterwards, so the next reader refills it. And
neither the new tail barrier nor the pass barrier beside it names the geometry shader stage, so
a `.gsh` that sampled a mipmapped target would read unsynchronised; the gap is shared with the
existing barrier and no pack of the corpus does it.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
