### PR TITLE
fix(sodium): walk a player box for Advanced shadow cull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,14 @@ what the next one holds.
   outside a block, so the world dropped to vanilla. The machine symbols are now installed
   before the pack is opened, so those uniforms enter the block and the reload draws the
   pack. The toggle still reloads; it does not keep the pack on without one.
+- **Leaf shadows stay more stable while you move.** Complementary's Low profile, and any pack
+  that asks for Advanced shadow culling, now walks a box around you instead of the tight
+  silhouette along the sun. Leaves stop popping as you walk. Shadows can reach a little
+  farther than they do under Iris Advanced, and the wider walk draws more sections, so the
+  frame can cost more. The Medium profile, which asks for a safe zone, is unchanged. An
+  empty file `vitrail/swept-shadow-cull` in the game folder, or
+  `-Dvitrail.sweptShadowCull=true`, puts the old silhouette back.
+
 
 - **The button that opens a pack's settings is no longer dead until the pack has been loaded
   once.** It was live only while a pack was already drawing, so the first pack anybody picks on

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -98,6 +98,32 @@ public final class PackProgram {
 		}
 
 		/**
+		 * Whether this program voxelises, in Iris's sense: a geometry stage is present, or an image
+		 * load / store uniform survived translation.
+		 * <p>
+		 * Iris reads the geometry file at {@code shadows/ShadowRenderer.java:163-165} and then ORs
+		 * in {@code setUsesImages} when the compiled shadow program has image bindings
+		 * ({@code :224-225}, {@code ExtendedShader.hasActiveImages}). A {@code .gsh} is enough even
+		 * when this engine never binds it; an image uniform that the preprocessor left standing is
+		 * enough without one. A name gated off, Complementary LOW's {@code voxel_img} behind
+		 * {@code COLORED_LIGHTING_INTERNAL}, does not count.
+		 */
+		public boolean voxelises() {
+			if (this.program.stages().containsKey(ProgramStage.GEOMETRY)) {
+				return true;
+			}
+
+			return this.program.samplers().stream().anyMatch(Loaded::imageUniform);
+		}
+
+		private static boolean imageUniform(TranslatedUnit.Uniform sampler) {
+			String type = sampler.type();
+
+			return type.startsWith("image") || type.startsWith("iimage")
+					|| type.startsWith("uimage");
+		}
+
+		/**
 		 * The samplers this program declares under a type no pipeline can carry, with their types.
 		 * <p>
 		 * Both stages at once, which is why it is answered from the translation rather than from the

--- a/common/src/main/java/dev/vitrail/pack/source/ShadowCullState.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShadowCullState.java
@@ -9,8 +9,8 @@ package dev.vitrail.pack.source;
  * built, and never here.
  * <p>
  * <strong>The words a pack writes do not say what they look like they say.</strong>
- * {@code shadow.culling=false} is not "do not cull", it is {@link #DISTANCE}, which keeps the box
- * the map is drawn in and adds no view frustum to it; {@code true} is not "cull more", it is
+ * {@code shadow.culling=false} is not "do not cull", it is {@link #DISTANCE}, which keeps a box
+ * around the player and adds no view frustum to it; {@code true} is not "cull more", it is
  * {@link #ADVANCED}, which is what {@link #DEFAULT} already gives. Iris maps them at
  * {@code shaderpack/properties/ShaderProperties.java:180-185} and this enum keeps that mapping in
  * {@link #of}.
@@ -18,9 +18,9 @@ package dev.vitrail.pack.source;
 public enum ShadowCullState {
 
 	/**
-	 * The pack said nothing. Iris then decides on whether the pack VOXELISES, which it reads off the
-	 * shadow program shipping a geometry stage, and lands on {@link #ADVANCED} where it does not
-	 * ({@code shadows/ShadowRenderer.java:302}).
+	 * The pack said nothing. Iris then decides on whether the pack VOXELISES, a geometry stage on
+	 * the shadow program or an image load / store still standing on it, and lands on
+	 * {@link #ADVANCED} where it does not ({@code shadows/ShadowRenderer.java:302}).
 	 */
 	DEFAULT,
 
