### PR TITLE
feat(render): measure what a pass's compute and copy waits cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ what the next one holds.
 
 ### Added
 
+- **A switch that measures what waiting for compute and for copies costs at the close of a pass.**
+  An empty file `vitrail/narrow-pass-barrier` in the game folder, or
+  `-Dvitrail.narrowPassBarrier=true`. A pack's passes end on a wait naming the stages the pass
+  after them reads and writes in, and two of those stages are there for a pack's own dispatch and
+  for the copies that fill a target's mip chain. The switch drops those two so what they cost a
+  frame can be read in one world rather than across two builds, and the log says which of the two
+  states a session ran in either way. Off is the default and is the engine as it stands; armed, a
+  pack's compute can read a target before the write to it is visible and the copies lose their
+  order, which is what makes it an instrument and not a setting to keep.
+  `vitrail/full-pass-barrier` still wins over it.
+
 - **A pack can read the shadow map under a second, hardware-compared name.** `shadowtex0HW` and
   `shadowtex1HW` are bound now, to the same two depth images as `shadowtex0` and `shadowtex1`,
   and each is compared by the hardware where the pack declares it that way. Both names read back

--- a/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
@@ -42,7 +42,9 @@ import java.util.function.Supplier;
  * Closing a pass still runs the encoder's full barrier. Our own labels start with {@code Vitrail}
  * and get a write-then-sample barrier instead, the rest of the frame keeping the original wait.
  * {@link PassBarrier} puts the original wait back on ours too, and sends the mip chain back to a
- * pass per level, for a machine where the narrow one is suspected of a wrong image.
+ * pass per level, for a machine where the named one is suspected of a wrong image. The same class
+ * also drops compute and transfer from that destination, behind a second file, so those two
+ * stages can be measured rather than assumed.
  */
 @Mixin(VulkanCommandEncoder.class)
 public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
@@ -98,7 +100,7 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 		// leaves nothing of the narrow one standing. {@link PassBarrier} carries why that switch
 		// exists at all.
 		if (label != null && !PassBarrier.full() && vitrail$ours(label)) {
-			vitrail$framebufferBarrier(commands, stack);
+			vitrail$framebufferBarrier(commands, stack, PassBarrier.narrow());
 		} else {
 			VulkanCommandEncoder.memoryBarrier(commands, stack);
 		}
@@ -111,7 +113,30 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 	}
 
 	@Unique
