### PR TITLE
perf(render): skip stable sampler writes after the first push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ what the next one holds.
 
 ## Unreleased
 
+### Changed
+
+- **A pack's programs stop rewriting the textures that do not move between two draws.** Every
+  draw of a geometry program used to hand the driver the whole list of images it reads, and most
+  of that list is the same image from one draw to the next inside a single pass: only the ones
+  that belong to the draw itself, a mob's own skin among them, actually change. Those are written
+  again and the rest are left where the first draw of the pass put them, which is fewer of them to
+  build and to hand over per draw. Anything that binds a pipeline of its own inside the pass, the
+  game's own immediate draws and a distant-terrain renderer among them, puts the next write back
+  to the full list, because the driver is free to drop what was left standing at that point.
+
 ### Fixed
 
 - **The block outline is drawn by the pack, as Iris draws it.** The thin box around the block

--- a/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
@@ -2,12 +2,15 @@ package dev.vitrail.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
 import com.mojang.blaze3d.vulkan.VulkanRenderPass;
 import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
+import dev.vitrail.render.SettledDescriptors;
 import dev.vitrail.render.ShadowCompare;
 import dev.vitrail.render.StorageBuffers;
 import dev.vitrail.render.StorageImages;
+import org.lwjgl.vulkan.VkCommandBuffer;
 import org.lwjgl.vulkan.VkDescriptorBufferInfo;
 import org.lwjgl.vulkan.VkDescriptorImageInfo;
 import org.lwjgl.vulkan.VkWriteDescriptorSet;
@@ -29,6 +32,10 @@ import java.util.List;
  * on {@code blockDataBuffer}. The comparison is the same shape of gap: no {@code GpuSampler}
  * describes one, so {@link ShadowCompare} makes it in Vulkan's own terms and this walk puts its
  * handle under the names the pipeline registered when it was built.
