### PR TITLE
perf(render): cache compute modules and drop load from the key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,14 @@ what the next one holds.
 
 ### Changed
 
-- **Loading a pack a second time no longer compiles its shaders again.** Everything the game
-  makes of a shader, the compiled module and the table of what it binds, is kept under
+- **Compute shaders now hit the compiled-module cache on a pack reload.** They used to miss
+  every time because the disk key hashed the load number the debug name carries. That number
+  is out of the key. Computes are compiled by this engine, not by the game's shader compiler;
+  what is kept is the compiled module and its bind table, the same files graphics shaders
+  already write under `vitrail/modules`. Vulkan pipelines are built each load as before.
+
+- **Loading a pack a second time no longer compiles its shaders again.** The compiled module
+  and the table of what it binds are kept under
   `vitrail/modules` in the game folder and read back when the same shader comes round again, so
   a warm load does no compiling and no inspecting at all. Editing a shader or moving a pack
   setting changes what is asked for, and so does updating the mod, the game or the loader, and

--- a/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
@@ -54,13 +54,16 @@ public abstract class GlslCompilerMixin {
 	 * shaderc sees: the method splices the compiler's own two global defines in behind the
 	 * version directive. They are built once in its constructor out of literals and nothing can
 	 * move them, so they say the same thing about every unit and cannot tell two of them apart.
+	 * The debug name is handed to {@link ModuleCache#lookup} so the rebuilt module carries this
+	 * chain's identifier, and it is not hashed: that name carries the load number the disk key
+	 * must not see.
 	 */
 	@WrapMethod(method = "createIntermediary", require = 1)
 	private IntermediaryShaderModule vitrail$module(String filename, String source, ShaderType type,
 			Operation<IntermediaryShaderModule> original) {
 		long began = System.nanoTime();
 		try {
-			String key = ModuleCache.keyOf(filename, source, type.name());
+			String key = ModuleCache.keyOf(source, type.name());
 			IntermediaryShaderModule served = ModuleCache.lookup(key, filename);
 			if (served != null) {
 				return served;

--- a/common/src/main/java/dev/vitrail/render/ComputeShader.java
+++ b/common/src/main/java/dev/vitrail/render/ComputeShader.java
@@ -96,8 +96,15 @@ public final class ComputeShader {
 		}
 	}
 
-	public static Compiled compile(VulkanDevice vulkan, String name, ByteBuffer spirv) {
-		try (IntermediaryShaderModule module = IntermediaryShaderModule.createFromSpirv(name, spirv)) {
+	/**
+	 * Remaps bindings and creates the device shader module. The SPIR-V and the reflection tables
+	 * are already on {@code module}, whether they came from {@code createFromSpirv} or from
+	 * {@link ModuleCache}. Does not close {@code module}: a cached unit and a just-reflected one
+	 * have the same lifetime as this call, and {@code rebind} rewrites the bytes after the store
+	 * has copied them.
+	 */
+	public static Compiled compile(VulkanDevice vulkan, IntermediaryShaderModule module) {
+		try {
 			IntermediaryShaderModuleAccessor access =
 					(IntermediaryShaderModuleAccessor) (Object) module;
 			List<VulkanBindGroupLayout.Entry> entries = new ArrayList<>();

--- a/common/src/main/java/dev/vitrail/render/ModuleCache.java
+++ b/common/src/main/java/dev/vitrail/render/ModuleCache.java
@@ -48,13 +48,23 @@ import java.util.stream.Stream;
  * stored beside the bytes it read rather than replayed over them.
  * <p>
  * <strong>The key IS the input, hashed</strong>, and nothing else: the exact text handed to the
- * compiler, the stage it is compiled for, the debug name the module carries, and everything that
- * decides what that text turns into, which is the mod's version, the game's, the loader with its
- * own version, and the LWJGL build whose bundled shaderc and SPIRV-Cross do the work. Nothing is
- * keyed on a pack name or a file path, so there is no invalidation to get wrong and none is
+ * compiler, the stage it is compiled for, and everything that decides what that text turns into,
+ * which is the mod's version, the game's, the loader with its own version, and the LWJGL build
+ * whose bundled shaderc and SPIRV-Cross do the work. Nothing is keyed on a pack name, a file path
+ * or the debug name the module carries, so there is no invalidation to get wrong and none is
  * written. An edited shader, a moved pack setting, a translator that emits one word differently, a
  * loader that patches the compiler: each is a different key, and the blob under the old one is
  * never asked for again.
+ * <p>
+ * <strong>The debug name stays out of the key on purpose.</strong> The game's pipeline cache is
+ * keyed on the identifier and never on the text, so this engine puts the load number in that name
+ * ({@code pack/<load>/...}): two chains must not share an identifier when their GLSL differs
+ * ({@code docs/internals/game-graphics-api.md}). The disk key already carries the text, so hashing
+ * the load number as well would make every Apply, every R and every portal a miss of identical
+ * GLSL. F3+T does not bump the load and already hit; a pack reload now hits too. The live name is
+ * still handed to {@link #lookup} so the rebuilt module carries the identifier this chain's
+ * pipelines will ask for. Two texts colliding under one blob would need a SHA-256 collision of
+ * the source, which is not the trap the load number exists to prevent.
  * <p>
  * <strong>What is stored is the module as its maker handed it over</strong>, at the one instant at
  * which it is finished and nothing has yet bent it to a pipeline: the bytes, the uniform buffers
@@ -169,13 +179,17 @@ public final class ModuleCache {
 	 * <p>
 	 * Worked out once by the caller and handed to both ends, because the source of a composite runs
 	 * to hundreds of kilobytes and hashing it twice to answer one question is work for nothing.
+	 * <p>
+	 * The debug name is not an argument. It used to be, and a pack reload then missed every unit
+	 * whose GLSL had not moved, because the name carries the load number ({@code pack/<load>/...})
+	 * and {@code PackChain} increments that number on every new chain. The file layout did not
+	 * change, so the format token stays; old blobs under the names-in-the-key hashes sit until
+	 * the sweep collects them.
 	 *
-	 * @param filename the debug name the module carries, which the compiler writes into the module
-	 *                 it emits and which therefore belongs in the key
-	 * @param source   the text the compiler was handed, the pipeline's defines already injected
-	 * @param stage    vertex or fragment, which decides the whole compile
+	 * @param source the text the compiler was handed, the pipeline's defines already injected
+	 * @param stage  vertex, fragment, or the compute recipe token, which decides the whole compile
 	 */
-	public static @Nullable String keyOf(String filename, String source, String stage) {
+	public static @Nullable String keyOf(String source, String stage) {
 		if (directory() == null || !ModuleShape.available()) {
 			return null;
 		}
@@ -189,7 +203,6 @@ public final class ModuleCache {
 		feed(digest, Vitrail.platform().loaderVersion());
 		feed(digest, Version.getVersion());
 		feed(digest, stage);
-		feed(digest, filename);
 		feed(digest, source);
 
 		return HexFormat.of().formatHex(digest.digest());

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -32,6 +32,7 @@ import com.mojang.blaze3d.vulkan.VulkanGpuBuffer;
 import com.mojang.blaze3d.vulkan.VulkanGpuSampler;
 import com.mojang.blaze3d.vulkan.VulkanGpuTextureView;
 import com.mojang.blaze3d.vulkan.VulkanUtils;
+import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MappableRingBuffer;
 import org.lwjgl.system.MemoryStack;
@@ -80,6 +81,14 @@ final class PackCompute implements AutoCloseable {
 
 	private static final int SHADERC_VULKAN_1_2 = 4202496;
 	private static final int SHADERC_COMPUTE = 2;
+
+	/**
+	 * Stage token hashed into {@link ModuleCache}'s key for this road, and nowhere else. The
+	 * game's compiler never sees a compute: shaderc kind, optimisation and target live only in
+	 * {@link Pass#compileSpirv}. Naming those here keeps a later {@code ShaderType.COMPUTE}
+	 * through {@code GlslCompiler} from serving this blob, or the other way around.
+	 */
+	private static final String MODULE_CACHE_STAGE = "COMPUTE/shaderc-opt2-vulkan1.2";
 
 	/**
 	 * A common ceiling on a pushed descriptor set, the same one the graphics side carries in
@@ -381,21 +390,45 @@ final class PackCompute implements AutoCloseable {
 			}
 
 			// Clocked as module work like everything the game's compiler makes: shaderc first,
-			// then the reflection inside ComputeShader.compile. Neither goes through the game's
-			// compiler, so the funnel clock cannot see them and this road counts itself. The
-			// layout and the pipeline below stay outside the figure: they are Vulkan object
-			// creation, not module work. One outer finally so that every exit, the refusal and
-			// the throw included, is counted exactly once.
+			// then the reflection inside createFromSpirv. Neither goes through the game's
+			// compiler, so the funnel clock cannot see them and this road counts itself. A cache
+			// hit skips both and still clocks the file read, the same way GlslCompilerMixin
+			// clocks a served graphics unit. The layout and the pipeline below stay outside the
+			// figure: they are Vulkan object creation, not module work. One outer finally so that
+			// every exit, the refusal and the throw included, is counted exactly once.
+			//
+			// Iris has no disk store for this. ProgramBuilder.beginCompute
+			// (ProgramBuilder.java:71-84) then GlShader (GlShader.java:24-49) calls
+			// glCompileShader on the render thread, and the binary cache is the OpenGL driver's
+			// (Iris.java:133-136 asks that driver for ten parallel compile threads). This engine's
+			// compute never entered GlslCompiler.createIntermediary, so it never entered
+			// ModuleCache either; the same store now holds it, same file layout, a stage token
+			// that names our shaderc options so a graphics COMPUTE through the game's compiler
+			// cannot serve this blob.
 			long began = System.nanoTime();
+			IntermediaryShaderModule module = null;
 			try {
-				ByteBuffer spirv = compileSpirv(unit.text());
-				if (spirv == null) {
-					return;
+				String source = unit.text();
+				String key = ModuleCache.keyOf(source, MODULE_CACHE_STAGE);
+				module = ModuleCache.lookup(key, this.label);
+				ByteBuffer spirv = null;
+				if (module == null) {
+					spirv = compileSpirv(source);
+					if (spirv == null) {
+						ModuleCache.building();
+						return;
+					}
+
+					ModuleCache.building();
 				}
 
 				try {
-					ComputeShader.Compiled compiled =
-							ComputeShader.compile(vulkan, this.label, spirv);
+					if (module == null) {
+						module = IntermediaryShaderModule.createFromSpirv(this.label, spirv);
+						ModuleCache.store(key, module);
+					}
+
+					ComputeShader.Compiled compiled = ComputeShader.compile(vulkan, module);
 					this.shaderModule = compiled.module();
 					this.entries = compiled.entries();
 					// Named and still dispatched, which is what the graphics path does with the
@@ -413,6 +446,10 @@ final class PackCompute implements AutoCloseable {
 					return;
 				}
 			} finally {
+				if (module != null) {
+					module.close();
+				}
+
 				LoadClock.module(System.nanoTime() - began);
 			}
 


### PR DESCRIPTION
## What changes

Compute shaders missed the compiled-module disk cache on every pack reload, because the disk key hashed the load number the debug name carries. That number is out of the key. Computes are compiled by this engine, not by the game's shader compiler; what is kept is the compiled module and its bind table, the same files graphics shaders already write under `vitrail/modules`. Vulkan pipelines are built each load as before.

## How it differs from the reference, and for what obstacle

It does not. Iris has no disk store of compiled modules. This is cache coverage for a road this engine already had for graphics units.

## What proves it

- [x] `gradlew build` green.
- [ ] The out-of-game harness, and which corpus it ran over.
- [ ] In the game: which pack, which place, and what was looked at.

## What it leaves owing

Vulkan pipelines are still built each load. A warm reload that still waits is waiting somewhere this cache does not look.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
