### PR TITLE
fix(screen): read a pack's settings before it is ever loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,14 @@ what the next one holds.
 
 ### Fixed
 
+- **The button that opens a pack's settings is no longer dead until the pack has been loaded
+  once.** It was live only while a pack was already drawing, so the first pack anybody picks on
+  a fresh install could not be configured at all: the only way in was to load it at whatever
+  profile its author shipped, which on a small machine is the one launch that hurts. It is now
+  live for the pack the list has selected, and pressing it reads that pack, which is parsing and
+  no work on the graphics card, and puts its settings on screen while the loaded pack goes on
+  drawing. Setting a heavy pack to its low profile before ever loading it now costs one load
+  instead of two. A pack that lays no settings out says so instead of opening an empty page.
 - **Breaking a block no longer paints flat black cracks over it.** The overlay that spreads as a
   block is mined was left to the game, and it multiplies its texture onto what is already drawn;
   it was landing on an empty layer instead of on the picture, so every crack came out opaque

--- a/common/src/main/java/dev/vitrail/screen/PackHost.java
+++ b/common/src/main/java/dev/vitrail/screen/PackHost.java
@@ -29,9 +29,12 @@ public interface PackHost {
 	void shadersToggled();
 
 	/**
-	 * Called when a row is picked, moving the focus down to the screen's bottom row. Iris does this so
-	 * that a keyboard lands on the way out rather than staying in the list, since picking a pack is
-	 * the last thing anybody does on this view.
+	 * Called when a row is picked, for the two things a pick owes the screen.
+	 * <p>
+	 * The focus goes down to the bottom row. Iris does this so that a keyboard lands on the way out
+	 * rather than staying in the list, since picking a pack is the last thing anybody does on this
+	 * view. And the button that walks into a pack's settings is refreshed, because the pack it would
+	 * read is the one that has just been picked.
 	 */
-	void focusBottomRow();
+	void packChosen();
 }

--- a/common/src/main/java/dev/vitrail/screen/PackList.java
+++ b/common/src/main/java/dev/vitrail/screen/PackList.java
@@ -591,7 +591,7 @@ public final class PackList extends AbstractSelectionList<PackList.BaseEntry> {
 				did = true;
 			}
 
-			this.list.host.focusBottomRow();
+			this.list.host.packChosen();
 
 			return did;
 		}

