### PR TITLE
fix(render): file a reshaped pipeline's comparison note

### DIFF
--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -960,10 +960,13 @@ final class GeometryProgram {
 	 * A draw a mod records into a pass this engine opened arrives with a vertex layout of the mod's
 	 * own, and a pipeline reads its buffer through the layout it was built with: binding
 	 * {@link #prepare}'s answer over such a mesh would read every attribute at the wrong offset.
-	 * The variant is this program's pipeline with the caller's layout on binding nought and
-	 * everything else kept, under a location of its own so the device caches the two apart. The
-	 * shaders do not move, so the layout is refused unless it leads with the attributes this
-	 * program names, which {@link #rebuild} sets out.
+	 * The variant is this program's pipeline with the caller's layout on binding nought, every
+	 * STATE of the pipeline kept, and the comparison note refiled beside it: the answers keyed on
+	 * the pipeline OBJECT rather than read off it do not travel through a rebuild on their own,
+	 * and {@code ShadowCompare} is one, so {@link #reshapeAs} files the variant where it files the
+	 * base. It sits under a location of its own so the device caches the two apart. The shaders
+	 * do not move, so the layout is refused unless it leads with the attributes this program
+	 * names, which {@link #rebuild} sets out.
 	 * <p>
 	 * Recompiled through {@code precompilePipeline} on every call, for the reason {@link #compile}
 	 * gives: a resource reload empties the device cache, and the call is a lookup while the cache
@@ -1085,7 +1088,15 @@ final class GeometryProgram {
 			}
 		}
 
-		return builder.build();
+		RenderPipeline built = builder.build();
+
+		// The comparison note is keyed on the pipeline object, not read off its states, so it is
+		// the one answer a rebuild does not carry by itself. Left unfiled, the descriptor walk
+		// answers no for every compared name of this program and the variant's depth-reference
+		// lookups run on an ordinary sampler, undefined and silent.
+		ShadowCompare.noteBeside(built, this.pipeline);
+
+		return built;
 	}
 
 	/** Whether {@link #compile} has already paid shaderc for this pipeline. */

--- a/common/src/main/java/dev/vitrail/render/ShadowCompare.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowCompare.java
@@ -146,6 +146,19 @@ public final class ShadowCompare {
 		noted = true;
 	}
 
+	/**
+	 * Files a rebuilt variant beside the pipeline it was rebuilt from. A reshape swaps the vertex
+	 * layout and nothing a comparison depends on, so the names are the base's, shared rather than
+	 * copied; nothing is filed where the base filed nothing. The warnings stay with the base's
+	 * filing: they speak of the pack's text, which the variant has not changed.
+	 */
+	static void noteBeside(RenderPipeline variant, RenderPipeline base) {
+		Set<String> names = COMPARED.get(base);
+		if (names != null) {
+			COMPARED.put(variant, names);
+		}
+	}
+
 	/** Whether any pipeline has filed anything, asked before the per-name question is worth asking. */
 	public static boolean noted() {
 		return noted;


### PR DESCRIPTION
## What changes

A shadow lookup a pack compares in hardware stopped being compared the moment its draw arrived
over a third-party mesh. The comparison names are filed against the pipeline object, and a
pipeline rebuilt over a foreign vertex layout is a new object under its own location: the
descriptor walk answered no for every compared name of the variant, so the depth-reference
lookups the translation had emitted ran on an ordinary sampler, undefined, while the log
announced the reshape as a success. The variant is now filed beside its base as it is built,
sharing the base's name set, since a reshape swaps the vertex layout and nothing a comparison
depends on.

## How it differs from the reference, and for what obstacle

It does not. Iris swaps the shader where it binds and keeps one sampler on the texture unit both
stages share, so a registered third-party draw reads the same comparison sampler as the game's
own particles; filing the variant reaches the same picture on the substitution road this engine
rides.

## What proves it

- `gradlew build` green.
- The gap and the path were established by reading and confirmed adversarially before the line
  was written: the filing has exactly two call sites, both on the base pipeline; the
  substitution is keyed by pipeline where the storage images and buffers are keyed by name; and
  two packs of the corpus reach the compared road from their particle program, one through its
  fallback tree. The fix shares the base's set rather than refiling, so the pack-text warnings
  are not repeated per variant.
- In game on the Fabric bench with AsyncParticles and Complementary Unbound: a world session
  with GPU particles on, nothing broken and no new log line, which is what an undefined read
  turning defined looks like from outside.

## What it leaves owing

The picture-level difference is not eyeball-provable on this machine: the defect needed a
third-party mod's draws and rendered a credible fraction either way. The proof stands on the
descriptor walk answering yes for the variant, which is by construction.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
      It rides the AsyncParticles entry already there: the crash fix's picture is now the
      compared one it claimed.
- [x] Every place that states a fact this branch changed now states the new one.
