### PR TITLE
fix(mixin): swap particle pipelines on the pass, not the renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,12 @@ what the next one holds.
   three used to share one line that named none of them, and the third only showed itself a
   world later, as an error about two lists of attributes that said nothing about the order
   that made them differ. Each now says which one it was, where it happened.
+- **The game no longer crashes when AsyncParticles draws its GPU-accelerated particles under a
+  shaderpack.** AsyncParticles can move its particles to the GPU and record their draws itself,
+  into the very pass this mod had opened over the pack's colour targets, with pipelines built
+  for a single target: the frame died on a colour attachment count mismatch a few seconds into
+  the world. Those draws now take the pack's own particle programs, rebuilt over
+  AsyncParticles' vertex layout, which is what Iris draws them with as well.
 
 ## 0.8.1-beta
 

--- a/common/src/main/java/dev/vitrail/mixin/QuadParticleFeatureRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/QuadParticleFeatureRendererMixin.java
@@ -3,6 +3,7 @@ package dev.vitrail.mixin;
 import dev.vitrail.render.GeometryHold;
 import dev.vitrail.render.ParticleDraw;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -10,14 +11,11 @@ import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderPassDescriptor;
-import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import net.minecraft.client.renderer.feature.FeatureFrameContext;
 import net.minecraft.client.renderer.feature.QuadParticleFeatureRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,24 +30,30 @@ import java.util.function.Supplier;
  * unchanged; this one implements the interface directly and has an {@code executeGroup} of its own,
  * which opens a render pass, walks the layers of the group and sets a pipeline and an atlas for each.
  * So the shape here is the sky's and the weather's rather than the entities': the pass is replaced
- * where it is opened and the pipeline swapped where it is set.
+ * where it is opened, and this class only opens and closes the group.
+ * <p>
+ * <strong>The pipeline and the atlas are swapped on the pass and not here</strong>, by
+ * {@link RenderPassMixin}, keyed to the pass this class hands the renderer. Wrapping the calls of
+ * {@code drawLayers} was tried first and it misses every draw a mod records into the group's pass
+ * from a handler of its own: AsyncParticles' GPU particles set pipelines carrying one colour state
+ * after {@code drawLayers} returns, which a pass carrying the pack's colour targets refuses by name.
  * <p>
  * <strong>Which half is being drawn is read off the submits and not worked out here.</strong> The
  * game reads the same field to decide which layers go into the group and which target they go to, so
  * taking it from anywhere else would be a second answer to a question already asked.
  * <p>
