### PR TITLE
fix(render): hold the shadow camera across a skipped map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,12 @@ what the next one holds.
 
 ### Fixed
 
+- **A skipped shadow map no longer walks the light with the player.** When the shadow stage
+  opens and then gives up without drawing, the published matrices now keep the camera of the
+  frame that last drew the map, instead of treating the miss as a fresh map. Written for the
+  Mac reports on #161 where lighting followed the player. It has not been tried on a Mac
+  from this machine.
+
 - **The button that opens a pack's settings is no longer dead until the pack has been loaded
   once.** It was live only while a pack was already drawing, so the first pack anybody picks on
   a fresh install could not be configured at all: the only way in was to load it at whatever

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -3,6 +3,7 @@ package dev.vitrail.render;
 import dev.vitrail.dh.DhDepth;
 import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.target.PackDirectives;
+import dev.vitrail.sodium.ShadowTerrain;
 import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.values.FrameSmoothed;
 import dev.vitrail.uniform.WorldState;
@@ -490,7 +491,7 @@ public final class FrameState implements WorldState {
 				this.directives.shadowIntervalSize(), this.shift.unshifted(),
 				this.directives.shadowDistance(), this.directives.shadowNearPlane(),
 				this.directives.shadowFarPlane(), inEndFlash(), this.endFlashXAngle,
-				this.endFlashYAngle);
+				this.endFlashYAngle, ShadowTerrain.takeMapState() == ShadowTerrain.MapState.SKIPPED);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -65,23 +65,29 @@ public final class ViewMatrices implements ViewSource {
 	private final Matrix4f shadowProjectionInverse = new Matrix4f();
 
 	/**
-	 * The pair the shadow map on hand was drawn with, which is the previous frame's, because the map
+	 * The pair the shadow map on hand was drawn with, usually the previous frame's, because the map
 	 * is drawn at the end of a frame for the next one. It is what every sampling pass is told as
 	 * {@code shadowModelView}, and it is the drawn pair moved onto this frame's camera.
 	 * <p>
 	 * <strong>That move is not a refinement, it is the difference between a lookup that lands and
 	 * one that does not.</strong> These matrices act on player space, and player space is the world
 	 * measured from wherever the camera of the frame doing the measuring stands. The map was drawn
-	 * around where the camera stood a frame ago, so the drawn matrix handed over as it is asks about
-	 * the point one frame of camera motion away from the one being shaded, and every shadow in the
-	 * picture sits that far out of place for as long as the player is moving. Adding the motion back
-	 * costs one translation and makes this pair say exactly what the map holds.
+	 * around where the camera stood when it was drawn, so the drawn matrix handed over as it is asks
+	 * about a point that far away from the one being shaded, and every shadow in the picture sits
+	 * that far out of place for as long as the player is moving. Adding the motion back costs one
+	 * translation and makes this pair say exactly what the map holds.
+	 * <p>
+	 * <strong>Usually the previous frame's, and not always, which is why the distance is measured
+	 * rather than assumed.</strong> The shadow stage opens and gives up without drawing on several
+	 * roads, so the map can be older than one frame with nothing saying so, and the motion added
+	 * back is the motion since the frame that really drew. {@code heldShadowModelView} holds that
+	 * pair.
 	 * <p>
 	 * Publishing the fresh pair instead does not do it either, and that is worth saying because it
 	 * looks like it should: the grid snap the pair carries is a function of the camera, so it lands
 	 * on the same place while the camera stays inside a cell and jumps a whole cell the frame it
-	 * leaves one, which is a map read a hundred texels out for that frame. What is left a frame late
-	 * here is the sun angle alone.
+	 * leaves one, which is a map read a hundred texels out for that frame. What is left late here is
+	 * the sun angle alone, and one frame of it on every frame that drew.
 	 */
 	private final Matrix4f mapShadowModelView = new Matrix4f();
 	private final Matrix4f mapShadowModelViewInverse = new Matrix4f();
@@ -90,6 +96,30 @@ public final class ViewMatrices implements ViewSource {
 
 	/** Where the camera stood when the pair above was built, so the re-origin has a distance. */
 	private final Vector3d shadowCamera = new Vector3d();
+
+	/**
+	 * The pair the map ON HAND was really drawn with, before any re-origin, and where the camera
+	 * stood at that moment. Where no stage is running at all there is no map on hand, and these
+	 * follow the fresh pair every frame instead, which is what a skipped-false, drew-false frame
+	 * asks for and what keeps the sun turning in the four matrices the whole corpus reads
+	 * regardless.
+	 * <p>
+	 * <strong>Kept apart from the frame's own history because the two only agree while every frame
+	 * draws a map.</strong> The shadow stage returns without drawing on several roads and its
+	 * throws are caught rather than fatal, so the map can be two frames old or older with nothing
+	 * saying so. Measuring the re-origin from here rather than from the previous frame is what makes
+	 * it the real distance instead of one frame of it, and the difference is exactly what a player
+	 * sees as the shadows sliding while they walk.
+	 * <p>
+	 * <strong>Held is not the same word as drawn</strong>, and the distinction is worth the longer
+	 * name: {@link #drawnShadowModelView()} answers the pair the map ABOUT to be drawn will use,
+	 * which is this frame's, where these three are the pair the map already on hand was drawn with,
+	 * which may be several frames old.
+	 */
+	private final Matrix4f heldShadowModelView = new Matrix4f();
+	private final Matrix4f heldShadowProjection = new Matrix4f();
+	private final Matrix4f heldShadowProjectionInverse = new Matrix4f();
+	private final Vector3d heldCamera = new Vector3d();
 
 	private final Vector4f convention = new Vector4f(ClipSpace.REVERSED);
 
@@ -399,24 +429,44 @@ public final class ViewMatrices implements ViewSource {
 	 * it stands.
 	 *
 	 * @param shadowAngle the angle of whichever body is casting, already divided by 360
+	 * @param skipped     true when the shadow stage opened and gave up without drawing, so the map
+	 *                    on hand is older than one frame and the held pair must not be overwritten
 	 */
 	void advanceShadow(float shadowAngle, float sunPathRotation, float intervalSize,
 			Vector3dc camera, float distance, float nearPlane, float farPlane, boolean endFlash,
-			float flashXAngle, float flashYAngle) {
-		// Shifted down before the fresh pair is built, the same move advance makes for previous:
-		// what was drawn with last frame is what the map on hand holds.
+			float flashXAngle, float flashYAngle, boolean skipped) {
+		// Shifted down before the fresh pair is built, the same move advance makes for previous,
+		// but NOT on a frame that opened a stage and gave up: what the map holds then is what an
+		// earlier draw was given, and that frame left it exactly where it was.
+		//
+		// A frame that ran no stage at all shifts like any other, and leaving it out is what turned
+		// this guard into a defect worse than the one it fixes. Nothing samples a map then, the
+		// stage being closed by a pack without a shadow program, by a shadow distance of nought or
+		// by a stage that failed and emptied the map behind it, but the four matrices are read by
+		// the composite stage of the whole corpus regardless. Frozen on the seed frame they would
+		// carry the sun angle of the first frame of the session for the rest of it, under a
+		// translate growing without bound as the player walks.
+		if (this.shadowSeeded && !skipped) {
+			this.heldShadowModelView.set(this.shadowModelView);
+			this.heldShadowProjection.set(this.shadowProjection);
+			this.heldShadowProjectionInverse.set(this.shadowProjectionInverse);
+			this.heldCamera.set(this.shadowCamera);
+		}
+
 		if (this.shadowSeeded) {
 			// On the right, where the grid snap already stands, so that the motion is added to the
 			// point before the light turns it rather than after: both offsets are distances in
 			// player space, and one applied on the far side of the rotation would be a different
-			// place on the ground.
-			this.mapShadowModelView.set(this.shadowModelView)
-					.translate((float) (camera.x() - this.shadowCamera.x),
-							(float) (camera.y() - this.shadowCamera.y),
-							(float) (camera.z() - this.shadowCamera.z));
+			// place on the ground. It stays right when the span is more than one frame, the product
+			// reducing to the held pair applied to the point expressed in the held frame's own
+			// player space whatever the distance.
+			this.mapShadowModelView.set(this.heldShadowModelView)
+					.translate((float) (camera.x() - this.heldCamera.x),
+							(float) (camera.y() - this.heldCamera.y),
+							(float) (camera.z() - this.heldCamera.z));
 			this.mapShadowModelView.invert(this.mapShadowModelViewInverse);
-			this.mapShadowProjection.set(this.shadowProjection);
-			this.mapShadowProjectionInverse.set(this.shadowProjectionInverse);
+			this.mapShadowProjection.set(this.heldShadowProjection);
+			this.mapShadowProjectionInverse.set(this.heldShadowProjectionInverse);
 		}
 
 		this.shadowCamera.set(camera);
@@ -462,11 +512,17 @@ public final class ViewMatrices implements ViewSource {
 
 		if (!this.shadowSeeded) {
 			// The first frame has no map and no history, so the published pair is the fresh one:
-			// wrong by nothing, since there is nothing to sample yet.
+			// wrong by nothing, since there is nothing to sample yet. The drawn pair is seeded with
+			// it as well, so that a second frame arriving before any map was drawn re-origins from
+			// somewhere real rather than from an identity nobody set.
 			this.mapShadowModelView.set(this.shadowModelView);
 			this.mapShadowModelViewInverse.set(this.shadowModelViewInverse);
 			this.mapShadowProjection.set(this.shadowProjection);
 			this.mapShadowProjectionInverse.set(this.shadowProjectionInverse);
+			this.heldShadowModelView.set(this.shadowModelView);
+			this.heldShadowProjection.set(this.shadowProjection);
+			this.heldShadowProjectionInverse.set(this.shadowProjectionInverse);
+			this.heldCamera.set(camera);
 			this.shadowSeeded = true;
 		}
 	}

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -129,6 +129,49 @@ public final class ShadowTerrain {
 	}
 
 	/**
+	 * What a frame left behind for the published shadow pair to measure itself from.
+	 * <p>
+	 * <strong>The published pair moves itself the camera motion separating it from the map, and it
+	 * can only do that if it knows how much motion that is.</strong> The walk below returns without
+	 * drawing on four roads and its throws are caught, so a frame drawing no map says nothing in any
+	 * log. The three cases are not one: a stage that opened and gave up leaves a map older than the
+	 * frame, while a stage that never opened leaves no map at all, and telling those apart is the
+	 * difference between a correction that tracks and one that freezes on the first frame of the
+	 * session.
+	 */
+	public enum MapState {
+
+		/** The stage opened and drew, so the map on hand is the ending frame's own. */
+		DREW,
+
+		/** The stage opened and gave up before drawing, so the map on hand is older than one frame. */
+		SKIPPED,
+
+		/**
+		 * No stage ran, so nothing is sampling a map of ours and there is nothing to stay faithful
+		 * to. The pack still reads the four matrices, the whole corpus doing so from its composites,
+		 * so the fresh pair is what they are given and the sun goes on turning in them.
+		 */
+		NONE
+	}
+
+	private static boolean served;
+
+	private static boolean drew;
+
+	/**
+	 * Reads the state and clears it, so one map cannot be counted fresh by two frames. Called once a
+	 * frame at the head of the frame, where the flags still carry what the previous frame's tail
+	 * did.
+	 */
+	public static MapState takeMapState() {
+		MapState taken = drew ? MapState.DREW : served ? MapState.SKIPPED : MapState.NONE;
+		served = false;
+		drew = false;
+		return taken;
+	}
+
+	/**
 	 * Walks the world for the light and draws the shadow map, using the state captured when this
 	 * frame was set up. One draw per capture: a frame that never set a graph up draws no map.
 	 * <p>
@@ -173,6 +216,10 @@ public final class ShadowTerrain {
 			walkCulling = null;
 			return;
 		}
+
+		// Past this line a stage is open and the pack is sampling a map of ours, so a frame that
+		// gives up below leaves one older than itself rather than none at all.
+		served = true;
 
 		RenderSectionManager manager =
 				((MixinSodiumWorldRenderer) renderer).vitrail$renderSectionManager();
@@ -277,6 +324,7 @@ public final class ShadowTerrain {
 			}
 
 			draw(renderer, minecraft, camera);
+			drew = true;
 		} finally {
 			// The flag finalizeRenderLists just lowered, back up whatever happened above: the
 			// camera's walk at the top of the next frame has to rebuild, or the world would be

--- a/common/src/main/java/dev/vitrail/uniform/ViewSource.java
+++ b/common/src/main/java/dev/vitrail/uniform/ViewSource.java
@@ -117,10 +117,11 @@ public interface ViewSource {
 	/**
 	 * The four published shadow matrices are the pair the shadow map ON HAND was drawn with, moved
 	 * onto this frame's camera. The map is drawn at the end of a frame for the next one, so its
-	 * light direction and its grid cell are the previous frame's; but these matrices act on player
-	 * space, which every frame measures from wherever its own camera stands, so the drawn matrix
-	 * handed over as it is would ask about a point one frame of camera motion away from the one
-	 * being shaded. What is left a frame late once that motion is added back is the sun angle alone.
+	 * light direction and its grid cell are those of the frame that drew it, usually the previous
+	 * one and older wherever the stage gave up without drawing. These matrices act on player space,
+	 * which every frame measures from wherever its own camera stands, so the drawn matrix handed
+	 * over as it is would ask about a point that whole distance away from the one being shaded.
+	 * What is left late once that motion is added back is the sun angle alone.
 	 * The {@code drawn} four are the pair as it stands, for the one stage that draws the map itself.
 	 */
 	Matrix4fc shadowModelView();

--- a/common/src/main/java/dev/vitrail/uniform/values/ShadowGeometryValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/ShadowGeometryValues.java
@@ -17,8 +17,9 @@ import org.joml.Matrix4f;
  * is a shadow map of exactly the wrong thing and looks like a shadow map all the same.
  * <p>
  * Everything here reads the DRAWN pair, this frame's, where the published {@code shadowModelView}
- * is the previous frame's: the map is drawn at the end of a frame for the next one, so the pair a
- * sampling pass needs is one frame older than the pair this stage draws with. The four explicit
+ * belongs to the frame that drew the map now on hand: the map is drawn at the end of a frame for
+ * the next one, so the pair a sampling pass needs is older than the pair this stage draws with, by
+ * one frame wherever every frame draws and by more wherever the stage gave up. The four explicit
  * names are overridden below for the same reason, and it is not optional: {@code shadow.vsh}
  * multiplies {@code shadowModelViewInverse * shadowProjectionInverse * ftransform()} and counts on
  * the product collapsing, which it only does when the inverses and the pair under

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -59,8 +59,9 @@ of the wrong thing and looks like a shadow map all the same.
 Separately, that stage typically multiplies the inverse shadow matrices by the fixed-function
 transform helper and counts on the product collapsing. It only collapses if the inverses and the
 pair under the helper are the *same frame's*, so the catalogue answers from the pair being drawn
-with, this frame's, while the published shadow matrices are the previous frame's. That is a
-consequence of drawing the map a frame ahead, described further down.
+with, this frame's, while the published shadow matrices are usually the previous frame's. That is a
+consequence of drawing the map a frame ahead, described further down. When the shadow stage opens
+and then skips the map, that published pair is held: it is not rebuilt from this frame's camera.
 
 ### Shadow depth uses the opposite convention from the scene
 


### PR DESCRIPTION
## What changes

**WAIT. Not tried on a Mac from this machine. Do not merge until a Mac reporter signs it.**

When the shadow stage opens and then gives up without drawing, the published matrices used to treat the miss as a fresh map and walk the light with the player. They now keep the camera of the frame that last drew the map. Written for the Mac reports on #161 where lighting followed the player. This does not close #161.

## How it differs from the reference, and for what obstacle

Iris draws the shadow map in the same frame it is sampled. This engine draws the map at the end of the frame for the next one, so the published pair is usually the previous frame's. A skipped map made that pair advance with the player while the texels stayed put, which reads as lighting that follows you. Holding the last drawn camera is the workaround for that skip. What it costs the image on a frame that did draw is nothing; the hold only runs on a skip.

## What proves it

- [x] `gradlew build` green.
- [ ] The out-of-game harness, and which corpus it ran over.
- [ ] In the game: not tried on a Mac from this machine. No Windows-verified claim.

## What it leaves owing

**WAIT on a Mac sign-off.** #161 stays open. This is the hold across a skipped map, not a proof that Apple Silicon is fast.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
