### PR TITLE
fix: judge a const through its macros and a condition on its whole line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ what the next one holds.
   read through. Photon writes its fog colours that way, and was refused at load on its blending
   pass.
 
+- **A condition continued over several lines with a backslash is read whole.** The pack's
+  conditionals decide which includes are followed, and one continued past its first line was
+  decided on that fragment alone, which stood for true. Photon undefines its waving switches
+  under one of those, so the include the switches guard was skipped and its terrain and shadow
+  programs compiled against a function that was not there.
+
 - **A mob standing just past the pack's shadow reach for entities keeps its shadow while any
   of it still reaches inside.** A pack that stops its moving casters short of the terrain
   (Complementary does, at an eighth of its shadow distance) had that reach measured on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack that writes a constant through a macro is no longer refused whole for it.** A
+  `const` whose initialiser the Vulkan compiler would not take loses the keyword at load, and
+  whether it would was judged on the names written on the line: a macro's name passed whatever
+  it stood for, so a macro over a value this engine had already had to demote left a constant
+  the compiler then refused, and one pass refusing takes the whole pack down. The macro is now
+  read through. Photon writes its fog colours that way, and was refused at load on its blending
+  pass.
+
 - **A mob standing just past the pack's shadow reach for entities keeps its shadow while any
   of it still reaches inside.** A pack that stops its moving casters short of the terrain
   (Complementary does, at an eighth of its shadow distance) had that reach measured on the

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -327,6 +327,12 @@ public final class GlslTranslator {
 	 */
 	private static final int MAX_STATEMENT_TOKENS = 4096;
 
+	/**
+	 * How far one macro may lead to another before the name is taken as non-constant, the same
+	 * figure {@code PreprocessorExpression} allows a chain of settings.
+	 */
+	private static final int MAX_MACRO_HOPS = 8;
+
 
 	private final ExpandedUnit unit;
 	private final ProgramStage stage;
@@ -360,6 +366,19 @@ public final class GlslTranslator {
 
 	/** Names the pack defines as macros. Their uses belong to the preprocessor, not to us. */
 	private final Set<String> packMacros = new HashSet<>();
+
+	/**
+	 * What the replacement text of each macro names, its own parameters left out. Read where a
+	 * name has to be judged as the compiler will see it, once the macro is gone.
+	 */
+	private final Map<String, Set<String>> macroBodies = new HashMap<>();
+
+	/**
+	 * What {@link #constantName} answered for each macro, so that a macro named from many places
+	 * is judged once: eighty macros naming each other ten at a time would otherwise be walked a
+	 * hundred million times within the hop bound.
+	 */
+	private final Map<String, Boolean> macroConstant = new HashMap<>();
 
 	/** Names the unit declares under a built-in type, which is how a declaration is told apart. */
 	private final Set<String> declaredNames = new HashSet<>();
@@ -1095,9 +1114,48 @@ public final class GlslTranslator {
 
 			this.tokens.set(name, this.tokens.get(name).naming());
 			if (token.directive().equals("define")) {
-				this.packMacros.add(this.tokens.get(name).text());
+				String macro = this.tokens.get(name).text();
+				this.packMacros.add(macro);
+				this.macroBodies.computeIfAbsent(macro, _ -> new HashSet<>()).addAll(bodyNames(name));
 			}
 		}
+	}
+
+	/**
+	 * Every identifier the replacement text of a macro names. The parameters of a function-like
+	 * macro are left out: they stand for the arguments, and the arguments are judged where they are
+	 * written. The parenthesis is a parameter list only when it touches the name, which is the
+	 * preprocessor's own rule; after a space it is the first token of the body.
+	 */
+	private Set<String> bodyNames(int name) {
+		Set<String> parameters = new HashSet<>();
+		int scan = name + 1;
+		if (scan < this.tokens.size() && this.tokens.get(scan).operator("(")) {
+			for (scan++; scan < this.tokens.size(); scan++) {
+				Token token = this.tokens.get(scan);
+				if (token.kind() == Kind.NEWLINE || token.operator(")")) {
+					break;
+				}
+
+				if (token.kind() == Kind.IDENTIFIER) {
+					parameters.add(token.text());
+				}
+			}
+		}
+
+		Set<String> names = new HashSet<>();
+		for (; scan < this.tokens.size(); scan++) {
+			Token token = this.tokens.get(scan);
+			if (token.kind() == Kind.NEWLINE) {
+				break;
+			}
+
+			if (token.kind() == Kind.IDENTIFIER && !parameters.contains(token.text())) {
+				names.add(token.text());
+			}
+		}
+
+		return names;
 	}
 
 	/**
@@ -2134,14 +2192,17 @@ public final class GlslTranslator {
 	 * and type constructors is left alone. Parameters keep {@code const}: that spelling means
 	 * immutable, not compile-time, and the language allows it.
 	 * <p>
-	 * A name the unit {@code #define}s is left alone too, and it has to be: this pass reads tokens,
-	 * the macro is expanded later by the compiler, and what stands here is a name where a literal
-	 * will be. Mellow builds its outline offsets out of {@code OUTLINE_THICKNESS}, a constructor
-	 * multiplied by it four times over, and hands the array to {@code textureGatherOffsets}, which
-	 * takes nothing but a constant expression. Read as non-constant, the keyword came off a
-	 * declaration that was constant all along, one fullscreen pass of the pack would not compile,
-	 * and a pack one of whose passes does not compile draws nothing at all. What #157 was about is
-	 * a call and a uniform, neither of which a macro name is.
+	 * A name the unit {@code #define}s is judged by what it stands for, and it has to be both ways:
+	 * this pass reads tokens, the macro is expanded later by the compiler, and what stands here is a
+	 * name where the compiler will see the body. Mellow builds its outline offsets out of
+	 * {@code OUTLINE_THICKNESS}, a constructor multiplied by it four times over, and hands the
+	 * array to {@code textureGatherOffsets}, which takes nothing but a constant expression: that
+	 * macro stands for a number, so the keyword stays, and read as non-constant the keyword came
+	 * off a declaration that was constant all along and one fullscreen pass of the pack would not
+	 * compile. Photon writes its fog colours through {@code from_srgb}, a macro over {@code pow}
+	 * and a matrix this very pass demotes: judged by the macro's name alone the keyword stayed, the
+	 * compiler refused what the name stood for, and a pack one of whose passes does not compile
+	 * draws nothing at all.
 	 */
 	private void demoteNonConstantInitialisers() {
 		int parens = 0;
@@ -2174,7 +2235,7 @@ public final class GlslTranslator {
 
 	/**
 	 * Whether this {@code const} declaration assigns something Vulkan will not take as a constant
-	 * expression: any identifier that is neither a type constructor nor a macro this unit defines.
+	 * expression: any identifier {@link #constantName} does not vouch for.
 	 */
 	private boolean nonConstantInitialiser(int keyword, int end) {
 		boolean seenEquals = false;
@@ -2189,13 +2250,66 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			if (!LegacyGlsl.TYPE_NAMES.contains(token.text())
-					&& !this.packMacros.contains(token.text())) {
+			if (!constantName(token.text(), new HashSet<>())) {
 				return true;
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * Whether this name is taken as constant inside an initialiser: a type constructor, or a macro
+	 * of the pack whose replacement text names nothing but those. A macro is read through because
+	 * it is gone by the time the compiler judges the line, and a call or another global inside it
+	 * counts exactly as it would written out. That is the coarseness of the rule above and not the
+	 * compiler's: the compiler folds a builtin over literals and keeps the keyword, and what it
+	 * refuses is a global this very pass demoted, which a macro is one way of naming. Reverie
+	 * writes ten colours through a macro over {@code mix}, {@code pow} and {@code step}, and they
+	 * lose a keyword the compiler would have kept, at no cost to the image.
+	 */
+	private boolean constantName(String name, Set<String> path) {
+		if (LegacyGlsl.TYPE_NAMES.contains(name)) {
+			return true;
+		}
+
+		if (!this.packMacros.contains(name)) {
+			return false;
+		}
+
+		Boolean judged = this.macroConstant.get(name);
+		if (judged != null) {
+			return judged;
+		}
+
+		// A macro naming itself is not expanded again by the preprocessor either.
+		if (path.contains(name)) {
+			return true;
+		}
+
+		// A chain of names is bounded as PreprocessorExpression bounds its own: a pack is
+		// downloaded content, and the overflow is an error nothing above here catches. Past the
+		// bound the name counts as non-constant, which costs the keyword and nothing else.
+		if (path.size() >= MAX_MACRO_HOPS) {
+			return false;
+		}
+
+		path.add(name);
+		try {
+			boolean constant = true;
+			for (String inside : this.macroBodies.getOrDefault(name, Set.of())) {
+				if (!constantName(inside, path)) {
+					constant = false;
+					break;
+				}
+			}
+
+			this.macroConstant.put(name, constant);
+
+			return constant;
+		} finally {
+			path.remove(name);
+		}
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
+++ b/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
@@ -110,7 +110,7 @@ public final class IncludeExpander {
 
 		ConditionStack conditions = new ConditionStack();
 
-		for (String line : this.source.readLines(file)) {
+		for (Logical logical : logicalLines(this.source.readLines(file))) {
 			// Checked here and not only on the way in. One file is enough on its own: a pack that
 			// ships a single shader of a million lines never expands anything, so a budget read
 			// once per file would never be read at all.
@@ -119,8 +119,9 @@ public final class IncludeExpander {
 				break;
 			}
 
+			String line = logical.text();
 			if (handleCondition(line, conditions, state)) {
-				state.emit(line, true);
+				state.emit(logical.physical(), true);
 				continue;
 			}
 
@@ -139,7 +140,7 @@ public final class IncludeExpander {
 
 			if (!conditions.active()) {
 				// Kept as it was, so that what the compiler discards is what is written here.
-				state.emit(line, false);
+				state.emit(logical.physical(), false);
 				continue;
 			}
 
@@ -149,16 +150,66 @@ public final class IncludeExpander {
 				// ones come from includes and would be an error where they land.
 				if (state.version == null) {
 					state.version = version.group(1).replaceAll("//.*", "").trim();
-					state.emit(line, true);
+					state.emit(logical.physical(), true);
 				}
 
 				continue;
 			}
 
-			state.emit(track(line, state), true);
+			String tracked = track(line, state);
+			if (tracked.equals(line)) {
+				state.emit(logical.physical(), true);
+			} else {
+				state.emit(tracked, true);
+			}
 		}
 
 		state.onPath.remove(relative);
+	}
+
+	/**
+	 * One line as the compiler reads it, and the lines of the file it was written over.
+	 * <p>
+	 * A backslash before a line break joins the next line onto this one before the compiler reads
+	 * a single directive, so the directives are matched and the conditions decided on the joined
+	 * text. Read line by line as written, a condition continued over three lines is decided on its
+	 * first: Photon undefines its waving switches under one written that way, the fragment on the
+	 * first line could not be decided and so stood for true, the switches came off the table, and
+	 * the include they guard was skipped while the compiler, seeing the whole condition, kept the
+	 * code that calls into it.
+	 * <p>
+	 * What is EMITTED stays the lines as written, because the compiler joins them again and joins
+	 * once: Bliss ends a comment with three backslashes and a blank line under it, the compiler
+	 * takes the last backslash with the blank line and the comment ends there, and a joined line
+	 * written out would end with the two backslashes left, which the compiler would then take
+	 * with the line of code below. Sixteen units lost a declaration that way. The one line written
+	 * out joined is a {@code #define} a setting rewrote, which no pack of the corpus continues.
+	 */
+	private record Logical(String text, List<String> physical) {
+	}
+
+	private static List<Logical> logicalLines(List<String> lines) {
+		List<Logical> logical = new ArrayList<>(lines.size());
+		StringBuilder joined = new StringBuilder();
+		List<String> physical = new ArrayList<>();
+		for (String line : lines) {
+			physical.add(line);
+			if (line.endsWith("\\")) {
+				joined.append(line, 0, line.length() - 1);
+				continue;
+			}
+
+			joined.append(line);
+			logical.add(new Logical(joined.toString(), List.copyOf(physical)));
+			joined.setLength(0);
+			physical.clear();
+		}
+
+		if (!physical.isEmpty()) {
+			logical.add(new Logical(joined.toString(), List.copyOf(physical)));
+		}
+
+		return logical;
 	}
 
 	/** Returns true when the line was a conditional directive and has been accounted for. */
@@ -312,6 +363,10 @@ public final class IncludeExpander {
 			this.live.set(this.output.size(), taken);
 			this.output.add(line);
 			this.characters += line.length() + 1;
+		}
+
+		private void emit(List<String> lines, boolean taken) {
+			lines.forEach(line -> emit(line, taken));
 		}
 
 		private boolean overBudget() {

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -68,10 +68,14 @@ function that disagree about them are a real conflict.
 
 **`const` on a variable whose initialiser is not a constant expression is stripped.** Vulkan
 refuses a global `const mat3` initialised from `transpose(...)`, or from a uniform, which OpenGL
-drivers took as merely immutable. The keyword comes off and the value stays. A declaration whose
-initialiser is only literals, type constructors and names the unit itself defines is left alone,
-because an array size still needs a real constant. Parameters keep `const`: that spelling means
-immutable, not compile-time.
+drivers took as merely immutable. The keyword comes off and the value stays. The rule is coarser
+than the compiler's, which folds a builtin over literals and keeps the keyword: here a declaration
+whose initialiser is only literals and type constructors is left alone, because an array size still
+needs a real constant, and any call or any other global takes the keyword off. A macro the unit
+defines is judged by what it stands for, since the compiler sees the body and not the name: one
+standing for a number leaves the keyword on, one hiding a call or another global takes it off, and
+that matters because what the compiler does refuse is a global this same rule had already demoted.
+Parameters keep `const`: that spelling means immutable, not compile-time.
 
 **Names that collide with newer builtins are renamed.** A function a pack defines can collide with
 a builtin introduced after the version the pack targets, and the error does not name the collision:

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -18,6 +18,12 @@ Two properties follow, and both are load-bearing:
 conditional branch, so the include graph is a function of the resolved option values. Changing a
 setting rebuilds the units; it does not patch them.
 
+**A condition is decided on the line the compiler reads.** A backslash before a line break joins
+the next line onto this one before the compiler sees a directive, so the expander decides a
+condition, matches an include and tracks a define on the joined text. What it writes out is the
+lines as they were, unless a setting rewrote the line: the compiler joins them again, and it joins
+once, so a joined line written out could end on a backslash the pack never meant as a continuation.
+
 **Order at load matters.** The table of values that supplies a pack's defines has to be installed
 *before* the pack is read, because those symbols decide which branches compile. Read the pack first
 and it sees none of them. The same table is only meaningful once a world exists, so the reload path


### PR DESCRIPTION
## What changes

Two rules of the translation, both of which Photon runs into. A `const` whose initialiser goes through a macro is now judged on what the macro stands for rather than on its name: a macro hiding a call or another global takes the keyword off, as the call written out would, and one standing for a number leaves it on. And the include expander decides a conditional continued with a backslash on the whole line, as the compiler does, while still writing the pack's lines out exactly as they were, since the compiler joins them again and joins once.

Before this, Photon was refused at load on its blending pass, whose fog colours are written through a macro over `pow` and a colour matrix this engine had already demoted; and its terrain and shadow vertex programs failed on a function whose include sits behind a switch the pack undefines under a three-line condition, decided on its first line alone.

The `const` rule stays coarser than the compiler, which folds a builtin over literals: Reverie writes ten colours through a macro over `mix`, `pow` and `step` and now loses a keyword it could have kept, and both spellings compile. A chain of macros is bounded at eight hops, as a chain of settings already is.

## How it differs from the reference, and for what obstacle

It does not. Iris hands the pack's text to OpenGL, which takes both spellings as written. Both rules exist only because the Vulkan compiler refuses a global `const` that is not a constant expression, and because this engine follows includes itself before any compiler runs.

## What proves it

- `gradlew build` green.
- The out-of-game harness, `Traduction` over the thirteen packs of the Fabric bench. Photon goes from 268 of its 339 entry points compiling to 324; every other pack keeps its count to the unit. What Photon still fails is what it switches off at default settings (depth of field, upscaling, coloured lights) and its far-terrain water. Without the second change its terrain and shadow vertex programs fail on `weather_wind`; without the first, sixty `const` declarations are refused across its three dimensions.
- In the game: not tried yet, the bench was held.

## What it leaves owing

Photon still cannot draw its sky. Its atmosphere lookup table is a three-dimensional volume of half floats asked to clamp, and the flat atlas this engine serves volumes through takes one byte a texel and repeating only, so the three deferred passes reading it are dropped. That is a batch of its own.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