- * <strong>All four handlers are required</strong>, and say so rather than lean on the
- * configuration's default. The pass and the pipeline are a pair, and half of them applying binds a
- * pipeline carrying eight colour states into a pass carrying one, which throws by name. The other
- * two each leave a picture with nothing in the log: particles drawn with the block of the group
- * before, or a group that kept this engine's program after the one that opened it was forgotten.
+ * <strong>Both handlers are required</strong>, and say so rather than lean on the configuration's
+ * default. Without the open, the pack's particle programs are never asked for and every group keeps
+ * the game's own shader, with nothing in the log to say why. Without the close, what the open armed
+ * outlives the group, and the hooks on the pass would answer for draws that are not particles at
+ * all.
  */
 @Mixin(QuadParticleFeatureRenderer.class)
 public abstract class QuadParticleFeatureRendererMixin {
 
 	/**
-	 * Prepares the pack's program for the half about to be drawn and hands back the pass it wants
-	 * opened.
+	 * Prepares the pack's program for the half about to be drawn, hands back the pass it wants
+	 * opened, and tells {@link ParticleDraw} which pass the group's draws will land in.
 	 * <p>
 	 * The submits cannot be empty here: the renderer only records a group when they are not, and it
 	 * is indexing that record one line above. Read defensively all the same, an empty list being a
@@ -73,45 +77,28 @@ public abstract class QuadParticleFeatureRendererMixin {
 				: ParticleDraw.group(submits.getFirst().translucent(), colour, depth);
 		RenderPassDescriptor descriptor = pipeline == null ? null : ParticleDraw.descriptor();
 
-		return descriptor == null
+		RenderPass pass = descriptor == null
 				? original.call(encoder, label, colour, clearColour, depth, clearDepth)
 				: GeometryHold.open(encoder, descriptor);
-	}
+		ParticleDraw.opened(pass);
 
-	@WrapOperation(method = "drawLayers", require = 1,
-			at = @At(value = "INVOKE",
-					target = "Lcom/mojang/blaze3d/systems/RenderPass;setPipeline("
-							+ "Lcom/mojang/blaze3d/pipeline/RenderPipeline;)V"))
-	private static void vitrail$pipeline(RenderPass pass, RenderPipeline pipeline,
-			Operation<Void> original) {
-		original.call(pass, ParticleDraw.pipeline(pipeline));
+		return pass;
 	}
 
 	/**
-	 * Lets the game bind the layer's own atlas and keeps what it bound, then binds the pack's block
-	 * and samplers over it, one line before the draw that reads them.
-	 * <p>
-	 * In {@code drawLayers} and not in {@code executeGroup}, which is what makes it the LAYER's atlas
-	 * rather than the group's: one group is drawn off the block atlas, the item atlas and the
-	 * particle atlas between its layers. The game's own binding costs nothing and its name is not the
-	 * one that is read, the descriptor flush walking the layout of the pipeline that is really bound.
+	 * Forgets the group at the way out, whichever way out it is. The two hooks on the pass stay
+	 * armed for as long as the group stands, so an exception thrown inside the renderer must
+	 * disarm them too: the group's pass may be one {@code GeometryHold} keeps open, and later
+	 * families join that same object.
 	 */
-	@WrapOperation(method = "drawLayers", require = 1,
-			at = @At(value = "INVOKE",
-					target = "Lcom/mojang/blaze3d/systems/RenderPass;bindTexture("
-							+ "Ljava/lang/String;"
-							+ "Lcom/mojang/blaze3d/textures/GpuTextureView;"
-							+ "Lcom/mojang/blaze3d/textures/GpuSampler;)V"))
-	private static void vitrail$texture(RenderPass pass, String name, GpuTextureView view,
-			GpuSampler sampler, Operation<Void> original) {
-		original.call(pass, name, view, sampler);
-		ParticleDraw.texture(pass, view, sampler);
-	}
-
-	/** Forgets the group, so that the next one cannot be handed this one's block. */
-	@Inject(method = "executeGroup", at = @At("RETURN"), require = 1)
-	private void vitrail$close(FeatureFrameContext context, int groupIndex, List<?> submits,
-			boolean strictlyOrdered, CallbackInfo callback) {
-		ParticleDraw.endGroup();
+	@WrapMethod(method = "executeGroup", require = 1)
+	private void vitrail$group(FeatureFrameContext context, int groupIndex,
+			List<QuadParticleFeatureRenderer.Submit> submits, boolean strictlyOrdered,
+			Operation<Void> original) {
+		try {
+			original.call(context, groupIndex, submits, strictlyOrdered);
+		} finally {
+			ParticleDraw.endGroup();
+		}
 	}
 }

--- a/common/src/main/java/dev/vitrail/mixin/RenderPassMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/RenderPassMixin.java
@@ -1,16 +1,28 @@
 package dev.vitrail.mixin;
 
 import dev.vitrail.render.GeometryHold;
+import dev.vitrail.render.ParticleDraw;
 
+import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.RenderPass;
+import com.mojang.blaze3d.textures.GpuSampler;
+import com.mojang.blaze3d.textures.GpuTextureView;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
- * Leaves a geometry pass open when the next program still writes the same images. Closing would
- * end the backend pass; {@link GeometryHold} is what decides that the FBO has not moved.
+ * Leaves a geometry pass open when the next program still writes the same images, and answers for
+ * every draw recorded into the pass a particle group holds, whoever records it.
+ * <p>
+ * Closing would end the backend pass; {@link GeometryHold} is what decides that the FBO has not
+ * moved. The particle hooks live on the pass and not on the renderer for the reason
+ * {@link QuadParticleFeatureRendererMixin} gives: the game's own draws go through
+ * {@code drawLayers}, but a mod may record draws of its own into the same pass from a handler of
+ * its own, and a hook on the renderer's method sees none of those. {@link ParticleDraw} scopes
+ * both to the one pass the group opened and stays out of the way on every other pass of the frame.
  */
 @Mixin(RenderPass.class)
 public abstract class RenderPassMixin {
@@ -20,5 +32,16 @@ public abstract class RenderPassMixin {
 		if (GeometryHold.keep((RenderPass) (Object) this)) {
 			callback.cancel();
 		}
+	}
+
+	@ModifyVariable(method = "setPipeline", at = @At("HEAD"), argsOnly = true, require = 1)
+	private RenderPipeline vitrail$particlePipeline(RenderPipeline pipeline) {
+		return ParticleDraw.pipeline((RenderPass) (Object) this, pipeline);
+	}
+
+	@Inject(method = "bindTexture", at = @At("TAIL"), require = 1)
+	private void vitrail$particleAtlas(String name, GpuTextureView view, GpuSampler sampler,
+			CallbackInfo callback) {
+		ParticleDraw.texture((RenderPass) (Object) this, name, view, sampler);
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -43,6 +43,7 @@ import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormatElement;
 import com.mojang.blaze3d.vulkan.VulkanDevice;
 import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
 import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
@@ -58,8 +59,10 @@ import org.joml.Vector4fc;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -396,6 +399,12 @@ final class GeometryProgram {
 	private final Sampled[] bound;
 	private final RenderPipeline pipeline;
 	private final ShaderSource source;
+
+	/**
+	 * Pipelines drawing this program over a mesh laid out by somebody else, keyed by that layout.
+	 * A refusal is held as null, latched the way {@link #compile}'s is.
+	 */
+	private final Map<VertexFormat, RenderPipeline> reshaped = new HashMap<>();
 
 	/**
 	 * Whether this program reads {@code gl_TextureMatrix[0]} out of the game's own per draw
@@ -943,6 +952,140 @@ final class GeometryProgram {
 		this.compiled = true;
 
 		return true;
+	}
+
+	/**
+	 * The same program, compiled to read a mesh laid out by somebody else.
+	 * <p>
+	 * A draw a mod records into a pass this engine opened arrives with a vertex layout of the mod's
+	 * own, and a pipeline reads its buffer through the layout it was built with: binding
+	 * {@link #prepare}'s answer over such a mesh would read every attribute at the wrong offset.
+	 * The variant is this program's pipeline with the caller's layout on binding nought and
+	 * everything else kept, under a location of its own so the device caches the two apart. The
+	 * shaders do not move, so the layout is refused unless it leads with the attributes this
+	 * program names, which {@link #rebuild} sets out.
+	 * <p>
+	 * Recompiled through {@code precompilePipeline} on every call, for the reason {@link #compile}
+	 * gives: a resource reload empties the device cache, and the call is a lookup while the cache
+	 * holds the key.
+	 *
+	 * @param layout the layout of the caller's mesh, on binding nought
+	 * @return the pipeline to bind over that mesh, or null when it refused to compile
+	 */
+	RenderPipeline reshape(GpuDevice device, VertexFormat layout) {
+		// The lock compile() takes, for the flag they share: a worker warming this program ahead
+		// writes broken under it, and this runs on the render thread while it does.
+		synchronized (this) {
+			if (this.broken) {
+				return null;
+			}
+
+			VertexFormat own = this.pipeline.getVertexFormatBinding(0);
+			if (layout.equals(own)) {
+				return this.pipeline;
+			}
+
+			RenderPipeline variant;
+			if (this.reshaped.containsKey(layout)) {
+				variant = this.reshaped.get(layout);
+			} else {
+				variant = rebuild(layout, own);
+				this.reshaped.put(layout, variant);
+			}
+
+			if (variant == null) {
+				return null;
+			}
+
+			if (!device.precompilePipeline(variant, this.source).isValid()) {
+				// Latched like compile()'s refusal, and for its reason: retrying would pay shaderc
+				// every draw for the same answer, and the caller has a fallback to hand the draw to.
+				this.reshaped.put(layout, null);
+				Vitrail.logger().error("{} did not compile over a mesh layout brought by another "
+						+ "mod, so the {} pass draws that mesh through its own layout", this.path,
+						this.pass.name());
+
+				return null;
+			}
+
+			return variant;
+		}
+	}
+
+	/**
+	 * Builds the variant, or hands back null with one line where the layout cannot carry this
+	 * program.
+	 * <p>
+	 * <strong>The layout has to lead with this program's own attributes, by name and in
+	 * order.</strong> The pipeline numbers a location for every element of the layout while the
+	 * shader numbers one for every element it declares, so an undeclared element sitting before a
+	 * declared one pulls the two counts apart and the shader reads the wrong attribute, silently.
+	 * Elements past the program's own are safe: their locations fall beyond every one the shader
+	 * asks for.
+	 * <p>
+	 * The build itself is guarded too: the builder refuses by throw, over sixteen attributes among
+	 * other things, and this is called from inside another mod's draw, where a throw would be the
+	 * very crash this door exists to close.
+	 */
+	private RenderPipeline rebuild(VertexFormat layout, VertexFormat own) {
+		List<VertexFormatElement> lead = own.getElements();
+		List<VertexFormatElement> given = layout.getElements();
+		boolean leads = given.size() >= lead.size();
+		for (int index = 0; leads && index < lead.size(); index++) {
+			leads = lead.get(index).name().equals(given.get(index).name());
+		}
+
+		if (!leads) {
+			Vitrail.logger().warn("A mesh brought by another mod does not lead with the attributes "
+					+ "the {} pass reads, so its draws keep the pass pipeline's own layout: attribute "
+					+ "locations are numbered over every element of a layout, and a stranger before "
+					+ "a known one would make the shader read the wrong attribute without a word",
+					this.pass.name());
+
+			return null;
+		}
+
+		try {
+			return reshapeAs(layout, this.reshaped.size());
+		} catch (RuntimeException e) {
+			Vitrail.logger().error("The " + this.pass.name() + " pass could not rebuild its "
+					+ "pipeline over a mesh layout brought by another mod, so those draws keep the "
+					+ "pipeline's own layout", e);
+
+			return null;
+		}
+	}
+
+	/**
+	 * The pipeline above with one layout swapped, which is a rebuild: the game's pipelines are
+	 * immutable and the builder is the public door. Every state is read off the built pipeline
+	 * rather than off this class's fields, so the two cannot drift.
+	 */
+	private RenderPipeline reshapeAs(VertexFormat layout, int index) {
+		RenderPipeline.Builder builder = RenderPipeline.builder()
+				.withLocation(this.pipeline.getLocation().withSuffix("/reshaped/" + index))
+				.withVertexShader(this.pipeline.getVertexShader())
+				.withFragmentShader(this.pipeline.getFragmentShader())
+				.withCull(this.pipeline.isCull())
+				.withPrimitiveTopology(this.pipeline.getPrimitiveTopology())
+				.withVertexBinding(0, layout);
+		this.pipeline.getBindGroupLayouts().forEach(builder::withBindGroupLayout);
+		if (this.pipeline.getDepthStencilState() != null) {
+			builder.withDepthStencilState(this.pipeline.getDepthStencilState());
+		}
+
+		// Null is how the builder holds an unused slot, so null is copied as unused; the count the
+		// pipeline carries beside the array is rebuilt by walking every slot in order.
+		ColorTargetState[] states = this.pipeline.getColorTargetStates();
+		for (int slot = 0; slot < states.length; slot++) {
+			if (states[slot] == null) {
+				builder.withUnusedColorTargetState(slot);
+			} else {
+				builder.withColorTargetState(slot, states[slot]);
+			}
+		}
+
+		return builder.build();
 	}
 
 	/** Whether {@link #compile} has already paid shaderc for this pipeline. */

--- a/common/src/main/java/dev/vitrail/render/ParticleDraw.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleDraw.java
@@ -18,6 +18,7 @@ import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderPipelines;
 
@@ -40,8 +41,8 @@ import java.util.Set;
  * without redefining it; the particles implement the interface directly and have an
  * {@code executeGroup} of their own, which opens a render pass, walks the layers of the group and
  * sets a pipeline and an atlas for each. So the shape here is the sky's and the weather's, a pass
- * replaced where it is opened and a pipeline swapped where it is set, and the layer's atlas is handed
- * over per draw as the entities' skin is.
+ * replaced where it is opened and a pipeline swapped as it is set on that pass, and the draw's atlas
+ * is handed over per draw as the entities' skin is.
  * <p>
  * <strong>The two halves are two programs on opposite sides of the frame, and this is the one family
  * that straddles the deferred stage.</strong> The game submits every group twice, once solid and once
@@ -154,16 +155,32 @@ public final class ParticleDraw {
 	private volatile boolean read;
 
 	/**
-	 * The reasons this engine has already said something about a group, one line each and not one a
-	 * frame. Most of them are hand-backs; the {@code foreign:} one is the opposite, a group kept and
-	 * a layer inside it that lost its own pipeline to it.
+	 * The reasons this engine has already handed a group back, one line each and not one a frame.
 	 */
 	private final Set<String> refused = new LinkedHashSet<>();
+
+	/** The foreign pipelines already written about, so that line comes out once per caller and
+	 * costs nothing on the draws after it. */
+	private final Set<RenderPipeline> foreign = new LinkedHashSet<>();
+
+	/** The name the game binds the primary texture under, and the one every atlas arrives as. */
+	private static final String ATLAS_SAMPLER = "Sampler0";
 
 	/** The program of the group being recorded, and the game pipeline it stands in for. */
 	private ParticleProgram drawing;
 	private RenderPipeline standsIn;
 	private RenderPipeline bound;
+
+	/** The pass the group's draws are recorded into, ours or the renderer's own. */
+	private RenderPass pass;
+
+	/**
+	 * True while {@link #texture} is binding the pack's own samplers, which go through the very
+	 * call it watches the atlas at. The names it binds are the pack's and the atlas name is the
+	 * game's, but nothing enforces that split, and a pack naming a sampler the way the game does
+	 * would re-enter it without end.
+	 */
+	private boolean binding;
 
 	/**
 	 * Whether the pipeline this engine last handed the renderer was its own. False for a layer that
@@ -259,44 +276,76 @@ public final class ParticleDraw {
 	}
 
 	/**
-	 * The pipeline one layer of the group is really drawn with.
+	 * Remembers the pass the group's draws are about to be recorded into, ours or the renderer's
+	 * own.
 	 * <p>
-	 * <strong>A layer whose pipeline is neither of the two the table names keeps its own wherever it
+	 * It is the pass and not the call site that scopes the two hooks on {@link RenderPass}: the
+	 * game's own draws go through {@code drawLayers}, but a mod may record draws of its own into
+	 * the same pass from a handler of its own, which AsyncParticles' GPU particles do after
+	 * {@code drawLayers} returns. A hook on the renderer's method sees none of those; a hook on
+	 * the pass sees them all, and this field is what tells it which pass is the group's.
+	 */
+	public static void opened(RenderPass pass) {
+		ParticleDraw draw = PackChain.particles();
+		if (draw != null && draw.drawing != null) {
+			draw.pass = pass;
+		}
+	}
+
+	/**
+	 * The pipeline one draw of the group is really recorded with, whoever asked for it.
+	 * <p>
+	 * <strong>A draw whose pipeline is neither of the two the table names keeps its own wherever it
 	 * can</strong>, which is what Iris does with it: an unassigned pipeline answers a null key
 	 * ({@code pipeline/IrisPipelines.java:224-231}) and its override then hands back nothing
 	 * ({@code mixin/MixinShaderManager_Overrides.java:97-101}), leaving the game's shader in place.
-	 * A layer like that is not a particle this engine was asked about, and drawing it with the pack's
+	 * A draw like that is not a particle this engine was asked about, and drawing it with the pack's
 	 * program would take its blend, its depth, its culling and its topology as well as its shader,
-	 * every one of them read off the pipeline the table names rather than off the layer's own.
+	 * every one of them read off the pipeline the table names rather than off the draw's own.
 	 * <p>
-	 * <strong>It cannot keep it once the pass is ours</strong>, and that is the one divergence here.
-	 * The pass was opened before any layer was seen, and where the pack took draw buffers it carries
-	 * a colour attachment for each; a pipeline declaring ONE colour state is refused by name in the
-	 * middle of it. So there the layer takes the pack's program, which draws rather than throws, and
-	 * the log says so. Where the pack took none, the pass is the renderer's own single attachment one
-	 * and the layer keeps everything.
+	 * <strong>It cannot keep it once the pass is ours, and there it takes the pack's program over
+	 * the caller's own vertex layout.</strong> The pass was opened before any draw was seen, and
+	 * where the pack took draw buffers it carries a colour attachment for each; a pipeline
+	 * declaring ONE colour state is refused by name in the middle of it. The program is recompiled
+	 * over the layout the caller's mesh really has ({@code GeometryProgram.reshape}) rather than
+	 * bound as built, which would read every vertex past the first at the wrong offset. That is
+	 * where Iris lands for the reachable caller: AsyncParticles' GPU particles record draws into
+	 * the group's pass after {@code drawLayers} returns, on a wider layout of their own, and it
+	 * registers those pipelines against Iris' two particle programs
+	 * ({@code GpuParticlePipelines.of} ends on {@code IrisApi.assignPipeline}), so Iris draws them
+	 * with the pack's program too. What stays divergent is a pipeline Iris was never told about,
+	 * which keeps the game's shader there and takes the pack's program here, the log saying so.
+	 * Where the pack took none, the pass is the renderer's own single attachment one and the draw
+	 * keeps everything.
 	 * <p>
-	 * <strong>The case is reachable and is not vanilla's.</strong> {@code SingleQuadParticle.Layer} is
-	 * a public record and {@code getLayer} is overridable, so a mod may put a layer carrying a
-	 * pipeline of its own into a group whose translucency matches. Every layer of the game pairs its
-	 * translucency with one of the two the table names, so nothing of the game reaches this.
+	 * <strong>The layer case is reachable and is not vanilla's.</strong>
+	 * {@code SingleQuadParticle.Layer} is a public record and {@code getLayer} is overridable, so a
+	 * layer may carry a pipeline of its own into a group whose translucency matches. Every layer of
+	 * the game pairs its translucency with one of the two the table names, so nothing of the game
+	 * reaches this.
 	 *
-	 * @param game the pipeline the layer asked for
-	 * @return the pipeline to bind instead, or the game's own
+	 * @param pass the pass the pipeline is being set on, which is what scopes this to the group
+	 * @param game the pipeline the draw asked for
+	 * @return the pipeline to bind instead, or the one asked for
 	 */
 	@SuppressWarnings("ReferenceEquality")
-	public static RenderPipeline pipeline(RenderPipeline game) {
+	public static RenderPipeline pipeline(RenderPass pass, RenderPipeline game) {
 		ParticleDraw draw = PackChain.particles();
-		if (draw == null || draw.drawing == null || draw.bound == null) {
+		if (draw == null || draw.drawing == null || draw.bound == null || pass != draw.pass) {
 			return game;
 		}
 
 		draw.handedOurs = true;
+		// Ours coming back around, re-set by a caller that kept a reference: nothing to swap.
+		if (game == draw.bound) {
+			return game;
+		}
+
 		if (draw.standsIn == game) {
 			return draw.bound;
 		}
 
-		// The pack took no draw buffer here, so the pass is the renderer's own and the layer's
+		// The pack took no draw buffer here, so the pass is the renderer's own and the draw's
 		// pipeline binds into it as it always did. Nothing is lost and nothing is said.
 		if (draw.descriptor == null) {
 			draw.handedOurs = false;
@@ -304,43 +353,71 @@ public final class ParticleDraw {
 			return game;
 		}
 
-		if (draw.refused.add("foreign:" + game.getLocation())) {
-			Vitrail.logger().warn("A particle layer asked for {}, which is neither of the two "
-					+ "pipelines the game draws its own quad particles with, inside a group whose "
-					+ "pass this engine had already opened over the pack's own colour targets. It "
-					+ "takes the pack's particle program, and with it that program's blend, depth, "
-					+ "culling and topology: a pipeline carrying one colour state is refused by name "
-					+ "in a pass carrying several, so its own could not be bound there. Iris leaves "
-					+ "the game's shader on a pipeline it was never assigned", game.getLocation());
+		// The binding read directly rather than through the array's length: the game hands the
+		// builder's raw sixteen slots through, so the array is never short and its entries are
+		// where the nulls live.
+		GpuDevice device = RenderSystem.tryGetDevice();
+		VertexFormat layout = game.getVertexFormatBinding(0);
+		RenderPipeline reshaped = device == null || layout == null
+				? null
+				: draw.drawing.reshape(device, layout);
+		if (draw.foreign.add(game)) {
+			if (reshaped != null) {
+				Vitrail.logger().warn("A particle draw asked for {}, which is neither of the two "
+						+ "pipelines the game draws its own quad particles with, inside a group "
+						+ "whose pass this engine had already opened over the pack's own colour "
+						+ "targets, where a pipeline carrying one colour state is refused by name. "
+						+ "It takes the pack's particle program over the caller's own vertex "
+						+ "layout, which is where Iris lands for the callers that register such "
+						+ "pipelines against its particle programs", game.getLocation());
+			} else {
+				Vitrail.logger().warn("A particle draw asked for {}, which is neither of the two "
+						+ "pipelines the game draws its own quad particles with, inside a group "
+						+ "whose pass this engine had already opened over the pack's own colour "
+						+ "targets, where a pipeline carrying one colour state is refused by name. "
+						+ "The pack's particle program could not be rebuilt over the caller's own "
+						+ "vertex layout, so it is bound as built and reads that mesh through its "
+						+ "own", game.getLocation());
+			}
 		}
 
-		return draw.bound;
+		return reshaped == null ? draw.bound : reshaped;
 	}
 
 	/**
-	 * The atlas the game was going to draw this layer with, on its way past, and the pack's block and
+	 * The atlas a draw of the group was going to read, on its way past, and the pack's block and
 	 * samplers bound over it.
 	 * <p>
-	 * One line before the draw that reads them, which is where the renderer binds its own: the layers
+	 * One line before the draw that reads them, which is where each caller binds its own: the draws
 	 * of one group come off three different atlases, so this is the draw's answer and not the pass's.
+	 * Only the name the game binds every atlas under is answered, the group's pass also carrying a
+	 * lightmap under another, and only outside this method's own binds, which go through the very
+	 * call it is watching.
 	 */
-	public static void texture(RenderPass pass, GpuTextureView view, GpuSampler sampler) {
+	public static void texture(RenderPass pass, String name, GpuTextureView view,
+			GpuSampler sampler) {
 		ParticleDraw draw = PackChain.particles();
 		// What the pass really got decides, as it does for the weather and for the sky. A foreign
-		// layer keeps its own pipeline wherever the pass allows it, which pipeline() answers just
+		// draw keeps its own pipeline wherever the pass allows it, which pipeline() answers just
 		// above and this would otherwise ignore: binding the pack's block over the game's shader is
 		// harmless in itself, the descriptor flush walking the layout of the pipeline really bound,
 		// but it makes this engine announce a first draw for a program that drew nothing.
-		if (draw == null || draw.drawing == null || draw.bound == null || !draw.handedOurs) {
+		if (draw == null || draw.drawing == null || draw.bound == null || !draw.handedOurs
+				|| pass != draw.pass || draw.binding || !ATLAS_SAMPLER.equals(name)) {
 			return;
 		}
 
-		draw.drawing.texture(view, sampler);
-		draw.drawing.bind(pass);
+		draw.binding = true;
+		try {
+			draw.drawing.texture(view, sampler);
+			draw.drawing.bind(pass);
+		} finally {
+			draw.binding = false;
+		}
 	}
 
 	/**
-	 * Forgets the group, at the return of the method that drew it.
+	 * Forgets the group, at the way out of the method that drew it, thrown ways out included.
 	 * <p>
 	 * Owed rather than tidy: the two halves of a frame are two calls, and a group that left its
 	 * program standing would hand the translucent half's layers the opaque half's block. Nothing
@@ -359,6 +436,7 @@ public final class ParticleDraw {
 		this.drawing = null;
 		this.standsIn = null;
 		this.bound = null;
+		this.pass = null;
 		this.descriptor = null;
 		this.handedOurs = false;
 	}
@@ -608,6 +686,7 @@ public final class ParticleDraw {
 		this.programs.values().forEach(ParticleProgram::release);
 		this.programs.clear();
 		this.refused.clear();
+		this.foreign.clear();
 		this.read = false;
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/ParticleProgram.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleProgram.java
@@ -13,6 +13,7 @@ import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vulkan.VulkanDevice;
 import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
@@ -163,6 +164,15 @@ final class ParticleProgram implements DumpedProgram {
 	 */
 	void bind(RenderPass pass) {
 		this.body.bind(pass);
+	}
+
+	/**
+	 * The same program over a mesh laid out by another mod.
+	 *
+	 * @see GeometryProgram#reshape
+	 */
+	RenderPipeline reshape(GpuDevice device, VertexFormat layout) {
+		return this.body.reshape(device, layout);
 	}
 
 	/** @see GeometryProgram#compile */


### PR DESCRIPTION
## What changes

With AsyncParticles installed and its GPU acceleration on, the game crashed a few seconds into any world while a shaderpack with draw buffers was active: AsyncParticles records its particle draws itself, into the render pass this engine had already opened over the pack's colour targets, with the game's single-target pipelines, and the pass refuses such a pipeline by name. The swap of pipeline and atlas now lives on `RenderPass` itself, scoped to the one pass the particle group opened, so it covers every draw recorded into that pass whoever records it. A draw arriving with a pipeline of its own takes the pack's particle program, rebuilt over the caller's vertex layout, and the group disarms on every way out of the renderer, exceptions included.

## How it differs from the reference, and for what obstacle

Iris reaches the same picture through its API: AsyncParticles registers these pipelines against Iris' particle programs (`GpuParticlePipelines.of` ends on `IrisApi.assignPipeline`), and Iris swaps the shader where it binds. This engine does not carry that API, so any pipeline that is neither of the game's two, set on the pack-owned particle pass, takes the pack's program. Two edges follow.

- A pipeline Iris was never told about keeps the game's shader there (`pipeline/IrisPipelines.java:224-231`) and takes the pack's program here: a pipeline carrying one colour state cannot be bound in a pass carrying several (`RenderPass.setPipeline` refuses it by name), and the pass is open before any draw is seen. It costs that draw its own shader, blend and depth, and the log names it once per caller.
- The program is recompiled over the caller's vertex layout, which OpenGL never needed: a Vulkan pipeline bakes the layout in, and AsyncParticles feeds 44-byte vertices where the game's particles are 28. A layout that does not lead with the program's own attributes is refused instead, because attribute locations are numbered over every element of a layout while the shader numbers only the ones it declares.

## What proves it

- `gradlew build` green, both loaders in the merged jar.
- The mechanism is confirmed in AsyncParticles' own source and in the game's: the handler records its draws after `drawLayers` returns, with pipelines derived from the game's two, and the attachment count check sits at the head of `setPipeline`.
- Not yet tried in game. The bench run with AsyncParticles 26.2.2.7 over Complementary is the remaining scope, planned before this merges.

## What it leaves owing

- The two hooks sit on every `setPipeline` and `bindTexture` of the frame, behind a two-field early-out; that cost is reasoned, not measured.
- The sky, weather and entity passes keep their per-renderer swaps: a mod recording draws into those passes from a handler of its own would still meet the refusal the particles met.
- A foreign mesh whose layout cannot carry the pack's program falls back to the pipeline as built, which misreads that mesh; it is logged, not skipped.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
