### PR TITLE
perf(glsl): keep a translated program between two loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ what the next one holds.
   the two hundred odd shaders a cold one compiles, and the wait before the pack draws is the
   same to the second. What a pack load really costs sits somewhere neither this nor the log
   line is looking.
+- **Loading a pack again no longer rewrites its shaders from scratch.** Turning a pack's GLSL
+  into the dialect this backend speaks is one of the three things a pack load pays for, and it
+  is the same answer every time the same pack comes back. What it came to is kept under
+  `vitrail/translations` in the game folder and read back instead. Editing a shader, moving a
+  pack setting, changing the shadow map scale, updating the mod or the game, or switching one of
+  the mod's own measurement switches all change what is asked for, and anything that has changed
+  is rewritten as before. Each version keeps its own folder and takes the older ones away with
+  it, the whole thing is capped at a quarter of a gigabyte, and the log says how many programs
+  came off the disk and how many were rewritten. It removes work rather than time: the wait
+  before a pack draws is the same, and what changes is that none of it is spent here.
 - **A shadow lookup a pack asks the hardware to compare is now compared by the hardware.** A
   pack declaring `sampler2DShadow` used to have that comparison rebuilt in shader
   arithmetic on every tap, a dozen instructions where a comparison sampler pays one, and a

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -651,6 +651,24 @@ public final class GlslTranslator {
 		return SOFT_COMPARE || softCompareArmed;
 	}
 
