### PR TITLE
fix(render): measure the entity shadow reach on the caster's box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
+## Unreleased
+
+### Fixed
+
+- **A mob standing just past the pack's shadow reach for entities keeps its shadow while any
+  of it still reaches inside.** A pack that stops its moving casters short of the terrain
+  (Complementary does, at an eighth of its shadow distance) had that reach measured on the
+  caster's position, so a mob whose body reached back inside the distance lost its whole shadow
+  where Iris drew it. The reach is measured on the caster's bounding box now, as Iris measures
+  it: the difference is the caster's half width, under a block for most mobs and a few for the
+  largest, and the shadow lands as far out as it does there.
+
 ## 0.9.0-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
@@ -20,6 +20,7 @@ import net.minecraft.world.TickRateManager;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 
 import org.joml.Matrix4f;
@@ -98,18 +99,6 @@ public final class ShadowGeometry {
 	private static boolean blockEntitiesAsked;
 	private static boolean emittersOnly;
 
-	/**
-	 * How far a caster that moves may stand from the camera and still reach the map, or a NEGATIVE
-	 * value where nothing bounds it beyond the light's own frustum.
-	 * <p>
-	 * Negative and not "not positive", because zero is a bound like any other: a pack that writes
-	 * {@code entityShadowDistanceMul 0}, or a player who drags the shadow distance to the bottom, is
-	 * asking for no moving caster in the map at all, and Iris hands both of them a box culler built
-	 * at zero rather than no culler ({@code shadows/ShadowRenderer.java:333-354}).
-	 */
-	private static float reach = -1.0F;
-
-
 	private ShadowGeometry() {
 	}
 
@@ -162,22 +151,19 @@ public final class ShadowGeometry {
 			return;
 		}
 
-		// The light's frustum, prepared about the camera because that is what the whole map is built
-		// around: the terrain is culled against this very matrix, and an entity measured against
-		// another one would be dropped out of a map its own shadow belongs in.
-		Frustum frustum = new Frustum(new Matrix4f(), light);
-		frustum.prepare(camera.x, camera.y, camera.z);
-
-		// The pack's own bound on the casters that move, read once for the walk. Iris measures them
-		// against a SECOND, shorter frustum where the pack asked for one, built at the shadow
-		// distance times entityShadowDistanceMul (shadows/ShadowRenderer.java:536-541); here the
-		// shape stays the light's and only the reach is cut, which is what the multiplier means.
+		// The light's frustum with the pack's reach cut out of it, prepared about the camera because
+		// that is what the whole map is built around: the terrain is culled against this very
+		// matrix, and an entity measured against another one would be dropped out of a map its own
+		// shadow belongs in. The reach is the pack's bound on the casters that move, read once for
+		// the walk, and Reached says what it is tested on.
 		//
 		// It is one bound and not two: the shadow distance the player set is folded into this same
 		// number rather than applied beside it, because Iris builds the entity frustum out of the
-		// PRODUCT of the two multipliers (:540) and the world's own is negative whenever the player
-		// governs. PackValues.entityShadowDistance carries that arithmetic and its sign.
-		reach = TerrainDraw.entityShadowDistance();
+		// PRODUCT of the two multipliers (shadows/ShadowRenderer.java:540) and the world's own is
+		// negative whenever the player governs. PackValues.entityShadowDistance carries that
+		// arithmetic and its sign.
+		Frustum frustum = new Reached(light, TerrainDraw.entityShadowDistance());
+		frustum.prepare(camera.x, camera.y, camera.z);
 
 		// The light's own camera, built the way Iris builds it and NOT the frame's borrowed: a state
 		// extracted fresh from the player camera (shadows/ShadowRenderer.java:390) and then
@@ -484,27 +470,24 @@ public final class ShadowGeometry {
 	 * refuses here anyway, by a different road. What is added is that test, and it is Iris's
 	 * ({@code shadows/ShadowRenderer.java:701}): a spectator is not in the world to be lit.
 	 * <p>
-	 * <strong>The pack's own reach is a bound of a DIFFERENT SHAPE from Iris's, and that is an open
-	 * gap rather than a workaround.</strong> Where the pack asked for one, Iris rebuilds a whole
-	 * second shadow frustum for the casters that move, at a shorter distance
-	 * ({@code shadows/ShadowRenderer.java:536-541}), and tests the caster's bounding box against it
-	 * ({@code :703}); where it did not, the entity frustum is the terrain's ({@code :537}). Here the
-	 * light's frustum is kept in both cases and the reach alone is cut, as an axis-aligned box about
-	 * the camera measured on the caster's POSITION. The two keep-sets are not nested, so the
-	 * difference runs both ways: a caster inside the light's frustum and inside the box but outside
-	 * that narrower frustum is kept here and dropped there, and one whose bounding box grazes Iris's
-	 * bound while its position stands outside ours is the reverse. Nothing makes Iris's shape
-	 * impossible here.
+	 * <strong>The pack's reach is measured on the caster's culling box, as Iris measures it, and the
+	 * shape beside it is not yet Iris's.</strong> Where the pack asked its movers to stop short,
+	 * Iris rebuilds a whole second shadow frustum for them at that distance
+	 * ({@code shadows/ShadowRenderer.java:536-541}): the camera's volume swept along the light with
+	 * an axis-aligned cube about the camera cut out of it, and the game's own {@code shouldRender}
+	 * hands both the caster's culling box inflated by half a block ({@code :703} there,
+	 * {@code entity/EntityRenderer.java:73-78}). {@link Reached} is that cube asked of that box.
+	 * What stands beside it is the light's own frustum rather than the sweep, and that is the open
+	 * gap: a caster inside the cube and the light's volume but outside the sweep is kept here and
+	 * dropped there, which costs a draw and never a pixel, the sweep being built so that nothing
+	 * outside it can shadow what the camera sees. The other way round is empty: Iris's entity
+	 * frustum never asks the light's volume, so a caster outside it is kept there and dropped here,
+	 * but outside the light's volume is outside the map, and what Iris keeps of it draws nothing.
+	 * Nothing makes Iris's shape impossible here.
 	 */
 	private static boolean visible(Minecraft minecraft, EntityRenderDispatcher entities, Entity entity,
 			Frustum frustum, Vec3 at) {
 		if (entity instanceof Player spectator && spectator.isSpectator()) {
-			return false;
-		}
-
-		if (reach >= 0.0F && (Math.abs(entity.getX() - at.x) > reach
-				|| Math.abs(entity.getY() - at.y) > reach
-				|| Math.abs(entity.getZ() - at.z) > reach)) {
 			return false;
 		}
 
@@ -557,6 +540,79 @@ public final class ShadowGeometry {
 			Vitrail.logger().info("On this frame the light's walk submitted {} entities and {} block "
 					+ "entities into the shadow map, on block table {}", entities, blockEntities,
 					counted);
+		}
+	}
+
+	/**
+	 * The light's frustum with the pack's reach cut out of it, which is what a caster that moves is
+	 * measured against.
+	 * <p>
+	 * <strong>The reach is a cube about the camera, asked of the caster's culling box and not of its
+	 * position, and the box is what decides.</strong> Iris hangs a {@code BoxCuller} off its entity
+	 * frustum and asks it of the box the game's {@code shouldRender} hands over, the caster's culling
+	 * box inflated by half a block ({@code shadows/frustum/BoxCuller.java}, {@code isCulled(AABB)},
+	 * reached from {@code shadows/ShadowRenderer.java:703} through
+	 * {@code entity/EntityRenderer.java:73-78}). A caster is kept as long as any of that box reaches
+	 * back inside the reach on every axis, so a wide one standing past the distance still lays its
+	 * shadow where a small one would not. Asked of the position instead, as this walk once did, the
+	 * difference is the caster's half width: under a block for most mobs, a few for the largest, and
+	 * seven for the test caster this was measured with, a cow scaled sixteen times, which cast under
+	 * Iris four blocks past the reach and cast nothing here.
+	 * <p>
+	 * <strong>Asked inside the frustum, so what the game never asks the frustum about escapes the
+	 * reach, exactly as it does under Iris.</strong> A renderer that answers
+	 * {@code affectedByCulling} false, a leash holder's box, the vehicle carrying the player: the
+	 * game settles those before or beside {@code isVisible} ({@code entity/EntityRenderer.java:69,
+	 * 82-88}), and the old position test, standing in front of {@code shouldRender}, bounded them
+	 * all. What it also costs is the game's own preamble, a distance test and an inflated box built
+	 * for every caster within the game's render distance before the cube can refuse it, where three
+	 * subtractions used to refuse first. That is Iris's cost too.
+	 * <p>
+	 * <strong>Negative means no reach, and not "not positive"</strong>, because zero is a bound like
+	 * any other: a pack that writes {@code entityShadowDistanceMul 0}, or a player who drags the
+	 * shadow distance to the bottom, is asking for no moving caster in the map at all, and Iris hands
+	 * both of them a box culler built at zero rather than no culler
+	 * ({@code shadows/ShadowRenderer.java:333-354}, and the safe zone's own distance culler at
+	 * {@code :370} likewise).
+	 * <p>
+	 * The cube is asked first and the planes after, which is Iris's order under both of its shapes
+	 * ({@code AdvancedShadowCullingFrustum.isVisible(AABB)}, and the distance culler of
+	 * {@code SafeZoneCullingFrustum.isVisible(AABB)}), so a box the cube refuses never reaches the
+	 * planes. The planes are the light's own and not the sweep Iris tests, and {@link #visible}
+	 * carries what that costs.
+	 */
+	private static final class Reached extends Frustum {
+
+		/** Half the side of the cube, in blocks, or negative where nothing bounds the casters. */
+		private final float reach;
+
+		Reached(Matrix4f light, float reach) {
+			super(new Matrix4f(), light);
+			this.reach = reach;
+		}
+
+		@Override
+		public boolean isVisible(AABB box) {
+			return !culled(box) && super.isVisible(box);
+		}
+
+		/**
+		 * Iris's {@code BoxCuller.isCulled}: wholly past the reach on any one axis is out. Centred
+		 * on what {@code prepare} was handed, read back off the frustum so that the cube and the
+		 * planes can never be centred apart.
+		 */
+		private boolean culled(AABB box) {
+			if (this.reach < 0.0F) {
+				return false;
+			}
+
+			double x = getCamX();
+			double y = getCamY();
+			double z = getCamZ();
+
+			return box.maxX < x - this.reach || box.minX > x + this.reach
+					|| box.maxY < y - this.reach || box.minY > y + this.reach
+					|| box.maxZ < z - this.reach || box.minZ > z + this.reach;
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -362,8 +362,9 @@ public final class TerrainDraw {
 	}
 
 	/**
-	 * How far from the camera a caster that moves may still be and reach the map, or a value that is
-	 * not positive where the pack sets no bound of its own. Answered here for the same reason the
+	 * How far from the camera a caster that moves may still be and reach the map, or minus one where
+	 * nothing bounds it beyond the light's own frustum. Zero is a bound and not the absence of one,
+	 * which {@link PackValues#shadowRenderDistance} says why. Answered here for the same reason the
 	 * caster set is: one directive, one reading.
 	 */
 	public static float entityShadowDistance() {

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -288,19 +288,25 @@ how many the camera walked and which shape was used. The debug screen carries on
 `Shadows: C: a/b D: d`, and not the shape. The picture is the place it will NOT show, because keeping
 a section too many costs a draw and not a pixel.
 
-All of the above is about the terrain. What moves is culled separately, and there is an open
-divergence there worth stating plainly, because it is a gap and not a workaround. A caster is
-measured against the light's own frustum, the box the map is drawn in, and where the pack asked for a
-shorter reach, that reach is cut as an axis-aligned box about the camera tested on the caster's
-position. Iris instead measures the movers against the same swept shape as the terrain, rebuilt at
-a shorter distance, and tests the caster's bounding box against it
-(`shadows/ShadowRenderer.java:536-541` then `:703`). The two keep-sets are different shapes, so the
-difference runs both ways: a caster inside the light's frustum and inside the box but outside that
-narrower frustum is kept here and dropped there, and one whose box grazes Iris's bound while its
-position sits outside ours is the reverse. Nothing makes Iris's shape impossible here; it has simply
-not been written yet. Advanced terrain walks a box here rather than the sweep, so the two halves
-already differ; even where the terrain does sweep (the safe zone), the movers still measure against
-the light frustum rather than that same sweep.
+All of the above is about the terrain. What moves is culled separately, against the light's own
+frustum, the box the map is drawn in, with the pack's reach cut out of it. Where the pack asks its
+movers to stop short of the terrain, through `entityShadowDistanceMul`, the reach is an axis-aligned
+cube about the camera, and it is asked of the caster's bounding box inflated by half a block, the box
+the game's own `shouldRender` hands every frustum. That cube and that box are Iris's
+(`shadows/frustum/BoxCuller.java`, reached from `shadows/ShadowRenderer.java:703`), and the box is
+what matters: a caster is kept as long as any of it reaches back inside the reach, so a giant
+standing past the distance still lays its shadow where a small one would not, exactly as far out as
+it does under Iris. Asked of the caster's position, the same giant loses its whole shadow, and the
+picture is where that shows.
+
+What remains open is the shape beside the cube, and it is a gap and not a workaround. Iris measures
+the movers against the same swept camera volume as the terrain, rebuilt at the shorter distance
+(`shadows/ShadowRenderer.java:536-541`); here they measure against the light's frustum. A caster
+inside the cube and the light's box but outside the sweep is kept here and dropped there, which
+costs a draw and never a pixel, the sweep being built so that nothing outside it can shadow what the
+camera sees. The other way round is empty: Iris never asks the light's box of a mover, so one outside
+it is kept there and dropped here, but outside the light's box is outside the map, and what Iris
+keeps of it draws nothing. Nothing makes Iris's shape impossible here; it has not been written yet.
 
 ### The experiment that separates the two failure modes
 

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -264,9 +264,9 @@ caster you cannot see. That is the reference's assumption, and packs are written
 
 **The shape is the pack's to choose**, through `shadow.culling`, and the four states and their words
 are described once under [the pack format](pack-format.md). Advanced, and the silent default when
-the pack does not voxelise, take a box around the player on this engine rather than that sweep:
-the sweep pops leaves at the sun silhouette here, and Iris Advanced does not. The safe zone still
-sweeps. The distance is a separate axis and composes with all of them: whichever shape is chosen,
+the pack does not voxelise, sweep as they do under Iris; a box around the player in their place is
+available behind a switch, described there too. The safe zone sweeps as well. The distance is a
+separate axis and composes with all of them: whichever shape is chosen,
 the box a shadow distance asks for is cut out of it, so the sweep and the bound never have to know
 about each other.
 


### PR DESCRIPTION
## What changes

Where a pack stops its moving casters short of the terrain (`entityShadowDistanceMul`, which
Complementary sets to an eighth of its shadow distance), the reach was a cube about the camera
asked of the caster's position. It is now asked of the caster's culling box, inflated by half a
block, the box the game's own `shouldRender` hands every frustum. A wide caster standing past the
distance is kept as long as any of its box reaches back inside the reach, so a giant mob four
blocks past the reach lays its shadow into the field instead of losing it whole. The cube lives on
a `Frustum` of its own handed to `shouldRender`, so the game computes the box exactly as it does
under Iris, and the position test is gone. A stale sentence of `docs/sky-and-shadows.md` that
still called the box the default shape for Advanced is corrected in a commit of its own.

## How it differs from the reference, and for what obstacle

The reach itself does not: cube, box and order of the two tests are Iris's
(`shadows/frustum/BoxCuller.java` `isCulled(AABB)`, asked from `shadows/ShadowRenderer.java:703`
through the game's `EntityRenderer.shouldRender`).

What still differs is what stands beside the cube, and it is a gap and not a workaround: Iris
measures its movers against the camera volume swept along the light, rebuilt at the shorter
distance (`shadows/ShadowRenderer.java:536-541`); here they still measure against the light's own
frustum (`render/ShadowGeometry.java`, `Reached`). A caster inside the cube and the light's box but
outside the sweep is kept here and dropped there, which costs a draw and never a pixel: the sweep is
built so that nothing outside it can shadow what the camera sees. Nothing prevents writing it here.

## What proves it

- [x] `gradlew build` green, no warning.
- [ ] The out-of-game harness: not run, nothing here touches translation, targets or varyings.
- [x] In the game, Fabric bench, Complementary Unbound at its stock profile (reach 24 blocks),
  frozen world, camera pinned, sun at tick 800, two cows scaled sixteen times summoned by
  datapack: one 28 blocks from the camera (position past the reach, box reaching back inside it),
  one 36 blocks away (box past it too), sun low in the west so the band runs towards the camera.
  Mean captures compared pairwise, luminance on a 4 by 6 grid: with the near giant, Iris and this
  branch both show the band across the same four cells of the lower field (a third to a half of
  their pixels moved), and `dev` shows the giant's body alone with the field unchanged; with the
  far giant all three show nothing on the ground. At rest afterwards, giants gone, the frame rate
  is the same on `dev` and on this branch, about 154 frames a second on both.

## What it leaves owing

The sweep for the movers, above. And a cost that is Iris's too: the cube now sits inside the
frustum, so every entity within the game's render distance pays the game's own `shouldRender`
preamble, an inflated box built per caster per frame, before the cube can refuse it, where three
subtractions on the position used to refuse first. At rest on the bench the frame rate did not move.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