--- a/common/src/main/java/dev/vitrail/screen/ScreenText.java
+++ b/common/src/main/java/dev/vitrail/screen/ScreenText.java
@@ -162,6 +162,14 @@ public final class ScreenText {
 	 */
 	public static final String PACK_MISSING = "options.vitrail.pack_missing";
 
+	/**
+	 * The fourth reason, and the only one about a pack that is perfectly fine: it was read and it
+	 * lays no settings out, which a pack is entitled to do. One argument, the pack's own file name,
+	 * because this is said while that name is on the row above it and {@link #NO_PACK} over it would
+	 * read as a fault of this mod.
+	 */
+	public static final String NO_SETTINGS = "options.vitrail.no_settings";
+
 	public static final String OPEN_SETTINGS = "key.vitrail.open_settings";
 
 	/**

--- a/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
@@ -550,8 +550,14 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 	 * The loaded pack is adopted as it always was when it IS the one selected, which is the ordinary
 	 * case and costs nothing: its session is already read.
 	 * <p>
-	 * A pack that cannot be read leaves the view where it was rather than opening an empty page over
-	 * a row of buttons, and says why on the bottom line.
+	 * A pack that cannot be read, and a pack that reads and lays nothing out, both leave the view
+	 * where it was rather than opening an empty page over a row of buttons. The first says why on
+	 * the bottom line, in red, because it is a fault. The second says it under the title, because it
+	 * is not: the reading was the whole point of the click and it happened.
+	 * <p>
+	 * A preview is only adopted once it is going to be kept. Adopting first and giving up after
+	 * would drop the page the player had walked into on the pack that is drawing, since taking a
+	 * session on drops any page the new one does not lay out.
 	 */
 	private void previewChosen() {
 		PackList list = this.packList;
@@ -574,14 +580,36 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 			Path path = PackLoader.directory(gameDirectory()).resolve(chosen);
 			PackSession preview = PackSession.read(gameDirectory(), path,
 					this.minecraft == null ? "en_us" : this.minecraft.options.languageCode);
+			if (preview.menu().main().slots().isEmpty()) {
+				announce(Component.translatable(ScreenText.NO_SETTINGS, preview.packFileName()));
+				giveUp(loaded);
+
+				return;
+			}
+
 			this.previewing = true;
 			adopt(preview);
 			this.error = null;
 		} catch (IOException | RuntimeException e) {
 			this.error = String.valueOf(e.getMessage());
 			Vitrail.logger().error("Vitrail could not read {} to show its settings", chosen, e);
-			this.optionsOpen = false;
+			giveUp(loaded);
 		}
+	}
+
+	/**
+	 * Leaves the view where the click came from, with the pack that was drawing back on screen.
+	 * <p>
+	 * <strong>Both halves matter.</strong> Without the first, the click opens a page with nothing on
+	 * it. Without the second, this screen is left holding a pack it read and threw away: the preview
+	 * flag would stay raised, and {@link #syncWithLoadedPack} refuses by design to swap a previewed
+	 * pack away under the player, so the loaded pack would never come back and every line drawn from
+	 * a session, the forced count on the bottom line included, would be the abandoned pack's.
+	 */
+	private void giveUp(@Nullable PackSession loaded) {
+		this.optionsOpen = false;
+		this.previewing = false;
+		adopt(loaded);
 	}
 
 	private void refreshViewSwitch() {
@@ -592,14 +620,54 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 
 		button.setMessage(Component
 				.translatable(this.optionsOpen ? ScreenText.PACKS : ScreenText.TITLE));
-		// Dead while there is nothing to configure, and it says why on hover: a folder with no pack in
-		// it and a pack that failed to read look the same from here otherwise.
+		// Live for the pack the LIST has selected, and not for the pack that happens to be loaded.
+		// Asking the loaded one was a circle: the first pack anybody ever picks has never been read,
+		// so nothing said it had settings, so the button that would have read it stayed dead, and
+		// the only way out was to load the pack at its own default profile first, which is exactly
+		// what reading without loading exists to avoid.
+		//
+		// A pack this screen has already read answers for itself, and a pack it has not is taken to
+		// have settings until the reading says otherwise. Being wrong that way costs one click and
+		// one sentence; being wrong the other way is the circle above.
 		PackList list = this.packList;
-		boolean anythingToConfigure = this.session != null
-				&& (list == null || list.shadersEnabled())
-				&& !this.session.menu().main().slots().isEmpty();
+		PackSession shown = this.session;
+		String chosen = list == null ? "" : list.chosenName();
+		boolean unread = !chosen.isEmpty() && (shown == null || !chosen.equals(shown.packFileName()));
+		boolean laysSomethingOut = shown != null && !shown.menu().main().slots().isEmpty();
+		boolean anythingToConfigure = (list == null || list.shadersEnabled())
+				&& (unread || laysSomethingOut);
 		button.active = this.optionsOpen || anythingToConfigure;
-		button.setTooltip(button.active ? null : Tooltip.create(noPackReason()));
+		// Dead only where this screen KNOWS there is nothing, and it says which nothing on hover: a
+		// folder with no pack in it, a pack turned off on purpose, a name the folder has not got, and
+		// a pack that was read and lays nothing out are four different answers.
+		button.setTooltip(button.active ? null : Tooltip.create(nothingToConfigure()));
+	}
+
+	/**
+	 * Why the view switch is dead, which is a different question once a pack can be read without
+	 * being loaded: a pack on screen that lays nothing out is not the same nothing as no pack at all,
+	 * and saying {@link ScreenText#NO_PACK} over a pack whose name is on the row above reads as a
+	 * fault of this mod.
+	 * <p>
+	 * The toggle is asked first and not last. It is the one answer that is about a choice rather
+	 * than about a pack, so it outranks whatever the pack on screen would have said: a player who
+	 * has just turned shaders off is told that, not that the pack they can still see the name of
+	 * has no settings.
+	 */
+	private Component nothingToConfigure() {
+		PackList list = this.packList;
+		if (list != null && !list.shadersEnabled()) {
+			// The toggle's own words, which is what makes the connection obvious: the sentence on
+			// the dead button is the one written on the row right above it.
+			return Component.translatable(ScreenText.SHADERS_DISABLED);
+		}
+
+		PackSession shown = this.session;
+		if (shown != null) {
+			return Component.translatable(ScreenText.NO_SETTINGS, shown.packFileName());
+		}
+
+		return noPackReason();
 	}
 
 	/**
@@ -645,8 +713,12 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 	}
 
 	@Override
-	public void focusBottomRow() {
+	public void packChosen() {
 		setFocused(this.folderButton);
+		// The switch is live for what the list has selected, so it has to hear that the selection
+		// moved. Nothing else rebuilds this screen when a row is clicked, and without this the very
+		// first pack picked on a fresh install left the button dead until something else did.
+		refreshViewSwitch();
 	}
 
 	@Override
@@ -920,6 +992,11 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 					.withStyle(ChatFormatting.ITALIC, ChatFormatting.YELLOW));
 			// Selected straight away: somebody who has just dragged a pack in wants to use it.
 			list.select(name);
+			// And the switch is told, because it is live for what the list has selected and this is
+			// the one road to a selection that does not go through a row being pressed. Without it
+			// a dropped pack sits selected under a dead button until something unrelated rebuilds
+			// the screen.
+			refreshViewSwitch();
 
 			return;
 		}

--- a/common/src/main/resources/assets/vitrail/lang/de_de.json
+++ b/common/src/main/resources/assets/vitrail/lang/de_de.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "Es ist kein Shaderpaket geladen",
 	"options.vitrail.pack_off": "Kein Shaderpaket: Das Spiel zeichnet sein eigenes Bild",
 	"options.vitrail.pack_missing": "Das Shaderpaket \"%s\" ist nicht in deinem Shaderpaket-Ordner",
+	"options.vitrail.no_settings": "Das Shaderpaket \"%s\" hat keine Einstellungen",
 	"key.vitrail.open_settings": "Shader-Einstellungen öffnen",
 	"key.vitrail.reload_pack": "Shader neu laden",
 	"options.vitrail.pack_reloaded": "Shader neu geladen!",

--- a/common/src/main/resources/assets/vitrail/lang/en_us.json
+++ b/common/src/main/resources/assets/vitrail/lang/en_us.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "No shader pack is loaded",
 	"options.vitrail.pack_off": "No shader pack: the game draws its own image",
 	"options.vitrail.pack_missing": "Shader pack \"%s\" is not in your Shader Packs folder",
+	"options.vitrail.no_settings": "Shader pack \"%s\" has no settings",
 	"key.vitrail.open_settings": "Open shader pack settings",
 	"key.vitrail.reload_pack": "Reload Shaders",
 	"options.vitrail.pack_reloaded": "Shaders Reloaded!",

--- a/common/src/main/resources/assets/vitrail/lang/es_es.json
+++ b/common/src/main/resources/assets/vitrail/lang/es_es.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "No hay ningún Shader Pack cargado",
 	"options.vitrail.pack_off": "Sin Shader Pack: el juego dibuja su propia imagen",
 	"options.vitrail.pack_missing": "El Shader Pack \"%s\" no está en tu carpeta de Shader Packs",
+	"options.vitrail.no_settings": "El Shader Pack \"%s\" no tiene ajustes",
 	"key.vitrail.open_settings": "Abrir la configuración del Shader Pack",
 	"key.vitrail.reload_pack": "Recargar Shaders",
 	"options.vitrail.pack_reloaded": "¡Shaders recargados!",

--- a/common/src/main/resources/assets/vitrail/lang/fr_fr.json
+++ b/common/src/main/resources/assets/vitrail/lang/fr_fr.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "Aucun pack de shaders n'est chargé",
 	"options.vitrail.pack_off": "Aucun pack de shaders : le jeu dessine sa propre image",
 	"options.vitrail.pack_missing": "Le pack de shaders \"%s\" n'est pas dans votre dossier de packs de shaders",
+	"options.vitrail.no_settings": "Le pack de shaders \"%s\" n'a aucun réglage",
 	"key.vitrail.open_settings": "Ouvrir les options du pack de shaders",
 	"key.vitrail.reload_pack": "Recharger les shaders",
 	"options.vitrail.pack_reloaded": "Shaders rechargés !",

--- a/common/src/main/resources/assets/vitrail/lang/it_it.json
+++ b/common/src/main/resources/assets/vitrail/lang/it_it.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "Nessun pacchetto di shader caricato",
 	"options.vitrail.pack_off": "Nessun pacchetto di shader: il gioco disegna la propria immagine",
 	"options.vitrail.pack_missing": "Il pacchetto di shader \"%s\" non è nella cartella dei pacchetti di shader",
+	"options.vitrail.no_settings": "Il pacchetto di shader \"%s\" non ha impostazioni",
 	"key.vitrail.open_settings": "Apri le impostazioni del pacchetto di shader",
 	"key.vitrail.reload_pack": "Riavvia Shaders",
 	"options.vitrail.pack_reloaded": "Shaders Ricaricate!",

--- a/common/src/main/resources/assets/vitrail/lang/ja_jp.json
+++ b/common/src/main/resources/assets/vitrail/lang/ja_jp.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "シェーダーパックが読み込まれていません",
 	"options.vitrail.pack_off": "シェーダーパックなし：ゲームが自前の映像を描画します",
 	"options.vitrail.pack_missing": "シェーダーパック「%s」がシェーダーパックフォルダーにありません",
+	"options.vitrail.no_settings": "シェーダーパック「%s」には設定がありません",
 	"key.vitrail.open_settings": "シェーダーパックの設定を開く",
 	"key.vitrail.reload_pack": "シェーダーを再読み込み",
 	"options.vitrail.pack_reloaded": "シェーダーを再読み込みしました！",

--- a/common/src/main/resources/assets/vitrail/lang/ko_kr.json
+++ b/common/src/main/resources/assets/vitrail/lang/ko_kr.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "불러온 셰이더 팩이 없습니다",
 	"options.vitrail.pack_off": "셰이더 팩 없음: 게임이 자체 화면을 그립니다",
 	"options.vitrail.pack_missing": "셰이더 팩 \"%s\"이(가) 셰이더 팩 폴더에 없습니다",
+	"options.vitrail.no_settings": "셰이더 팩 \"%s\"에는 설정이 없습니다",
 	"key.vitrail.open_settings": "셰이더 팩 설정 열기",
 	"key.vitrail.reload_pack": "셰이더 새로고침",
 	"options.vitrail.pack_reloaded": "셰이더를 다시 불러왔습니다.",

--- a/common/src/main/resources/assets/vitrail/lang/nl_nl.json
+++ b/common/src/main/resources/assets/vitrail/lang/nl_nl.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "Er is geen shader pack geladen",
 	"options.vitrail.pack_off": "Geen shader pack: het spel tekent zijn eigen beeld",
 	"options.vitrail.pack_missing": "Shader pack \"%s\" staat niet in je shader pack-map",
+	"options.vitrail.no_settings": "Shader pack \"%s\" heeft geen instellingen",
 	"key.vitrail.open_settings": "Shader pack-instellingen openen",
 	"key.vitrail.reload_pack": "Herlaad Shaders",
 	"options.vitrail.pack_reloaded": "Shaders herladen!",

--- a/common/src/main/resources/assets/vitrail/lang/pl_pl.json
+++ b/common/src/main/resources/assets/vitrail/lang/pl_pl.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "Nie wczytano żadnego pakietu shaderów",
 	"options.vitrail.pack_off": "Brak pakietu shaderów: gra rysuje własny obraz",
 	"options.vitrail.pack_missing": "Pakietu shaderów \"%s\" nie ma w folderze pakietów shaderów",
+	"options.vitrail.no_settings": "Pakiet shaderów \"%s\" nie ma żadnych ustawień",
 	"key.vitrail.open_settings": "Otwórz ustawienia pakietu shaderów",
 	"key.vitrail.reload_pack": "Przeładuj Shadery",
 	"options.vitrail.pack_reloaded": "Przeładowano Shadery!",

--- a/common/src/main/resources/assets/vitrail/lang/pt_br.json
+++ b/common/src/main/resources/assets/vitrail/lang/pt_br.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "Nenhum pacote de sombreadores carregado",
 	"options.vitrail.pack_off": "Sem pacote de sombreadores: o jogo desenha a própria imagem",
 	"options.vitrail.pack_missing": "O pacote de sombreadores \"%s\" não está na sua pasta de pacotes de sombreadores",
+	"options.vitrail.no_settings": "O pacote de sombreadores \"%s\" não tem configurações",
 	"key.vitrail.open_settings": "Abrir configurações do pacote de sombreadores",
 	"key.vitrail.reload_pack": "Recarregar sombreadores",
 	"options.vitrail.pack_reloaded": "Sombreadores recarregados!",

--- a/common/src/main/resources/assets/vitrail/lang/ru_ru.json
+++ b/common/src/main/resources/assets/vitrail/lang/ru_ru.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "Набор шейдеров не загружен",
 	"options.vitrail.pack_off": "Набора шейдеров нет: игра рисует собственное изображение",
 	"options.vitrail.pack_missing": "Набора шейдеров \"%s\" нет в вашей папке с наборами шейдеров",
+	"options.vitrail.no_settings": "У набора шейдеров \"%s\" нет настроек",
 	"key.vitrail.open_settings": "Открыть настройки набора шейдеров",
 	"key.vitrail.reload_pack": "Перезагрузить шейдеры",
 	"options.vitrail.pack_reloaded": "Шейдеры перезагружены.",

--- a/common/src/main/resources/assets/vitrail/lang/tr_tr.json
+++ b/common/src/main/resources/assets/vitrail/lang/tr_tr.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "Yüklü bir shader paketi yok",
 	"options.vitrail.pack_off": "Shader paketi yok: oyun kendi görüntüsünü çiziyor",
 	"options.vitrail.pack_missing": "\"%s\" Shader Paketi senin Shader Paket klasöründe yok",
+	"options.vitrail.no_settings": "\"%s\" Shader Paketinin ayarı yok",
 	"key.vitrail.open_settings": "Shader paketi ayarlarını aç",
 	"key.vitrail.reload_pack": "Shaderları Yenile",
 	"options.vitrail.pack_reloaded": "Shaderlar Yeniden Yüklendi!",

--- a/common/src/main/resources/assets/vitrail/lang/uk_ua.json
+++ b/common/src/main/resources/assets/vitrail/lang/uk_ua.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "Пакет шейдерів не завантажено",
 	"options.vitrail.pack_off": "Пакета шейдерів немає: гра малює власне зображення",
 	"options.vitrail.pack_missing": "Пакета шейдерів \"%s\" немає у вашій папці пакетів шейдерів",
+	"options.vitrail.no_settings": "У пакета шейдерів \"%s\" немає налаштувань",
 	"key.vitrail.open_settings": "Відкрити налаштування пакета шейдерів",
 	"key.vitrail.reload_pack": "Перезавантажити шейдери",
 	"options.vitrail.pack_reloaded": "Шейдери перезавантажено!",

--- a/common/src/main/resources/assets/vitrail/lang/zh_cn.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_cn.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "未加载光影包",
 	"options.vitrail.pack_off": "无光影包：游戏绘制自己的画面",
 	"options.vitrail.pack_missing": "光影包\"%s\"不在光影包文件夹中",
+	"options.vitrail.no_settings": "光影包\"%s\"没有可调选项",
 	"key.vitrail.open_settings": "打开光影包设置",
 	"key.vitrail.reload_pack": "重新加载光影包",
 	"options.vitrail.pack_reloaded": "已重新加载光影包！",

--- a/common/src/main/resources/assets/vitrail/lang/zh_tw.json
+++ b/common/src/main/resources/assets/vitrail/lang/zh_tw.json
@@ -50,6 +50,7 @@
 	"options.vitrail.no_pack": "未載入光影包",
 	"options.vitrail.pack_off": "無光影包：遊戲繪製自己的畫面",
 	"options.vitrail.pack_missing": "「%s」光影包不在光影包資料夾中",
+	"options.vitrail.no_settings": "「%s」光影包沒有可調選項",
 	"key.vitrail.open_settings": "開啟光影包設定",
 	"key.vitrail.reload_pack": "重新載入光影",
 	"options.vitrail.pack_reloaded": "已重新載入光影！",


### PR DESCRIPTION
## What changes

The button that walks from the pack list into a pack's settings was live only while a pack was already drawing. That is a circle: a pack nobody has loaded has never been read, so nothing said it had settings, so the button that would have read it stayed dead, and the only way in was to load the pack at whatever profile its author shipped. On a machine that cannot afford that profile, the one launch it cannot afford is the launch it has to make to ask for a cheaper one.

The button is now live for the pack the list has selected. Pressing it reads that pack, which is parsing and no work on the graphics card, and puts its settings on screen while the loaded pack goes on drawing. Setting a heavy pack to its low profile before ever loading it costs one load instead of two. The reading itself already existed and already wrote the pack's own settings file on its way through; what is new is that picking a row reaches the screen at all, the list's callback having carried the focus alone.

A pack that reads and lays no settings out keeps the view where it was and says so under its own name, instead of opening a page with nothing on it. A pack that cannot be read does the same and says why in red. Both give the pack that was drawing back, so the screen is never left holding one it read and threw away.

## How it differs from the reference, and for what obstacle

Iris applies the pack at this point instead of reading it, and its own note gives the reason. That reason is right: picking a pack and then opening the settings would otherwise open the settings of the pack before it. Its price is not, because applying is the whole of a pack switch and it lands on the pack's own default profile, which is all the player has chosen so far. Reading answers the same need for nothing, since a pack's menu comes out of its `shaders.properties` and its directives. That divergence is older than this branch; what changes here is only which pack the button asks about.

## What proves it

- `gradlew build` green.
- Read by hand across the states the screen can be in: no pack in the folder, a named pack missing from it, shaders toggled off, the selected pack already on screen, a selected pack that is not, a loaded pack with an empty menu, and nothing loaded at all.
- Not tried in the game.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