+	/**
+	 * The state of every switch that changes what this translator EMITS, as one word.
+	 * <p>
+	 * It exists for {@link TranslationCache}, and it is the whole of what that cache cannot work
+	 * out from the arguments it is handed: a translation kept on disk is the same answer only while
+	 * these are the same, and a switch missing from this line would serve a unit emitted under the
+	 * other state, which is a wrong picture with no error anywhere to point at it.
+	 * <p>
+	 * <strong>It lives here, beside the switches, because that is the only place it stays
+	 * true.</strong> A switch added to this class is a line away from this method; a list of them
+	 * kept over in the cache is a file away, and the day somebody adds the next one that file is
+	 * the one they will not open.
+	 */
+	public static String emissionSwitches() {
+		return (reduceTrig ? "trig-reduced" : "trig-driver")
+				+ (softCompare() ? " compare-in-shader" : " compare-on-sampler");
+	}
+
 	private void rewrite() {
 		collectMacroNames();
 		collectDeclarations();

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -186,10 +186,25 @@ public final class ProgramTranslator {
 			VertexInputs inputs, List<String> boundElements, AlphaTest alphaTest, boolean coverage,
 			String program, Map<String, VolumeAtlas> volumes) {
 		// Every overload above funnels through here, which is what makes this the one place a
-		// program's whole translation can be clocked.
+		// program's whole translation can be clocked, and the one place it can be kept.
+		//
+		// The clock encloses the cache rather than sitting beside it, so a served program is
+		// counted like a translated one: the figure is what getting a program cost, whichever way
+		// it came, and a load whose translation post has collapsed says so instead of going quiet.
 		long began = System.nanoTime();
 		try {
-			return translated(units, inputs, boundElements, alphaTest, coverage, program, volumes);
+			String key = TranslationCache.keyOf(units, inputs, boundElements, alphaTest, coverage,
+					program, volumes);
+			TranslatedProgram served = TranslationCache.lookup(key, inputs);
+			if (served != null) {
+				return served;
+			}
+
+			TranslatedProgram built =
+					translated(units, inputs, boundElements, alphaTest, coverage, program, volumes);
+			TranslationCache.store(key, built);
+
+			return built;
 		} finally {
 			LoadClock.translation(System.nanoTime() - began);
 		}

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
@@ -1,0 +1,228 @@
+package dev.vitrail.glsl;
+
+import dev.vitrail.pack.program.ProgramStage;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A translated program written down and read back, byte for byte the same object either way.
+ * <p>
+ * It exists so that {@link TranslationCache} can keep a translation between two loads. Everything a
+ * {@link ProgramTranslator.TranslatedProgram} carries is written: the text of each stage, the notes
+ * the translation took on the way, the uniform block in the order that IS its layout, the samplers
+ * in the order they bind, and the names the translator synthesised. Leaving one of them out would
+ * not fail: it would hand back a program that draws with a block laid out differently from the one
+ * the engine fills, which is a wrong picture and not a crash.
+ * <p>
+ * <strong>Every string is written behind its length in bytes</strong> rather than through
+ * {@code writeUTF}, whose count is a short: a translated composite runs to tens of thousands of
+ * characters, and every one of them would be refused at the write.
+ * <p>
+ * Nothing here validates. A file that does not read back is caught by the digest the cache checks
+ * before this is ever called, and anything this throws is a miss.
+ */
+final class TranslatedProgramCodec {
+
+	/** Bumped by hand when the layout changes. It is part of the key, so old blobs go unread. */
+	static final String FORMAT = "vitrail-translation-1";
+
+	private TranslatedProgramCodec() {
+	}
+
+	static byte[] write(ProgramTranslator.TranslatedProgram program) throws IOException {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+		try (DataOutputStream out = new DataOutputStream(bytes)) {
+			text(out, program.inputs().name());
+
+			out.writeInt(program.stages().size());
+			for (Map.Entry<ProgramStage, TranslatedUnit> stage : program.stages().entrySet()) {
+				text(out, stage.getKey().name());
+				unit(out, stage.getValue());
+			}
+
+			uniforms(out, program.uniforms());
+			uniforms(out, program.samplers());
+
+			out.writeInt(program.synthesized().size());
+			for (Map.Entry<String, String> made : program.synthesized().entrySet()) {
+				text(out, made.getKey());
+				text(out, made.getValue());
+			}
+		}
+
+		return bytes.toByteArray();
+	}
+
+	/**
+	 * The program a blob describes.
+	 * <p>
+	 * The vertex inputs are read back and checked against the ones the caller asked for rather than
+	 * trusted: they are in the key, so a disagreement means the key and the blob have come apart,
+	 * and a program built for another format declares other attribute names.
+	 */
+	static ProgramTranslator.TranslatedProgram read(byte[] raw, int length, VertexInputs inputs)
+			throws IOException {
+		try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(raw, 0, length))) {
+			String written = text(in);
+			if (!written.equals(inputs.name())) {
+				throw new IOException("a stored translation was made for " + written);
+			}
+
+			Map<ProgramStage, TranslatedUnit> stages = new LinkedHashMap<>();
+			for (int left = in.readInt(); left > 0; left--) {
+				stages.put(ProgramStage.valueOf(text(in)), unit(in));
+			}
+
+			List<TranslatedUnit.Uniform> uniforms = uniforms(in);
+			List<TranslatedUnit.Uniform> samplers = uniforms(in);
+
+			Map<String, String> synthesized = new LinkedHashMap<>();
+			for (int left = in.readInt(); left > 0; left--) {
+				synthesized.put(text(in), text(in));
+			}
+
+			return new ProgramTranslator.TranslatedProgram(Map.copyOf(stages), uniforms, samplers,
+					Map.copyOf(synthesized), inputs);
+		} catch (IllegalArgumentException | NullPointerException e) {
+			// A stage name no enum has, or a null where the format promised a string. Both are a
+			// damaged blob and neither is worth its own catch upstream.
+			throw new IOException(e);
+		}
+	}
+
+	private static void unit(DataOutputStream out, TranslatedUnit unit) throws IOException {
+		text(out, unit.entry());
+		text(out, unit.stage().name());
+		text(out, unit.text());
+		notes(out, unit.notes());
+
+		out.writeInt(unit.drawBuffers().size());
+		for (int buffer : unit.drawBuffers()) {
+			out.writeInt(buffer);
+		}
+
+		uniforms(out, unit.blockMembers());
+		uniforms(out, unit.samplers());
+	}
+
+	private static TranslatedUnit unit(DataInputStream in) throws IOException {
+		String entry = text(in);
+		ProgramStage stage = ProgramStage.valueOf(text(in));
+		String body = text(in);
+		TranslatedUnit.Notes notes = notes(in);
+
+		List<Integer> drawBuffers = new ArrayList<>();
+		for (int left = in.readInt(); left > 0; left--) {
+			drawBuffers.add(in.readInt());
+		}
+
+		return new TranslatedUnit(entry, stage, body, notes, List.copyOf(drawBuffers),
+				uniforms(in), uniforms(in));
+	}
+
+	private static void notes(DataOutputStream out, TranslatedUnit.Notes notes) throws IOException {
+		out.writeInt(notes.fragmentOutputs());
+		out.writeInt(notes.dynamicFragData());
+		out.writeInt(notes.uniformConflicts());
+		out.writeInt(notes.shadowCalls());
+		out.writeInt(notes.unwrappedShadow());
+		out.writeInt(notes.strippedExtensions());
+		out.writeInt(notes.depthEpilogue());
+		out.writeInt(notes.alphaEpilogue());
+		out.writeInt(notes.coverage());
+		out.writeInt(notes.depthLookups());
+		out.writeInt(notes.parameterLookups());
+		out.writeInt(notes.fragCoordZ());
+		out.writeInt(notes.fragCoordXyz());
+		out.writeInt(notes.fragCoordUnhandled());
+		out.writeInt(notes.fragDepthWrites());
+		out.writeInt(notes.fragDepthUnhandled());
+		names(out, notes.conflictNames());
+		names(out, notes.comparedSamplers());
+		names(out, notes.hardwareCompared());
+		names(out, notes.storageBlocks());
+		out.writeInt(notes.volumeLookups());
+		out.writeInt(notes.volumesLeftAlone());
+		out.writeInt(notes.trigCalls());
+		out.writeInt(notes.gameTextureMatrix());
+		out.writeInt(notes.gameModelView());
+	}
+
+	private static TranslatedUnit.Notes notes(DataInputStream in) throws IOException {
+		return new TranslatedUnit.Notes(in.readInt(), in.readInt(), in.readInt(), in.readInt(),
+				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(),
+				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(),
+				names(in), names(in), names(in), names(in),
+				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt());
+	}
+
+	private static void uniforms(DataOutputStream out, List<TranslatedUnit.Uniform> uniforms)
+			throws IOException {
+		out.writeInt(uniforms.size());
+		for (TranslatedUnit.Uniform uniform : uniforms) {
+			text(out, uniform.name());
+			text(out, uniform.type());
+			text(out, uniform.declaration());
+		}
+	}
+
+	private static List<TranslatedUnit.Uniform> uniforms(DataInputStream in) throws IOException {
+		List<TranslatedUnit.Uniform> uniforms = new ArrayList<>();
+		for (int left = in.readInt(); left > 0; left--) {
+			uniforms.add(new TranslatedUnit.Uniform(text(in), text(in), text(in)));
+		}
+
+		return List.copyOf(uniforms);
+	}
+
+	private static void names(DataOutputStream out, List<String> names) throws IOException {
+		out.writeInt(names.size());
+		for (String name : names) {
+			text(out, name);
+		}
+	}
+
+	private static List<String> names(DataInputStream in) throws IOException {
+		List<String> names = new ArrayList<>();
+		for (int left = in.readInt(); left > 0; left--) {
+			names.add(text(in));
+		}
+
+		return List.copyOf(names);
+	}
+
+	private static void text(DataOutputStream out, String text) throws IOException {
+		byte[] raw = text.getBytes(StandardCharsets.UTF_8);
+		out.writeInt(raw.length);
+		out.write(raw);
+	}
+
+	/**
+	 * A string, bounded by what is left in the blob before the array is asked for.
+	 * <p>
+	 * {@code readFully} would refuse a length past the end anyway, but only after the array has
+	 * been allocated, and a damaged word read as two gigabytes takes the process down before it can
+	 * be refused. The stream is over a byte array, so what is left is exact and free to ask for.
+	 */
+	private static String text(DataInputStream in) throws IOException {
+		int length = in.readInt();
+		if (length < 0 || length > in.available()) {
+			throw new IOException("a stored translation claims a string of " + length + " bytes");
+		}
+
+		byte[] raw = new byte[length];
+		in.readFully(raw);
+
+		return new String(raw, StandardCharsets.UTF_8);
+	}
+}

