### PR TITLE
fix(pack): walk the breaking overlay into the target plan

### DIFF
--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -156,6 +156,14 @@ public final class ChainPlan {
 					// targets as written in every place a plan is built for, which is every place
 					// none of the six is standing.
 					new NamedProgram("gbuffers_spidereyes", true, false, NOT_EVERYWHERE),
+					// The overlay over a block being mined, drawn among the translucent features
+					// beside the eyes and on the same side of the stage. Left out of this list, its
+					// family drew one output onto the game's cleared target, and the multiply the
+					// overlay blends with came out opaque black over every crack.
+					//
+					// Not counted, on the hand's argument: a crack is drawn where somebody is mining
+					// a block, which is a per frame answer no per place map may carry.
+					new NamedProgram("gbuffers_damagedblock", true, false, NOT_EVERYWHERE),
 					// The hand's two passes, which straddle the stage as the particles do and for the
 					// same kind of reason: the solid one is drawn among the game's opaque features and
 					// the blending one at the end of the level. Not counted, and not by a switch:


### PR DESCRIPTION
## What changes

The cracks over a block being mined still came out opaque black under a pack, even served by the
pack's own program: the target plan had never been asked about `gbuffers_damagedblock`, and a
program the plan was never asked about answers empty, which is also its answer for a walk it
refused. The crumbling family therefore drew one output onto the game's cleared target, composed
by alpha over the picture, and the multiply the overlay blends with turned every crack opaque
black over an empty destination. One entry in the named-program list walks the overlay's targets
like the eyes beside it, and the multiply lands on the picture the chain composed.

## How it differs from the reference, and for what obstacle

It does not. Iris binds every gbuffers program to a framebuffer over the pack's declared draw
buffers; the entry hands this family the same answer through the plan's walk.

## What proves it

- `gradlew build` green after the rebase.
- In game on the Fabric bench, Complementary Unbound: before the entry, a fresh launch drew every
  crack opaque black; with it, the crack darkens the face it lies on, on the sunlit face and the
  shadowed one alike, judged against the game's own renderer on the same block. The served draw
  logs the same line on both sides of the change, which is what pointed at the destination
  rather than at the program.

## What it leaves owing

Nothing new. The named-program list remains the one place a served family's targets are granted,
so any future family served by name owes its entry there; the list's own comment carries that.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
      The entry describing the mined overlay is already there; this makes its claim true.
- [x] Every place that states a fact this branch changed now states the new one.
