### PR TITLE
perf: put the shadow comparison back on the sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ what the next one holds.
 
 ### Changed
 
+- **A shadow lookup a pack asks the hardware to compare is now compared by the hardware.** A
+  pack declaring `sampler2DShadow` used to have that comparison rebuilt in shader
+  arithmetic on every tap, a dozen instructions where a comparison sampler pays one, and a
+  shadow's blur loop makes many taps per pixel. The comparison now rides the sampler, the pair
+  Iris binds when a pack asks for its hardware shadow filtering, which every pack that declares
+  the type does; the picture it computes is the same blend of the same four texels. For a
+  machine where the sampler road is suspected of a wrong image, a file
+  `vitrail/soft-shadow-compare` in the game directory, or `-Dvitrail.softShadowCompare=true`,
+  puts the arithmetic back in one launch, and removing it again takes a pack reload.
 - **A patch of this mod that stops fitting the game now refuses to start it, instead of drawing a
   wrong picture.** Those patches used to be dropped without a word when a game or Sodium update
   moved what they attach to, and what reached the screen was an effect quietly missing or a

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 /**
  * Turns one flattened pack unit into GLSL a Vulkan compiler will take.
@@ -166,6 +167,21 @@ public final class GlslTranslator {
 
 	/** The comparison a {@code sampler2DShadow} would have had the hardware make. */
 	private static final String SHADOW_COMPARE = "ofShadowCompare";
+
+	/**
+	 * Whether every comparison goes back to the arithmetic of {@link #SHADOW_COMPARE} instead of
+	 * staying on the sampler. The hardware road cannot be watched from inside: a comparison bound
+	 * wrong does not fail, it hands back a fraction of the wrong thing, and the picture stays
+	 * credible. So the trade is on a switch, the way the pass barrier is: an image that comes right
+	 * with this on has named the comparison sampler rather than the pass that shows it, in one
+	 * launch and without a build.
+	 * <p>
+	 * The property is read here so that the harness answers it too; the file in the game directory
+	 * is the render side's to see, which is what {@link #askSoftCompare} is for.
+	 */
+	private static final boolean SOFT_COMPARE = Boolean.getBoolean("vitrail.softShadowCompare");
+
+	private static volatile boolean softCompareArmed;
 
 	/**
 	 * What a call to {@code sin} or {@code cos} becomes: a sine of this translation's own, and
@@ -363,10 +379,16 @@ public final class GlslTranslator {
 	private final Map<String, VolumeAtlas> readVolumes = new LinkedHashMap<>();
 
 	/**
-	 * The samplers the pack declared as comparison samplers, and which are declared here as ordinary
-	 * ones. {@link #rewriteShadowCompare} says why they cannot stay what they were.
+	 * The comparison samplers whose comparison is made in arithmetic, their declarations rewritten
+	 * ordinary. {@link #collectComparisonSamplers} says how a name lands here rather than below.
 	 */
 	private final List<Scoped> comparisonSamplers = new ArrayList<>();
+
+	/**
+	 * The comparison samplers that keep their spelling, so the lookup compiles to a depth-reference
+	 * sample and the binding owes each name a comparison sampler.
+	 */
+	private final List<Scoped> hardwareComparisonSamplers = new ArrayList<>();
 
 	/**
 	 * The samplers a function takes as a parameter, over the lines of that function. Nothing is
@@ -423,8 +445,12 @@ public final class GlslTranslator {
 	private int volumeLookups;
 	private int volumesLeftAlone;
 
-	/** Lookups this unit makes the comparison for itself, because the backend cannot. */
+	/** Lookups on a comparison sampler, whichever of the two roads makes the comparison. */
 	private int shadowCompares;
+
+	/** The lookups of those that were really rewritten onto {@link #SHADOW_COMPARE}, which is what
+	 * says whether the header owes the helper at all. */
+	private int softRewrites;
 
 	/** Calls to {@code sin} or {@code cos} sent through the reduced-argument helpers. */
 	private int trigCalls;
@@ -610,6 +636,21 @@ public final class GlslTranslator {
 		return new Stage(translator);
 	}
 
