### PR TITLE
perf(render): overlap floodfill with the rest of the frame

### DIFF
--- a/common/src/main/java/dev/vitrail/render/AsyncCompute.java
+++ b/common/src/main/java/dev/vitrail/render/AsyncCompute.java
@@ -1,0 +1,48 @@
+package dev.vitrail.render;
+
+import net.minecraft.client.Minecraft;
+
+import java.nio.file.Files;
+
+/**
+ * Whether Complementary-style {@code shadowcomp} may leave the graphics command buffer.
+ * <p>
+ * Off by default, so a jar that nobody A/B'd cannot change the order every player is running.
+ * A file {@code vitrail/async-compute} in the game directory, or
+ * {@code -Dvitrail.asyncCompute=true} where a launcher can take it, is the same shape as
+ * {@link PassBarrier}: it arms a launch, not a frame.
+ */
+public final class AsyncCompute {
+
+	private static final boolean PROPERTY = Boolean.getBoolean("vitrail.asyncCompute");
+
+	private static final String ARM_FILE = "async-compute";
+
+	/** Null until the game directory can be resolved, which is not true on the first calls. */
+	private static Boolean armed;
+
+	private AsyncCompute() {
+	}
+
+	/**
+	 * True while shadow compute may be submitted on a spare compute queue. The serial path is
+	 * byte-identical in ordering when this is false: same command buffer, head of the frame.
+	 */
+	public static boolean on() {
+		if (PROPERTY) {
+			return true;
+		}
+
+		if (armed == null) {
+			Minecraft minecraft = Minecraft.getInstance();
+			if (minecraft == null || minecraft.gameDirectory == null) {
+				return false;
+			}
+
+			armed = Files.isRegularFile(minecraft.gameDirectory.toPath()
+					.resolve("vitrail").resolve(ARM_FILE));
+		}
+
+		return armed;
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -131,6 +131,8 @@ final class PackCompute implements AutoCloseable {
 	private final Set<Integer> storageTargets;
 
 	private boolean announced;
+	private boolean fallbackAnnounced;
+	private ShadowComputeQueue asyncQueue;
 
 	/** The passes whose computes have been announced once, which is once per pass and not per frame. */
 	private final Set<String> announcedChains = new LinkedHashSet<>();
@@ -329,6 +331,33 @@ final class PackCompute implements AutoCloseable {
 			afterShadowGeometry(commands, stack);
 		}
 
+		VulkanCommandEncoder vulkanEncoder = vulkanEncoder(encoder);
+		VkCommandBuffer record = commands;
+		ShadowComputeQueue async = null;
+		if (AsyncCompute.on() && vulkanEncoder != null && ShadowComputeQueue.dedicated(vulkan)) {
+			try {
+				if (this.asyncQueue == null) {
+					this.asyncQueue = ShadowComputeQueue.create(vulkan);
+				}
+
+				async = this.asyncQueue;
+				record = async.begin();
+			} catch (RuntimeException e) {
+				if (!this.fallbackAnnounced) {
+					this.fallbackAnnounced = true;
+					Vitrail.logger().info("Shadow compute stays on the graphics command buffer: {}",
+							e.toString());
+				}
+
+				async = null;
+				record = commands;
+			}
+		} else if (AsyncCompute.on() && !this.fallbackAnnounced) {
+			this.fallbackAnnounced = true;
+			Vitrail.logger().info("Shadow compute stays on the graphics command buffer: no "
+					+ "dedicated compute queue to overlap with");
+		}
+
 		// Asked of the game and not of ColorTargets, which is the same number one frame late or
 		// nought on the first. ColorTargets.screenWidth is only written by its ensure(), which
 		// runs inside the world render, while this dispatch is placed at the head of the frame
@@ -342,7 +371,7 @@ final class PackCompute implements AutoCloseable {
 		int height = main == null ? 0 : main.height;
 		for (Pass pass : this.passes) {
 			try {
-				pass.dispatch(vulkan, commands, values, targets, width, height, null);
+				pass.dispatch(vulkan, record, values, targets, width, height, null);
 			} catch (RuntimeException e) {
 				if (pass.failed.add(e.toString())) {
 					Vitrail.logger().warn("shadow compute {} failed: {}", pass.path, e.toString());
@@ -351,7 +380,17 @@ final class PackCompute implements AutoCloseable {
 		}
 
 		try (MemoryStack stack = MemoryStack.stackPush()) {
-			afterCompute(commands, stack);
+			afterCompute(record, stack);
+		}
+
+		if (async != null) {
+			async.submit(vulkanEncoder, record);
+			VkCommandBuffer graphics = commands(encoder);
+			if (graphics != null) {
+				try (MemoryStack stack = MemoryStack.stackPush()) {
+					afterCompute(graphics, stack);
+				}
+			}
 		}
 
 		if (!this.announced) {
@@ -363,6 +402,11 @@ final class PackCompute implements AutoCloseable {
 
 	@Override
 	public void close() {
+		if (this.asyncQueue != null) {
+			this.asyncQueue.close();
+			this.asyncQueue = null;
+		}
+
 		this.passes.forEach(Pass::close);
 	}
 
@@ -375,6 +419,11 @@ final class PackCompute implements AutoCloseable {
 	private static VulkanDevice vulkan(GpuDevice device) {
 		GpuDeviceBackend backend = ((GpuDeviceAccessor) device).vitrail$backend();
 		return backend instanceof VulkanDevice found ? found : null;
+	}
+
+	private static VulkanCommandEncoder vulkanEncoder(CommandEncoder encoder) {
+		return ((CommandEncoderAccessor) encoder).vitrail$backend() instanceof VulkanCommandEncoder found
+				? found : null;
 	}
 
 	/**
@@ -434,7 +483,8 @@ final class PackCompute implements AutoCloseable {
 	 * Makes the shadow fragment {@code imageStore} into voxel volumes visible to
 	 * {@code shadowcomp}'s {@code texelFetch} of the same images. The game's barrier is
 	 * compute-to-compute storage only, which does not cover a sampled read of a volume the
-	 * geometry just wrote.
+	 * geometry just wrote. Cross-queue the volumes are concurrent, so this stays a memory
+	 * barrier ({@code VK_QUEUE_FAMILY_IGNORED}); {@link ShadowComputeQueue} carries the wait.
 	 */
 	private static void afterShadowGeometry(VkCommandBuffer commands, MemoryStack stack) {
 		shaderBarrier(commands, stack,
@@ -450,7 +500,8 @@ final class PackCompute implements AutoCloseable {
 
 	/**
 	 * Makes the floodfill {@code imageStore} visible to the next frame's gbuffers, which sample
-	 * those volumes as {@code sampler3D}.
+	 * those volumes as {@code sampler3D}. Same concurrent rule as {@link #afterShadowGeometry}:
+	 * no ownership transfer to name, the semaphore is the cross-queue half.
 	 */
 	private static void afterCompute(VkCommandBuffer commands, MemoryStack stack) {
 		shaderBarrier(commands, stack, VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,

--- a/common/src/main/java/dev/vitrail/render/ShadowComputeQueue.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowComputeQueue.java
@@ -1,0 +1,183 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
+import com.mojang.blaze3d.vulkan.VulkanCommandPool;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.VulkanQueue;
+import com.mojang.blaze3d.vulkan.VulkanUtils;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.VK12;
+import org.lwjgl.vulkan.VK13;
+import org.lwjgl.vulkan.VkCommandBuffer;
+import org.lwjgl.vulkan.VkCommandBufferBeginInfo;
+import org.lwjgl.vulkan.VkQueue;
+import org.lwjgl.vulkan.VkSemaphoreCreateInfo;
+import org.lwjgl.vulkan.VkSemaphoreTypeCreateInfo;
+
+import java.nio.LongBuffer;
+
+/**
+ * Submits the pack's shadow compute on the game's dedicated compute queue, when there is one.
+ * <p>
+ * <strong>What Iris does.</strong> It runs {@code shadowcomp} on the GL context inside the shadow
+ * stage ({@code ShadowRenderer.java:631-632}, the debug group and the
+ * {@code compositeRenderer.renderAll()} under it), before the gbuffers of the same frame.
+ * <p>
+ * <strong>What prevents that here.</strong> This backend records at the head of the next frame,
+ * which is that moment's translation under a deferred shadow stage, and the 26.2 device already
+ * creates a compute-capable graphics queue plus a spare compute queue when the hardware has
+ * another family ({@code VulkanDevice.java:116-125}). The Java facade has no compute, so the
+ * dispatch cannot follow Iris onto a shared GL context; the spare {@code VkQueue} is the overlap
+ * the backend actually offers.
+ * <p>
+ * <strong>What it costs the image.</strong> None, when the graphics submission waits on the
+ * compute semaphore before the gbuffers sample those volumes as {@code sampler3D}. The wait is
+ * the public {@code VulkanCommandEncoder.waitSemaphore} split, not a CPU spin.
+ * <p>
+ * One extra {@code vkQueueSubmit2KHR} per frame on the compute queue, counted by the same census
+ * that issue 161 reads. None when this object is never built.
+ */
+final class ShadowComputeQueue implements AutoCloseable {
+
+	private static final long GRAPHICS_AND_COMPUTE = VK13.VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT
+			| VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+
+	private final VulkanDevice vulkan;
+	private final VulkanQueue compute;
+	private final VulkanCommandPool[] pools;
+	private final long graphicsToCompute;
+	private final long computeToGraphics;
+	private long timeline;
+	private int slot;
+
+	private ShadowComputeQueue(VulkanDevice vulkan, VulkanQueue compute, VulkanCommandPool[] pools,
+			long graphicsToCompute, long computeToGraphics) {
+		this.vulkan = vulkan;
+		this.compute = compute;
+		this.pools = pools;
+		this.graphicsToCompute = graphicsToCompute;
+		this.computeToGraphics = computeToGraphics;
+	}
+
+	/**
+	 * True when {@link VulkanDevice#computeQueue()} is a different {@code VkQueue} than the
+	 * graphics one, so a submit there can overlap. The device never returns null: without a spare
+	 * family it hands the graphics queue back, and that is a fall-back, not an overlap.
+	 */
+	static boolean dedicated(VulkanDevice vulkan) {
+		VkQueue graphics = vulkan.graphicsQueue().vkQueue();
+		VkQueue compute = vulkan.computeQueue().vkQueue();
+		return graphics.address() != compute.address();
+	}
+
+	static ShadowComputeQueue create(VulkanDevice vulkan) {
+		VulkanQueue compute = vulkan.computeQueue();
+		VulkanCommandPool[] pools = new VulkanCommandPool[2];
+		long graphicsToCompute = 0L;
+		long computeToGraphics = 0L;
+		try {
+			pools[0] = new VulkanCommandPool(vulkan, compute);
+			pools[1] = new VulkanCommandPool(vulkan, compute);
+			graphicsToCompute = timelineSemaphore(vulkan);
+			computeToGraphics = timelineSemaphore(vulkan);
+		} catch (RuntimeException e) {
+			destroyPools(pools);
+			destroySemaphore(vulkan, graphicsToCompute);
+			destroySemaphore(vulkan, computeToGraphics);
+			throw e;
+		}
+
+		Vitrail.logger().info("Shadow compute overlaps the rest of the frame on the dedicated "
+				+ "compute queue (family {}, extra vkQueueSubmit per frame); graphics waits before "
+				+ "gbuffers sample the voxel volumes", compute.queueFamilyIndex());
+		return new ShadowComputeQueue(vulkan, compute, pools, graphicsToCompute, computeToGraphics);
+	}
+
+	/**
+	 * A command buffer from the pool two frames ago, begun for one submit. The game keeps two
+	 * graphics submits in flight and waits for the older one before recycling that pool; this
+	 * pair follows that depth, reset here at the head of the frame that reuses it.
+	 */
+	VkCommandBuffer begin() {
+		VulkanCommandPool pool = this.pools[this.slot];
+		pool.reset();
+		VkCommandBuffer commands = pool.allocateBuffer();
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			VkCommandBufferBeginInfo begin = VkCommandBufferBeginInfo.calloc(stack).sType$Default();
+			begin.flags(VK12.VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+			VulkanUtils.crashIfFailure(this.vulkan,
+					VK12.vkBeginCommandBuffer(commands, begin),
+					"shadow compute command buffer begin");
+		}
+
+		return commands;
+	}
+
+	/**
+	 * Ends the compute buffer, splits the graphics submission around it, and submits the compute
+	 * queue. The graphics commands already recorded (the reanchor and the barrier that waits for
+	 * the previous frame's shadow geometry) signal first; gbuffers recorded after this wait on
+	 * compute. The compute submit itself is the extra {@code vkQueueSubmit2KHR}.
+	 */
+	void submit(VulkanCommandEncoder encoder, VkCommandBuffer compute) {
+		VulkanUtils.crashIfFailure(this.vulkan, VK12.vkEndCommandBuffer(compute),
+				"shadow compute command buffer end");
+		this.timeline++;
+		long value = this.timeline;
+		encoder.signalSemaphore(this.graphicsToCompute, value, GRAPHICS_AND_COMPUTE);
+		try (VulkanQueue.Submission submission = this.compute.beginSubmit()) {
+			submission.waitSemaphore(this.graphicsToCompute, value,
+					VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT);
+			submission.executeCommands(compute);
+			submission.signalSemaphore(this.computeToGraphics, value,
+					VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT);
+		}
+
+		encoder.waitSemaphore(this.computeToGraphics, value, GRAPHICS_AND_COMPUTE);
+		this.slot ^= 1;
+	}
+
+	@Override
+	public void close() {
+		VulkanDevice vulkan = this.vulkan;
+		VulkanCommandPool[] pools = this.pools;
+		long graphicsToCompute = this.graphicsToCompute;
+		long computeToGraphics = this.computeToGraphics;
+		GpuRecording.destroyLater(() -> {
+			destroyPools(pools);
+			destroySemaphore(vulkan, graphicsToCompute);
+			destroySemaphore(vulkan, computeToGraphics);
+		});
+	}
+
+	private static long timelineSemaphore(VulkanDevice vulkan) {
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			VkSemaphoreTypeCreateInfo type = VkSemaphoreTypeCreateInfo.calloc(stack).sType$Default();
+			type.semaphoreType(VK12.VK_SEMAPHORE_TYPE_TIMELINE);
+			type.initialValue(0L);
+			VkSemaphoreCreateInfo info = VkSemaphoreCreateInfo.calloc(stack).sType$Default();
+			info.pNext(type);
+			LongBuffer handle = stack.callocLong(1);
+			VulkanUtils.crashIfFailure(vulkan,
+					VK12.vkCreateSemaphore(vulkan.vkDevice(), info, null, handle),
+					"shadow compute timeline semaphore");
+			return handle.get(0);
+		}
+	}
+
+	private static void destroyPools(VulkanCommandPool[] pools) {
+		for (VulkanCommandPool pool : pools) {
+			if (pool != null) {
+				pool.destroy();
+			}
+		}
+	}
+
+	private static void destroySemaphore(VulkanDevice vulkan, long semaphore) {
+		if (semaphore != 0L) {
+			VK12.vkDestroySemaphore(vulkan.vkDevice(), semaphore, null);
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/StorageImages.java
+++ b/common/src/main/java/dev/vitrail/render/StorageImages.java
@@ -563,7 +563,7 @@ public final class StorageImages implements AutoCloseable {
 						| VK12.VK_IMAGE_USAGE_SAMPLED_BIT
 						| VK12.VK_IMAGE_USAGE_TRANSFER_SRC_BIT
 						| VK12.VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-				imageInfo.sharingMode(VK12.VK_SHARING_MODE_EXCLUSIVE);
+				sharing(vulkan, imageInfo, stack);
 				imageInfo.samples(VK12.VK_SAMPLE_COUNT_1_BIT);
 				VmaAllocationCreateInfo allocationInfo = VmaAllocationCreateInfo.calloc(stack);
 				allocationInfo.usage(8);
@@ -652,6 +652,23 @@ public final class StorageImages implements AutoCloseable {
 				}
 			});
 		}
+	}
+
+	/**
+	 * Exclusive when compute shares the graphics family, which is every MoltenVK device and the
+	 * switch-off path. Concurrent listing both families when they differ, so a floodfill submitted
+	 * on the spare compute queue can store without an ownership transfer.
+	 */
+	private static void sharing(VulkanDevice vulkan, VkImageCreateInfo imageInfo, MemoryStack stack) {
+		int graphics = vulkan.graphicsQueue().queueFamilyIndex();
+		int compute = vulkan.computeQueue().queueFamilyIndex();
+		if (!AsyncCompute.on() || graphics == compute) {
+			imageInfo.sharingMode(VK12.VK_SHARING_MODE_EXCLUSIVE);
+			return;
+		}
+
+		imageInfo.sharingMode(VK12.VK_SHARING_MODE_CONCURRENT);
+		imageInfo.pQueueFamilyIndices(stack.ints(graphics, compute));
 	}
 
 	private static int imageType(PackTexture.Shape shape) {


### PR DESCRIPTION
## What changes

Shadow compute stays on the graphics command buffer at the head of the frame. An empty file `vitrail/async-compute` in the game directory, or `-Dvitrail.asyncCompute=true`, lets the floodfill leave that buffer when `VulkanDevice.computeQueue()` is a distinct `VkQueue`. Graphics waits on a timeline semaphore before gbuffers sample the voxel volumes. If there is no spare queue, or creating one fails, the engine logs once and keeps the serial path: no extra submit. Storage images are concurrent across the two families when the switch is on and the families differ; exclusive otherwise.

## How it differs from the reference, and for what obstacle

Iris runs `shadowcomp` on the GL context inside the shadow stage (`common/src/main/java/net/irisshaders/iris/shadows/ShadowRenderer.java:631-632`, the debug group and `compositeRenderer.renderAll()` under it), before the gbuffers of the same frame.

Here the Java facade has no compute, so that dispatch cannot follow Iris onto a shared GL context. Minecraft 26.2 already creates a spare compute queue when the hardware has another family (`VulkanDevice.java:118-127`; `computeQueue()` falls back to the graphics queue when it does not). The opt-in submits the floodfill there (`common/src/main/java/dev/vitrail/render/PackCompute.java:186-243` and `ShadowComputeQueue.java`) and waits before gbuffers sample the volumes.

None of the image, if the wait is correct. An extra `vkQueueSubmit` can cost on Mac.

## What proves it

- [x] `gradlew build` green.
- The out-of-game harness does not apply: no translation, chain, or target change.
- [ ] In the game: not tried.

## What it leaves owing

An in-game A/B with Complementary Ultra colored lighting: dedicated queue present or not, submit count, and the switch off matching today's image.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine prints at load.