+ * <p>
+ * After the first push of a geometry program into a pass, {@link SettledDescriptors} shrinks the
+ * write list to uniforms plus sampled names that follow the draw. The substitutions below still
+ * run on every name that is written; a name left out keeps what the last full push put there.
  */
 @Mixin(VulkanRenderPass.class)
 public abstract class VulkanRenderPassMixin {
@@ -39,15 +46,41 @@ public abstract class VulkanRenderPassMixin {
 	@Shadow
 	protected VulkanRenderPipeline pipeline;
 
+	@WrapOperation(method = "pushDescriptors", require = 2,
+			at = @At(value = "INVOKE", target = "Ljava/util/List;size()I"))
+	private int vitrail$size(List<?> entries, Operation<Integer> original) {
+		return SettledDescriptors.size(entries, original.call(entries), info());
+	}
+
 	@WrapOperation(method = "pushDescriptors", require = 1,
 			at = @At(value = "INVOKE", target = "Ljava/util/List;get(I)Ljava/lang/Object;", ordinal = 0))
 	private Object vitrail$entry(List<?> entries, int index, Operation<Object> original) {
-		Object entry = original.call(entries, index);
+		Object entry = original.call(entries, SettledDescriptors.index(index, info()));
 		if (entry instanceof VulkanBindGroupLayout.Entry named) {
 			CURRENT.set(named);
 		}
 
 		return entry;
+	}
+
+	@WrapOperation(method = "pushDescriptors", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/VkWriteDescriptorSet;dstBinding(I)"
+							+ "Lorg/lwjgl/vulkan/VkWriteDescriptorSet;"))
+	private VkWriteDescriptorSet vitrail$binding(VkWriteDescriptorSet set, int binding,
+			Operation<VkWriteDescriptorSet> original) {
+		return original.call(set, SettledDescriptors.index(binding, info()));
+	}
+
+	@WrapOperation(method = "pushDescriptors", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/KHRPushDescriptor;vkCmdPushDescriptorSetKHR("
+							+ "Lorg/lwjgl/vulkan/VkCommandBuffer;IJI"
+							+ "Lorg/lwjgl/vulkan/VkWriteDescriptorSet$Buffer;)V"))
+	private void vitrail$pushed(VkCommandBuffer commands, int bindPoint, long layout, int set,
+			VkWriteDescriptorSet.Buffer writes, Operation<Void> original) {
+		original.call(commands, bindPoint, layout, set, writes);
+		SettledDescriptors.afterPush(info());
 	}
 
 	@WrapOperation(method = "pushDescriptors", require = 1,
@@ -131,6 +164,11 @@ public abstract class VulkanRenderPassMixin {
 		}
 
 		return original.call(set, type);
+	}
+
+	@Unique
+	private RenderPipeline info() {
+		return this.pipeline == null ? null : this.pipeline.info();
 	}
 
 	@Unique

--- a/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
@@ -18,6 +18,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
 
@@ -35,7 +37,9 @@ import java.util.List;
  * <p>
  * After the first push of a geometry program into a pass, {@link SettledDescriptors} shrinks the
  * write list to uniforms plus sampled names that follow the draw. The substitutions below still
- * run on every name that is written; a name left out keeps what the last full push put there.
+ * run on every name that is written; a name left out keeps what the last full push put there,
+ * which holds only as long as no other pipeline is bound into the pass, so every
+ * {@code setPipeline} is reported and a foreign one puts the next push back to its full width.
  */
 @Mixin(VulkanRenderPass.class)
 public abstract class VulkanRenderPassMixin {
@@ -45,6 +49,11 @@ public abstract class VulkanRenderPassMixin {
 
 	@Shadow
 	protected VulkanRenderPipeline pipeline;
+
+	@Inject(method = "setPipeline", at = @At("TAIL"), require = 1)
+	private void vitrail$pipelineBound(RenderPipeline bound, CallbackInfo callback) {
+		SettledDescriptors.bound(bound);
+	}
 
 	@WrapOperation(method = "pushDescriptors", require = 2,
 			at = @At(value = "INVOKE", target = "Ljava/util/List;size()I"))

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -397,6 +397,12 @@ final class GeometryProgram {
 	 * pass open resolved for it. Read by the bind and by nothing else.
 	 */
 	private final Sampled[] bound;
+
+	/**
+	 * Sampled names whose image follows the DRAW, handed to {@link SettledDescriptors} so the push
+	 * can leave the rest standing.
+	 */
+	private final Set<String> moving;
 	private final RenderPipeline pipeline;
 	private final ShaderSource source;
 
@@ -655,6 +661,14 @@ final class GeometryProgram {
 		this.bound = this.samplers.stream()
 				.map(name -> new Sampled(name, material(name), ATLAS.contains(name)))
 				.toArray(Sampled[]::new);
+		Set<String> moving = new HashSet<>();
+		for (Sampled one : this.bound) {
+			if (one.followsTheImage()) {
+				moving.add(one.name);
+			}
+		}
+
+		this.moving = Set.copyOf(moving);
 
 		String vertex = loaded.program().stages().get(ProgramStage.VERTEX).text();
 		String fragment = loaded.program().stages().get(ProgramStage.FRAGMENT).text();
@@ -1244,15 +1258,19 @@ final class GeometryProgram {
 							: "");
 		}
 
-		pass.setUniform(UNIFORM_BLOCK, blockSlice());
-		StorageBuffers.bind(pass, this.storage);
-
 		// The rest are already standing in this pass, put there by this program's own last bind into
 		// it, and writing them again would allocate a pair and put back what the map already holds.
-		// {@link #settledIn} says what can undo that and why nothing else can.
+		// {@link #settledIn} says what can undo that and why nothing else can. The GPU walk is the
+		// same question: {@link SettledDescriptors} leaves those names out of the next push.
 		boolean settle = settledIn != pass || settled != this;
 		settledIn = pass;
 		settled = this;
+		SettledDescriptors.prepare(this.pipeline, this.moving, settle);
+
+		if (settle) {
+			pass.setUniform(UNIFORM_BLOCK, blockSlice());
+			StorageBuffers.bind(pass, this.storage);
+		}
 
 		for (Sampled one : this.bound) {
 			if (one.followsTheImage()) {
@@ -1289,6 +1307,7 @@ final class GeometryProgram {
 		// release, so its static bind can reach a program that has never come back through here.
 		settledIn = null;
 		settled = null;
+		SettledDescriptors.clear();
 		boolean labPbr = PbrAtlases.labPbr();
 		for (Sampled one : this.bound) {
 			one.interpolates = one.material != null && one.material.interpolates(labPbr);
@@ -1742,6 +1761,7 @@ final class GeometryProgram {
 		if (settled == this) {
 			settled = null;
 			settledIn = null;
+			SettledDescriptors.clear();
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/render/SettledDescriptors.java
+++ b/common/src/main/java/dev/vitrail/render/SettledDescriptors.java
@@ -35,6 +35,12 @@ public final class SettledDescriptors {
 	/** Applied after the first full push of a freshly settled program. */
 	private static Set<String> pending;
 
+	/**
+	 * Set when a pipeline that is not the prepared one has been bound into the pass, which drops
+	 * everything left standing until one full push has gone out again.
+	 */
+	private static boolean disturbed;
+
 	private static List<?> cachedEntries;
 
 	private static int[] mapped;
@@ -53,12 +59,35 @@ public final class SettledDescriptors {
 		pipeline = bound;
 		cachedEntries = null;
 		mapped = null;
-		if (settle) {
+		if (settle || disturbed) {
 			SettledDescriptors.moving = null;
 			pending = moving;
+			disturbed = false;
 		} else {
 			SettledDescriptors.moving = moving;
 			pending = null;
+		}
+	}
+
+	/**
+	 * A pipeline has been bound into the pass. Binding one whose layout is not compatible with the
+	 * layout the descriptors were pushed under discards them, so nothing this class left standing
+	 * can be assumed to stand any more, and the next push of ours goes out at full width. The game
+	 * answers the same fact its own way, marking every descriptor dirty after each
+	 * {@code vkCmdBindPipeline} and pushing all of them again.
+	 * <p>
+	 * The passes a hold adopts are what makes this reachable every frame: the game's immediate
+	 * draws and a distant-terrain renderer record into the pass a geometry program opened, and
+	 * each of them binds a pipeline of its own between two of our draws.
+	 */
+	@SuppressWarnings("ReferenceEquality")
+	public static void bound(RenderPipeline pipeline) {
+		if (SettledDescriptors.pipeline != pipeline) {
+			disturbed = true;
+			moving = null;
+			pending = null;
+			cachedEntries = null;
+			mapped = null;
 		}
 	}
 
@@ -69,6 +98,7 @@ public final class SettledDescriptors {
 		pending = null;
 		cachedEntries = null;
 		mapped = null;
+		disturbed = false;
 	}
 
 	/** After a push that really went out, so a settle's first walk is complete before the rest shrink. */

--- a/common/src/main/java/dev/vitrail/render/SettledDescriptors.java
+++ b/common/src/main/java/dev/vitrail/render/SettledDescriptors.java
@@ -1,0 +1,149 @@
+package dev.vitrail.render;
+
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
+import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout.VulkanBindGroupEntryType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Compacts {@code VulkanRenderPass.pushDescriptors} after the first push of a geometry program into
+ * a pass, so pass-stable sampled names are not rebuilt from Java on every draw.
+ * <p>
+ * The game's graphics layout is one descriptor set. {@code VulkanRenderPipeline.compile} creates it
+ * with a single {@code VkDescriptorSetLayout}, and the push always writes set 0. Extra
+ * {@code BindGroupLayout}s on the Java pipeline flatten into that one set; they do not become a
+ * second set the atlas could live in, and a raw {@code vkCreatePipelineLayout} with two sets would
+ * leave Sodium's push-constant patch writing into a layout the game never compiled. So the walk
+ * shrinks instead: uniforms still go out every time (a Distant Horizons section block and the
+ * game's per-draw transforms move), and only the sampled names that follow the DRAW are written
+ * again. Bindings that this step leaves out stay as the last push left them.
+ * <p>
+ * Substitutions in {@code VulkanRenderPassMixin} still run on every name that is written. A
+ * pipeline this class has not prepared is walked in full, which is the leftover draws a hold
+ * adopts: their names are not ours.
+ */
+public final class SettledDescriptors {
+
+	private static RenderPipeline pipeline;
+
+	/** Sampled names that follow the draw, or null to write every entry. */
+	private static Set<String> moving;
+
+	/** Applied after the first full push of a freshly settled program. */
+	private static Set<String> pending;
+
+	private static List<?> cachedEntries;
+
+	private static int[] mapped;
+
+	private SettledDescriptors() {
+	}
+
+	/**
+	 * Called from {@link GeometryProgram#bind} before any name is written into the pass.
+	 *
+	 * @param bound  the pipeline about to record, compared by identity at the push
+	 * @param moving sampled names whose image follows the draw
+	 * @param settle whether this is the first bind of this program into this pass
+	 */
+	static void prepare(RenderPipeline bound, Set<String> moving, boolean settle) {
+		pipeline = bound;
+		cachedEntries = null;
+		mapped = null;
+		if (settle) {
+			SettledDescriptors.moving = null;
+			pending = moving;
+		} else {
+			SettledDescriptors.moving = moving;
+			pending = null;
+		}
+	}
+
+	/** Drops the compacting, which {@link GeometryProgram#resolve} and a release both need. */
+	static void clear() {
+		pipeline = null;
+		moving = null;
+		pending = null;
+		cachedEntries = null;
+		mapped = null;
+	}
+
+	/** After a push that really went out, so a settle's first walk is complete before the rest shrink. */
+	@SuppressWarnings("ReferenceEquality")
+	public static void afterPush(RenderPipeline bound) {
+		if (pipeline != bound || pending == null) {
+			return;
+		}
+
+		moving = pending;
+		pending = null;
+		cachedEntries = null;
+		mapped = null;
+	}
+
+	/**
+	 * The number of writes this push should allocate, which is every entry until this pipeline has
+	 * been prepared and has something to leave standing.
+	 */
+	@SuppressWarnings("ReferenceEquality")
+	public static int size(List<?> entries, int n, RenderPipeline bound) {
+		if (!applies(bound)) {
+			return n;
+		}
+
+		if (mapped == null || cachedEntries != entries) { // identity: the layout's list does not move
+			mapped = scan(entries, n);
+			cachedEntries = entries;
+		}
+
+		return mapped.length;
+	}
+
+	/** The original binding of the compacted write at {@code index}. */
+	public static int index(int compacted, RenderPipeline bound) {
+		if (!applies(bound) || mapped == null) {
+			return compacted;
+		}
+
+		return mapped[compacted];
+	}
+
+	@SuppressWarnings("ReferenceEquality")
+	private static boolean applies(RenderPipeline bound) {
+		return pipeline != null && pipeline == bound && moving != null;
+	}
+
+	private static int[] scan(List<?> entries, int n) {
+		int[] indices = new int[n];
+		int written = 0;
+		int binding = 0;
+		for (Object one : entries) {
+			if (binding >= n) {
+				break;
+			}
+
+			if (keep(one)) {
+				indices[written++] = binding;
+			}
+
+			binding++;
+		}
+
+		return Arrays.copyOf(indices, written);
+	}
+
+	private static boolean keep(Object one) {
+		if (!(one instanceof VulkanBindGroupLayout.Entry entry)) {
+			return true;
+		}
+
+		if (entry.type() != VulkanBindGroupEntryType.SAMPLED_IMAGE) {
+			return true;
+		}
+
+		return moving.contains(entry.name());
+	}
+}


### PR DESCRIPTION
## What changes

After the first push of a geometry program into a pass, later draws of that program rewrite only uniforms and the sampled names whose image follows the draw. Pass-stable samplers stay as the last full push left them.

## How it differs from the reference, and for what obstacle

Iris binds GL textures on every draw (`pipeline/programs/SodiumShader.java:127-131, 159-169` `setupState` / `bindTextures`). The game's pipeline layout is one descriptor set (`SettledDescriptors.java:15-18`); a second set cannot hold the atlas without leaving Sodium's push-constant patch. Skipping the stable writes is the workaround. Cost to the image: none; a missing bind throws rather than drawing with a stale sampler.

## What proves it

- `gradlew.bat build` is green on this worktree.
- The out-of-game harness was not run: this is a render-path change.
- In the game: not tried. Out of scope here.

## What it leaves owing

Leftover Immediate draws and Distant Horizons' generic renderer still walk the full list. Distant Horizons' per-section UBO still goes out every draw. MoltenVK is untried.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