+	/**
+	 * Sends every unit translated from here on down the {@link #SHADOW_COMPARE} road, or lets it
+	 * back off it, which matters as much: the switch is read again at every pack load, so removing
+	 * the arming file and reloading has to put the comparison back on the sampler without a
+	 * restart. Called by whoever can see the game directory; the system property is this class's
+	 * own to read, so a harness run answers it without a game around.
+	 */
+	public static void askSoftCompare(boolean asked) {
+		softCompareArmed = asked;
+	}
+
+	private static boolean softCompare() {
+		return SOFT_COMPARE || softCompareArmed;
+	}
+
 	private void rewrite() {
 		collectMacroNames();
 		collectDeclarations();
@@ -617,8 +658,8 @@ public final class GlslTranslator {
 		// much later, after the depth conversion, and a set filled there would be empty at the one
 		// moment it decides something.
 		collectComparisonSamplers();
-		// After it, and for the same reason: the comparison has already been taken out of the
-		// spelling by then, so a compared parameter is collected here under sampler2D like any other.
+		// After it, and for the same reason: the road has been settled by then, so a compared
+		// parameter is collected here like any other sampler, under whichever spelling it kept.
 		collectSamplerParameters();
 		collectStorageBlocks();
 		collectDrawBuffers();
@@ -1227,23 +1268,34 @@ public final class GlslTranslator {
 				}
 
 				if (close >= 0) {
-					// A legacy shadow lookup on a sampler this backend cannot compare with is
-					// rewritten here rather than later: the injection below fuses the name into one
-					// token with the parenthesis, and the depth conversion matches names.
+					// A legacy shadow lookup is rewritten here rather than later: the injection
+					// below fuses the name into one token with the parenthesis, and the depth
+					// conversion matches names.
 					int first = significantAfter(callOpener(index));
-					boolean compared = first >= 0
+					String argument = first >= 0
 							&& this.tokens.get(first).kind() == Kind.IDENTIFIER
-							&& comparisonAt(this.tokens.get(first).text(), lines[index]);
+							? this.tokens.get(first).text() : null;
+					boolean hardware = argument != null
+							&& hardwareComparisonAt(argument, lines[index]);
+					boolean compared = argument != null && !hardware
+							&& comparisonAt(argument, lines[index]);
 
-					// Only the plain lookups are ours to make, as in rewriteShadowCompare and for
-					// the same reason: a projective comparison divides before it compares, which is
-					// a different expression and not a different name. It keeps the modern spelling
-					// and is counted rather than quietly turned into something it is not.
+					// Only the plain lookups are the arithmetic road's to make, as in
+					// rewriteShadowCompare and for the same reason: a projective comparison divides
+					// before it compares, which is a different expression and not a different name.
+					// It keeps the modern spelling and is counted rather than quietly turned into
+					// something it is not. The hardware road has no such edge: textureProj on a
+					// comparison sampler is the division and the comparison in one call, so it
+					// counts as a comparison made rather than as one left on the floor.
 					if (compared && shadow.equals("textureProj")) {
 						this.unwrappedShadowCalls++;
 						compared = false;
-					} else if (compared) {
+					} else if (compared || hardware) {
 						this.shadowCompares++;
+					}
+
+					if (compared) {
+						this.softRewrites++;
 					}
 
 					// The wrap adds an opening parenthesis, so it has to add a closing one too.
@@ -1810,32 +1862,45 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Turns a lookup on a comparison sampler into a comparison this engine makes itself.
+	 * Recognises a lookup on a comparison sampler, and on the arithmetic road puts
+	 * {@link #SHADOW_COMPARE} in its place.
 	 * <p>
-	 * <strong>The declaration is rewritten because the backend cannot honour it.</strong> A
-	 * {@code sampler2DShadow} asks the hardware to compare the third coordinate against the texel
-	 * and hand back a fraction, and {@code GpuSampler} carries no comparison at all: two address
-	 * modes, two filters, an anisotropy and a maximum level of detail. Bound as an ordinary sampler
-	 * the comparison means nothing, and what a pack gets back is not a wrong shadow but no shadow
-	 * information whatever, which reads on screen as a world entirely in shadow.
+	 * <strong>On the hardware road nothing is rewritten at all.</strong> The declaration kept its
+	 * spelling, so the lookup compiles to a depth-reference sample and the comparison is made by
+	 * the sampler the binding put under the name, {@code GL_COMPARE_REF_TO_TEXTURE} in the terms
+	 * Iris binds it in. The call is still counted and still answers true, because whatever road
+	 * makes the comparison, what comes back is a fraction of the light and not a depth.
 	 * <p>
-	 * Only the plain lookups are rewritten. A projective or gathered comparison is left as it stands
-	 * and counted: what it needs is a different expression, not a different name, and a call that
-	 * silently kept a hardware comparison is exactly the thing this whole rewrite exists to stop.
+	 * The arithmetic road exists because {@code GpuSampler} carries no comparison at all: two
+	 * address modes, two filters, an anisotropy and a maximum level of detail. Bound as an ordinary
+	 * sampler the comparison means nothing, and what a pack gets back is not a wrong shadow but no
+	 * shadow information whatever, which reads on screen as a world entirely in shadow. On that
+	 * road only the plain lookups are rewritten; a projective or gathered comparison is left as it
+	 * stands and counted, since what it needs is a different expression, not a different name.
 	 *
 	 * @param line where the call stands, since a comparison sampler taken as a parameter only means
 	 *             one inside the function that took it
 	 * @return whether this call was a comparison, in which case it is not a depth read as well
 	 */
 	private boolean rewriteShadowCompare(int index, int line) {
-		if (this.comparisonSamplers.isEmpty()) {
+		if (this.comparisonSamplers.isEmpty() && this.hardwareComparisonSamplers.isEmpty()) {
 			return false;
 		}
 
 		int open = callOpener(index);
 		int first = open < 0 ? -1 : significantAfter(open);
-		if (first < 0 || this.tokens.get(first).kind() != Kind.IDENTIFIER
-				|| !comparisonAt(this.tokens.get(first).text(), line)) {
+		if (first < 0 || this.tokens.get(first).kind() != Kind.IDENTIFIER) {
+			return false;
+		}
+
+		String argument = this.tokens.get(first).text();
+		if (hardwareComparisonAt(argument, line)) {
+			this.shadowCompares++;
+
+			return true;
+		}
+
+		if (!comparisonAt(argument, line)) {
 			return false;
 		}
 
@@ -1851,6 +1916,7 @@ public final class GlslTranslator {
 		// which is what a comparison sampler with no mipmaps would have done anyway.
 		replace(index, SHADOW_COMPARE);
 		this.shadowCompares++;
+		this.softRewrites++;
 
 		return true;
 	}
@@ -3144,13 +3210,15 @@ public final class GlslTranslator {
 		// writes every sampler in the order the program settled, which is what MoltenVK numbers.
 		boolean opaque = LegacyGlsl.isOpaqueType(type);
 
-		// The comparison is already out of the token stream by now, taken there by
-		// collectComparisonSamplers, so this only has to record it under the same spelling.
-		String plain = withoutComparison(type);
-
+		// Recorded under the spelling the token carries, which is the road decision made real:
+		// collectComparisonSamplers has already taken the comparison out of every declaration it
+		// sent to the arithmetic, and one still spelling it is one the binding owes a comparison
+		// sampler, so the header has to keep saying so. Taking it out here again is what once
+		// declared a kept comparison ordinary, and every lookup on it stopped compiling.
+		//
 		// Recorded for an opaque uniform alone, which is the only declaration these can be
 		// written on and the only one that reads them back out of the header.
-		if (!readDeclarators(parts, cursor + 1, plain, opaque ? String.join(" ", memory) : "",
+		if (!readDeclarators(parts, cursor + 1, type, opaque ? String.join(" ", memory) : "",
 				opaque ? this.samplers : this.blockMembers)) {
 			return;
 		}
@@ -3159,8 +3227,10 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Finds every sampler the pack declared as a comparison sampler, takes the comparison out of its
-	 * declaration, and remembers the name so that {@link #rewriteShadowCompare} knows its lookups.
+	 * Finds every sampler the pack declared as a comparison sampler, remembers the name so that
+	 * {@link #rewriteShadowCompare} knows its lookups, and settles which of the two roads each
+	 * takes: the declaration keeps its spelling and the binding carries a comparison sampler, or it
+	 * is declared ordinary and {@link #SHADOW_COMPARE} makes the comparison in arithmetic.
 	 * <p>
 	 * A pass of its own, and early, because of when the others run: the uniforms are lifted after
 	 * the depth conversion, and the conversion is the one place that has to know. It walks the
@@ -3178,11 +3248,32 @@ public final class GlslTranslator {
 	 * is not composite1; taking the dead one would make every lookup on that name a comparison, in a
 	 * program whose texture is not one. The bracket count still walks every token, live or not,
 	 * because it is the shape of the text and not a statement about the program.
+	 * <p>
+	 * The road is decided per declaration, by the name and by nothing a stage chooses, so the same
+	 * name answers the same way in every stage that spells it the same. A file-scope declaration
+	 * keeps its spelling when every name it introduces is one of the shadow map's own and the pack
+	 * has not taken the name over as a custom image, because those are the names the binding can
+	 * really put a comparison sampler under; anything else compared is rewritten ordinary and
+	 * handed the arithmetic, as every name once was. What this cannot close is a pack spelling one
+	 * name two ways across the stages of one program: the sampler is the pipeline's, so the plain
+	 * spelling would read through the comparison, undefined exactly as it is under Iris, and the
+	 * binding says so by name when it meets one.
+	 * <p>
+	 * A parameter follows the unit: it keeps its spelling where the unit keeps a comparison at file
+	 * scope, since that is what its callers pass, and goes back to ordinary with everything else,
+	 * which is what the callers hold then. A unit mixing both roads at file scope leaves a helper
+	 * with one type and a caller with the other, which fails to compile, loudly; no pack of the
+	 * corpus does. A compute unit is all-arithmetic whatever it declares, its descriptors being
+	 * pushed on a road the render-pass substitution never sees, and so is every unit of a launch
+	 * whose soft-compare switch is armed.
 	 */
 	private void collectComparisonSamplers() {
 		int[] lines = lineNumbers();
 		int depth = 0;
 		int parameters = -1;
+		boolean arithmetic = softCompare() || this.stage == ProgramStage.COMPUTE;
+		List<Integer> parameterTypes = new ArrayList<>();
+		List<Scoped> parameterNames = new ArrayList<>();
 
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
@@ -3206,11 +3297,11 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			replace(index, plain);
-
 			// Every identifier this declaration introduces, and how far what it introduces them
 			// into reaches. Array bounds and commas are not identifiers, so they are stepped over.
 			int last = depth > 0 ? functionEnd(parameters) : this.tokens.size() - 1;
+			List<Scoped> introduced = new ArrayList<>();
+			boolean bindable = !arithmetic;
 			for (int scan = significantAfter(index); scan >= 0; scan = significantAfter(scan)) {
 				Token next = this.tokens.get(scan);
 				if (next.operator(";") || (depth > 0 && (next.operator(",") || next.operator(")")))) {
@@ -3218,10 +3309,39 @@ public final class GlslTranslator {
 				}
 
 				if (next.kind() == Kind.IDENTIFIER) {
-					this.comparisonSamplers.add(new Scoped(next.text(), lines[index], lines[last]));
+					introduced.add(new Scoped(next.text(), lines[index], lines[last]));
+					if (depth == 0 && (SamplerPlan.classify(next.text())
+							!= SamplerPlan.Kind.SHADOW_DEPTH
+							|| CustomImages.named(next.text()))) {
+						bindable = false;
+					}
 				}
 			}
+
+			// A parameter waits for the file-scope verdict, since what it must match is whatever
+			// its callers will be holding by then.
+			if (depth > 0) {
+				parameterTypes.add(index);
+				parameterNames.addAll(introduced);
+			} else if (bindable) {
+				this.hardwareComparisonSamplers.addAll(introduced);
+			} else {
+				replace(index, plain);
+				this.comparisonSamplers.addAll(introduced);
+			}
 		}
+
+		if (!this.hardwareComparisonSamplers.isEmpty()) {
+			this.hardwareComparisonSamplers.addAll(parameterNames);
+
+			return;
+		}
+
+		for (int index : parameterTypes) {
+			replace(index, withoutComparison(this.tokens.get(index).text()));
+		}
+
+		this.comparisonSamplers.addAll(parameterNames);
 	}
 
 	/**
@@ -3795,6 +3915,11 @@ public final class GlslTranslator {
 		return scoped(this.comparisonSamplers, name, line);
 	}
 
+	/** The same question for the comparison samplers that kept their spelling. */
+	private boolean hardwareComparisonAt(String name, int line) {
+		return scoped(this.hardwareComparisonSamplers, name, line);
+	}
+
 	/** Whether one of these names means what the list says it does on this line. */
 	private static boolean scoped(List<Scoped> names, String name, int line) {
 		for (Scoped scoped : names) {
@@ -3968,17 +4093,17 @@ public final class GlslTranslator {
 			}
 		}
 
-		// The four taps a hardware comparison blends, made here because 26.2 has no comparison to
-		// bind: GpuSampler carries two address modes, two filters, an anisotropy and a maximum level
-		// of detail, and neither GlSampler nor VulkanGpuSampler ever writes a compare mode. What the
-		// hardware does is compare each of the four texels a bilinear filter would
-		// have taken and blend the four RESULTS, so that is what this does: textureGather brings the
-		// four back whatever filter is bound, the comparison is made on each, and the blend uses the
-		// weights of the filter. Comparing an already filtered depth is the one thing it must not
-		// do, and that is the difference: the average of four depths is a surface standing nowhere,
-		// while the average of four comparisons is a fraction of the light, which is the whole point
-		// of the thing. Iris binds GL_LINEAR plus GL_COMPARE_REF_TO_TEXTURE for it, in
-		// ShadowRenderTargets.getSamplerFor.
+		// The four taps a hardware comparison blends, for the lookups the road decision sent here:
+		// GpuSampler carries no compare mode, so when the comparison cannot ride the binding, what
+		// the hardware does is done in arithmetic instead. The hardware compares each of the four
+		// texels a bilinear filter would have taken and blends the four RESULTS, so that is what
+		// this does: textureGather brings the four back whatever filter is bound, the comparison is
+		// made on each, and the blend uses the weights of the filter. Comparing an already filtered
+		// depth is the one thing it must not do, and that is the difference: the average of four
+		// depths is a surface standing nowhere, while the average of four comparisons is a fraction
+		// of the light, which is the whole point of the thing. Iris binds GL_LINEAR plus
+		// GL_COMPARE_REF_TO_TEXTURE for it, in ShadowRenderTargets.getSamplerFor, and the hardware
+		// road binds the same pair through the descriptor instead of coming here.
 		//
 		// Not conditioned on shadowHardwareFiltering, and nothing here could condition it: the
 		// header is written per stage, before any of the pack's directives are folded. It costs
@@ -3993,7 +4118,7 @@ public final class GlslTranslator {
 		//
 		// The level of detail is dropped, which is what a comparison sampler with no mipmaps would
 		// have done with it anyway: nothing ever fills a chain on the shadow map.
-		if (this.shadowCompares > 0) {
+		if (this.softRewrites > 0) {
 			lines.add("float " + SHADOW_COMPARE + "(sampler2D ofMap, vec3 ofAt) {"
 					+ " vec4 ofTests = step(vec4(ofAt.z), textureGather(ofMap, ofAt.xy, 0));"
 					+ " vec2 ofPart = fract(ofAt.xy * vec2(textureSize(ofMap, 0)) - 0.5);"
@@ -4356,17 +4481,29 @@ public final class GlslTranslator {
 				this.covers ? 1 : 0, this.depthLookups,
 				this.parameterLookups, this.fragCoordZ, this.fragCoordXyz,
 				this.fragCoordUnhandled, this.fragDepthWrites, this.fragDepthUnhandled,
-				List.copyOf(this.conflicts), comparedSamplers(), List.copyOf(this.storageBlocks),
+				List.copyOf(this.conflicts), comparedSamplers(), hardwareComparedSamplers(),
+				List.copyOf(this.storageBlocks),
 				this.volumeLookups, this.volumesLeftAlone, this.trigCalls, this.gameTextureMatrix,
 				this.gameModelView);
 	}
 
 	/**
-	 * The comparison samplers this stage is handed from outside, which are the only ones anything
-	 * binds: one taken as a parameter is a name inside a function and never a descriptor.
+	 * The comparison samplers this stage is handed from outside, both roads together, which are the
+	 * only ones anything binds: one taken as a parameter is a name inside a function and never a
+	 * descriptor.
 	 */
 	private List<String> comparedSamplers() {
-		return this.comparisonSamplers.stream()
+		return descriptors(Stream.concat(this.comparisonSamplers.stream(),
+				this.hardwareComparisonSamplers.stream()));
+	}
+
+	/** The bound ones of the road that kept its spelling, which the binding owes a comparison. */
+	private List<String> hardwareComparedSamplers() {
+		return descriptors(this.hardwareComparisonSamplers.stream());
+	}
+
+	private List<String> descriptors(Stream<Scoped> scoped) {
+		return scoped
 				.map(Scoped::name)
 				.distinct()
 				.filter(this.samplers::containsKey)

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedUnit.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedUnit.java
@@ -92,9 +92,12 @@ public record TranslatedUnit(String entry, ProgramStage stage, String text, Note
 	 *                           reads back a value the stage never wrote
 	 * @param conflictNames      the names behind {@code uniformConflicts}, so a run over a corpus
 	 *                           can name them rather than only count them
-	 * @param comparedSamplers   the samplers the pack asked the hardware to compare and that are
-	 *                           declared here as ordinary ones. Read off the declarations rather
-	 *                           than off {@code samplers}, whose types have already been rewritten
+	 * @param comparedSamplers   the samplers the pack asked the hardware to compare, read off the
+	 *                           declarations, both roads together
+	 * @param hardwareCompared   the ones of those that kept their comparison spelling, so that the
+	 *                           binding owes each a comparison sampler and the lookup is the
+	 *                           hardware's. The rest are declared ordinary, with the comparison
+	 *                           made in arithmetic where each lookup stood
 	 * @param storageBlocks      the storage blocks this unit declares at file scope. A
 	 *                           {@code bufferObject} that matches one is bound; the rest refuse
 	 *                           the program that carries them
@@ -122,7 +125,8 @@ public record TranslatedUnit(String entry, ProgramStage stage, String text, Note
 			int depthLookups, int parameterLookups,
 			int fragCoordZ, int fragCoordXyz, int fragCoordUnhandled,
 			int fragDepthWrites, int fragDepthUnhandled,
-			List<String> conflictNames, List<String> comparedSamplers, List<String> storageBlocks,
+			List<String> conflictNames, List<String> comparedSamplers,
+			List<String> hardwareCompared, List<String> storageBlocks,
 			int volumeLookups, int volumesLeftAlone, int trigCalls, int gameTextureMatrix,
 			int gameModelView) {
 	}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
@@ -4,12 +4,15 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
 import com.mojang.blaze3d.vulkan.VulkanRenderPass;
+import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
+import dev.vitrail.render.ShadowCompare;
 import dev.vitrail.render.StorageBuffers;
 import dev.vitrail.render.StorageImages;
 import org.lwjgl.vulkan.VkDescriptorBufferInfo;
 import org.lwjgl.vulkan.VkDescriptorImageInfo;
 import org.lwjgl.vulkan.VkWriteDescriptorSet;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -17,18 +20,24 @@ import java.util.List;
 
 /**
  * Pushes a storage-image descriptor, a 3D sampled view, and a storage-buffer descriptor for
- * names {@link StorageImages} and {@link StorageBuffers} hold.
+ * names {@link StorageImages} and {@link StorageBuffers} hold, and the comparison sampler for a
+ * shadow name the pipeline being drawn declared a comparison.
  * <p>
  * The game always writes a combined image sampler from a 2D {@code GpuTextureView}, and a
  * uniform buffer from a {@code GpuBufferSlice}. Complementary needs type 3 and a 3D view on
  * {@code voxel_img}, a 3D sampled view on {@code voxel_sampler}, and type 7 plus the VMA handle
- * on {@code blockDataBuffer}.
+ * on {@code blockDataBuffer}. The comparison is the same shape of gap: no {@code GpuSampler}
+ * describes one, so {@link ShadowCompare} makes it in Vulkan's own terms and this walk puts its
+ * handle under the names the pipeline registered when it was built.
  */
 @Mixin(VulkanRenderPass.class)
 public abstract class VulkanRenderPassMixin {
 
 	@Unique
 	private static final ThreadLocal<VulkanBindGroupLayout.Entry> CURRENT = new ThreadLocal<>();
+
+	@Shadow
+	protected VulkanRenderPipeline pipeline;
 
 	@WrapOperation(method = "pushDescriptors", require = 1,
 			at = @At(value = "INVOKE", target = "Ljava/util/List;get(I)Ljava/lang/Object;", ordinal = 0))
@@ -64,6 +73,15 @@ public abstract class VulkanRenderPassMixin {
 		StorageImages.Bound bound = currentBound();
 		if (bound != null && bound.storage()) {
 			sampler = 0L;
+		} else if (ShadowCompare.noted()) {
+			// Behind the one flag: until the first pack that compares is loaded, every pass of the
+			// game's own pays a volatile read here and nothing else. Once one has been, the flag
+			// stays up for the session and the per-name lookup is the price of having the road.
+			VulkanBindGroupLayout.Entry entry = CURRENT.get();
+			if (entry != null && this.pipeline != null
+					&& ShadowCompare.compared(this.pipeline.info(), entry.name())) {
+				sampler = ShadowCompare.sampler(this.pipeline.device());
+			}
 		}
 
 		return original.call(info, sampler);

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -875,6 +875,11 @@ final class ColorTargets {
 			return false;
 		}
 
+		// The device's own set first, made here because this runs outside any pass and the passes
+		// below cannot: it carries the far plane in a depth format, which is the one fallback a
+		// comparison sampler can be bound against.
+		ConstantTextures.of(RenderSystem.getDevice());
+
 		// One pixel each, and clamped when they are bound, so the value is what a lookup reads
 		// wherever it lands. None of them carries a chain: a constant has nothing to average, and
 		// the noise image is a field a pack indexes itself rather than one anything reads at a lod.

--- a/common/src/main/java/dev/vitrail/render/ConstantTextures.java
+++ b/common/src/main/java/dev/vitrail/render/ConstantTextures.java
@@ -43,6 +43,7 @@ final class ConstantTextures {
 
 	private final TextureTarget black;
 	private final TextureTarget white;
+	private final TextureTarget farPlane;
 	private final Map<PbrMap, TextureTarget> flatMaps = new EnumMap<>(PbrMap.class);
 
 	/**
@@ -52,6 +53,7 @@ final class ConstantTextures {
 	private ConstantTextures(GpuDevice device) {
 		this.black = new TextureTarget("Vitrail terrain black", 1, 1, false, FORMAT);
 		this.white = new TextureTarget("Vitrail terrain white", 1, 1, false, FORMAT);
+		this.farPlane = new TextureTarget("Vitrail far plane", 1, 1, true, FORMAT);
 		for (PbrMap map : PbrMap.values()) {
 			this.flatMaps.put(map, new TextureTarget("Vitrail terrain " + map.sampler(), 1, 1,
 					false, FORMAT));
@@ -60,6 +62,7 @@ final class ConstantTextures {
 		CommandEncoder encoder = device.createCommandEncoder();
 		encoder.clearColorTexture(this.black.getColorTexture(), OPAQUE_BLACK);
 		encoder.clearColorTexture(this.white.getColorTexture(), OPAQUE_WHITE);
+		encoder.clearDepthTexture(this.farPlane.getDepthTexture(), 1.0);
 		this.flatMaps.forEach((map, target) ->
 				encoder.clearColorTexture(target.getColorTexture(), map.missing()));
 	}
@@ -89,6 +92,7 @@ final class ConstantTextures {
 
 		instance.black.destroyBuffers();
 		instance.white.destroyBuffers();
+		instance.farPlane.destroyBuffers();
 		instance.flatMaps.values().forEach(TextureTarget::destroyBuffers);
 		instance = null;
 	}
@@ -99,6 +103,26 @@ final class ConstantTextures {
 
 	GpuTextureView white() {
 		return this.white.getColorTextureView();
+	}
+
+	/**
+	 * The far plane in a depth format, for a shadow name a comparison sampler reads. The comparison
+	 * is only defined against a depth image, so the RGBA white above cannot answer it; this one
+	 * texel holds one, which is the far plane of the map's own window, and a comparison against it
+	 * says "nothing between here and the light" exactly as the white does for a plain read. Read
+	 * without a comparison it answers one in the red channel, which is the component a depth read
+	 * takes, so serving it to a name only some programs compare changes neither.
+	 */
+	GpuTextureView farPlane() {
+		return this.farPlane.getDepthTextureView();
+	}
+
+	/**
+	 * The same texel for a caller that cannot make the set, because it is inside a render pass
+	 * where the clears above are refused. Null until somebody outside one has asked.
+	 */
+	static GpuTextureView farPlaneIfReady() {
+		return instance == null ? null : instance.farPlane();
 	}
 
 	/** One texel of what the absence of this material map means. */

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -747,6 +747,10 @@ final class GeometryProgram {
 
 		this.pipeline = builder.build();
 
+		// Filed against the pipeline and not the program, because the pipeline is what the
+		// descriptor walk can see when it has to answer for a name.
+		ShadowCompare.note(this.pipeline, this.path, loaded);
+
 		// A storage block this engine has no bufferObject for is the one refusal that does not
 		// announce itself. An unbindable sampler stops the pipeline from being built and this class
 		// already falls back on that; a storage block compiles, never enters a bind group, and
@@ -1760,19 +1764,23 @@ final class GeometryProgram {
 	}
 
 	/**
-	 * The shadow map, or white for the far plane.
+	 * The shadow map, or the far plane where there is none.
 	 * <p>
-	 * White, and the same white {@link #depth(String)} falls back to, for the same reason: a
-	 * {@code shadowtex} lookup is never rewritten, so what is stored is what the pack reads, and the
-	 * map stores the forward window where one is the far plane. A shadow lookup that finds nothing
-	 * has to say "nothing between here and the light".
+	 * The far plane, for the reason {@link #depth(String)} answers white: a {@code shadowtex}
+	 * lookup is never rewritten, so what is stored is what the pack reads, and the map stores the
+	 * forward window where one is the far plane. A shadow lookup that finds nothing has to say
+	 * "nothing between here and the light". It is the depth-format texel and not the RGBA white,
+	 * because the name may be read through a comparison sampler, which is only defined against a
+	 * depth image; read plainly its red channel answers the one the white texel did, and the red
+	 * channel is what a depth read takes.
 	 * <p>
-	 * A shadow pass reads white whatever the map holds: the image it would read is an attachment of
-	 * the very pass it is drawn in, and sampling an attachment is a thing Vulkan gives no meaning to.
+	 * A shadow pass reads the far plane whatever the map holds: the image it would read is an
+	 * attachment of the very pass it is drawn in, and sampling an attachment is a thing Vulkan
+	 * gives no meaning to.
 	 */
 	private GpuTextureView shadowDepth(String sampler) {
 		if (this.pass.shadow()) {
-			return this.constants.white();
+			return this.constants.farPlane();
 		}
 
 		// shadowtex1 is the map without the translucents and shadowtex0 the map with them. Serving
@@ -1784,7 +1792,7 @@ final class GeometryProgram {
 				? this.shadow.depthWithoutTranslucents()
 				: this.shadow.depth();
 
-		return map == null ? this.constants.white() : map;
+		return map == null ? this.constants.farPlane() : map;
 	}
 
 	/** A shadow colour target, on the same two rules as the depth above. */
@@ -2173,19 +2181,29 @@ final class GeometryProgram {
 
 		// Said because nothing on screen would. A pack declaring sampler2DShadow asks the hardware
 		// to compare and hand back a filtered fraction; blaze3d's GpuSampler carries no comparison
-		// at all, so the translation makes it instead: four texels gathered, four steps, and the
-		// same bilinear blend the hardware would have applied. Nothing of the shape is lost. What
-		// it costs is the gather and the arithmetic, on a lookup a PCF loop makes many times.
+		// at all, so the map's own names are bound under the comparison sampler this engine makes
+		// in Vulkan's terms, and anything else compared is made in the shader instead: four texels
+		// gathered, four steps, and the same bilinear blend the hardware would have applied.
 		//
-		// Asked of the notes and not of the samplers: by the time a sampler is one of those, its
-		// type has been rewritten to the ordinary one and there is nothing left to recognise.
+		// Asked of the notes and not of the samplers: on the arithmetic road the type has been
+		// rewritten to the ordinary one and there is nothing left to recognise.
+		List<String> hardware = this.loaded.program().stages().values().stream()
+				.flatMap(unit -> unit.notes().hardwareCompared().stream())
+				.distinct()
+				.toList();
+		if (!hardware.isEmpty()) {
+			Vitrail.logger().info("{} asked the hardware to compare {}, which the binding carries "
+					+ "as a comparison sampler", this.path, hardware);
+		}
+
 		List<String> compared = this.loaded.program().stages().values().stream()
 				.flatMap(unit -> unit.notes().comparedSamplers().stream())
 				.distinct()
+				.filter(name -> !hardware.contains(name))
 				.toList();
 		if (!compared.isEmpty()) {
-			Vitrail.logger().info("{} asked the hardware to compare {}, which this backend cannot "
-					+ "bind, so the comparison is made in the shader over the four texels the "
+			Vitrail.logger().info("{} asked the hardware to compare {}, which this binding does not "
+					+ "carry, so the comparison is made in the shader over the four texels the "
 					+ "hardware would have blended", this.path, compared);
 		}
 

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2026,10 +2026,12 @@ public final class PackChain {
 
 		awaitFamilyWarmups();
 
-		// The far terrain's two corner rings and the one-texel constants survive every release on
-		// purpose, so the shutdown is the one caller that really frees them.
+		// The far terrain's two corner rings, the one-texel constants and the comparison sampler
+		// survive every release on purpose, so the shutdown is the one caller that really frees
+		// them.
 		DistantDraw.close();
 		ConstantTextures.close();
+		ShadowCompare.close();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackDefines.java
+++ b/common/src/main/java/dev/vitrail/render/PackDefines.java
@@ -58,6 +58,10 @@ public final class PackDefines {
 	 * every symbol here is fixed for as long as the world is.
 	 */
 	public static void install() {
+		// Beside the machine table because it is the same moment: a launch-wide answer the
+		// translation has to hold before the first unit is read, and this is the one caller that
+		// stands before every read with the game directory in reach.
+		ShadowCompare.armIfAsked();
 		EngineDefines.machine(gather());
 		settle();
 	}

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -257,6 +257,11 @@ final class PackPass {
 		}
 
 		this.pipeline = builder.build();
+
+		// Filed against the pipeline and not the program, because the pipeline is what the
+		// descriptor walk can see when it has to answer for a name.
+		ShadowCompare.note(this.pipeline, this.path, loaded);
+
 		noteGaps(declared);
 	}
 
@@ -553,13 +558,16 @@ final class PackPass {
 				// against the camera. It follows the image rather than the convention of the
 				// target, which is what makes it the same answer as the shadow map's.
 				case DEPTH -> depth(binding.sampler(), targets, depthView);
-				// White where the map is not there, and white is the far plane rather than a
-				// placeholder: a shadowtex lookup is the one depth read the translation never wraps,
-				// so the map stores the forward window and a lookup that finds nothing has to say
-				// "nothing between here and the light". Black would put the world in its own shadow.
+				// The far plane where the map is not there, rather than a placeholder: a shadowtex
+				// lookup is the one depth read the translation never wraps, so the map stores the
+				// forward window and a lookup that finds nothing has to say "nothing between here
+				// and the light". Black would put the world in its own shadow. In a depth format
+				// first, because a comparison sampler is only defined against one; the RGBA white
+				// stays as the answer of last resort for the frames before the constants exist.
 				case SHADOW_DEPTH -> or(this.loaded.samplers().withoutTranslucents(binding.sampler())
 						? targets.shadow().depthWithoutTranslucents()
-						: targets.shadow().depth(), targets.white());
+						: targets.shadow().depth(),
+						or(ConstantTextures.farPlaneIfReady(), targets.white()));
 				case SHADOW_COLOUR -> or(targets.shadow().colour(binding.index()), targets.white());
 				case NOISE -> targets.noise();
 				// White until the pass behind it has drawn once, which is the far plane in the pack's

--- a/common/src/main/java/dev/vitrail/render/ShadowCompare.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowCompare.java
@@ -1,0 +1,222 @@
+package dev.vitrail.render;
+
+import dev.vitrail.glsl.GlslTranslator;
+import dev.vitrail.glsl.PackProgram;
+import dev.vitrail.glsl.TranslatedUnit;
+import dev.vitrail.mixin.GpuDeviceAccessor;
+import dev.vitrail.pack.target.SamplerPlan;
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.GpuDeviceBackend;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import net.minecraft.client.Minecraft;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.VK12;
+import org.lwjgl.vulkan.VkSamplerCreateInfo;
+
+import java.nio.LongBuffer;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+/**
+ * The comparison sampler a {@code sampler2DShadow} lookup runs on, and which pipelines owe it to
+ * which names.
+ * <p>
+ * The translation leaves a comparison sampler its spelling wherever the map's own names are behind
+ * it, so the lookup compiles to a depth-reference sample; what the hardware then needs is a sampler
+ * with the comparison enabled, and {@code GpuSampler} cannot describe one. So the sampler is made
+ * here, once, in Vulkan's own terms, and {@code VulkanRenderPassMixin} puts its handle into the
+ * descriptor wherever the pipeline being drawn declared the name a comparison. That substitution
+ * road already exists for the storage images, and this rides it rather than growing a second one.
+ * <p>
+ * The pair it carries is the pair Iris binds when a pack asks for its hardware shadow filtering
+ * ({@code ShadowRenderTargets.getSamplerFor}, under {@code shadowHardwareFiltering}), {@code
+ * GL_LINEAR} plus {@code GL_COMPARE_REF_TO_TEXTURE}; every pack of the corpus that declares the
+ * type writes that directive, and without it Iris leaves what such a declaration reads undefined.
+ * The sense is LEQUAL: OptiFine sets that on a shadow texture, so it is what every pack is written
+ * against, and the map stores the forward window where nearer is smaller. Filtered, the hardware
+ * compares each of the four texels and blends the RESULTS with the bilinear weights, which is
+ * exactly the arithmetic the translation writes on its other road; the two roads answer the same
+ * fraction. The level of detail is pinned to the base: nothing here ever fills a chain on the
+ * shadow map, where Iris can mip it under {@code shadowtexMipmap}, and that gap is the map's and
+ * not this sampler's.
+ * <p>
+ * The registry is weak on the pipeline, because that is the lifetime being described: a pipeline
+ * dropped on a pack change takes its entry with it, and a reload registers the new ones as they
+ * are built.
+ */
+public final class ShadowCompare {
+
+	private static final String ARM_FILE = "soft-shadow-compare";
+
+	private static final Map<RenderPipeline, Set<String>> COMPARED =
+			Collections.synchronizedMap(new WeakHashMap<>());
+
+	/** Whether anything is filed at all, so the walk over every descriptor asks one flag first. */
+	private static volatile boolean noted;
+
+	private static boolean announced;
+
+	private static long sampler;
+
+	private ShadowCompare() {
+	}
+
+	/**
+	 * Puts the translation on the arithmetic road when somebody asked for it, and back off it when
+	 * they stopped asking: a file {@code vitrail/soft-shadow-compare} in the game directory, or
+	 * {@code -Dvitrail.softShadowCompare=true}. Called before a pack is read, every time one is,
+	 * so removing the file and reloading undoes it without a restart. The trade cannot be watched
+	 * from inside, a comparison bound wrong handing back a credible fraction rather than an error,
+	 * so an image that comes right with this on has named the comparison sampler in one launch,
+	 * the same bargain the pass barrier's file makes.
+	 */
+	public static void armIfAsked() {
+		Minecraft minecraft = Minecraft.getInstance();
+		if (minecraft == null || minecraft.gameDirectory == null) {
+			return;
+		}
+
+		boolean asked = Files.isRegularFile(minecraft.gameDirectory.toPath()
+				.resolve("vitrail").resolve(ARM_FILE));
+		GlslTranslator.askSoftCompare(asked);
+		if (asked && !announced) {
+			announced = true;
+			Vitrail.logger().warn("Every shadow comparison is made in shader arithmetic, asked for "
+					+ "by vitrail/{}. The image should not move; the shadow lookups are slower. "
+					+ "Remove it and reload the pack to put the comparison back on the sampler",
+					ARM_FILE);
+		}
+	}
+
+	/**
+	 * Files which sampler names this pipeline reads through a comparison, which is the question the
+	 * descriptor substitution asks back at every push. Nothing is filed for a program with none,
+	 * which is what keeps the common case behind {@link #noted()}.
+	 * <p>
+	 * The sampler follows the declaration, wherever that leads, because the shader's side is
+	 * already settled: the lookup compiles to a depth-reference sample, and a comparison sampler
+	 * against a wrong image and no comparison sampler under a depth-reference sample are both
+	 * undefined, so withholding it would repair nothing. What this can add is the word nothing on
+	 * screen would say: a pack that has put something that is not the shadow map behind a compared
+	 * name, or that spells one name two ways across the stages of one program, is named here. The
+	 * sampler serves the whole pipeline, so the stage that spelled the name ordinary reads through
+	 * the comparison all the same, undefined exactly as under Iris, where the sampler sits on the
+	 * texture unit both stages share.
+	 */
+	static void note(RenderPipeline pipeline, String path, PackProgram.Loaded loaded) {
+		Set<String> names = new LinkedHashSet<>();
+		for (TranslatedUnit unit : loaded.program().stages().values()) {
+			names.addAll(unit.notes().hardwareCompared());
+		}
+
+		if (names.isEmpty()) {
+			return;
+		}
+
+		for (String name : names) {
+			if (loaded.samplers().binding(name).kind() != SamplerPlan.Kind.SHADOW_DEPTH) {
+				Vitrail.logger().warn("{} declares {} as a comparison sampler, and the pack has "
+						+ "put something that is not the shadow map behind the name: the "
+						+ "comparison runs against it all the same, which is undefined here as "
+						+ "it is under Iris", path, name);
+			}
+		}
+
+		for (TranslatedUnit unit : loaded.program().stages().values()) {
+			for (String name : names) {
+				if (!unit.notes().hardwareCompared().contains(name)
+						&& unit.samplers().stream().anyMatch(one -> one.name().equals(name))) {
+					Vitrail.logger().warn("{} declares {} as a comparison sampler in one stage and "
+							+ "an ordinary one in another. The sampler is the pipeline's, so the "
+							+ "ordinary read goes through the comparison too, which is undefined "
+							+ "here as it is under Iris", path, name);
+				}
+			}
+		}
+
+		COMPARED.put(pipeline, Set.copyOf(names));
+		noted = true;
+	}
+
+	/** Whether any pipeline has filed anything, asked before the per-name question is worth asking. */
+	public static boolean noted() {
+		return noted;
+	}
+
+	/** Whether this pipeline reads this name through a comparison, asked while pushing descriptors. */
+	public static boolean compared(RenderPipeline pipeline, String name) {
+		Set<String> names = COMPARED.get(pipeline);
+
+		return names != null && names.contains(name);
+	}
+
+	/**
+	 * The comparison sampler itself, made on the first ask and kept for the device's life. Must run
+	 * on the render thread, which pushing descriptors always is.
+	 */
+	public static long sampler(VulkanDevice device) {
+		if (sampler != 0L) {
+			return sampler;
+		}
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			VkSamplerCreateInfo info = VkSamplerCreateInfo.calloc(stack)
+					.sType$Default()
+					.magFilter(VK12.VK_FILTER_LINEAR)
+					.minFilter(VK12.VK_FILTER_LINEAR)
+					.mipmapMode(VK12.VK_SAMPLER_MIPMAP_MODE_NEAREST)
+					.addressModeU(VK12.VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
+					.addressModeV(VK12.VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
+					.addressModeW(VK12.VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
+					.compareEnable(true)
+					.compareOp(VK12.VK_COMPARE_OP_LESS_OR_EQUAL)
+					// Level nought and no further, which is what a lookup's level of detail came
+					// to on the other road as well: nothing ever fills a chain on the shadow map.
+					.minLod(0.0F)
+					.maxLod(0.0F);
+			LongBuffer handle = stack.mallocLong(1);
+			int result = VK12.vkCreateSampler(device.vkDevice(), info, null, handle);
+			if (result != VK12.VK_SUCCESS) {
+				throw new IllegalStateException("vkCreateSampler answered " + result);
+			}
+
+			sampler = handle.get(0);
+		}
+
+		return sampler;
+	}
+
+	/** Called when the client shuts down, while the device is still alive. */
+	static void close() {
+		COMPARED.clear();
+		noted = false;
+		if (sampler == 0L) {
+			return;
+		}
+
+		VulkanDevice device = vulkan();
+		if (device != null) {
+			VK12.vkDestroySampler(device.vkDevice(), sampler, null);
+		}
+
+		sampler = 0L;
+	}
+
+	private static VulkanDevice vulkan() {
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (device == null) {
+			return null;
+		}
+
+		GpuDeviceBackend backend = ((GpuDeviceAccessor) device).vitrail$backend();
+		return backend instanceof VulkanDevice vulkan ? vulkan : null;
+	}
+}

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -74,7 +74,7 @@ the pack gets a view without translucents), but it is never converted, so it has
 the convention the pack expects. The two are the same rule, hand the pack the window it reads in,
 applied at different places.
 
-### A shadow sampler implies a comparison this backend cannot express
+### A shadow sampler implies a comparison the game's sampler cannot express
 
 This was the hard wall of the whole feature, and it is worth stating precisely.
 
@@ -87,14 +87,23 @@ Bound naively, a shadow sampler becomes an ordinary sampler and the comparison m
 symptom is not a crash: the entire world comes back uniformly in shadow, which looks exactly like a
 badly drawn shadow map, and sends you looking in the wrong place.
 
-The engine instead strips the comparison from the declaration and rewrites each *plain* read into a
-comparison emitted in the translated shader, in the sense the format specifies and every pack is
-written against. It agrees with the forward depth window, where nearer to the light is smaller.
+The engine answers it on two roads. Where the names behind the declaration are the shadow map's
+own, the declaration keeps its spelling, the lookup compiles to a depth-reference sample, and the
+binding slips a comparison sampler made in Vulkan's own terms under the name, past the game's
+abstraction: linear filtering, clamped edges, and the LEQUAL sense the format specifies, agreeing
+with the forward depth window where nearer to the light is smaller. It is the pair Iris binds when
+a pack asks for its hardware shadow filtering, and a projective comparison needs nothing more
+there: the call is the division and the comparison in one.
 
-Only the plain lookups. A projective or gathered comparison divides or spreads before it compares,
-which needs a different expression and not a different name, so it is left as it stands and counted
-instead: a call that silently kept a hardware comparison is exactly what the rewrite exists to
-stop.
+Everything else compared, and every compute program, takes the arithmetic road: the comparison is
+stripped from the declaration and each *plain* read is rewritten into a comparison emitted in the
+translated shader, the same four texels compared and then blended by the same bilinear weights the
+hardware would use. Only the plain lookups: a projective or gathered comparison divides or spreads
+before it compares, which needs a different expression and not a different name, so it is left as
+it stands and counted instead. A launch can send every unit down this road with a file
+`vitrail/soft-shadow-compare` in the game directory or `-Dvitrail.softShadowCompare=true`, for the
+day the comparison sampler is suspected of a wrong image: bound wrong it does not fail, it hands
+back a credible fraction of the wrong thing.
 
 Two ordering traps come with it. The comparison samplers have to be collected *before* the depth
 rewrite runs, because uniforms are only lifted afterwards and the set that decides would otherwise


### PR DESCRIPTION
## What changes

A shadow lookup a pack declares as a comparison (`sampler2DShadow`) now runs on a real
comparison sampler instead of arithmetic emitted into the shader. The game's `GpuSampler`
carries no compare mode, so the engine makes the sampler in Vulkan's own terms, compareEnable
with the LEQUAL sense of the format, and slips its handle into the descriptor for the pipelines
that registered the name, on the same substitution road the storage images already ride. The
translation leaves the comparison spelling on the shadow map's own names, so the lookup compiles
to a depth-reference sample: one instruction where the arithmetic paid a gather, four steps and
a blend on every tap of every PCF loop. Anything else compared, and every compute unit, keeps
the arithmetic; a projective shadow comparison, which the arithmetic road could only count as
unserved, is a single valid call on the sampler road. The fallback texel bound where the map is
absent becomes one texel of far plane in a depth format, a comparison being only defined against
a depth image. A file `vitrail/soft-shadow-compare` (or `-Dvitrail.softShadowCompare=true`)
sends every unit back to the arithmetic, re-read at each pack load.

## How it differs from the reference, and for what obstacle

Iris keys the comparison sampler on the pack's `shadowHardwareFiltering` directive
(`ShadowRenderTargets.getSamplerFor:357-362`, filled from the directive at `:60`), never on the
declaration. Here the header is written per stage before any pack directive is folded
(`GlslTranslator.header`), so the declaration that survived translation is the gate
(`GlslTranslator.collectComparisonSamplers`). It costs the image nothing on the corpus: every
pack that declares the type also writes the directive, and without it Iris leaves what such a
declaration reads undefined. Iris can also mip the shadow map under `shadowtexMipmap`; this
engine never fills a chain on the map, which predates this branch, so the sampler pins its level
to the base as the arithmetic already did.

## What proves it

`gradlew build` green after the rebase. The off-game harness's translation gate over the
ten-pack corpus, against the same run on the previous engine: identical totals to the digit
(2178 of 2369 units compiled, same per-pack error inventory), with the shadow-map names keeping
their comparison spelling and every dref form taken by the compiler. The comparison senses were
checked against each other and against the map's own window: the map stores forward depth
cleared to 1.0, the arithmetic renders `step(ref, texel)`, and LEQUAL renders `ref <= texel`,
the same fraction under the same bilinear weights. Not tried in game yet: the substituted
sampler and the picture need the bench, on a pack whose PCF loop reads `sampler2DShadow`
(Complementary, BSL).

## What it leaves owing

An in-game reading on the bench, and the frame's shadow share against the arithmetic road
through the switch. A pack that spells one shadow name two ways across the stages of one
program, or that puts a custom image or a texture override behind a compared shadow name, is
warned by name and left undefined, which is where Iris leaves it too; no pack of the corpus
does either.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