--- a/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
@@ -1,0 +1,533 @@
+package dev.vitrail.glsl;
+
+import dev.vitrail.pack.option.EngineDefines;
+import dev.vitrail.pack.program.AlphaTest;
+import dev.vitrail.pack.program.ProgramStage;
+import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
+import dev.vitrail.pack.texture.VolumeAtlas;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileTime;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterOutputStream;
+
+/**
+ * Keeps a translated program on disk, so that loading the same pack again does not translate the
+ * same text into the same text.
+ * <p>
+ * It is the third and last of the posts a pack load is made of. A clock around the load named them:
+ * the compile, the reflection that reads what the compile emitted, and this. With the first two
+ * served from disk this is what a warm load still pays, and it is a pure function of its input like
+ * the other two.
+ * <p>
+ * <strong>It lives here and not beside the renderer, and that is what shapes it.</strong>
+ * {@code dev.vitrail.glsl} and {@code dev.vitrail.pack} name no Minecraft API, which is what lets
+ * the whole translator be run over the pack corpus without starting the game. A cache written in
+ * the render tree could not be reached from here without ending that, so this one takes its
+ * directory from whoever installs it and knows nothing about a game directory. That is also what
+ * makes it PROVABLE: the off-game harness translates the corpus, and translating it twice with this
+ * in the way has to produce the same tree to the byte.
+ * <p>
+ * <strong>The key is every input the translation has</strong>, and the list is short because the
+ * translator has no others: the expanded text of each stage with the lines the preprocessor left
+ * live, the vertex format, the elements the pass binds, the alpha test, the coverage flag, the name
+ * of the program, the volumes the pack ships, and the engine's own define table, which carries the
+ * game version, the driver's vendor and renderer, the mipmap level and everything else the machine
+ * decides. The table goes in whole rather than field by field, so a define added later is in the
+ * key the day it is added rather than the day somebody remembers this class.
+ * <p>
+ * <strong>A wrong hit is a wrong picture and never a crash</strong>, which is why every file
+ * carries a digest of its own bytes and a blob its digest does not answer for is never used. The
+ * vertex format is written into the blob as well as into the key, and read back and compared, so a
+ * key that has come apart from its blob is caught rather than believed.
+ * <p>
+ * Absent, unreadable, corrupt, or of a shape this build cannot read: every one of them is a MISS,
+ * and a miss is the translation that would have happened anyway.
+ * <p>
+ * The store is bounded at a quarter of a gigabyte and bounded per edition, and it is off until
+ * somebody installs it. {@code -Dvitrail.translationDir=<path>} installs it outside the game, which
+ * is how the harness reaches it.
+ * <p>
+ * <strong>The edition is the version this build DECLARES</strong>, and that is all it can be.
+ * Two builds carrying one version number share a folder and share every key, which is every
+ * build made between two releases: a translator changed without the version moving is served its
+ * predecessor's units, and nothing says so. What answers that in the workshop is deleting the
+ * folder, or bumping {@code TranslatedProgramCodec.FORMAT} by hand, and neither is automatic.
+ */
+public final class TranslationCache {
+
+	/** How the harness, or anything else without a game around it, turns this on. */
+	private static final String DIRECTORY_PROPERTY = "vitrail.translationDir";
+
+	private static final String FOLDER = "translations";
+	private static final String SUFFIX = ".tr";
+	private static final String PART_SUFFIX = ".part";
+
+	/** SHA-256, sitting behind the blob in every file and answering for it. */
+	private static final int DIGEST_BYTES = 32;
+
+	private static final long CEILING_BYTES = 256L * 1024L * 1024L;
+	private static final long SWEEP_TARGET = CEILING_BYTES / 4L * 3L;
+
+	private static final long SWEEP_BACKOFF_NANOS = 60_000_000_000L;
+
+	private static final AtomicLong SERVED = new AtomicLong();
+	private static final AtomicLong TRANSLATED = new AtomicLong();
+	private static final AtomicLong BYTES = new AtomicLong();
+
+	/** Held for the one scan at install and for every sweep. */
+	private static final Object LOCK = new Object();
+
+	/** Where the blobs live, or null while the cache is off, which is until somebody installs it. */
+	private static volatile Path directory;
+	private static volatile String problem = "";
+
+	/** How long a sweep that could not finish stays out of the way of the next write. */
+	private static volatile long nextSweepNanos;
+
+	static {
+		// Inside the try and not beside it: Path.of refuses a name Windows will not have, and an
+		// exception out of a static initialiser is an Error, which goes straight past every catch
+		// that turns a bad pack into a report and takes the pack load down with it.
+		try {
+			String outside = System.getProperty(DIRECTORY_PROPERTY, "");
+			if (!outside.isEmpty()) {
+				open(Path.of(outside).resolve(FOLDER).resolve("outside-the-game"), false);
+			}
+		} catch (RuntimeException e) {
+			problem = e.toString();
+		}
+	}
+
+	private TranslationCache() {
+	}
+
+	/**
+	 * Puts the cache under a directory of the caller's choosing, and clears out every other
+	 * edition's.
+	 * <p>
+	 * The edition names a whole set of keys at once: nothing under another one can ever be asked for
+	 * again, and the ceiling has to be about what is still reachable. Called once, before the first
+	 * pack is read; a failure here leaves the cache off for the run and the loads exactly as long as
+	 * they were.
+	 */
+	public static void install(Path parent, String edition) {
+		open(parent.resolve(FOLDER).resolve(edition.replaceAll("[^A-Za-z0-9._-]", "_")), true);
+	}
+
+	/**
+	 * Makes the directory, measures what is in it, and takes it into service.
+	 *
+	 * @param dropOthers whether every sibling edition goes with it. True for the game, where the
+	 *                   edition is the only one that can ever be asked for again and the ceiling
+	 *                   has to be about what is still reachable. False for the road the property
+	 *                   opens, which runs in a static initialiser and would therefore delete the
+	 *                   game's own edition a moment before the game installed it
+	 */
+	private static void open(Path mine, boolean dropOthers) {
+		synchronized (LOCK) {
+			try {
+				Files.createDirectories(mine);
+				if (dropOthers) {
+					dropOtherEditions(mine.getParent(), mine);
+				}
+
+				BYTES.set(total(scan(mine, true)));
+				directory = mine;
+				problem = "";
+			} catch (IOException | RuntimeException e) {
+				directory = null;
+				problem = e.toString();
+			}
+		}
+	}
+
+	/** What went wrong at install, for whoever has a logger, or empty when nothing did. */
+	public static String problem() {
+		return problem;
+	}
+
+	public static boolean installed() {
+		return directory != null;
+	}
+
+	public static long served() {
+		return SERVED.get();
+	}
+
+	public static long translated() {
+		return TRANSLATED.get();
+	}
+
+	/** Emptied at the head of a load, like the clock beside it: a tally belongs to one load. */
+	public static void reset() {
+		SERVED.set(0L);
+		TRANSLATED.set(0L);
+	}
+
+	/**
+	 * What this exact translation came to last time, or null when it has to be done.
+	 * <p>
+	 * The key is worked out by the caller and handed to both ends, the expanded text of a composite
+	 * being large enough that hashing it twice to answer one question is work for nothing.
+	 */
+	static ProgramTranslator.TranslatedProgram lookup(String key, VertexInputs inputs) {
+		Path root = directory;
+		if (key == null || root == null) {
+			return null;
+		}
+
+		Path file = root.resolve(key + SUFFIX);
+		byte[] raw;
+		try {
+			raw = Files.readAllBytes(file);
+		} catch (IOException e) {
+			// Absent is the ordinary case and unreadable the rare one. What follows either way is
+			// the translation that would have happened anyway.
+			return null;
+		}
+
+		int length = raw.length - DIGEST_BYTES;
+		if (length <= 0 || !answersForItself(raw, length)) {
+			return null;
+		}
+
+		ProgramTranslator.TranslatedProgram program;
+		try {
+			byte[] blob = inflate(raw, length);
+			program = TranslatedProgramCodec.read(blob, blob.length, inputs);
+		} catch (IOException | RuntimeException e) {
+			return null;
+		}
+
+		touch(file);
+		SERVED.incrementAndGet();
+
+		return program;
+	}
+
+	/** Keeps what the translator has just made, under the key of everything it was made from. */
+	static void store(String key, ProgramTranslator.TranslatedProgram program) {
+		TRANSLATED.incrementAndGet();
+
+		Path root = directory;
+		if (key == null || root == null) {
+			return;
+		}
+
+		byte[] raw;
+		try {
+			raw = deflate(TranslatedProgramCodec.write(program));
+		} catch (IOException | RuntimeException e) {
+			return;
+		}
+
+		Path file = root.resolve(key + SUFFIX);
+		Path part = root.resolve(key + "-"
+				+ Long.toHexString(Thread.currentThread().threadId()) + PART_SUFFIX);
+
+		try {
+			// The blob, then the digest that answers for it, then the move. A process killed
+			// halfway through leaves a neighbour and never half a translation under a whole name.
+			Files.write(part, raw);
+			Files.write(part, sha256(raw), StandardOpenOption.APPEND);
+			move(part, file);
+			// Added whether or not this replaced a blob already under the same key, which happens
+			// whenever a lookup refused one and the translation wrote over it. The count then runs
+			// ahead of the directory until a sweep rescans and puts it right, which is what the
+			// sweep does before it deletes anything.
+			BYTES.addAndGet(raw.length + (long) DIGEST_BYTES);
+		} catch (IOException e) {
+			try {
+				Files.deleteIfExists(part);
+			} catch (IOException ignored) {
+				// The next install collects it: that scan deletes the neighbours it comes across.
+			}
+
+			return;
+		}
+
+		if (BYTES.get() > CEILING_BYTES) {
+			sweep(root);
+		}
+	}
+
+	/**
+	 * What names this translation on disk, or null when there is nowhere to look.
+	 * <p>
+	 * Each piece goes in behind its own length, so that two different splits of the same characters
+	 * cannot hash alike. The stages are walked in the enum's own order rather than the map's, a
+	 * map's order being the caller's business and not a property of what is being translated.
+	 */
+	static String keyOf(Map<ProgramStage, ExpandedUnit> units,
+			VertexInputs inputs, List<String> boundElements, AlphaTest alphaTest, boolean coverage,
+			String program, Map<String, VolumeAtlas> volumes) {
+		if (directory == null) {
+			return null;
+		}
+
+		MessageDigest digest = sha256();
+		feed(digest, TranslatedProgramCodec.FORMAT);
+		// The switches of the translator itself, which are the one input that is not an argument:
+		// the trig substitution and the shadow comparison both change what it emits and neither
+		// says so in the text it was handed.
+		feed(digest, GlslTranslator.emissionSwitches());
+
+		// The whole table, in its own order, which is fixed by the code that builds it. It carries
+		// the game version, the operating system, the driver's vendor and renderer, the mipmap
+		// level and every other symbol the machine decides, and a define added to it later is in
+		// the key from that day without a line here.
+		for (Map.Entry<String, String> define
+				: EngineDefines.table(EngineDefines.machine()).entrySet()) {
+			feed(digest, define.getKey());
+			feed(digest, define.getValue());
+		}
+
+		feed(digest, inputs.name());
+		feed(digest, program);
+		feed(digest, alphaTest.function().name());
+		digest.update(intBytes(Float.floatToIntBits(alphaTest.reference())));
+		digest.update(new byte[] {(byte) (coverage ? 1 : 0)});
+
+		digest.update(intBytes(boundElements.size()));
+		for (String element : boundElements) {
+			feed(digest, element);
+		}
+
+		// IN THE MAP'S OWN ORDER, and not sorted, because the order is not decoration: the
+		// translator walks this map to flatten the lookups and emits one helper body per volume in
+		// the order it walked, so two maps holding the same entries in a different order are two
+		// different texts. Sorting here would have given them one key.
+		digest.update(intBytes(volumes.size()));
+		for (Map.Entry<String, VolumeAtlas> volume : volumes.entrySet()) {
+			feed(digest, volume.getKey());
+			digest.update(intBytes(volume.getValue().width()));
+			digest.update(intBytes(volume.getValue().height()));
+			digest.update(intBytes(volume.getValue().depth()));
+		}
+
+		for (ProgramStage stage : ProgramStage.values()) {
+			ExpandedUnit unit = units.get(stage);
+			if (unit == null) {
+				continue;
+			}
+
+			feed(digest, stage.name());
+			feed(digest, unit.entry());
+			feed(digest, unit.version());
+			feed(digest, unit.text());
+			// The lines the preprocessor left live, which the translator reads on nearly every walk
+			// it makes: two texts that differ only in which of their lines are dead translate
+			// differently and would otherwise share a key.
+			byte[] live = unit.live().toByteArray();
+			digest.update(intBytes(live.length));
+			digest.update(live);
+		}
+
+		return HexFormat.of().formatHex(digest.digest());
+	}
+
+	/**
+	 * Squeezed before it goes to disk, because what a translated program mostly is, is GLSL.
+	 * <p>
+	 * Measured on the corpus: a program comes to a quarter of a megabyte written out plainly, and
+	 * ten packs fill a quarter of a gigabyte, which is the whole ceiling. Text of this shape gives
+	 * most of that back for a millisecond of work either way, against the sixty a translation
+	 * costs. The digest answers for the squeezed bytes, which is what is actually on the disk and
+	 * therefore what has to be checked before anything unpacks it.
+	 */
+	private static byte[] deflate(byte[] blob) throws IOException {
+		ByteArrayOutputStream packed = new ByteArrayOutputStream();
+		Deflater deflater = new Deflater(Deflater.BEST_SPEED);
+		try (DeflaterOutputStream out = new DeflaterOutputStream(packed, deflater)) {
+			out.write(blob);
+		} finally {
+			deflater.end();
+		}
+
+		return packed.toByteArray();
+	}
+
+	private static byte[] inflate(byte[] raw, int length) throws IOException {
+		ByteArrayOutputStream blob = new ByteArrayOutputStream();
+		Inflater inflater = new Inflater();
+		try (InflaterOutputStream out = new InflaterOutputStream(blob, inflater)) {
+			out.write(raw, 0, length);
+		} finally {
+			inflater.end();
+		}
+
+		return blob.toByteArray();
+	}
+
+	private static boolean answersForItself(byte[] raw, int length) {
+		MessageDigest digest = sha256();
+		digest.update(raw, 0, length);
+
+		return Arrays.equals(digest.digest(), 0, DIGEST_BYTES, raw, length, raw.length);
+	}
+
+	private static void feed(MessageDigest digest, String text) {
+		byte[] raw = text.getBytes(StandardCharsets.UTF_8);
+		digest.update(intBytes(raw.length));
+		digest.update(raw);
+	}
+
+	private static byte[] intBytes(int value) {
+		return new byte[] {
+				(byte) (value >>> 24), (byte) (value >>> 16), (byte) (value >>> 8), (byte) value,
+		};
+	}
+
+	private static byte[] sha256(byte[] raw) {
+		return sha256().digest(raw);
+	}
+
+	private static MessageDigest sha256() {
+		try {
+			return MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 is required of every Java runtime", e);
+		}
+	}
+
+	private static void move(Path part, Path file) throws IOException {
+		try {
+			Files.move(part, file, StandardCopyOption.ATOMIC_MOVE);
+		} catch (AtomicMoveNotSupportedException e) {
+			Files.move(part, file, StandardCopyOption.REPLACE_EXISTING);
+		}
+	}
+
+	/** Marks a blob as asked for, so a sweep drops what nothing loads rather than what is oldest. */
+	private static void touch(Path file) {
+		try {
+			Files.setLastModifiedTime(file, FileTime.from(Instant.now()));
+		} catch (IOException ignored) {
+			// A stamp that cannot be set costs a worse choice at the next sweep and nothing now.
+		}
+	}
+
+	private static void dropOtherEditions(Path root, Path mine) throws IOException {
+		try (Stream<Path> entries = Files.list(root)) {
+			for (Path entry : entries.toList()) {
+				if (!entry.equals(mine)) {
+					dropTree(entry);
+				}
+			}
+		}
+	}
+
+	private static void dropTree(Path entry) throws IOException {
+		try (Stream<Path> tree = Files.walk(entry)) {
+			for (Path found : tree.sorted(Comparator.reverseOrder()).toList()) {
+				Files.deleteIfExists(found);
+			}
+		}
+	}
+
+	/**
+	 * Every blob on disk, oldest stamp first.
+	 * <p>
+	 * <strong>A neighbour is only deleted when {@code prunePartials} says so, which is at install
+	 * and nowhere else.</strong> A sweep runs while other workers are in the middle of their own
+	 * writes, and deleting what they hold open takes their blob down on one system and aborts the
+	 * sweep on the other. What a sweep does with a neighbour is ignore it.
+	 */
+	private static List<Blob> scan(Path root, boolean prunePartials) throws IOException {
+		List<Blob> blobs = new ArrayList<>();
+
+		try (Stream<Path> entries = Files.list(root)) {
+			for (Path entry : entries.toList()) {
+				if (entry.getFileName().toString().endsWith(PART_SUFFIX)) {
+					if (prunePartials) {
+						Files.deleteIfExists(entry);
+					}
+				} else {
+					try {
+						blobs.add(new Blob(entry, Files.getLastModifiedTime(entry).toMillis(),
+								Files.size(entry)));
+					} catch (IOException ignored) {
+						// Gone, or momentarily unreadable. One blob uncounted, and the next sweep
+						// counts it.
+					}
+				}
+			}
+		}
+
+		blobs.sort(Comparator.comparingLong(Blob::stamp));
+
+		return blobs;
+	}
+
+	private static long total(List<Blob> blobs) {
+		long sum = 0L;
+		for (Blob blob : blobs) {
+			sum += blob.size();
+		}
+
+		return sum;
+	}
+
+	/**
+	 * Brings the directory back under the ceiling, oldest stamp first.
+	 * <p>
+	 * The count is put down in a {@code finally}, because the caller's test is that same count: a
+	 * refusal anywhere in here without it leaves the count high and turns every later write into a
+	 * full walk of the directory under this lock, for the rest of the session and with nothing said.
+	 */
+	private static void sweep(Path root) {
+		synchronized (LOCK) {
+			if (System.nanoTime() < nextSweepNanos) {
+				return;
+			}
+
+			long total = BYTES.get();
+			try {
+				List<Blob> blobs = scan(root, false);
+				total = total(blobs);
+
+				for (Blob blob : blobs) {
+					if (total <= SWEEP_TARGET) {
+						break;
+					}
+
+					Files.deleteIfExists(blob.path());
+					total -= blob.size();
+				}
+			} catch (IOException e) {
+				// The ceiling is a courtesy and a refusal here is not worth a load. What it must not
+				// do is come straight back: a scan that throws leaves the count where it was, which
+				// is over the ceiling, and every later write would then walk the directory again
+				// under this lock for the rest of the session.
+				nextSweepNanos = System.nanoTime() + SWEEP_BACKOFF_NANOS;
+			} finally {
+				BYTES.set(total);
+			}
+		}
+	}
+
+	/** One file of the cache, with what the sweep needs to order it and to subtract it. */
+	private record Blob(Path path, long stamp, long size) {
+	}
+}

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -1,5 +1,6 @@
 package dev.vitrail.platform;
 