-	private static void vitrail$framebufferBarrier(VkCommandBuffer commands, MemoryStack stack) {
+	private static void vitrail$framebufferBarrier(VkCommandBuffer commands, MemoryStack stack,
+			boolean narrow) {
+		// Compute and every transfer sit on the destination by default: a pass of ours can be
+		// followed by a pack's own dispatch, and a mip blit of a target the pass just wrote is
+		// a transfer. Dropping those two is what {@link PassBarrier#narrow()} measures, and only
+		// that: the source is untouched, and the wide wait never reaches here.
+		long dstStages = KHRSynchronization2.VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR
+				| KHRSynchronization2.VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR
+				| KHRSynchronization2.VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR
+				| KHRSynchronization2.VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR;
+		long dstAccess = KHRSynchronization2.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT_KHR
+				| KHRSynchronization2.VK_ACCESS_2_SHADER_STORAGE_READ_BIT_KHR
+				| KHRSynchronization2.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT_KHR
+				| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT_KHR
+				| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR
+				| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT_KHR
+				| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT_KHR;
+		if (!narrow) {
+			dstStages |= KHRSynchronization2.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR
+					| KHRSynchronization2.VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR;
+			dstAccess |= KHRSynchronization2.VK_ACCESS_2_TRANSFER_READ_BIT_KHR
+					| KHRSynchronization2.VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR;
+		}
+
 		VkMemoryBarrier2.Buffer barrier = VkMemoryBarrier2.calloc(1, stack)
 				.sType$Default()
 				// The shader stages are here for the image stores of a pack's own geometry, which
@@ -127,28 +152,15 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 				// declared in a pack's vertex unit is kept and bound like any other
 				// (ProgramTranslator collects the samplers of every stage), so a program whose
 				// vertex shader reads a target the pass before it wrote would race the write.
-				.dstStageMask(KHRSynchronization2.VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR
-						| KHRSynchronization2.VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR
-						| KHRSynchronization2.VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR
-						| KHRSynchronization2.VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR
-						| KHRSynchronization2.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR
-						| KHRSynchronization2.VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR)
+				.dstStageMask(dstStages)
 				// The writes sit here beside the reads, and each of the three is reached every frame:
 				// a colour target the next pass writes, or that the emptying writes through its
 				// load-op; the depth image the next geometry pass tests and writes, and that the
 				// shadow map's own emptying clears; and the mip blit filling the levels of a target
 				// whose base the pass that just closed wrote. Named as reads alone, all three were
 				// write-after-write with nothing between them, which a driver is free to run in
-				// either order.
-				.dstAccessMask(KHRSynchronization2.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT_KHR
-						| KHRSynchronization2.VK_ACCESS_2_SHADER_STORAGE_READ_BIT_KHR
-						| KHRSynchronization2.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT_KHR
-						| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT_KHR
-						| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR
-						| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT_KHR
-						| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT_KHR
-						| KHRSynchronization2.VK_ACCESS_2_TRANSFER_READ_BIT_KHR
-						| KHRSynchronization2.VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR);
+				// either order. The last of those three is the transfer the narrow switch drops.
+				.dstAccessMask(dstAccess);
 		VkDependencyInfo info = VkDependencyInfo.calloc(stack)
 				.sType$Default()
 				.pMemoryBarriers(barrier);

--- a/common/src/main/java/dev/vitrail/render/PassBarrier.java
+++ b/common/src/main/java/dev/vitrail/render/PassBarrier.java
@@ -7,7 +7,8 @@ import net.minecraft.client.Minecraft;
 import java.nio.file.Files;
 
 /**
- * Whether a pass of ours closes on the game's full memory barrier instead of the narrow one.
+ * Which wait a pass of ours closes on: the game's full memory barrier, the named one this engine
+ * uses by default, or a still narrower destination that drops compute and transfer.
  * <p>
  * The game ends every render pass by waiting for the whole of memory. Iris binds a framebuffer and
  * draws, so it waits for nothing, and on a backend where each pass is a queue submission that wait
@@ -26,20 +27,45 @@ import java.nio.file.Files;
  * the game's own wait back on both roads where this engine traded one away: the close of a pass of
  * ours, and the mip chain, which gave up a pass per level and the barrier each of those ended on.
  * It is slower and it cannot be the cause of anything, so an image that comes right with it names
- * the synchronisation.
+ * the synchronisation. That file's meaning does not move: it is still the wide wait, and it still
+ * wins over the rest.
  * <p>
- * Asked once and the answer kept: it arms a launch, not a frame.
+ * A second file, {@code vitrail/narrow-pass-barrier}, or {@code -Dvitrail.narrowPassBarrier=true},
+ * goes the other way and is an instrument rather than a road: the default destination names compute
+ * and every transfer, and this drops those two so a reading can say what waiting for them costs on
+ * a backend. Off is the default, so a jar nobody has armed is the engine as it stands, down to the
+ * masks written at the close.
+ * <p>
+ * <strong>Armed, the image may race, and the two stages dropped are the two that would show
+ * it.</strong> Compute is on the destination for a pack's own dispatch, which reads a target the
+ * pass that just closed wrote as a colour attachment; without the stage, that read is free to run
+ * before the write is visible. Transfer is there for the blit that fills a target's mip chain and
+ * for the depth copies, each of which writes an image the closing pass also wrote: ordered by
+ * nothing else, those are write-after-write, and a driver may run them in either order. A frame
+ * read with the file in place is therefore a figure for what the two waits cost, never an image to
+ * judge.
+ * <p>
+ * Asked once and the answer kept: each arms a launch, not a frame. The first close of a pass of
+ * ours reads the directory once and every close after it reads a field.
  */
 public final class PassBarrier {
 
 	private static final boolean PROPERTY = Boolean.getBoolean("vitrail.fullPassBarrier");
 
+	private static final boolean NARROW_PROPERTY = Boolean.getBoolean("vitrail.narrowPassBarrier");
+
 	private static final String ARM_FILE = "full-pass-barrier";
+
+	private static final String NARROW_FILE = "narrow-pass-barrier";
 
 	/** Null until the game directory can be resolved, which is not true on the first calls. */
 	private static Boolean armed;
 
+	private static Boolean narrowArmed;
+
 	private static boolean announced;
+
+	private static boolean narrowAnnounced;
 
 	private PassBarrier() {
 	}
@@ -70,6 +96,37 @@ public final class PassBarrier {
 	}
 
 	/**
+	 * True while a pass of ours drops compute and transfer from the destination of its close.
+	 * False, which is the default, keeps those two on the destination, the wait this engine ships.
+	 * {@link #full()} wins over this: the wide wait is the one that cannot be the cause of a wrong
+	 * image, so it is the one a reporter arms first.
+	 */
+	public static boolean narrow() {
+		if (NARROW_PROPERTY) {
+			announceNarrow(true);
+
+			return true;
+		}
+
+		// Announced only once the directory has been resolved, and not before: a line saying
+		// "default" while the answer is still unknown would latch, and every reading of the session
+		// would then name a destination the passes were not closing on.
+		if (narrowArmed == null) {
+			Minecraft minecraft = Minecraft.getInstance();
+			if (minecraft == null || minecraft.gameDirectory == null) {
+				return false;
+			}
+
+			narrowArmed = Files.isRegularFile(minecraft.gameDirectory.toPath()
+					.resolve("vitrail").resolve(NARROW_FILE));
+		}
+
+		announceNarrow(narrowArmed);
+
+		return narrowArmed;
+	}
+
+	/**
 	 * Said once, and it has to be said: a session running on the wide barrier is measuring a
 	 * different engine, and a frame rate read there means nothing beside one read without it.
 	 */
@@ -82,5 +139,24 @@ public final class PassBarrier {
 		Vitrail.logger().warn("Every render pass closes on the game's full memory barrier, asked "
 				+ "for by vitrail/{} or by -Dvitrail.fullPassBarrier. The image is the safe one and "
 				+ "the frame is slower; remove it to go back to the narrow wait", ARM_FILE);
+	}
+
+	/**
+	 * Said once and said BOTH WAYS. A line that only appeared when the file was there would make
+	 * every reading taken without one unable to name the destination it closed on.
+	 */
+	private static void announceNarrow(boolean asked) {
+		if (narrowAnnounced) {
+			return;
+		}
+
+		narrowAnnounced = true;
+		if (asked) {
+			Vitrail.logger().warn("pass-barrier narrow=true file={} property=vitrail.narrowPassBarrier",
+					NARROW_FILE);
+			return;
+		}
+
+		Vitrail.logger().info("pass-barrier narrow=false default");
 	}
 }

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -262,6 +262,18 @@ game's full memory barrier and sends the mip chain back to a pass per level. It 
 cannot be the cause of a wrong image, so it is the first thing to ask of a machine that draws one
 this one does not.
 
+**What the compute and copy waits cost can be measured.** Every pass of ours closes on a wait
+naming the stages the pass after it reads and writes in, and compute and every transfer are two of
+them: the first is there for a pack's own dispatch, the second for the copies that fill a target's
+mip chain. An empty file `vitrail/narrow-pass-barrier` in the instance, or
+`-Dvitrail.narrowPassBarrier=true` among the JVM arguments, drops those two from the destination, so
+what they cost a frame can be read as two measurements in one world rather than across two builds.
+The state is written to the log in both directions at the first close of a pass, so a reading always
+names the state it belongs to. It is an instrument and not a setting to keep: armed, a pack's
+compute can read a target before the colour write is visible, and the mip blit and the depth copies
+become write-after-write with nothing ordering them, which a driver is free to run in either order.
+Off is the default and is the wait this engine ships. The wide file above still wins over it.
+
 **The block atlas filter can be put back the way it was.** An empty file
 `vitrail/legacy-terrain-filter` in the instance, or `-Dvitrail.legacyTerrainFilter=true`, sends a
 pack's terrain and its shadow back through the game's filtered sampler, which is what this engine

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -126,7 +126,10 @@ accident looks exactly like a correct one until somebody else's machine draws it
 `vitrail/full-pass-barrier` in the instance, or `-Dvitrail.fullPassBarrier=true`, puts the game's own
 wait back at the close of our passes and sends the mip chain back to a pass per level. It is slower
 and it cannot be the cause of anything, which is the whole point: an image that comes right with it
-has named the synchronisation rather than the pass that shows it.
+has named the synchronisation rather than the pass that shows it. A second file,
+`vitrail/narrow-pass-barrier`, goes the other way and drops compute and transfer from that
+destination, to measure what waiting for them costs; armed, the image may race, off is the default,
+and the wide file still wins.
 
 The practical consequence is that reading in pass N+1 what pass N wrote still requires no
 synchronisation code of our own: close, open, bind. But the barrier exists only if the pass is


### PR DESCRIPTION
## What changes

Every render pass of ours closes on a memory barrier naming the stages and the accesses the pass
after it reads and writes in. Two of the stages on that destination are compute and every transfer:
compute for a pack's own dispatch, transfer for the blit that fills a target's mip chain and for the
depth copies. This branch adds one switch that drops those two, so what waiting for them costs on
this backend can be read instead of assumed. An empty file `vitrail/narrow-pass-barrier` in the
instance, or `-Dvitrail.narrowPassBarrier=true`, arms it for a launch, and the log names the state in
both directions so a reading can never be filed under the wrong one. It is an instrument and not a
setting to keep: armed, a pack's compute may read a target before the write to it is visible, and the
mip blit and the depth copies write images the closing pass also wrote with nothing left to order
them. Off is the default. `vitrail/full-pass-barrier`, the wide wait, still wins over it.

## How it differs from the reference, and for what obstacle

It does not. Iris binds a framebuffer and draws, so OpenGL orders those writes for it and there is no
wait of its own to take away. The road this branch leaves as the default is the same wait this engine
already shipped, and the switch exists only because that wait cannot be priced by reading it.

## What proves it

- `gradlew build` green, after the rebase onto `dev` and not before it.
- The default road is unchanged by reading, not by measurement: with no file and no property, the
  destination is assembled from the same stage and access bits it carried before, compute and
  transfer included. Nothing here is benchmarked and no figure is claimed.
- The measurement has not been taken. In the game it is three steps, and it needs one build:
  1. One world, one fixed viewpoint, one pack, and a flat repeatable place to stand (the arena
     bench here). Read the frame rate over a settled window.
  2. Quit, put the empty file `vitrail/narrow-pass-barrier` in the instance, relaunch to the same
     viewpoint and pack, read it again.
  3. Each log carries `pass-barrier narrow=true` or `pass-barrier narrow=false`, so neither of the
     two readings can be attributed to the other state.

## What it leaves owing

The measurement itself, and the decision that follows it. A difference worth having turns into
finding a destination that is genuinely narrower and still correct, rather than into shipping this
one. No difference means the switch comes back out instead of staying in the tree as an instrument
nobody reaches for.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