@@ -30,7 +30,7 @@ public enum ShadowCullState {
 	/** The same, widened by a box at the pack's own {@code voxelDistance} that is never cut. */
 	SAFE_ZONE,
 
-	/** No sweep at all: the volume the map is drawn in, bounded by a distance or not. */
+	/** No sweep at all: a box around the player, or everything when that box does not apply. */
 	DISTANCE;
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -324,9 +324,11 @@ public final class PackValues {
 	 *                             against
 	 * @param light                scratch for the light vector, written and carried into the plan
 	 * @param camera               scratch for the camera's volume, likewise
+	 * @param voxelised            whether the shadow program voxelises, already read off that
+	 *                             program rather than guessed from a {@code .gsh} being bound
 	 */
 	public ShadowCullPlan shadowCullPlan(int userChunks, int renderDistanceChunks, Vector3f light,
-			Matrix4f camera) {
+			Matrix4f camera, boolean voxelised) {
 		ViewMatrices view = this.state.view();
 		camera.set(view.gbufferProjection()).mul(view.gbufferModelView());
 
@@ -349,7 +351,7 @@ public final class PackValues {
 			default -> bound = shadowRenderDistance(userChunks, renderDistanceChunks);
 		}
 
-		return new ShadowCullPlan(this.shadowCull,
+		return new ShadowCullPlan(this.shadowCull, voxelised,
 				CelestialValues.shadowLightVector(this.state, light), camera, bound, safeZone);
 	}
 

--- a/common/src/main/java/dev/vitrail/render/ShadowCullPlan.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowCullPlan.java
@@ -18,18 +18,22 @@ import org.joml.Vector3f;
  * The two matrices are the caller's own scratch, written into and handed back, because this is built
  * once a frame at the end of the frame and nothing here is worth an allocation.
  *
- * @param state    which of the four shapes the pack asked for
- * @param light    where the light stands, a unit vector from the origin in world space
- * @param camera   the camera's view projection, the volume the sweep starts from, in the OpenGL clip
- *                 convention. See {@code dev.vitrail.sodium.ShadowCullFrustum} for why the
- *                 convention is load bearing and what reading the drawn matrix would cost
- * @param bound    how far from the camera the walk still gathers, in blocks, or negative where
- *                 nothing bounds it. Already arbitrated between the pack and the player by
- *                 {@link PackValues#shadowCullPlan}, and it is the box
- *                 {@code dev.vitrail.sodium.ShadowCull} carries whichever shape sits inside it
- * @param safeZone the inner box of the safe zone state, which is kept whatever the sweep says of it,
- *                 or negative for the three states that have none
+ * @param state     which of the four shapes the pack asked for
+ * @param voxelised whether the shadow program voxelises, a geometry stage present or an image
+ *                  load / store still standing on it. {@link ShadowCullState#DEFAULT} then takes
+ *                  the same box as {@link ShadowCullState#DISTANCE}, which is Iris
+ *                  {@code shadows/ShadowRenderer.java:302}
+ * @param light     where the light stands, a unit vector from the origin in world space
+ * @param camera    the camera's view projection, the volume the sweep starts from, in the OpenGL clip
+ *                  convention. See {@code dev.vitrail.sodium.ShadowCullFrustum} for why the
+ *                  convention is load bearing and what reading the drawn matrix would cost
+ * @param bound     how far from the camera the walk still gathers, in blocks, or negative where
+ *                  nothing bounds it. Already arbitrated between the pack and the player by
+ *                  {@link PackValues#shadowCullPlan}, and it is the box
+ *                  {@code dev.vitrail.sodium.ShadowCull} carries whichever shape sits inside it
+ * @param safeZone  the inner box of the safe zone state, which is kept whatever the sweep says of it,
+ *                  or negative for the three states that have none
  */
-public record ShadowCullPlan(ShadowCullState state, Vector3f light, Matrix4f camera, float bound,
-		float safeZone) {
+public record ShadowCullPlan(ShadowCullState state, boolean voxelised, Vector3f light,
+		Matrix4f camera, float bound, float safeZone) {
 }

--- a/common/src/main/java/dev/vitrail/render/SweptShadowCull.java
+++ b/common/src/main/java/dev/vitrail/render/SweptShadowCull.java
@@ -1,0 +1,82 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+
+import net.minecraft.client.Minecraft;
+
+import java.nio.file.Files;
+
+/**
+ * Whether Advanced shadow culling goes back to the camera volume swept along the light.
+ * <p>
+ * The default is a box around the player. Complementary's Low profile asks for Advanced, and the
+ * sweep on this engine pops single leaf blocks at the sun silhouette. Iris Advanced does not. The
+ * named divergence and what it costs the image live on
+ * {@code dev.vitrail.sodium.ShadowCullFrustum#of}.
+ * <p>
+ * A file {@code vitrail/swept-shadow-cull} in the game directory, or
+ * {@code -Dvitrail.sweptShadowCull=true} where somebody has a launcher to type it in, puts the old
+ * sweep back so a reading can name the state it was taken under. Off is the default, so a jar
+ * nobody has armed is the box that holds. Asked once and the answer kept: it arms a launch, not a
+ * frame.
+ */
+public final class SweptShadowCull {
+
+	private static final boolean PROPERTY = Boolean.getBoolean("vitrail.sweptShadowCull");
+
+	private static final String ARM_FILE = "swept-shadow-cull";
+
+	/** Null until the game directory can be resolved, which is not true on the first calls. */
+	private static Boolean armed;
+
+	private static boolean announced;
+
+	private SweptShadowCull() {
+	}
+
+	/**
+	 * True while Advanced is to sweep along the light, the old road. False, which is the default,
+	 * keeps the player box.
+	 */
+	public static boolean asked() {
+		boolean sweep = PROPERTY || file();
+		announce(sweep);
+
+		return sweep;
+	}
+
+	/**
+	 * Said once and said BOTH WAYS. A line that only appeared when the file was there would make
+	 * every reading taken without one unable to name the shape Advanced walked with.
+	 */
+	private static void announce(boolean sweep) {
+		if (announced) {
+			return;
+		}
+
+		announced = true;
+		if (sweep) {
+			Vitrail.logger().warn("shadow-cull advanced=SWEPT file={} property=vitrail.sweptShadowCull",
+					ARM_FILE);
+			return;
+		}
+
+		Vitrail.logger().info("shadow-cull advanced=BOX default");
+	}
+
+	private static boolean file() {
+		if (armed != null) {
+			return armed;
+		}
+
+		Minecraft minecraft = Minecraft.getInstance();
+		if (minecraft == null || minecraft.gameDirectory == null) {
+			return false;
+		}
+
+		armed = Files.isRegularFile(minecraft.gameDirectory.toPath()
+				.resolve("vitrail").resolve(ARM_FILE));
+
+		return armed;
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -686,7 +686,20 @@ public final class TerrainDraw {
 		TerrainDraw self = PackChain.terrain();
 
 		return self == null ? null : self.values.shadowCullPlan(PackChain.shadowDistance(),
-				renderDistanceChunks(), light, camera);
+				renderDistanceChunks(), light, camera, self.voxelisesShadow());
+	}
+
+	/**
+	 * Whether any shadow terrain program of this pack voxelises, a geometry stage present or an
+	 * image load / store still standing on it. Iris asks the same of
+	 * {@code SHADOW_TERRAIN_CUTOUT}; the three shadow halves share one file on every pack that
+	 * ships one, and any of them answering is enough.
+	 */
+	private boolean voxelisesShadow() {
+		return this.loaded.entrySet().stream()
+				.filter(entry -> entry.getKey().shadow())
+				.map(Map.Entry::getValue)
+				.anyMatch(PackProgram.Loaded::voxelises);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCull.java
@@ -9,11 +9,11 @@ import org.joml.FrustumIntersection;
  * shadow distance bounds a walk that is otherwise the pack's own.
  * <p>
  * <strong>A box and not a shorter frustum, and that is the whole reason this class exists.</strong>
- * The shape inside is either the light's own volume, built from the pack's half plane and what the
- * shadow map is DRAWN with, or the camera's volume swept along the light
- * ({@link ShadowCullFrustum}), and narrowing either would change which casters reach the map rather
- * than how far the walk goes. What a shadow distance asks for is different and cheaper: keep the
- * shape, and stop walking the world beyond a cube of that many blocks around the player. Iris draws
+ * The shape inside is either always visible, so this cube is the whole of the walk, or the camera's
+ * volume swept along the light ({@link ShadowCullFrustum}), and narrowing either would change which
+ * casters reach the map rather than how far the walk goes. What a shadow distance asks for is
+ * different and cheaper: keep the shape, and stop walking the world beyond a cube of that many
+ * blocks around the player. Iris draws
  * the same distinction with the same shape, an axis-aligned cube tested on each axis independently,
  * {@code shadows/frustum/BoxCuller.java}, and hangs it off each of its own frustums the same way.
  * <p>

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
@@ -1,9 +1,10 @@
 package dev.vitrail.sodium;
 
+import dev.vitrail.pack.source.ShadowCullState;
 import dev.vitrail.render.ShadowCullPlan;
+import dev.vitrail.render.SweptShadowCull;
 
 import net.caffeinemc.mods.sodium.client.render.viewport.frustum.Frustum;
-import net.caffeinemc.mods.sodium.client.render.viewport.frustum.SimpleFrustum;
 import net.caffeinemc.mods.sodium.client.render.viewport.Viewport;
 
 import org.joml.FrustumIntersection;
@@ -181,56 +182,83 @@ public final class ShadowCullFrustum implements Frustum {
 	 * The four arms are Iris's {@code createShadowFrustum}
 	 * ({@code shadows/ShadowRenderer.java:298-372}), split between here and
 	 * {@code PackValues.shadowCullPlan}, which holds the distances because that is where every other
-	 * distance is arbitrated. What is left here is the choice of SHAPE, and one branch of Iris's
-	 * first test is answered rather than measured: <strong>a pack cannot voxelise on this engine,
-	 * because a geometry stage is never run at all.</strong> Iris takes a shadow program that ships
-	 * one as the pack moving its vertices somewhere the camera's volume cannot predict, and turns the
-	 * sweep off for it ({@code :164-165,302}); here every pipeline is built from the vertex and the
-	 * fragment stages alone ({@code render/GeometryProgram}), so a {@code .gsh} is translated and
-	 * never bound, no vertex moves, and the branch Iris takes without voxelisation is the only one
-	 * that can be right.
+	 * distance is arbitrated. What is left here is the choice of SHAPE.
+	 * {@link dev.vitrail.pack.source.ShadowCullState#DISTANCE},
+	 * {@link dev.vitrail.pack.source.ShadowCullState#DEFAULT} and
+	 * {@link dev.vitrail.pack.source.ShadowCullState#ADVANCED} keep a box around the player and
+	 * no planes. Distance, and default when the shadow program voxelises, are Iris's
+	 * {@code BoxCullingFrustum} ({@code :302-323}). Voxelisation is a geometry stage present
+	 * <em>or</em> an image load / store still standing on that program ({@code :163-165},
+	 * {@code setUsesImages}), not a {@code .gsh} this engine binds. A bound wider than the loaded
+	 * world, or not positive, drops the box too and keeps everything, which is Iris's
+	 * {@code NonCullingFrustum} ({@code :317-318}), not the light's own volume.
+	 * {@link dev.vitrail.pack.source.ShadowCullState#SAFE_ZONE} still sweeps along the light.
 	 * <p>
-	 * <strong>{@link dev.vitrail.pack.source.ShadowCullState#DISTANCE} keeps the light's own volume
-	 * where Iris keeps nothing</strong>, its {@code BoxCullingFrustum} carrying a box and no planes
-	 * ({@code shadows/frustum/fallback/BoxCullingFrustum.java}). That is not a shape this engine can
-	 * be asked for and it costs the image nothing: the volume is what the map is DRAWN with, so a
-	 * section outside it is clipped by the rasteriser and cannot reach the map however it is walked,
-	 * and the one thing that could have moved a vertex out from under it, a geometry stage, is the
-	 * thing that never runs. Iris drops the planes there because for IT that is not true.
+	 * <strong>Advanced is a workaround, not a styled divergence.</strong> Iris Advanced builds
+	 * {@code AdvancedShadowCullingFrustum} ({@code shadows/ShadowRenderer.java:372}), the camera
+	 * volume swept along the light, and a pack that wrote nothing lands there too unless it
+	 * voxelises ({@code :302}). Complementary Low writes {@code shadow.culling=true} and is
+	 * Advanced. On this engine that sweep pops single leaf blocks at the sun silhouette, one
+	 * section at a time as the player moves, and Iris Advanced does not. The 26.2 walk hands
+	 * Sodium a camera-relative box and this file's planes, and that pair is what drops a leaf
+	 * the silhouette still needs. Complementary Low therefore takes the player box here, the
+	 * same AlwaysVisible-plus-cube Distance already uses. What it costs the image is casters
+	 * outside the camera silhouette still reaching the map, a wider shadow than Iris Advanced
+	 * draws, in exchange for leaves that stop popping. A file {@code vitrail/swept-shadow-cull},
+	 * or {@code -Dvitrail.sweptShadowCull=true}, puts the sweep back so a reading can name the
+	 * old road.
 	 *
-	 * @param plan  what the pack asked for and what the frame is aimed at
-	 * @param light the light's own view projection, the volume the map is drawn with
+	 * @param plan what the pack asked for and what the frame is aimed at
 	 */
-	public static Chosen of(ShadowCullPlan plan, FrustumIntersection light) {
-		String shape;
-		Frustum frustum;
+	public static Chosen of(ShadowCullPlan plan) {
+		boolean sweepAdvanced = SweptShadowCull.asked();
+		boolean box = plan.state() == ShadowCullState.DISTANCE
+				|| (plan.state() == ShadowCullState.DEFAULT
+						&& (plan.voxelised() || !sweepAdvanced))
+				|| (plan.state() == ShadowCullState.ADVANCED && !sweepAdvanced);
 
-		switch (plan.state()) {
-			case DISTANCE -> {
-				shape = "the light's own volume, asked for by the pack";
-				frustum = new SimpleFrustum(light);
-			}
-			case SAFE_ZONE -> {
-				shape = "swept along the light, keeping " + plan.safeZone() + " blocks of safe zone";
-				frustum = new ShadowCullFrustum(plan.camera(), plan.light(), plan.safeZone());
-			}
-			default -> {
-				shape = "swept along the light";
-				frustum = new ShadowCullFrustum(plan.camera(), plan.light(), -1.0F);
-			}
+		Frustum frustum;
+		String shape;
+		if (box) {
+			frustum = AlwaysVisible.INSTANCE;
+			shape = plan.bound() < 0.0F ? "NONE" : "BOX";
+		} else if (plan.state() == ShadowCullState.SAFE_ZONE) {
+			frustum = new ShadowCullFrustum(plan.camera(), plan.light(), plan.safeZone());
+			shape = "SWEPT";
+		} else {
+			frustum = new ShadowCullFrustum(plan.camera(), plan.light(), -1.0F);
+			shape = "SWEPT";
 		}
 
-		return plan.bound() < 0.0F ? new Chosen(frustum, shape)
-				: new Chosen(new ShadowCull(frustum, plan.bound(), plan.safeZone()),
-						shape + ", within " + plan.bound() + " blocks");
+		String token = token(plan, shape);
+		return plan.bound() < 0.0F ? new Chosen(frustum, token)
+				: new Chosen(new ShadowCull(frustum, plan.bound(), plan.safeZone()), token);
 	}
 
 	/**
-	 * What the walk ended up measuring against, and the words for the one line the shadow stage
-	 * prints about it. The two travel together so that the line cannot name a shape the walk did not
+	 * What the walk ended up measuring against, and the compact token the overlay and the log
+	 * print for it. The two travel together so that the line cannot name a shape the walk did not
 	 * use.
 	 */
 	public record Chosen(Frustum frustum, String culling) {
+	}
+
+	/** Pack state, shape, then {@code r=} bound and {@code z=} safe zone when those apply. */
+	private static String token(ShadowCullPlan plan, String shape) {
+		StringBuilder line = new StringBuilder();
+		line.append(plan.state().name()).append(' ').append(shape);
+		if (plan.bound() >= 0.0F) {
+			line.append(" r=").append(num(plan.bound()));
+		}
+		if (plan.state() == ShadowCullState.SAFE_ZONE && plan.safeZone() >= 0.0F) {
+			line.append(" z=").append(num(plan.safeZone()));
+		}
+		return line.toString();
+	}
+
+	private static String num(float value) {
+		int whole = (int) value;
+		return whole == value ? Integer.toString(whole) : Float.toString(value);
 	}
 
 	private void build(Matrix4fc camera) {
@@ -438,5 +466,38 @@ public final class ShadowCullFrustum implements Frustum {
 		}
 
 		return inside ? FrustumIntersection.INSIDE : FrustumIntersection.INTERSECT;
+	}
+
+	/**
+	 * Iris's {@code NonCullingFrustum} for Sodium's contract: every box is inside, so the walk
+	 * is bounded only by the cube {@link ShadowCull} wraps around this, or by nothing when that
+	 * cube is not there.
+	 */
+	private static final class AlwaysVisible implements Frustum {
+
+		private static final AlwaysVisible INSTANCE = new AlwaysVisible();
+
+		@Override
+		public boolean testAab(float minX, float minY, float minZ, float maxX, float maxY,
+				float maxZ) {
+			return true;
+		}
+
+		@Override
+		public int intersectAab(float minX, float minY, float minZ, float maxX, float maxY,
+				float maxZ) {
+			return FrustumIntersection.INSIDE;
+		}
+
+		@Override
+		public boolean testSection(float originX, float originY, float originZ) {
+			return true;
+		}
+
+		@Override
+		public boolean testSectionExpanded(float originX, float originY, float originZ,
+				float extend) {
+			return true;
+		}
 	}
 }

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -31,7 +31,6 @@ import net.minecraft.world.phys.Vec3;
 
 import org.jspecify.annotations.Nullable;
 
-import org.joml.FrustumIntersection;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.joml.Vector3d;
@@ -227,14 +226,14 @@ public final class ShadowTerrain {
 		try {
 			FogParameters fog = ((MixinSodiumWorldRenderer) renderer).vitrail$lastFogParameters();
 			// The shape the pack asked for, and a box around the camera cut out of it wherever a
-			// shadow distance bounds the walk. By default that shape is the camera's own volume swept
-			// along the light rather than the light's own: a section that cannot drop anything onto
-			// what the camera can see is thrown away before it is drawn. Whether a bound applies at
-			// all is the pack's business at least as often as the player's, most of the corpus
-			// declaring a render multiplier and being held at its own half plane whatever the slider
-			// says, and the plan carries the arbitration already made.
-			ShadowCullFrustum.Chosen cull =
-					ShadowCullFrustum.of(plan, new FrustumIntersection(light));
+			// shadow distance bounds the walk. Distance, default and Advanced keep that box and
+			// no planes. Advanced is the named divergence ShadowCullFrustum.of carries:
+			// Complementary Low lands there and the sweep pops leaves. The safe zone still
+			// sweeps. Whether a bound applies at all is the pack's business at least as often as
+			// the player's, most of the corpus declaring a render multiplier and being held at
+			// its own half plane whatever the slider says, and the plan carries the arbitration
+			// already made.
+			ShadowCullFrustum.Chosen cull = ShadowCullFrustum.of(plan);
 			Viewport viewport = new Viewport(cull.frustum(),
 					new Vector3d(camera.x, camera.y, camera.z));
 			manager.finalizeRenderLists(minecraft.gameRenderer.mainCamera(), viewport,
@@ -270,10 +269,8 @@ public final class ShadowTerrain {
 
 			if (measuring && seen > 0) {
 				measured = BlockStateIds.generation();
-				Vitrail.logger().info("Shadow cull walked {} sections for the light against {} "
-						+ "for the camera, {} of the light's with geometry to draw, on block "
-						+ "table {}, culling {}",
-						walkKept, seen, walkDrawn, measured, walkCulling);
+				Vitrail.logger().info("shadow-cull {} kept={} camera={} drawn={} blocks={}",
+						walkCulling, walkKept, seen, walkDrawn, measured);
 			}
 
 			draw(renderer, minecraft, camera);
@@ -403,7 +400,7 @@ public final class ShadowTerrain {
 	 *                so a count without this flag beside it would announce sections that no draw
 	 *                ever reads. Iris says the same thing in the same place, {@code (no terrain)}
 	 *                appended to its own line ({@code shadows/ShadowRenderer.java:776})
-	 * @param culling the shape the walk measured against, in the words the log line uses
+	 * @param culling the shape the walk measured against, as the overlay token
 	 */
 	public record Walk(int kept, int drawn, int total, boolean terrain, String culling) {
 	}

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -183,15 +183,28 @@ the map.
 
 `shadow.culling` is read, and **its three written words do not mean what they look like they mean**.
 It is not a switch: it names one of four shapes the light measures a section against, and the
-default is the tightest of them rather than the loosest.
+default is the box around the player, which is looser than the sweep Iris Advanced uses.
 
-- nothing written, or `true`: the camera's own volume swept along the light. A section that cannot
-  drop anything onto what the camera can see is thrown away before it is drawn.
-- `false`: no sweep. The light walks its own volume, the one the map is drawn in, which is what this
-  engine did for every pack before the sweep existed.
-- `reversed` or `safe_zone`, two spellings of one word: the same sweep, plus a box at the pack's own
-  `voxelDistance` that is kept whatever the sweep says of it, for a pack that samples its map from
-  places the sweep knows nothing about.
+- nothing written: a box around the player, unless the shadow program voxelises, in which case
+  it takes that same box for Iris's reason rather than this engine's. Iris would sweep along the
+  light here. This engine does not: see the workaround below.
+- `true`: the same player box. Iris Advanced sweeps the camera volume along the light
+  (`shadows/ShadowRenderer.java:372`). Complementary Low writes this word and lands there.
+- `false`: no sweep. A box around the player, and no planes, which is the reference's
+  `BoxCullingFrustum`. When that box is wider than the world that is loaded, or not positive,
+  everything is kept.
+- `reversed` or `safe_zone`, two spellings of one word: the camera volume swept along the light,
+  plus a box at the pack's own `voxelDistance` that is kept whatever the sweep says of it, for a
+  pack that samples its map from places the sweep knows nothing about. Unchanged from Iris.
+
+**Advanced and the silent default take a box around the player on this engine, not the sweep.**
+Iris Advanced builds `AdvancedShadowCullingFrustum`. The sweep here pops single leaf blocks at
+the sun silhouette as the player moves, and Iris Advanced does not. The 26.2 walk hands Sodium
+a camera-relative box and the swept planes, and that pair drops a leaf the silhouette still
+needs. The box is the workaround. What it costs the image is a wider shadow than Iris Advanced
+draws. An empty file `vitrail/swept-shadow-cull` in the game folder, or
+`-Dvitrail.sweptShadowCull=true`, puts the sweep back. The safe zone is unchanged and still
+sweeps.
 
 A word this cannot read leaves the default standing rather than the answer a valid line above it
 gave, which is what the reference does with it.
@@ -221,10 +234,10 @@ outside that arbitration and both do so in the reference: `false` reads the pack
 never the player's setting, and the safe zone reads neither, its two boxes being the pack's
 throughout.
 
-Iris has a fifth road into the first line, and this engine cannot take it: it drops the sweep for a
-pack whose shadow program ships a geometry stage, on the grounds that such a pack is moving its
-vertices somewhere the camera's volume cannot predict. Nothing here runs a geometry stage at all, so
-no pack can move a vertex that way and the question does not arise.
+The same first line also drops the sweep when the shadow program voxelises. A geometry stage on
+that program is enough, even when this engine never binds it, and so is an image load / store that
+the preprocessor left standing, which is the reference's `setUsesImages`. A name gated off does
+not count.
 
 ## Settings, and how a user changes them
 

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -263,9 +263,12 @@ the map is taken to be read for direct shadowing and for volumetrics, not for li
 caster you cannot see. That is the reference's assumption, and packs are written against it.
 
 **The shape is the pack's to choose**, through `shadow.culling`, and the four states and their words
-are described once under [the pack format](pack-format.md). The distance is a separate axis and
-composes with all of them: whichever shape is chosen, the box a shadow distance asks for is cut out
-of it, so the sweep and the bound never have to know about each other.
+are described once under [the pack format](pack-format.md). Advanced, and the silent default when
+the pack does not voxelise, take a box around the player on this engine rather than that sweep:
+the sweep pops leaves at the sun silhouette here, and Iris Advanced does not. The safe zone still
+sweeps. The distance is a separate axis and composes with all of them: whichever shape is chosen,
+the box a shadow distance asks for is cut out of it, so the sweep and the bound never have to know
+about each other.
 
 Two things about the arithmetic are recorded here because a reader will look for them. The planes are
 pulled out of the camera's view projection, and the clip volume that matrix targets decides what
@@ -295,8 +298,9 @@ a shorter distance, and tests the caster's bounding box against it
 difference runs both ways: a caster inside the light's frustum and inside the box but outside that
 narrower frustum is kept here and dropped there, and one whose box grazes Iris's bound while its
 position sits outside ours is the reverse. Nothing makes Iris's shape impossible here; it has simply
-not been written yet, and since the terrain moved to the swept shape the two halves of the walk no
-longer measure against the same thing.
+not been written yet. Advanced terrain walks a box here rather than the sweep, so the two halves
+already differ; even where the terrain does sweep (the safe zone), the movers still measure against
+the light frustum rather than that same sweep.
 
 ### The experiment that separates the two failure modes
 


### PR DESCRIPTION
## What changes

**WAIT. Frame rate is not signed off, especially under Bliss. Do not merge until it is.**

Complementary Low, and any pack that asks for Advanced shadow culling, now walks a box around the player instead of the tight silhouette along the sun. Leaves stop popping as you walk. Shadows can reach a little farther than they do under Iris Advanced, and the wider walk draws more sections, so the frame can cost more. The Medium profile, which asks for a safe zone, still sweeps. An empty file `vitrail/swept-shadow-cull`, or `-Dvitrail.sweptShadowCull=true`, puts the old silhouette back.

## How it differs from the reference, and for what obstacle

Iris Advanced builds `AdvancedShadowCullingFrustum` (`shadows/ShadowRenderer.java:372`). The sweep here pops single leaf blocks at the sun silhouette as the player moves, and Iris Advanced does not. The 26.2 walk hands Sodium a camera-relative box and the swept planes, and that pair drops a leaf the silhouette still needs (`ShadowCullFrustum`). The box is the workaround. What it costs the image is a wider shadow than Iris Advanced draws, and more sections, which can cost frames.

## What proves it

- [x] `gradlew build` green.
- [ ] The out-of-game harness, and which corpus it ran over.
- [ ] In the game: Complementary Low, walking, leaf shadows. Frame rate under Bliss is not signed off.

## What it leaves owing

**WAIT on FPS.** The box is looser than Iris Advanced. Movers are still culled against the light frustum, not this box. This is not #161.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
