### PR TITLE
fix(render): serve the block breaking overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ what the next one holds.
 
 ### Fixed
 
+- **Breaking a block no longer paints flat black cracks over it.** The overlay that spreads as a
+  block is mined was left to the game, and it multiplies its texture onto what is already drawn;
+  it was landing on an empty layer instead of on the picture, so every crack came out opaque
+  black from the first stage rather than darkening the face as it broke. It is drawn through the
+  pack now, on `gbuffers_damagedblock` and its fallback onto the terrain, which is what a pack
+  expects to be asked for.
 - **A pack written with the old shadow lookups could be translated wrong, without a word.**
   Wrapping those lookups shifted the translator's own note of which words are macro names,
   which could rename one of them or leave a local variable reading a global value instead.

--- a/common/src/main/java/dev/vitrail/glsl/CrumblingVertex.java
+++ b/common/src/main/java/dev/vitrail/glsl/CrumblingVertex.java
@@ -1,0 +1,117 @@
+package dev.vitrail.glsl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What the mesh a block's breaking overlay is drawn from carries, and how the names a pack reads are
+ * made out of it.
+ * <p>
+ * {@code DefaultVertexFormat.BLOCK} holds four elements in twenty-eight bytes: {@code Position} as
+ * three floats, {@code Color} as four normalised bytes, {@code UV0} as two floats, {@code UV2} as
+ * two signed shorts. The order is the format's own and is not the particle mesh's, which carries the
+ * same four names in another one.
+ * <p>
+ * <strong>Named after the family and not after the format</strong>, which {@link GlintVertex} is the
+ * other instance of. The beacon beam binds that same format and is not served, and the name says
+ * which of the two this head was written against rather than claiming the format outright. Nothing
+ * here would refuse the beam: Iris draws it at full light as well
+ * ({@code pipeline/programs/ShaderKey.java:70}), so this head would answer it. What it wants is a
+ * row of its own, its program, its alpha test and its fog being none of the crumbling's.
+ * <p>
+ * <strong>The light map is answered at full light, and that is read off Iris rather than
+ * chosen.</strong> {@code pipeline/programs/ShaderKey.java:61} gives the crumbling key
+ * {@code LightingModel.FULLBRIGHT}, and {@link VertexInputs#fullbright} carries the other half of
+ * that answer, the white pixel behind the light map sampler. The element itself is bound and
+ * declared all the same, the format carrying it. This is the camera's contract and the only one:
+ * the shadow map files no twin for this overlay, because the reference's map never receives the
+ * draw, which the crumbling row of {@code EntityDraw} carries with its file and line.
+ * <p>
+ * <strong>Iris draws this overlay from a WIDER mesh than the game's, so four of the names a pack
+ * reads are constants here and values there. That is a divergence and it is written out in the
+ * three parts one owes.</strong>
+ * <p>
+ * What Iris does: it widens this very format on the way to the buffer,
+ * {@code mixin/vertices/MixinBufferBuilder.iris$extendFormat:102-106} handing back
+ * {@code IrisVertexFormats.TERRAIN} for {@code DefaultVertexFormat.BLOCK}, and then fills what it
+ * added. The normal and the tangent are computed per polygon and the mid texture coordinate written
+ * beside them ({@code MixinBufferBuilder:240-260}); {@code at_midBlock} is filled at every vertex
+ * ({@code :127-134}). The block id is the one it does NOT fill on this draw: nothing opens a block
+ * around the overlay's buffer, so {@code currentBlock} stays at the {@code -1} it is declared with
+ * ({@code :74}) and a pack reads that pair rather than a block.
+ * <p>
+ * What stops that here: widening a mesh is what {@code EntityMesh} does, for one format and one
+ * only, and it is a format of this engine's with a Sodium serializer behind it. Nothing widens the
+ * block format, so the four elements above are the whole of what reaches this stage.
+ * <p>
+ * What it costs the image: a pack whose {@code gbuffers_damagedblock} does its own normal mapping
+ * or relief reads a fixed direction where Iris hands it the face's, a tangent that is the
+ * prologue's default and a mid texture coordinate of nought, so a crack is shaded flat instead of
+ * following the face it lies on. The normal is the value Iris itself hands every format carrying
+ * none ({@code transform/transformer/VanillaTransformer.java:152-154}), and the one
+ * {@link ParticleVertex} and {@link SkyVertex} give for the same reason, a normalise of a zero
+ * vector being a NaN that spreads into the colour through the tangent frame. What is left is flat
+ * rather than absent: the crack darkens the albedo it is multiplied onto either way, that being
+ * what the game's own blend does with it. And {@code mc_Entity} is nought here where it is
+ * {@code -1} there, so a pack branching on it takes the same branch as an unnamed block on both,
+ * unless it tests for one of those two values by name.
+ * <p>
+ * <strong>Declaring an element is not the same as keeping it</strong>, and the risk is sharper on
+ * this family than on any other. An input a stage declares and never reads may be dropped from the
+ * compiled module, and {@code rebind} only counts the ones that survived: {@code Color} is second
+ * of the four, so a stage that never reads {@code gl_Color} and loses it would have {@code UV0}
+ * read out of the colour's bytes and {@code UV2} out of the coordinate's. {@code UV2} is the one
+ * the camera's side never reads by construction, its light map being answered with a constant. The
+ * off-game harness compiles every such program of the corpus and reads the disassembly back to
+ * check the four are still there, which is the check the particle mesh already had.
+ * <p>
+ * <strong>There is no overlay here.</strong> {@code UV1} is what an entity carries and a block has
+ * not got, so {@code entityColor} is not made in this head and {@link VertexInputs#overlay} leaves
+ * this contract out.
+ */
+public final class CrumblingVertex {
+
+	/** The elements of the block mesh, in the format's own order. */
+	public static final List<String> ATTRIBUTES = List.of("Position", "Color", "UV0", "UV2");
+
+	private CrumblingVertex() {
+	}
+
+	/**
+	 * The head of a crumbling vertex stage: the four elements, the names a pack reads made out of
+	 * them, and constants for everything the mesh has not got.
+	 *
+	 * @param used        every name the rewritten body mentions, so that nothing is declared for a
+	 *                    pack that never asks
+	 * @param synthesized the vertex inputs the pack declared for itself and that were taken out of
+	 *                    the body, by name and with the type the pack gave them
+	 */
+	public static List<String> prologue(Set<String> used, Map<String, String> synthesized) {
+		List<String> lines = new ArrayList<>();
+
+		for (String attribute : ATTRIBUTES) {
+			lines.add("in " + VertexPrologue.elementType(attribute) + " " + attribute + ";");
+		}
+
+		lines.add("#define of_Vertex vec4(Position, 1.0)");
+		lines.add("#define of_Color Color");
+		lines.add("#define of_MultiTexCoord0 vec4(UV0, 0.0, 1.0)");
+		// Both units that name the light map, answered at full light like every other piece the
+		// game draws at the camera: Iris keys this draw FULLBRIGHT (ShaderKey.java:61), and no
+		// other side of the stage reaches this head, the map filing no twin for the overlay.
+		lines.add("#define of_MultiTexCoord1 " + EntityVertex.FULL_LIGHT);
+		lines.add("#define of_MultiTexCoord2 " + EntityVertex.FULL_LIGHT);
+		lines.addAll(VertexPrologue.blankTexCoords());
+
+		lines.add("#define of_Normal vec3(0.0, 0.0, 1.0)");
+
+		// mc_Entity among them, and it is a constant under Iris too on this draw, at -1 rather than at
+		// the nought this hands back. A pack branching on it here is branching on a constant either
+		// way.
+		lines.addAll(VertexPrologue.tail(used, synthesized));
+
+		return List.copyOf(lines);
+	}
+}

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -4071,6 +4071,7 @@ public final class GlslTranslator {
 				case ENTITY, ENTITY_FULLBRIGHT -> lines.addAll(
 						EntityVertex.prologue(this.used, this.synthesized, this.inputs.fullbright()));
 				case GLINT -> lines.addAll(GlintVertex.prologue(this.used, this.synthesized));
+				case CRUMBLING -> lines.addAll(CrumblingVertex.prologue(this.used, this.synthesized));
 				case PARTICLE -> lines.addAll(ParticleVertex.prologue(this.used, this.synthesized));
 				case SKY -> lines.addAll(SkyVertex.prologue(this.bound, this.used, this.synthesized));
 				case CLOUDS -> lines.addAll(CloudVertex.prologue(this.used, this.synthesized));

--- a/common/src/main/java/dev/vitrail/glsl/VertexInputs.java
+++ b/common/src/main/java/dev/vitrail/glsl/VertexInputs.java
@@ -89,6 +89,14 @@ public enum VertexInputs {
 	GLINT,
 
 	/**
+	 * The mesh a block's breaking overlay is drawn from: the four elements of
+	 * {@code DefaultVertexFormat.BLOCK} and nothing else. It comes in by the entity door like the
+	 * glint and is no more that mesh than the glint is: {@link CrumblingVertex} carries what the four
+	 * answer for, why the light map is answered at full light, and what the missing normal costs.
+	 */
+	CRUMBLING,
+
+	/**
 	 * The game's own sky meshes. Alone among these, it is not one format: {@code SkyRenderer} binds
 	 * four between its eight passes, so the elements to declare come from the pass rather than from
 	 * this constant. {@link SkyVertex} carries the renaming and says what the sky has not got.
@@ -150,7 +158,7 @@ public enum VertexInputs {
 	 * the mesh.
 	 */
 	public boolean fullbright() {
-		return this == ENTITY_FULLBRIGHT;
+		return this == ENTITY_FULLBRIGHT || this == CRUMBLING;
 	}
 
 	/**
@@ -204,6 +212,7 @@ public enum VertexInputs {
 			case TERRAIN, TERRAIN_SEPARATE_AO -> SodiumVertex.ATTRIBUTES;
 			case ENTITY, ENTITY_FULLBRIGHT -> EntityVertex.ATTRIBUTES;
 			case GLINT -> GlintVertex.ATTRIBUTES;
+			case CRUMBLING -> CrumblingVertex.ATTRIBUTES;
 			case PARTICLE -> ParticleVertex.ATTRIBUTES;
 			case SKY -> SkyVertex.ATTRIBUTES;
 			case CLOUDS -> CloudVertex.ATTRIBUTES;

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -108,9 +108,10 @@ import java.util.stream.Stream;
  * {@link FeatureLayer} carries it, with what Iris does instead and what it costs the image.
  * <p>
  * <strong>What is still the game's inside this window</strong>, and therefore still goes to that
- * layer, is the beacon beam, the lightning, and the text of a name plate or a sign. All three of
- * those families bind a mesh this door cannot decode, which {@link #decodable} says and which is why
- * none of them is a row here. The shadow map is a family of its own and is NOT in either window, a
+ * layer, is the beacon beam, the lightning, and the text of a name plate or a sign. The lightning
+ * and the text bind a mesh this door cannot decode, which {@link #decodable} says and which is why
+ * neither is a row here; the beam binds the block format, which the door reads for the crumbling,
+ * and what it still wants is a row of its own. The shadow map is a family of its own and is NOT in either window, a
  * pass of its own that neither bracket reaches.
  * <p>
  * <strong>The eyes are not among them</strong>: they alone of the four bind
@@ -118,8 +119,9 @@ import java.util.stream.Stream;
  * {@link #FIXED}, which says why it is not the mob table.
  * <p>
  * <strong>An enchantment's glint comes in by this same door and is alone in it</strong>, in two ways
- * that are one: it is the only piece served here that is not drawn from an entity mesh, and the only
- * one whose pipeline carries more than one render type's worth of answers. {@link #GLINT_EARLY}
+ * that are one: it is one of the two pieces served here that are not drawn from an entity mesh, the
+ * cracks over a mined block being the other, and the only one whose pipeline carries more than one
+ * render type's worth of answers. {@link #GLINT_EARLY}
  * carries what that costs it, which is four pieces where every other family has one per table.
  * <p>
  * <strong>The hand comes in by this same door and is not one of those.</strong> {@link HandDraw}
@@ -239,7 +241,8 @@ public final class EntityDraw {
 	 *                      carries false here
 	 * @param fullbright    whether the game draws this piece at full light, so that the light map
 	 *                      names are answered with a constant and the sampler behind them with one
-	 *                      white texel. True for the two rows of {@link #FIXED} and no other so far.
+	 *                      white texel. True for the three rows of {@link #FIXED} and no other so
+	 *                      far.
 	 *                      <strong>A column of the row and not a reading of the program name</strong>,
 	 *                      which is where Iris keeps it as well: its lighting model hangs off the
 	 *                      {@code ShaderKey} ({@code pipeline/programs/ShaderKey.java:44,45}), and
@@ -296,22 +299,37 @@ public final class EntityDraw {
 		}
 
 		/**
+		 * Whether this piece is the overlay that spreads over a block being mined, asked of the
+		 * PIPELINE for the reason {@link #glint} is: what it answers differently is its MESH, the game
+		 * drawing it from the block format rather than from the entity one.
+		 */
+		@SuppressWarnings("ReferenceEquality")
+		boolean crumbling() {
+			return this.pipeline == RenderPipelines.CRUMBLING;
+		}
+
+		/**
 		 * The format this piece is drawn from, which is the entity mesh for every row but the glint's
-		 * four.
+		 * four and the crumbling's one.
 		 * <p>
-		 * Derived from {@link #glint} rather than tabulated beside it, so that the two cannot drift: a
-		 * row whose format did not match the pipeline it names would declare the wrong inputs and read
-		 * its texture coordinates off whatever the format really carries, without a word being said.
-		 * {@link #decodable} is where the claim is checked against the pipeline in hand.
+		 * Derived from {@link #glint} and {@link #crumbling} rather than tabulated beside them, so
+		 * that a row and its format cannot drift: a row whose format did not match the pipeline it
+		 * names would declare the wrong inputs and read its texture coordinates off whatever the
+		 * format really carries, without a word being said. {@link #decodable} is where the claim is
+		 * checked against the pipeline in hand.
 		 * <p>
 		 * The entity one is {@link EntityMesh}'s rather than the game's own: this is what a pipeline
 		 * of this engine's is built to bind, and it is what the game's own entity pipelines report
 		 * while the mesh carries. The rows are only ever read while it does, {@link #served} refusing
 		 * the whole family otherwise, so the two answers cannot be taken under different ones. The
-		 * glint keeps the game's, its two elements being untouched by any of this.
+		 * other two keep the game's, their elements being untouched by any of this.
 		 */
 		VertexFormat format() {
-			return glint() ? DefaultVertexFormat.POSITION_TEX : EntityMesh.format();
+			if (glint()) {
+				return DefaultVertexFormat.POSITION_TEX;
+			}
+
+			return crumbling() ? DefaultVertexFormat.BLOCK : EntityMesh.format();
 		}
 
 		/**
@@ -332,10 +350,17 @@ public final class EntityDraw {
 				return VertexInputs.GLINT;
 			}
 
+			// One crumbling contract, the camera's, answering the light map at full light: the map
+			// files no twin for it, the FIXED row's javadoc saying why the reference's map never
+			// receives this draw.
+			if (crumbling()) {
+				return VertexInputs.CRUMBLING;
+			}
+
 			return this.fullbright ? VertexInputs.ENTITY_FULLBRIGHT : VertexInputs.ENTITY;
 		}
 
-		/** One word for the log, which has to say which of the four families a line is about. */
+		/** What the log calls this line, which has to say which of the five families it is about. */
 		String family() {
 			if (shadow()) {
 				return "entities in the shadow map";
@@ -343,6 +368,10 @@ public final class EntityDraw {
 
 			if (glint()) {
 				return "glint";
+			}
+
+			if (crumbling()) {
+				return "block breaking";
 			}
 
 			return hand() ? "hand" : "entities";
@@ -519,6 +548,14 @@ public final class EntityDraw {
 	private static final String ENTITIES_TRANSLUCENT = "gbuffers_entities_translucent";
 
 	private static final String BLOCK_TRANSLUCENT = "gbuffers_block_translucent";
+
+	/**
+	 * What the cracks spreading over a block being mined ask for. It falls back onto the terrain
+	 * ({@code ProgramFallbacks} carries the tree), which is where Iris sends it too,
+	 * {@code ProgramId.DamagedBlock} naming {@code Terrain} as its parent at
+	 * {@code shaderpack/loading/ProgramId.java:33}.
+	 */
+	private static final String DAMAGED_BLOCK = "gbuffers_damagedblock";
 
 	/**
 	 * What the glowing eyes of a mob ask for, and the one name of this class that answers whatever
@@ -875,7 +912,8 @@ public final class EntityDraw {
 	 */
 	private static void shadowTwins(Map<RenderPipeline, Element> from) {
 		from.values().stream()
-				.filter(mob -> mob.pipeline() != RenderPipelines.ENTITY_SHADOW)
+				.filter(mob -> mob.pipeline() != RenderPipelines.ENTITY_SHADOW
+						&& mob.pipeline() != RenderPipelines.CRUMBLING)
 				.map(mob -> new Element(mob.pipeline(), "shadow_" + mob.element(), SHADOW_ENTITIES,
 						CUTOUT, RenderStage.ENTITIES, false))
 				.forEach(element -> SHADOW_ELEMENTS.put(element.pipeline(), element));
@@ -966,8 +1004,8 @@ public final class EntityDraw {
 	}
 
 	/**
-	 * The pieces whose program does not depend on what else is going on, which is the eyes and
-	 * nothing else so far.
+	 * The pieces whose program does not depend on what else is going on, which is the eyes and the
+	 * overlay a block being mined is drawn under.
 	 * <p>
 	 * <strong>A table of its own because Iris keys these rows differently, and the difference is
 	 * exactly what a twin would destroy.</strong> Most rows of {@link #ELEMENTS} reach Iris through
@@ -1017,7 +1055,7 @@ public final class EntityDraw {
 	 * <p>
 	 * <strong>Both bind {@code DefaultVertexFormat.ENTITY}</strong> ({@code RenderPipelines.java:361}
 	 * and the {@code ENTITY_EMISSIVE_SNIPPET} at {@code :64}), which is why this family could be
-	 * served at all and the four beside it could not: the door decodes that one format.
+	 * served at all when the door decoded that format alone.
 	 * <p>
 	 * Neither render type carries a layering transform or a texture transform
 	 * ({@code rendertype/RenderTypes.java:190-198,242-244}), so there is no depth nudge to reproduce
@@ -1038,6 +1076,46 @@ public final class EntityDraw {
 	 * declared {@code LightingModel.LIGHTMAP} ({@code pipeline/programs/ShaderKey.java:79}) where the
 	 * two the camera reaches are {@code FULLBRIGHT} ({@code :44,45}), so the twins take the row every
 	 * other caster gets rather than the full light of their own side.
+	 *
+	 * <h4>The cracks over a block being mined</h4>
+	 *
+	 * <strong>The second family here, and it is here for the reason the eyes are.</strong> Iris keys
+	 * it on a constant, {@code p -> ShaderKey.CRUMBLING} ({@code pipeline/IrisPipelines.java:79}),
+	 * which consults neither the hand nor the block entity phase. That phase is the one a twin would
+	 * really be reached in, a chest being as breakable as the stone beside it, and the twin would ask
+	 * for {@code gbuffers_block} inside a draw Iris keeps on {@code gbuffers_damagedblock}.
+	 * <p>
+	 * The key is {@code ProgramId.DamagedBlock} at a tenth, drawn at full light with the fog off
+	 * ({@code pipeline/programs/ShaderKey.java:61}). The tenth is what {@link #CUTOUT} already is
+	 * here; the name falls back onto the terrain, which is Iris's tree as well.
+	 * <p>
+	 * <strong>It is the one row of this door drawn from a mesh of the world.</strong> The game binds
+	 * {@code DefaultVertexFormat.BLOCK} for it, four elements and no normal, where every other row is
+	 * the entity mesh or the glint's two: {@link VertexInputs#CRUMBLING} is the contract that reads it
+	 * and {@code CrumblingVertex} carries what the four answer for and what the missing normal costs.
+	 * <p>
+	 * <strong>Leaving it to the game is not the neutral answer it looks like.</strong> The game draws
+	 * it in the {@code SubmitNodeCollection.breakingOverlay} phase, which
+	 * {@code FeatureRenderDispatcher.PreparedFrame.executeTranslucent} runs between the translucent
+	 * blocks and the water mask, and that call is the stretch {@code PackChain.openFeatures}
+	 * redirects into {@link FeatureLayer}; that
+	 * layer is cleared to transparent black and composed as though every draw caught in it blended by
+	 * alpha. This pipeline multiplies instead, {@code DST_COLOR} by {@code SRC_COLOR}, so left there
+	 * it multiplies against the clear and every crack comes out black. Served, it multiplies onto the
+	 * colour the chain composed, which is where the game would have put it.
+	 * <p>
+	 * <strong>It has no shadow twin here, and that is Iris's map rather than a divergence.</strong>
+	 * Iris holds a shadow key for this pipeline,
+	 * {@code assignToShadow(RenderPipelines.CRUMBLING, p -> ShaderKey.SHADOW_TEX)}
+	 * ({@code pipeline/IrisPipelines.java:95}), but its shadow stage replays only what it submits
+	 * itself, the entities and the block entities
+	 * ({@code shadows/ShadowRenderer.java:572,580}), so the overlay over a mined block never
+	 * reaches its map and the key sits unused. Here the light's walk replays the game's whole
+	 * translucent feature window, overlay included, so a filed twin fed the map a draw the
+	 * reference never makes. What that draw wrote there was the map's COLOUR half alone, the
+	 * vanilla state keeping its depth write off ({@code RenderPipelines.CRUMBLING}, kept by
+	 * {@code EntityProgram.intoMap}); a pack reading {@code shadowcolor} then tints the sun with
+	 * the crack, and the face being mined wears a crack-shaped shadow.
 	 */
 	private static final Map<RenderPipeline, Element> FIXED = new LinkedHashMap<>();
 
@@ -1047,11 +1125,16 @@ public final class EntityDraw {
 		FIXED.put(RenderPipelines.ENTITY_TRANSLUCENT_EMISSIVE,
 				new Element(RenderPipelines.ENTITY_TRANSLUCENT_EMISSIVE, "eyes_emissive", SPIDER_EYES,
 						CUTOUT, RenderStage.NONE, false, true));
+		// Under NONE and not under DESTROY, which the stage enum carries and nobody poses: Iris
+		// declares that phase too (pipeline/WorldRenderingPhase.java:20) and never sets it, so a pack
+		// reading renderStage here reads what it reads there.
+		FIXED.put(RenderPipelines.CRUMBLING, new Element(RenderPipelines.CRUMBLING, "crumbling",
+				DAMAGED_BLOCK, CUTOUT, RenderStage.NONE, false, true));
 	}
 
 	static {
 		// Here and not beside the call for the mob table: this one is declared below it, so a block up
-		// there would read it while it is still empty and lose both rows without a word.
+		// there would read it while it is still empty and lose every row of it without a word.
 		shadowTwins(FIXED);
 	}
 
@@ -1426,10 +1509,11 @@ public final class EntityDraw {
 		// ten draws in a hand pass.
 		boolean inMoment = (element != null && element.hand()) ? HandDraw.wanted()
 				: wanted && element != null && inWindow(element);
-		// And the mesh has to be carrying, whatever the moment says. Every row but the glint's is read
-		// against EntityMesh.format, so a draw served before the mesh settled would bind fifty-six
-		// bytes of layout over a vertex of thirty-six. It lasts from the load that
-		// asked until the extract that rebuilds the world, which is one frame in the ordinary case.
+		// And the mesh has to be carrying, whatever the moment says. Every row but the glint's and the
+		// crumbling's is read against EntityMesh.format, so a draw served before the mesh settled
+		// would bind fifty-six bytes of layout over a vertex of thirty-six. It lasts from the load
+		// that asked until the extract that rebuilds the world, which is one frame in the ordinary
+		// case.
 		//
 		// What it costs is NOT the same thing on the two roads, and saying it once would be wrong on
 		// the second. In the picture's windows a no hands the draw back, so the frame's mobs are drawn
@@ -1960,16 +2044,22 @@ public final class EntityDraw {
 	 * <p>
 	 * The vertex head declares the elements of that format BY NAME, and an element the stage does not
 	 * declare shifts the location of every one after it without a word being said: the picture stays a
-	 * picture and reads its texture coordinates out of the light map. Two formats come in by this door
-	 * now, the entity mesh and the glint's two elements, so the claim is the piece's and the check is
-	 * against the game's own binding.
+	 * picture and reads its texture coordinates out of the light map. Three formats come in by this
+	 * door now, the entity mesh, the glint's two elements and the block one the crumbling is drawn
+	 * from, so the claim is the piece's and the check is against the game's own binding.
 	 * <p>
-	 * It is also what keeps the three families beside the eyes out of these tables, and that is a
-	 * fact about this engine rather than about them: the beacon beam binds
-	 * {@code DefaultVertexFormat.BLOCK}, the lightning and the dragon rays {@code POSITION_COLOR} and
-	 * the world text {@code POSITION_TEX_LIGHTMAP_COLOR}, and {@code VertexInputs} has a decoder for
-	 * none of the three. A row added for any of them would be caught here and reported, rather than
-	 * drawn out of the wrong offsets.
+	 * It is also what keeps two of the families beside the eyes out of these tables, and that is a
+	 * fact about this engine rather than about them: the lightning and the dragon rays bind
+	 * {@code POSITION_COLOR} and the world text {@code POSITION_TEX_LIGHTMAP_COLOR}, and
+	 * {@code VertexInputs} has a decoder for neither. A row added for either would be caught here and
+	 * reported, rather than drawn out of the wrong offsets.
+	 * <p>
+	 * <strong>The beacon beam is no longer one of them and is still not served</strong>, which is
+	 * worth separating: it binds {@code DefaultVertexFormat.BLOCK} as the crumbling does, so this
+	 * gate would let it through. What it wants is a row, and the row is not the crumbling's under
+	 * another name. Iris gives it {@code ProgramId.BeaconBeam} with no alpha test and its fog per
+	 * fragment ({@code pipeline/programs/ShaderKey.java:70}), where the crumbling is
+	 * {@code DamagedBlock} at a tenth with the fog off, and the two agree on the light alone.
 	 */
 	private static boolean decodable(Element element) {
 		VertexFormat format = element.pipeline().getVertexFormatBinding(0);
@@ -2000,7 +2090,7 @@ public final class EntityDraw {
 				.toList();
 	}
 
-	/** The fixed rows this engine can decode the mesh of, which today is both of them. */
+	/** The fixed rows this engine can decode the mesh of, which today is all three of them. */
 	private static List<Element> fixed() {
 		return FIXED.values().stream().filter(EntityDraw::decodable).toList();
 	}

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -250,10 +250,12 @@ them. The mesh only carries them while the pack is drawing the entities or the h
 switch asks the game to rebuild the world, the same door F3+A uses, and it does not ask for a
 restart.
 
-That is the whole reason the beacon beam, the lightning bolt and the text of a sign or a name plate
-still come from the game's own shader: they bind the block, position-colour and glyph layouts. They
-reach the pack's image through the layer described below, which means they are visible but flat, and
-drawn in front of what should hide them.
+That is the whole reason the lightning bolt and the text of a sign or a name plate still come from
+the game's own shader: they bind the position-colour and glyph layouts, which nothing here reads.
+The beacon beam is with them for another reason, the block layout it binds being read since the
+cracks of a mined block are drawn through the pack: what the beam still wants is a pass of its own.
+All three reach the pack's image through the layer described below, which means they are visible but
+flat, and drawn in front of what should hide them.
 
 Which target is seeded is the first draw buffer of the pass that draws the terrain, resolved through
 the fallback tree, and it is not always target zero: one pack of the corpus serves its terrain

--- a/docs/internals/entities.md
+++ b/docs/internals/entities.md
@@ -319,8 +319,8 @@ as dark as the block it stands on, and the additive blend the reference hangs on
 what would make that darkness the thing being added. The element is still declared and still bound
 either way, because the head has to declare the whole format; what changes is one line of it.
 
-**The glint.** It is the only piece served here that is not drawn from an entity mesh, and the only
-one whose pipeline carries more than one render type's worth of answers. It is four compiled pieces
+**The glint.** It is one of the two pieces served here that are not drawn from an entity mesh, and
+the only one whose pipeline carries more than one render type's worth of answers. It is four compiled pieces
 of one program name, one per moment, because the side of the deferred stage is baked into a piece and
 the glint arrives on both: which carrier goes where is the game's sort, an enchanted book being
 submitted among the solid features foil and all, an enchanted armour piece and a trident and a shield
@@ -337,9 +337,22 @@ really alternates pays each time it comes back; geometry that does not alternate
 pair in the game is known to reach it, which is not a reason to leave it open: the cost of being
 wrong is silent and the cost of the guard is one draw.
 
+**The cracks over a block being mined** are the other piece drawn from a mesh of the game's, the
+block format, and they are here rather than with the terrain because the game submits them through
+these same feature renderers. Leaving them to the game is not the neutral answer it looks like: the
+game draws them among the translucent features, which is the stretch the full-screen layer catches,
+and that layer is cleared to transparent black and composed as though every draw in it blended by
+alpha. The crumbling multiplies instead, so left there it multiplies against the clear and the
+cracks come out opaque black rather than darkening the face they lie on. Served, the multiply lands
+on the picture, which is where the game meant to put it.
+
 Three families in this window stay the game's, and are carried in flat by the full-screen layer: the
-beacon beam, the lightning, and the text of a name plate or a sign. All three bind a mesh this door
-cannot decode. That is not taken on trust either. Every piece states the format it claims, and the
+beacon beam, the lightning, and the text of a name plate or a sign. The lightning and the text bind
+a mesh this door cannot decode. The beam binds the block format, which the door now reads, and what
+it still wants is a row of its own: the reference gives it another program, no alpha test and its
+fog per fragment, so it is not the cracks' row under another name.
+
+That is not taken on trust either. Every piece states the format it claims, and the
 claim is compared against what the pipeline really binds before the pack is read for it, because the
 failure it guards is the silent one from
 [the terrain page](terrain.md#vertex-inputs-are-matched-by-name-and-one-direction-is-silent): a


### PR DESCRIPTION
## What changes

Mining a block used to paint flat opaque black over it instead of darkening the face as it broke.
The overlay that spreads while a block is being mined was served by no program: it stayed the
game's own draw, and the game makes it inside the stretch this engine redirects into its
full-screen feature layer. That layer is cleared to transparent black and composed as though every
draw caught in it blended by alpha, while the overlay multiplies its texture onto what is already
there, so it multiplied against the clear and every crack came out black at full strength from the
first stage. It is drawn through the pack now, on `gbuffers_damagedblock` and its fallback onto the
terrain, so the multiply lands on the picture. Serving it needed a vertex contract for the game's
block format, which nothing here decoded before: four elements read by a head of their own, with
the light map answered at full light as the reference does for this program.

## How it differs from the reference, and for what obstacle

Two divergences, both in what the mesh carries rather than in what is drawn.

**A narrower mesh than the reference's.** Iris widens the block format on the way to the buffer,
`mixin/vertices/MixinBufferBuilder.iris$extendFormat:102-106` handing back its own terrain format,
then fills what it added: the normal and the tangent per polygon, the mid texture coordinate beside
them, and `at_midBlock` at every vertex. Widening a mesh here is `EntityMesh`, which exists for one
format and has a chunk-renderer serializer behind it; nothing widens the block one, so those four
names are constants, the normal taking the value Iris itself hands every format carrying none. A
pack whose `gbuffers_damagedblock` does its own normal mapping or relief shades a crack flat instead
of following the face it lies on. The crack still darkens the albedo it is multiplied onto, which is
what the blend does with it. The block id is a constant on both sides: nothing opens a block around
that buffer there either, so a pack reads `-1` under the reference where it reads nought here.

**The shadow map files no twin for it, and that is the reference's map rather than a divergence.**
Iris holds a shadow key for this pipeline (`pipeline/IrisPipelines.java:95`), but its shadow stage
replays only what it submits itself, the entities and the block entities
(`shadows/ShadowRenderer.java:572,580`), so this overlay never reaches its map and the key sits
unused. This engine's light walk replays the game's whole translucent feature window, overlay
included, and a filed twin fed the map's colour half a crack the depth write never followed, the
vanilla pipeline keeping it off: a pack reading `shadowcolor` then tinted the sun with the crack,
and every sunlit face being mined wore a crack-shaped shadow. The twin is not filed, which is the
same map with one draw fewer.

## What proves it

- `gradlew build` green.
- The out-of-game harness, over the ten packs of the corpus: 119 programs translated against the
  block format, every one declaring the four elements it carries and nothing else, and the four
  still present in the disassembly of every vertex stage. 214 of 238 stages compile; the 24 that
  do not are one pack whose programs fail the same way through the particle tool, on an image
  variable that has nothing to do with the vertex format.
- In game, on the Fabric bench: the engine logs the served draw on Complementary Unbound and on
  BSL, the crack on a sunlit face darkens the face it lies on instead of shadowing it, and the
  look against the game's own renderer on the same block matches, the light chips of the crack
  texture brightening where the blend doubles them, which is the formula's own behaviour.

## What it leaves owing

The normal above: closing it means widening the block mesh the way the entity one is widened,
which is a batch of its own. And the crack's tint never reaches `shadowcolor` here, exactly as it
never reaches it under the reference.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
