### PR TITLE
fix(pack): install machine defines before the pack is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,11 @@ what the next one holds.
   numbers varyings by count, and a matrix occupies several slots. Each matrix is now split into
   one vector per column before compile. Complementary never declared one, so it did not show
   the oval.
+- **Turning Distant Horizons on reloads Complementary and then draws it.** The pack used to
+  be reread with Distant Horizons present and then refused, because four uniforms stayed
+  outside a block, so the world dropped to vanilla. The machine symbols are now installed
+  before the pack is opened, so those uniforms enter the block and the reload draws the
+  pack. The toggle still reloads; it does not keep the pack on without one.
 
 - **The button that opens a pack's settings is no longer dead until the pack has been loaded
   once.** It was live only while a pack was already drawing, so the first pack anybody picks on

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -3322,7 +3322,13 @@ public final class GlslTranslator {
 
 			// A declaration in a branch nobody takes stays where it is. Moving it to the header
 			// would make it unconditional, and packs do declare a name as a uniform in one branch
-			// and as an ordinary global in the other.
+			// and as an ordinary global in the other. Complementary's dhProjection six are the
+			// other side of that rule: they are ordinary pack uniforms under DISTANT_HORIZONS,
+			// Iris registers them as such (CommonUniforms.java:184-186, MatrixUniforms.java:41-45)
+			// and OpenGL accepts the loose form. They enter OfGlobals only when that branch is
+			// live. If the expander never saw the symbol and the header still defines it, they
+			// stay in the body and Vulkan refuses the unit; PackChain.load installs the table
+			// before SettingSet.resolve so the two readers agree.
 			if (this.unit.isLive(lines[index])) {
 				liftOne(index);
 			}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -858,6 +858,15 @@ public final class PackChain {
 					+ "is written as a plain number", askedFor.shadowMapScale());
 			}
 
+			// Before OpenedPack.open, not after. SettingSet.resolve copies EngineDefines.table as
+			// it is built, and the expander's liveness is that copy. The translator writes the
+			// live machine() table back out as #define lines. Installed after the copy, the two
+			// disagree: DISTANT_HORIZONS lands in the header, the DH uniforms stay in the body
+			// because liftUniforms will not move a dead line, and Vulkan refuses a non-opaque
+			// uniform outside a block. Complementary's deferred1 died that way on a DH toggle.
+			// Iris has one table for both jobs, StandardMacros.java:64-65.
+			PackDefines.install();
+
 			try (OpenedPack opened = OpenedPack.open(pack, chosen, settings.profile())) {
 				// The world decides the directory, and the pack decides which world that is: a folder
 				// may be named anything and mapped in dimension.properties, so the name is read from
@@ -865,8 +874,6 @@ public final class PackChain {
 				String place = PackPlace.place(opened.source());
 				String world = PackPlace.world();
 
-				// Before the translation and not after: this is what installs the machine's own
-				// symbols, and the biome ones among them decide which branch of the pack compiles.
 				PackValues values = PackValues.read(opened, place);
 
 				long began = System.nanoTime();

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -108,10 +108,11 @@ public final class PackValues {
 	/**
 	 * Reads one pack's directives and its own uniforms.
 	 * <p>
-	 * The machine is installed first and not last, and the caller has to read a pack's values
-	 * before translating its programs. The biome symbols decide which branch of
-	 * {@code shaders.properties} is live and which branch of the GLSL compiles, so they have to be
-	 * in the table before either is read.
+	 * The machine has to have been installed before this pack was opened. The biome symbols decide
+	 * which branch of {@code shaders.properties} is live and which branch of the GLSL compiles, so
+	 * they have to be in the table before either is read, and {@code SettingSet} copies that table
+	 * at {@code OpenedPack.open}. Installing here would be too late for the expander, and would
+	 * point the translator at a newer table than the one the expander walked.
 	 *
 	 * @param pack      the pack, already opened and already read for its settings. Handed in rather
 	 *                  than opened here because the load reads it half a dozen times over, and
@@ -122,7 +123,6 @@ public final class PackValues {
 	 */
 	public static PackValues read(OpenedPack pack, String dimension) throws IOException {
 		PackValues values = new PackValues();
-		PackDefines.install();
 
 		ShaderPackSource source = pack.source();
 		OptionIndex options = pack.options();


### PR DESCRIPTION
## What changes

Turning Distant Horizons on used to reread Complementary and then refuse it, because four uniforms stayed outside a block, so the world dropped to vanilla. The machine symbols are now installed before the pack is opened, so those uniforms enter the block and the reload draws the pack. The toggle still reloads; it does not keep the pack on without one.

## How it differs from the reference, and for what obstacle

Iris keeps one table for the symbols a pack is opened with and the symbols a unit is compiled with. Here `SettingSet` copies the machine table at `OpenedPack.open`. Installed after that copy, `DISTANT_HORIZONS` reached the header while Complementary's DH uniforms stayed in the body, and Vulkan refused the unit. Install first so both readers agree. The image after the reload is the pack Iris would have kept drawing.

## What proves it

- [x] `gradlew build` green.
- [ ] The out-of-game harness, and which corpus it ran over.
- [x] In the game: Complementary, Distant Horizons toggled on. The pack reloads and then draws instead of dropping to vanilla.

## What it leaves owing

Nothing on the install order. A toggle still costs a pack reload.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