+import dev.vitrail.glsl.TranslationCache;
 import dev.vitrail.render.EntityDraw;
 import dev.vitrail.render.HandDraw;
 import dev.vitrail.render.ModuleCache;
@@ -63,9 +64,38 @@ public final class EngineStages {
 		// at whatever the arena held. EntityMeshSerializer says the rest.
 		EntityMeshSerializer.register();
 
+		// Before the pack, because the first pack read is the one whose translation is worth
+		// keeping. The cache knows nothing of a game and takes its directory from here, which is
+		// what lets its whole package go on compiling and running without one.
+		openTranslationCache();
+
 		// The report of the pack goes with the reading of it, in PackChain, where which pack is
 		// being drawn is known.
 		PackChain.load(Vitrail.platform().gameDirectory());
+	}
+
+	/**
+	 * Puts the translation cache under the game directory, named for the edition whose translations
+	 * it holds.
+	 * <p>
+	 * The edition is the mod's version and the game's, and it names a whole set of keys at once: a
+	 * translator that emits one word differently answers differently to every key it ever held, so
+	 * a RELEASE takes its predecessor's folder away rather than filling a second one beside it.
+	 * Two builds declaring one version share the folder and every key in it, which is every build
+	 * made between two releases; what answers that in the workshop is deleting the folder by hand.
+	 * The loader is not in the name, and does not need to be: the two loaders run the same
+	 * translator over the same text, and what does differ between them is in the key of every
+	 * entry.
+	 */
+	private static void openTranslationCache() {
+		TranslationCache.install(
+				Vitrail.platform().gameDirectory().resolve(Vitrail.MOD_ID),
+				Vitrail.platform().modVersion() + "+mc" + Vitrail.platform().minecraftVersion());
+
+		if (!TranslationCache.installed()) {
+			Vitrail.logger().warn("No translation cache this run, so every pack load translates "
+					+ "from scratch: {}", TranslationCache.problem());
+		}
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -3,6 +3,7 @@ package dev.vitrail.render;
 import dev.vitrail.dh.DhLods;
 import dev.vitrail.glsl.LoadClock;
 import dev.vitrail.glsl.PackProgram;
+import dev.vitrail.glsl.TranslationCache;
 import dev.vitrail.mixin.GpuDeviceAccessor;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.RenderStage;
@@ -617,8 +618,15 @@ public final class PackChain {
 		// below this point that reads a pack translates one.
 		DriverTrig.read(gameDirectory);
 		// Beside the trig switch and for the same reason: what follows is what these tallies
-		// are a tally of.
+		// are a tally of. The cache empties its own on the same line, so that its counts and the
+		// clock's milliseconds are read off one load.
+		//
+		// Two loads can smear into each other here, in both directions, exactly as they do for
+		// the clock: a family worker of the chain that has just been released lands its own
+		// hits after this reset, and a swap empties the tallies while the outgoing chain's
+		// workers are still translating.
 		LoadClock.reset();
+		TranslationCache.reset();
 		// The storage blocks the translator files away, emptied at the head of a load and NOT beside
 		// the CustomImages line in release(), though the two are installed on the same line.
 		//
@@ -917,6 +925,14 @@ public final class PackChain {
 						+ "the chain went live; the modules follow on the draws and the workers, "
 						+ "counted into the report that closes the warmup",
 						LoadClock.translationMillis(), LoadClock.translated());
+				// Both ways, whichever way it went. A cache that only speaks when it helps leaves
+				// every later reading of a log ambiguous, since a silence would then mean either
+				// that nothing was served or that nothing was asked. It rides the line above rather
+				// than standing on its own, so a load this method turned back from is silent on
+				// both counts rather than on one of the two.
+				Vitrail.logger().info("Translation cache: {} programs served from disk, {} "
+								+ "translated, counted at the same point of the load as the line "
+								+ "above", TranslationCache.served(), TranslationCache.translated());
 			}
 
 			active.startFamilyPrefetch();


### PR DESCRIPTION
## What changes

Turning a pack's GLSL into the dialect this backend speaks is the third thing a pack load pays for, and it is the same answer every time the same pack comes back. It is now kept under `vitrail/translations` in the game folder and read back, squeezed, so a warm load rewrites nothing.

The whole branch rests on the key covering every input the translation has, because a program emitted under one state and served under another is a wrong picture with no error anywhere to point at it. The key carries the expanded text of each stage with the lines the preprocessor left live, the vertex format, the elements the pass binds, the alpha test, the coverage flag, the program name, the volumes the pack ships in the order the emission follows them, and the engine's define table in full, so a define added later is in the key the day it is added. The translator's own two switches, the trig substitution and the shadow comparison, are not arguments and would have been the hole: they change what it emits and neither says so in the text it was handed, so it names them itself, in a line that sits beside them.

The cache names no Minecraft API and takes its directory from whoever installs it, which is what keeps the package runnable over the pack corpus without a game.

## How it differs from the reference, and for what obstacle

It does not. Iris hands its patched GLSL to a driver and keeps nothing between two loads, but nothing here changes what a pack is handed: the text a program is built from is the text it was built from before.

## What proves it

- `gradlew build` green.
- The out-of-game harness, over the ten packs of the shaderpack corpus, through this same funnel: translated three times, once with no cache and twice with one, and the 1962 translated units came out identical to the byte. The second of the two cached runs served all 1005 programs and translated none. A second pass through the harness tool that drives the funnel with the other vertex formats gave the same report cold and warm.
- In the game, Fabric bench, Complementary Unbound: fourteen programs translated cold, fourteen served and none translated warm, the same picture.

**And it buys work removed, not time.** The same jar with the store deleted and with it warm reaches the first drawn chunk pass at the same second.

## What it leaves owing

The half translation that answers which mesh elements a chunk program reads is not cached and still runs, which is the couple of hundred milliseconds a warm load still spends here. The folder is named for the version this build declares, so two builds carrying one version share every key: between two releases, deleting the folder is the only way to be sure a translator change is seen.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
