### PR TITLE
build: raise the version to 0.9.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.9.0-beta
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ what the next one holds.
   a frame without their shadow while you walk, if you run a mod that narrows what the game
   considers visible. That is being fixed at its cause instead.
 
+- **A switch that hands every sine and cosine a pack writes back to the graphics driver.** An
+  empty file `vitrail/driver-trig` in the game folder, or `-Dvitrail.driverTrig=true`. They are
+  normally replaced at load with a helper that keeps its accuracy over a whole world coordinate,
+  where a driver's own can shed the low bits and show as shimmer. The switch exists so the two
+  can be compared in one world rather than across two builds, and the log says which of them a
+  pack load ended up with either way. A pack that defines its own sine keeps it in both states.
+
 ### Changed
 
 - **Compute shaders now hit the compiled-module cache on a pack reload.** They used to miss

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.8.1-beta
+mod_version=0.9.0-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

Closes the `Unreleased` section as `0.9.0-beta` and raises `mod_version` to match, so the tag,
the number inside the jar and the changelog section are one number. One entry was owing and is
added first: the switch that hands a pack's sine and cosine back to the graphics driver, which
ships in this version and had no line.

## How it differs from the reference, and for what obstacle

It does not. No engine code is touched.

## What proves it

- `gradlew build` green, which is what checks the changelog and the properties file agree.
- The out-of-game harness was not run: nothing this branch touches is code.
- In the game: nothing to look at.

## What it leaves owing

Nothing. The tag goes on the version commit, which is the tip of `dev`.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
