### PR TITLE
perf(render): fold independent fullscreen pack passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ what the next one holds.
 
 ## Unreleased
 
+### Changed
+
+- **Consecutive full-screen passes of a pack that write the same images share one render
+  pass** when the later one reads none of them. A pass that samples what the one before it
+  wrote, clears a target, fills a mip chain or binds a storage image still closes the pass
+  first, so the picture is the same and fewer passes close per frame. The pass census names
+  every join and every refusal with its reason.
+
 ### Fixed
 
 - **The block outline is drawn by the pack, as Iris draws it.** The thin box around the block

--- a/common/src/main/java/dev/vitrail/render/GeometryHold.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryHold.java
@@ -44,6 +44,7 @@ public final class GeometryHold {
 	private static final int PLAN_INCOMPLETE = -6;
 	private static final int CLEARS = -7;
 	private static final int SAMPLES_HELD = -8;
+	private static final int BINDS_STORAGE = -9;
 
 	private static RenderPass current;
 	private static GpuTexture[] colours;
@@ -86,16 +87,24 @@ public final class GeometryHold {
 	 * Geometry {@link #open} does not ask this: those programs paint over the world rather than
 	 * filter it. A later composite that samples what the hold still has attached would read an
 	 * image the pass has not stored. {@code sampled} null means the sampler plan cannot name every
-	 * image, and that is a refusal: a join would be a guess.
+	 * image, and that is a refusal: a join would be a guess. {@code bindsStorage} refuses as well:
+	 * a storage image is written through {@code imageStore} and not through an attachment, so no
+	 * attachment comparison can tell whether the program before it wrote what this one reads, and
+	 * only a closed pass orders that write before the read.
 	 */
 	public static RenderPass openFullscreen(CommandEncoder encoder, RenderPassDescriptor descriptor,
-			List<GpuTexture> sampled) {
-		return open(encoder, descriptor, fitFullscreen(descriptor, sampled));
+			List<GpuTexture> sampled, boolean bindsStorage) {
+		return open(encoder, descriptor, fitFullscreen(descriptor, sampled, bindsStorage));
 	}
 
 	private static RenderPass open(CommandEncoder encoder, RenderPassDescriptor descriptor, int fit) {
 		if (fit == JOINS) {
 			resetArea(current);
+			// Counted under the same roof as the refusals: a census that only listed why passes
+			// opened could not say whether a join ever happened at all.
+			if (PassTimings.censusArmed()) {
+				PassTimings.censusReopen(descriptor.label(), "joined the pass already recording");
+			}
 
 			return current;
 		}
@@ -230,7 +239,8 @@ public final class GeometryHold {
 	 * name every image. Asked only when the images would otherwise join, so a first open is still
 	 * {@link #NO_HOLD} rather than one of those.
 	 */
-	private static int fitFullscreen(RenderPassDescriptor descriptor, List<GpuTexture> sampled) {
+	private static int fitFullscreen(RenderPassDescriptor descriptor, List<GpuTexture> sampled,
+			boolean bindsStorage) {
 		int fit = fit(descriptor);
 		if (fit != JOINS) {
 			return fit;
@@ -238,6 +248,10 @@ public final class GeometryHold {
 
 		if (sampled == null) {
 			return PLAN_INCOMPLETE;
+		}
+
+		if (bindsStorage) {
+			return BINDS_STORAGE;
 		}
 
 		if (clears(descriptor)) {
@@ -286,6 +300,7 @@ public final class GeometryHold {
 			case PLAN_INCOMPLETE -> "its sampler plan cannot name every image it samples";
 			case CLEARS -> "it clears an attachment";
 			case SAMPLES_HELD -> "it samples an attachment of the hold";
+			case BINDS_STORAGE -> "it binds a storage image, which only a closed pass orders";
 			case NO_HOLD -> ended == null ? "nothing was being held" : "the hold ended on " + ended.get();
 			default -> "it joins";
 		};

--- a/common/src/main/java/dev/vitrail/render/GeometryHold.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryHold.java
@@ -13,7 +13,7 @@ import java.util.OptionalDouble;
 import java.util.function.Supplier;
 
 /**
- * Keeps one Vulkan render pass open across geometry that Iris would have drawn into the same FBO.
+ * Keeps one Vulkan render pass open across draws that write the same colour and depth images.
  * <p>
  * Iris binds {@code defaultFB} once and leaves it bound through solid, cutout, sky pieces and
  * entities ({@code pipeline/IrisRenderingPipeline.java:1383-1388}). Each of those is a
@@ -21,10 +21,14 @@ import java.util.function.Supplier;
  * stop OpenGL's bind is not. Consecutive programs that write the same colour and depth images, at
  * the same area, therefore keep the pass that is already recording and only switch pipeline.
  * <p>
- * A later pass that samples what the last one wrote, or that names different attachments, or that
- * is a composite, a copy or a clear, ends the hold first. The encoder mixin is that door: every
- * foreign {@code createRenderPass}, copy or clear flushes. This class's own open is the exception,
- * so a matching geometry program does not flush itself.
+ * Full-screen pack programs go through {@link #openFullscreen}: they join only when the images and
+ * the area match and the new program samples none of the attachments still bound. Iris still issues
+ * a separate GL draw per composite, often into a flipped target; folding two that do not depend on
+ * each other is a Vulkan-only win. A later pass that samples what the last one wrote, that names
+ * different attachments, that clears, that cannot name every sampled image, or a copy, a mip chain
+ * or a depth conversion, ends the hold first. The encoder mixin is that door for every foreign
+ * {@code createRenderPass}. This class's own open is the exception, so a matching program does not
+ * flush itself.
  */
 public final class GeometryHold {
 
@@ -37,6 +41,9 @@ public final class GeometryHold {
 	private static final int COUNT_DIFFERS = -3;
 	private static final int DEPTH_DIFFERS = -4;
 	private static final int AREA_DIFFERS = -5;
+	private static final int PLAN_INCOMPLETE = -6;
+	private static final int CLEARS = -7;
+	private static final int SAMPLES_HELD = -8;
 
 	private static RenderPass current;
 	private static GpuTexture[] colours;
@@ -69,7 +76,24 @@ public final class GeometryHold {
 	 * Load-ops on a reused descriptor are ignored: the first open already applied them.
 	 */
 	public static RenderPass open(CommandEncoder encoder, RenderPassDescriptor descriptor) {
-		int fit = fit(descriptor);
+		return open(encoder, descriptor, fit(descriptor));
+	}
+
+	/**
+	 * Opens a pass for a full-screen pack program, or hands back the one already recording when it
+	 * writes the same images, at the same area, and samples none of them.
+	 * <p>
+	 * Geometry {@link #open} does not ask this: those programs paint over the world rather than
+	 * filter it. A later composite that samples what the hold still has attached would read an
+	 * image the pass has not stored. {@code sampled} null means the sampler plan cannot name every
+	 * image, and that is a refusal: a join would be a guess.
+	 */
+	public static RenderPass openFullscreen(CommandEncoder encoder, RenderPassDescriptor descriptor,
+			List<GpuTexture> sampled) {
+		return open(encoder, descriptor, fitFullscreen(descriptor, sampled));
+	}
+
+	private static RenderPass open(CommandEncoder encoder, RenderPassDescriptor descriptor, int fit) {
 		if (fit == JOINS) {
 			resetArea(current);
 
@@ -135,8 +159,8 @@ public final class GeometryHold {
 	}
 
 	/**
-	 * Ends the hold so a copy, a clear, a composite or a different framebuffer can run, naming what
-	 * is ending it so the next family to open can say why it had to.
+	 * Ends the hold so a copy, a clear, a mip chain, a depth conversion or a different framebuffer
+	 * can run, naming what is ending it so the next family to open can say why it had to.
 	 *
 	 * @param cause what the census reports against the pass that opens next, or {@code null} where
 	 *              the caller has already reported one of its own
@@ -201,6 +225,50 @@ public final class GeometryHold {
 	}
 
 	/**
+	 * {@link #fit} plus the reasons a full-screen program cannot join even when the images match: a
+	 * clear load-op, a sample of an image the hold still has attached, or a sampler plan that cannot
+	 * name every image. Asked only when the images would otherwise join, so a first open is still
+	 * {@link #NO_HOLD} rather than one of those.
+	 */
+	private static int fitFullscreen(RenderPassDescriptor descriptor, List<GpuTexture> sampled) {
+		int fit = fit(descriptor);
+		if (fit != JOINS) {
+			return fit;
+		}
+
+		if (sampled == null) {
+			return PLAN_INCOMPLETE;
+		}
+
+		if (clears(descriptor)) {
+			return CLEARS;
+		}
+
+		return samplesHeld(sampled) ? SAMPLES_HELD : JOINS;
+	}
+
+	private static boolean samplesHeld(List<GpuTexture> sampled) {
+		for (int at = 0; at < sampled.size(); at++) {
+			GpuTexture texture = sampled.get(at);
+			if (texture == null) {
+				continue;
+			}
+
+			if (texture == depth) {
+				return true;
+			}
+
+			for (GpuTexture colour : colours) {
+				if (texture == colour) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * What {@link #fit} found, in words, for the census line. Reached only while a census is armed.
 	 * <p>
 	 * The no-hold answer is the one that carries the frame's real story: the family did not fail any
@@ -215,6 +283,9 @@ public final class GeometryHold {
 			case COUNT_DIFFERS -> "it writes a different number of colour images";
 			case DEPTH_DIFFERS -> "its depth image is not the one held";
 			case AREA_DIFFERS -> "its area is not the one held";
+			case PLAN_INCOMPLETE -> "its sampler plan cannot name every image it samples";
+			case CLEARS -> "it clears an attachment";
+			case SAMPLES_HELD -> "it samples an attachment of the hold";
 			case NO_HOLD -> ended == null ? "nothing was being held" : "the hold ended on " + ended.get();
 			default -> "it joins";
 		};

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2244,10 +2244,9 @@ public final class PackChain {
 						this.programs.size())
 				: -1;
 
-		// Each pass opens and closes its own render pass. Closing one is what makes the next able
-		// to read it: the Vulkan backend ends a pass with a full memory barrier, so the cost of
-		// the chain is one whole serialisation of the GPU per program and there is no way around
-		// it short of knowing which passes do not overlap.
+		// Consecutive full-screen programs that write the same images and sample none of them
+		// keep one Vulkan pass and only switch pipeline. A later program that samples what the
+		// last wrote, a mip chain, a pending clear or a different set of attachments ends it.
 		CommandEncoder encoder = device.createCommandEncoder();
 		GpuBuffer buffer = this.block.currentBuffer();
 		// The chains this walk has filled and nothing has written over since, by target and side.
@@ -2331,6 +2330,13 @@ public final class PackChain {
 		if (!this.seeded && seedAt >= from && seedAt <= to) {
 			paintSeed(encoder, ready);
 		}
+
+		// A deferred hold left standing would meet the translucent geometry that follows this
+		// half: those programs write the images the deferreds just flipped onto, and
+		// GeometryHold.open would join them without asking whether the water samples what the
+		// deferred still has attached. Iris rebinds between composites and geometry; this is
+		// that rebind.
+		GeometryHold.flush(() -> "the pack chain of this half closing");
 	}
 
 	/** What one frame of the chain is drawn against, settled once and read by both halves. */

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -451,6 +451,17 @@ final class PackPass {
 				.collect(Collectors.joining(", "));
 	}
 
+	/** Whether one of this program's names is a storage image, written by imageStore and not by a pass. */
+	private boolean bindsStorage() {
+		for (SamplerPlan.Binding binding : this.samplerBindings) {
+			if (binding.kind() == SamplerPlan.Kind.CUSTOM_IMAGE) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	/**
 	 * The images this program samples, resolved to the textures {@link GeometryHold} compares.
 	 * Null when the sampler plan cannot name them all: the caller must not join.
@@ -529,7 +540,7 @@ final class PackPass {
 		}
 
 		try (RenderPass pass = GeometryHold.openFullscreen(encoder, descriptor,
-				sampledImages(targets, depthView, distantView))) {
+				sampledImages(targets, depthView, distantView), bindsStorage())) {
 			record(pass, targets, depthView, distantView, quad, uniforms);
 		}
 	}

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -31,6 +31,7 @@ import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuSampler;
+import com.mojang.blaze3d.textures.GpuTexture;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import net.minecraft.client.renderer.BindGroupLayouts;
@@ -451,8 +452,46 @@ final class PackPass {
 	}
 
 	/**
-	 * Opens and closes its own render pass, which is what makes the next one able to read what
-	 * this one wrote: the Vulkan backend ends a pass with a full memory barrier. Nothing is
+	 * The images this program samples, resolved to the textures {@link GeometryHold} compares.
+	 * Null when the sampler plan cannot name them all: the caller must not join.
+	 */
+	private List<GpuTexture> sampledImages(ColorTargets targets, GpuTextureView depthView,
+			GpuTextureView distantView) {
+		if (this.samplerBindings.size() != this.samplers.size()) {
+			return null;
+		}
+
+		List<GpuTexture> sampled = new ArrayList<>();
+		for (int at = 0; at < this.samplers.size(); at++) {
+			SamplerPlan.Binding binding = this.samplerBindings.get(at);
+			if (binding.kind() == SamplerPlan.Kind.UNBINDABLE) {
+				return null;
+			}
+
+			GpuTextureView view = switch (binding.kind()) {
+				case COLORTEX -> targets.view(binding.index(), binding.side());
+				case DEPTH -> depth(binding.sampler(), targets, depthView);
+				case DISTANT_DEPTH -> SamplerPlan.distantWithoutWater(binding.sampler())
+						? or(targets.depth().distantOpaque(), targets.white())
+						: or(distantView, targets.white());
+				default -> null;
+			};
+			if (binding.kind() == SamplerPlan.Kind.COLORTEX && view == null) {
+				return null;
+			}
+
+			if (view != null) {
+				sampled.add(view.texture());
+			}
+		}
+
+		return sampled;
+	}
+
+	/**
+	 * Records this program into a render pass, joining the one already recording when it writes
+	 * the same images and samples none of them. A join that would read an attachment still bound
+	 * is refused, and the Vulkan store then happens on the close that follows. Nothing is
 	 * allocated here. The first write of a target this frame loads as a clear, which is
 	 * {@code glClear} as the FBO is bound; later writes load what the last pass left.
 	 */
@@ -489,7 +528,8 @@ final class PackPass {
 			targets.flushPending(encoder);
 		}
 
-		try (RenderPass pass = encoder.createRenderPass(descriptor)) {
+		try (RenderPass pass = GeometryHold.openFullscreen(encoder, descriptor,
+				sampledImages(targets, depthView, distantView))) {
 			record(pass, targets, depthView, distantView, quad, uniforms);
 		}
 	}

--- a/common/src/main/java/dev/vitrail/render/PassTimings.java
+++ b/common/src/main/java/dev/vitrail/render/PassTimings.java
@@ -163,8 +163,9 @@ public final class PassTimings {
 	 * <p>
 	 * The counts above say a family opened nine passes; without this, that nine can only be guessed
 	 * at, and a guess about a number is how a frame gets attacked at the wrong end. Only the passes
-	 * {@link GeometryHold} arbitrates appear here: a composite or a mip level is not a family
-	 * reopening, it is a pass of its own, and each of those is a cause rather than an effect.
+	 * {@link GeometryHold} arbitrates appear here, the full-screen passes of a pack included since
+	 * they may join the one before them, and a join is counted beside the refusals so that the
+	 * census can say it happened; a mip level is not a reopening, it is a pass of its own.
 	 */
 	private static final Map<String, Map<String, Integer>> censusReopens = new HashMap<>();
 

--- a/docs/internals/entities.md
+++ b/docs/internals/entities.md
@@ -20,7 +20,7 @@ A run and not the group. One pass carries one set of attachments, so the run las
 draws that follow keep writing the same colour and depth images over the same area, whatever program
 they belong to: `GeometryHold` is what arbitrates that, and a different set of attachments, a
 different area, or anything that cannot be recorded inside a pass at all, which is a copy, a clear
-or a composite, is what ends it. Nothing is reordered to make runs longer, because the order the
+or a composite that reads what the run has bound, is what ends it. Nothing is reordered to make runs longer, because the order the
 game walks its draws in is the order things overlap in. A run therefore outlives the group that
 started it, and the encoder still allows one pass at a time: a foreign `createRenderPass` ends the
 hold on its way in, which is what keeps a pass left standing from making the next thing the game

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -115,8 +115,9 @@ the first is obvious: two Vulkan passes writing one image are ordered by nothing
 framebuffer of OpenGL orders them for free, and the emptying of a target now rides the load-op of
 a pass rather than being a clear of its own, which makes it one of those writes. Consecutive
 geometry that writes the same colour and depth images stays in one pass, which is what Iris does by
-leaving `defaultFB` bound (`IrisRenderingPipeline.bindDefault`). A later composite, a copy, or a
-different framebuffer ends that hold first. Mip chains are filled with `vkCmdBlitImage` on the
+leaving `defaultFB` bound (`IrisRenderingPipeline.bindDefault`). A copy, a different framebuffer,
+or a composite that reads, clears or binds a storage image ends that hold first; a composite
+that writes the same images and reads none of them joins it. Mip chains are filled with `vkCmdBlitImage` on the
 frame's command buffer, the Vulkan form of `glGenerateMipmap`, rather than a pass per level, which
 gives up the barrier each of those passes ended on and keeps transfer barriers between the levels
 instead.


### PR DESCRIPTION
## What changes

`GeometryHold` keeps one Vulkan pass open across consecutive full-screen pack programs when they write the same colour and depth images, at the same area, and the new program reads none of them. A read-after-write of an attachment, a clear, a mip chain, an incomplete sampler plan, unmatched attachments, or a storage image bound by the new program still ends the hold first: a storage image is written through `imageStore` and not through an attachment, so no attachment comparison can say whether the program before wrote what the next one reads, and only a closed pass orders that write before the read. The pass census counts every join beside every refusal and its reason, so a run can say whether a join happened at all.

## How it differs from the reference, and for what obstacle

Iris issues a separate GL draw per composite (`pipeline/CompositeRenderer.java:283-329`, `_drawElements` in `renderAll`). OpenGL leaves the FBO bound. Closing a pass here is `vkCmdEndRendering` plus a barrier (`GeometryHold.java:18-20`; Iris's bind is `pipeline/IrisRenderingPipeline.java:1383-1388`). The join is refused when the sampler plan cannot name every image, when a bound image is sampled, or when a storage image is bound. Cost to the image: none where the refusal list is complete.

## What proves it

- `gradlew build` green after the rebase onto `dev`.
- The out-of-game harness was not run: this is a render-path change.
- In the game: not tried. The census (`vitrail/pass-census`) now prints "joined the pass already recording" per pass label, which is what an in-game run should look for first: whether any pack of the bench joins at all, and on which packs the reflection and cloud passes still refuse because they sample what the hold has bound.

## What it leaves owing

The in-game run above, on Complementary and Photon, before this merges. Whether real packs actually join consecutive composites: ping-pong attachments typically refuse, because the next program samples what the hold still has bound.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
