### PR TITLE
feat(glsl): say where a pack load's time goes

### DIFF
--- a/common/src/main/java/dev/vitrail/glsl/LoadClock.java
+++ b/common/src/main/java/dev/vitrail/glsl/LoadClock.java
@@ -1,0 +1,93 @@
+package dev.vitrail.glsl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Where the time of a pack load goes, split into the two posts nothing else can separate: the
+ * translation of the pack's GLSL, and turning the translated text into modules, which is shaderc
+ * and the SPIRV-Cross reflection together.
+ * <p>
+ * <strong>It exists because the split decides what gets built next.</strong> With shaderc served
+ * from disk and the driver's own cache accepted, a load still costs seconds, so the remaining
+ * cost is one of these two, and they call for different remedies: a translation cache is keyed
+ * on the pack and the settings before any text exists, a reflection cache stores binding tables
+ * against bytes that already do. Building either without this number is building blind.
+ * <p>
+ * The module count listens at the game's own compiler, which is the funnel every road goes
+ * through: the background warmup, the terrain, the composite passes, and whatever a first draw
+ * or a resource reload still owes. The one road that does not pass there is the shadow
+ * computes' own, which counts itself. The funnel is class-wide, so a module that is not pack
+ * text lands in the figure too when it compiles while a tally is live, the game's and Sodium's
+ * own pipelines and this engine's helper passes alike; on a load into a world those follow the
+ * first draws. Outside both figures: the {@code rebind} rewrite and the compute's layout, both
+ * small, and the driver's own pipeline build behind {@code vkCreateGraphicsPipelines}, which on
+ * a cold driver cache is not.
+ * <p>
+ * Both counts are tallies in the sense the trig counter is: they are emptied at the head of a
+ * load, a first report prints beside the pack-opened line for every installed chain, and a
+ * second prints when the background warmup hands back its own figure, the families then in.
+ * Two loads can smear into each other in both directions and neither reaches a live program:
+ * a worker of the chain that has just been released can land its spans after the reset, and a
+ * swap can reset the tallies while the outgoing chain's warmup is still in flight, whose
+ * report then reads the incoming load's figures beside its own leftover count. A shadow
+ * compute compiles at its first dispatch, so whether it is in a report depends on whether a
+ * shadow frame ran before that report printed.
+ * <p>
+ * In this package and not in {@code render}, where the line that prints it lives: the off-game
+ * harness compiles this package without the render tree, and the translator could not name a
+ * class over there without taking the harness down with it.
+ */
+public final class LoadClock {
+
+	private static final AtomicLong TRANSLATION_NANOS = new AtomicLong();
+
+	private static final AtomicInteger TRANSLATED = new AtomicInteger();
+
+	private static final AtomicLong MODULE_NANOS = new AtomicLong();
+
+	private static final AtomicInteger MODULES = new AtomicInteger();
+
+	private LoadClock() {
+	}
+
+	/** Emptied at the head of a pack load: a tally belongs to the load it was taken under. */
+	public static void reset() {
+		TRANSLATION_NANOS.set(0);
+		TRANSLATED.set(0);
+		MODULE_NANOS.set(0);
+		MODULES.set(0);
+	}
+
+	/** One translator call's worth of {@link System#nanoTime} span, workers included. */
+	public static void translation(long nanos) {
+		TRANSLATION_NANOS.addAndGet(nanos);
+		TRANSLATED.incrementAndGet();
+	}
+
+	/**
+	 * One module's span through shaderc and SPIRV-Cross, whichever of the two really ran.
+	 * Called by the mixin on the game's compiler for every road that goes through it, and by the
+	 * shadow-compute road for itself.
+	 */
+	public static void module(long nanos) {
+		MODULE_NANOS.addAndGet(nanos);
+		MODULES.incrementAndGet();
+	}
+
+	public static long translationMillis() {
+		return TRANSLATION_NANOS.get() / 1_000_000L;
+	}
+
+	public static int translated() {
+		return TRANSLATED.get();
+	}
+
+	public static long moduleMillis() {
+		return MODULE_NANOS.get() / 1_000_000L;
+	}
+
+	public static int modules() {
+		return MODULES.get();
+	}
+}

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -148,8 +148,15 @@ public final class ProgramTranslator {
 	 */
 	public static Set<String> reads(ExpandedUnit vertex, VertexInputs inputs, AlphaTest alphaTest,
 			boolean coverage, String program, Map<String, VolumeAtlas> volumes) {
-		return GlslTranslator.prepare(vertex, ProgramStage.VERTEX, inputs, inputs.elements(),
-				alphaTest, coverage, program, volumes).reads();
+		// Clocked like the whole translations: this half-translation is real translator work a
+		// chunk program pays before its full one, and leaving it out would undercount terrain.
+		long began = System.nanoTime();
+		try {
+			return GlslTranslator.prepare(vertex, ProgramStage.VERTEX, inputs, inputs.elements(),
+					alphaTest, coverage, program, volumes).reads();
+		} finally {
+			LoadClock.translation(System.nanoTime() - began);
+		}
 	}
 
 	/**
@@ -176,6 +183,19 @@ public final class ProgramTranslator {
 	 * @param volumes by the name the pack samples them under, each with the layout of its atlas
 	 */
 	public static TranslatedProgram translate(Map<ProgramStage, ExpandedUnit> units,
+			VertexInputs inputs, List<String> boundElements, AlphaTest alphaTest, boolean coverage,
+			String program, Map<String, VolumeAtlas> volumes) {
+		// Every overload above funnels through here, which is what makes this the one place a
+		// program's whole translation can be clocked.
+		long began = System.nanoTime();
+		try {
+			return translated(units, inputs, boundElements, alphaTest, coverage, program, volumes);
+		} finally {
+			LoadClock.translation(System.nanoTime() - began);
+		}
+	}
+
+	private static TranslatedProgram translated(Map<ProgramStage, ExpandedUnit> units,
 			VertexInputs inputs, List<String> boundElements, AlphaTest alphaTest, boolean coverage,
 			String program, Map<String, VolumeAtlas> volumes) {
 		Map<ProgramStage, GlslTranslator.Stage> prepared = new LinkedHashMap<>();

--- a/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
@@ -1,18 +1,32 @@
 package dev.vitrail.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.shaders.ShaderType;
 import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
+import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
+import dev.vitrail.glsl.LoadClock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Coerce;
 
 /**
- * Lets a sampled or stored 3D image through the bind-group walk.
+ * Lets a sampled or stored 3D image through the bind-group walk, and clocks the one call that
+ * turns GLSL into a module, for {@link LoadClock}.
  * <p>
  * {@code addToBindGroup} refuses anything whose SPIR-V dimension is not 2D or Cube. SpvDim3D is 2.
  * Pretending it is 2D is enough for the check; the view that is actually bound is the 3D one
  * {@code StorageImages} allocated.
+ * <p>
+ * The clock sits here and not at this engine's own call sites, because the game's compiler is
+ * the funnel and the call sites are not: the background warmup goes through
+ * {@code GeometryProgram}, but the terrain, every composite pass and anything a first draw or a
+ * resource reload still owes goes through {@code precompilePipeline}, which lands in this same
+ * method without a line of this engine on the way. Clocking the funnel counts every road once;
+ * clocking a call site counted one road and read as all of them. A wrap rather than a pair of
+ * injections, so that a refusal thrown by the compile is still counted: the span ends in a
+ * finally, and a module that failed still cost what it cost.
  */
 @Mixin(GlslCompiler.class)
 public abstract class GlslCompilerMixin {
@@ -23,5 +37,16 @@ public abstract class GlslCompilerMixin {
 	private static int vitrail$allow3d(@Coerce Object sampler, Operation<Integer> original) {
 		int dimension = original.call(sampler);
 		return dimension == 2 ? 1 : dimension;
+	}
+
+	@WrapMethod(method = "createIntermediary", require = 1)
+	private IntermediaryShaderModule vitrail$clock(String filename, String source, ShaderType type,
+			Operation<IntermediaryShaderModule> original) {
+		long began = System.nanoTime();
+		try {
+			return original.call(filename, source, type);
+		} finally {
+			LoadClock.module(System.nanoTime() - began);
+		}
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1,6 +1,7 @@
 package dev.vitrail.render;
 
 import dev.vitrail.dh.DhLods;
+import dev.vitrail.glsl.LoadClock;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.mixin.GpuDeviceAccessor;
 import dev.vitrail.pack.option.OptionValue;
@@ -604,6 +605,9 @@ public final class PackChain {
 		// Here and not lower down: it decides what the translation emits, and every road
 		// below this point that reads a pack translates one.
 		DriverTrig.read(gameDirectory);
+		// Beside the trig switch and for the same reason: what follows is what these tallies
+		// are a tally of.
+		LoadClock.reset();
 		// The storage blocks the translator files away, emptied at the head of a load and NOT beside
 		// the CustomImages line in release(), though the two are installed on the same line.
 		//
@@ -894,6 +898,14 @@ public final class PackChain {
 				// thread the player is waiting on, and each opens the pack for itself.
 				Vitrail.logger().info("Opened {} {} times to load it", chain.packName(),
 						ShaderPackSource.openings() - openings);
+				// Once per installed chain, whatever else this load does or fails to do later:
+				// the second report, with the families in, only exists when a warmup fans out.
+				// Translation only, because this method does no device work by design: the
+				// modules follow on the first draws and the workers, and land in the next report.
+				Vitrail.logger().info("Translating cost {} ms over {} translator calls before "
+						+ "the chain went live; the modules follow on the draws and the workers, "
+						+ "counted into the report that closes the warmup",
+						LoadClock.translationMillis(), LoadClock.translated());
 			}
 
 			active.startFamilyPrefetch();
@@ -2936,6 +2948,13 @@ public final class PackChain {
 						+ "first draw, {} ms of background work, translations included",
 						this.warmServed.get(), this.warmWalked.get(),
 						(System.nanoTime() - start.get()) / 1_000_000L);
+				// Beside the total it explains. The spans are summed per program across workers,
+				// so together they can pass the wall clock of the load; they compare with each
+				// other, not with it.
+				Vitrail.logger().info("With the families in, translating cost {} ms over {} "
+						+ "translator calls and making modules cost {} ms over {} modules, "
+						+ "shaderc and SPIRV-Cross together", LoadClock.translationMillis(),
+						LoadClock.translated(), LoadClock.moduleMillis(), LoadClock.modules());
 			}
 
 			return (Void) null;

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -1,5 +1,6 @@
 package dev.vitrail.render;
 
+import dev.vitrail.glsl.LoadClock;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.glsl.TranslatedUnit;
 import dev.vitrail.mixin.CommandEncoderAccessor;
@@ -379,27 +380,40 @@ final class PackCompute implements AutoCloseable {
 				return;
 			}
 
-			ByteBuffer spirv = compileSpirv(unit.text());
-			if (spirv == null) {
-				return;
-			}
-
+			// Clocked as module work like everything the game's compiler makes: shaderc first,
+			// then the reflection inside ComputeShader.compile. Neither goes through the game's
+			// compiler, so the funnel clock cannot see them and this road counts itself. The
+			// layout and the pipeline below stay outside the figure: they are Vulkan object
+			// creation, not module work. One outer finally so that every exit, the refusal and
+			// the throw included, is counted exactly once.
+			long began = System.nanoTime();
 			try {
-				ComputeShader.Compiled compiled = ComputeShader.compile(vulkan, this.label, spirv);
-				this.shaderModule = compiled.module();
-				this.entries = compiled.entries();
-				// Named and still dispatched, which is what the graphics path does with the same
-				// ceiling: a device is only obliged to allow this many descriptors in one pushed
-				// set, and going past it is undefined rather than slow. Said here, once, so that a
-				// driver error later has a line in the log that predicted it.
-				if (this.entries.size() > PUSH_DESCRIPTORS) {
-					Vitrail.logger().warn("shadow compute {} pushes {} descriptors in one set, past "
-							+ "the {} a device commonly allows at once", this.path,
-							this.entries.size(), PUSH_DESCRIPTORS);
+				ByteBuffer spirv = compileSpirv(unit.text());
+				if (spirv == null) {
+					return;
 				}
-			} catch (Exception e) {
-				Vitrail.logger().warn("shadow compute {} SPIR-V failed: {}", this.path, e.toString());
-				return;
+
+				try {
+					ComputeShader.Compiled compiled =
+							ComputeShader.compile(vulkan, this.label, spirv);
+					this.shaderModule = compiled.module();
+					this.entries = compiled.entries();
+					// Named and still dispatched, which is what the graphics path does with the
+					// same ceiling: a device is only obliged to allow this many descriptors in one
+					// pushed set, and going past it is undefined rather than slow. Said here, once,
+					// so that a driver error later has a line in the log that predicted it.
+					if (this.entries.size() > PUSH_DESCRIPTORS) {
+						Vitrail.logger().warn("shadow compute {} pushes {} descriptors in one set, "
+								+ "past the {} a device commonly allows at once", this.path,
+								this.entries.size(), PUSH_DESCRIPTORS);
+					}
+				} catch (Exception e) {
+					Vitrail.logger().warn("shadow compute {} SPIR-V failed: {}", this.path,
+							e.toString());
+					return;
+				}
+			} finally {
+				LoadClock.module(System.nanoTime() - began);
 			}
 
 			try (MemoryStack stack = MemoryStack.stackPush()) {

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -273,6 +273,17 @@ anything for the switch to bite on. It is an instrument and not a setting to kee
 replacement a pack feeding whole world coordinates to a sine gets whatever the driver makes of
 them.
 
+**Where a pack load's time goes is in the log at every load that installs a chain.** A first
+report prints beside the pack-opened line and carries the translation alone, that being all the
+load itself runs; the modules follow on the first draws and the compile workers, counted at the
+game's own compiler so that every road lands in the tally, and the report that closes the
+background warmup reads both figures with the families in. What a first draw pays after that
+report stays in the tally rather than in any line. The spans are summed per program across the
+compile workers, so the two figures compare with each other rather than with the wall clock,
+and the driver's own pipeline build is in neither. The split is what says whether a faster load
+needs a translation cache or a reflection cache, which are different designs keyed on different
+things.
+
 **The card's time per pass is in the log on request.** Started with `-Dvitrail.passTimings=N`
 among the JVM arguments, the game prints every N seconds a table of GPU time per render pass
 label, the game's and Sodium's passes beside the pack's, sorted by cost, with the share of the pass


### PR DESCRIPTION
## What changes

The engine now says where a pack load's time goes, split into the two posts nothing measured
apart: translating the pack's GLSL, and turning the translated text into modules, which is
shaderc and the SPIRV-Cross reflection together. Translation is clocked at the one overload
every translation funnels through, plus the terrain's half-translation. Modules are clocked at
the game's own compiler, the funnel every road goes through, so the background warmup, the
terrain, the composites and the first-draw leftovers all count once; the shadow computes
compile off that funnel and count themselves. A first report prints beside the pack-opened
line and carries the translation alone, that being all the load itself runs; a second closes
the background warmup with both figures, the families in. The split is what decides which
cache is worth building for faster loads: a translation cache is keyed on the pack and the
settings before any text exists, a reflection cache stores binding tables against bytes that
already do.

## How it differs from the reference, and for what obstacle

It does not. Iris has no equivalent instrument, but nothing here changes what a pack is handed
or what reaches the screen: two tallies, two log lines, and a wrap around the game's compiler
that measures the call and changes nothing about it.

## What proves it

- `gradlew build` green locally.
- The off-game harness compiles with the new class, which sits in the glsl package precisely
  so the harness keeps compiling that package without the render tree.
- The wrap target was checked against the game jar itself: `createIntermediary(String, String,
  ShaderType)` exists exactly once on `GlslCompiler`, no overload, and a target miss refuses
  the launch rather than skipping, `require` being explicit.
- An in-game reading on the Fabric bench is the remaining half: the two lines printing around
  a Complementary load, which is also the measurement this instrument exists for. The merge
  waits for it.

## What it leaves owing

The figures are tallies, not exact censuses, and the javadoc names every edge: two loads can
smear into each other in both directions when a swap resets the counts under a warmup still in
flight, a module that is not pack text lands in the figure when it compiles while a tally is
live, and the driver's own pipeline build behind `vkCreateGraphicsPipelines` is in neither
figure. None of it reaches a live program.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
