### PR TITLE
feat(screen): show Iris profile name and dirty count on F3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ what the next one holds.
   is out of the key. Computes are compiled by this engine, not by the game's shader compiler;
   what is kept is the compiled module and its bind table, the same files graphics shaders
   already write under `vitrail/modules`. Vulkan pipelines are built each load as before.
+- **F3 names the pack the way Iris does.** The profile line is the scanned name or Custom, with
+  how many options sit outside it, and the shadow line is Sodium's `C: a/b D: d` without this
+  engine's own cull dialect.
 
 - **Loading a pack a second time no longer compiles its shaders again.** The compiled module
   and the table of what it binds are kept under

--- a/common/src/main/java/dev/vitrail/pack/menu/MenuValues.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/MenuValues.java
@@ -190,6 +190,70 @@ public final class MenuValues {
 		return match(this::pending);
 	}
 
+	/**
+	 * Which profile the values the pack was built with amount to, or the empty string when they
+	 * amount to none of them.
+	 * <p>
+	 * The overlay asks this and not {@link #matchedProfile}, which is what the screen is about to
+	 * apply. A capture with F3 open has to name what is drawn, not what is waiting on Apply.
+	 */
+	public String matchedAppliedProfile() {
+		return match(this::applied);
+	}
+
+	/**
+	 * Iris's F3 profile sentence ({@code ShaderPack.java:276}): the scanned name or
+	 * {@code Custom}, then how many applied options sit outside that profile.
+	 * <p>
+	 * The count is applied-minus-profile, the same subtraction Iris does
+	 * ({@code getOptionsChanged} of the loaded values minus that of the matched profile). A pack
+	 * that matches Low exactly reads {@code (+0 options changed by user)}; two extras on top of
+	 * Low read {@code (+2 options changed by user)}; nothing matching reads {@code Custom} and
+	 * the whole applied count.
+	 */
+	public String profileInfo() {
+		String matched = matchedAppliedProfile();
+		String name = matched.isEmpty() ? "Custom" : matched;
+		int extra = appliedOptionsChanged() - profileOptionsChanged(matched);
+		return "Profile: " + name + " (+" + extra + " option"
+				+ (extra == 1 ? "" : "s") + " changed by user)";
+	}
+
+	/** Applied settings that are not the pack's own default, the ones Iris keeps in its maps. */
+	private int appliedOptionsChanged() {
+		int count = 0;
+		for (String name : this.menu.optionNames()) {
+			if (!applied(name).equals(packDefault(name))) {
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+	/**
+	 * Settings the matched profile itself moves off the pack's default. An empty name is Custom,
+	 * which has none, the way Iris builds an empty {@code MutableOptionValues} when the scan
+	 * matches nothing.
+	 */
+	private int profileOptionsChanged(String profileName) {
+		if (profileName.isEmpty()) {
+			return 0;
+		}
+
+		int count = 0;
+		for (Map.Entry<String, String> setting : this.menu.profile(profileName).entrySet()) {
+			if (this.menu.option(setting.getKey()).isEmpty()) {
+				continue;
+			}
+			if (!setting.getValue().equals(packDefault(setting.getKey()))) {
+				count++;
+			}
+		}
+
+		return count;
+	}
+
 	private String match(UnaryOperator<String> layer) {
 		String best = "";
 		int constraints = -1;

--- a/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
@@ -231,6 +231,11 @@ public final class PackMenu {
 		return this.options.size();
 	}
 
+	/** Every setting the pages place, for a scan that has to visit each. */
+	public Set<String> optionNames() {
+		return this.options.keySet();
+	}
+
 	/** From the most constrained to the least, which is the order the selector walks through. */
 	public List<String> profileNames() {
 		return this.profileOrder;

--- a/common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java
+++ b/common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java
@@ -15,11 +15,10 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import org.jspecify.annotations.Nullable;
 
 /**
- * The engine's lines of the F3 screen: version, the pack being drawn, and the profile it stands
- * on. They are the heart of what Iris shows, because they answer the questions a screenshot gets asked -
- * which engine drew this, with which pack, set how - and a capture with the F3 open is how those
- * questions arrive. Without them a Vitrail frame and an Iris frame of the same pack read as the
- * same picture.
+ * The engine's lines of the F3 screen, in Iris's wording so a capture of one reads against a
+ * capture of the other: version, shaderpack, the scanned profile with the dirty count, then
+ * Sodium's shadow {@code C: a/b D: d}. Color space is omitted: this engine has no color-space
+ * setting to name, and inventing one would be a line Iris cannot match the other way.
  * <p>
  * A pack that is not being drawn says why in one line, and the three reasons are kept apart the
  * way {@link PackChain} keeps them: asked off, named but missing, or refused. Saying "none" for a
@@ -47,10 +46,7 @@ public final class VitrailDebugEntry implements DebugScreenEntry {
 
 		PackChain.session().ifPresentOrElse(session -> {
 			displayer.addToGroup(GROUP, PREFIX + "Shaderpack: " + session.packFileName());
-			String profile = session.settings().profile();
-			if (!profile.isEmpty()) {
-				displayer.addToGroup(GROUP, PREFIX + "Profile: " + profile);
-			}
+			displayer.addToGroup(GROUP, PREFIX + session.profileInfo());
 			if (level != null) {
 				shadowLines(displayer);
 			}
@@ -58,32 +54,22 @@ public final class VitrailDebugEntry implements DebugScreenEntry {
 	}
 
 	/**
-	 * What the shadow map cost to fill, said the way the reference says it so that a capture of one
-	 * screen reads against a capture of the other.
+	 * What the shadow map cost to fill, said the way Iris says it on the default F3
+	 * ({@code gui/debug/IrisDebugEntry.java:26}): Sodium's {@code C: a/b D: d} for the light.
+	 * The cull shape stays in the log ({@code ShadowTerrain}'s {@code shadow-cull} line), not
+	 * here: a capture next to Iris has to read the same family of lines, and
+	 * {@code ADVANCED BOX r=} is a dialect only this engine speaks.
 	 * <p>
-	 * The first line is Sodium's own shape for the camera, which Iris reuses for the light and
-	 * shows by default ({@code gui/debug/IrisDebugEntry}, raising its shadow flag around the ask):
-	 * sections drawn over sections loaded, then the render distance. <strong>The number to read
-	 * against Iris is the first one</strong>, both sides counting the sections that carry block
-	 * geometry and no others.
-	 * <p>
-	 * The second line is what Iris keeps for its debug options and this engine has no reason to
-	 * hide: the shape the walk measured against, and how many sections came back. Two counts that
-	 * differ by little say the cull is running and finding nothing to drop, which is a state worth
-	 * seeing rather than guessing at.
+	 * <strong>The number to read against Iris is the first one</strong>, both sides counting the
+	 * sections that carry block geometry and no others. Iris does not append {@code (no terrain)}
+	 * on this default line; that fragment lives on its extra debug entry.
 	 */
 	private static void shadowLines(DebugScreenDisplayer displayer) {
 		ShadowTerrain.Walk walk = ShadowTerrain.lastWalk();
-		if (walk == null) {
-			displayer.addToGroup(GROUP, PREFIX + "Shadows: (unavailable)");
-			return;
-		}
-
-		displayer.addToGroup(GROUP, PREFIX + "Shadows: C: " + walk.drawn() + "/" + walk.total()
-				+ " D: " + Minecraft.getInstance().options.getEffectiveRenderDistance()
-				+ (walk.terrain() ? "" : " (no terrain)"));
-		displayer.addToGroup(GROUP, PREFIX + "Shadow cull: " + walk.kept() + " sections kept, "
-				+ walk.culling());
+		int drawn = walk == null ? 0 : walk.drawn();
+		int total = walk == null ? 0 : walk.total();
+		displayer.addToGroup(GROUP, PREFIX + "Shadows: C: " + drawn + "/" + total
+				+ " D: " + Minecraft.getInstance().options.getEffectiveRenderDistance());
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/settings/PackSession.java
+++ b/common/src/main/java/dev/vitrail/settings/PackSession.java
@@ -1,5 +1,6 @@
 package dev.vitrail.settings;
 
+import dev.vitrail.pack.menu.MenuValues;
 import dev.vitrail.pack.menu.PackMenu;
 import dev.vitrail.pack.option.OptionIndex;
 import dev.vitrail.pack.option.OptionValue;
@@ -92,6 +93,15 @@ public record PackSession(Path gameDirectory, Path packPath, String packFileName
 	/** The pack's own file with {@code options.txt} over it, ready to build the pack with. */
 	public SettingsLayers.Resolved settings() {
 		return SettingsLayers.resolve(this.saved, this.forced);
+	}
+
+	/**
+	 * Iris's F3 profile sentence for what is drawn right now, not for what the settings screen
+	 * is about to apply. Built from the same scan the selector uses
+	 * ({@link dev.vitrail.pack.menu.MenuValues#profileInfo}).
+	 */
+	public String profileInfo() {
+		return MenuValues.of(this.menu, this.saved.values(), forcedText()).profileInfo();
 	}
 
 	/**

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -281,9 +281,9 @@ than in the light's clip space, which is also the space the boxes arrive in, so 
 is owed anywhere: the light's own volume never enters the cull at all.
 
 What this buys is read off the log, where the shadow stage prints how many sections the light walked,
-how many the camera walked and which shape was used, or off the debug screen, which carries the shape
-and the count that survived it. The picture is the place it will NOT show, because keeping a section
-too many costs a draw and not a pixel.
+how many the camera walked and which shape was used. The debug screen carries only the counts,
+`Shadows: C: a/b D: d`, and not the shape. The picture is the place it will NOT show, because keeping
+a section too many costs a draw and not a pixel.
 
 All of the above is about the terrain. What moves is culled separately, and there is an open
 divergence there worth stating plainly, because it is a gap and not a workaround. A caster is


### PR DESCRIPTION
## What changes

F3 names the pack the way Iris does. The profile line is the scanned name or Custom, with how many options sit outside it. The shadow line is Sodium's `Shadows: C: a/b D: d`, without this engine's own cull dialect. The log still prints the shape the light walked.

## How it differs from the reference, and for what obstacle

It does not, on the words. Iris prints the profile name and a dirty count; Sodium prints `C: a/b D: d`. This engine used to print its own cull shape on F3. That shape still exists and still lives in the log.

## What proves it

- [x] `gradlew build` green.
- [ ] The out-of-game harness, and which corpus it ran over.
- [ ] In the game: which pack, which place, and what was looked at.

## What it leaves owing

Nothing. The cull shape is still in the log, not on F3.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
