### PR TITLE
fix(sodium): gather the shadow casters after the light's walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ what the next one holds.
   it: the difference is the caster's half width, under a block for most mobs and a few for the
   largest, and the shadow lands as far out as it does there.
 
+- **A mob the player cannot see casts no shadow.** With Sodium's entity culling on, which is
+  its default, a creature standing where the player's view does not reach, behind the player
+  first of all, was left out of the shadow map even where its shadow fell in plain sight, and
+  it came back the moment the player turned towards it. The casters that move are now chosen
+  after the light's own walk of the world, off what the light sees, as Iris does.
+
+- **The shadow map stopped where the camera's fog did.** With Sodium's fog occlusion on, rain
+  and water shortened the walk that fills the shadow map along with the one that draws the
+  world, so a far hill still casting into the view dropped out of the map. The light's walk is
+  no longer shortened by the camera's fog.
+
 ## 0.9.0-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/mixin/MixinSodiumWorldRenderer.java
+++ b/common/src/main/java/dev/vitrail/mixin/MixinSodiumWorldRenderer.java
@@ -2,21 +2,17 @@ package dev.vitrail.mixin;
 
 import net.caffeinemc.mods.sodium.client.render.SodiumWorldRenderer;
 import net.caffeinemc.mods.sodium.client.render.chunk.RenderSectionManager;
-import net.caffeinemc.mods.sodium.client.util.FogParameters;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 /**
- * Reaches the two pieces of state the shadow stage walks the world with: the section manager the
- * light's cull runs against, and the fog the camera's own walk was bounded by, so both walks of a
- * frame measure distance the same way.
+ * Reaches the section manager the light's cull runs against. The camera's fog is not taken with
+ * it: the light's walk is bounded by the render distance and by the pack's, and by no fog of the
+ * camera's, which is the note {@code ShadowTerrain} carries beside the walk.
  */
 @Mixin(value = SodiumWorldRenderer.class, remap = false)
 public interface MixinSodiumWorldRenderer {
 
 	@Accessor("renderSectionManager")
 	RenderSectionManager vitrail$renderSectionManager();
-
-	@Accessor("lastFogParameters")
-	FogParameters vitrail$lastFogParameters();
 }

--- a/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
@@ -103,20 +103,28 @@ public final class ShadowGeometry {
 	}
 
 	/**
-	 * Works out which entities the light can see, before the light's own walk of the sections runs.
+	 * Works out which entities the light can see, AFTER the light's own walk of the sections has
+	 * run, and the order is load bearing.
 	 * <p>
-	 * <strong>For the entities the order settles nothing, and it is worth saying why.</strong> A
-	 * caster is kept or dropped by {@code LevelRenderer.isSectionCompiledAndVisible}, which Sodium
-	 * replaces outright ({@code mixin/core/render/world/LevelRendererMixin}) and answers off its own
-	 * section state; the game's own answer, a fade since the section's own upload
-	 * ({@code chunk/SectionRenderDispatcher.java:223-225}), is not the one that runs here. Neither
-	 * that state nor the frustum this builds is moved by the walk below, so asked before or after it
-	 * the test answers the same thing. Iris carries the same test
-	 * ({@code shadows/ShadowRenderer.java:703-705}). This sits here because it is the plainer place
-	 * to ask, and for no other reason.
+	 * Past the early exits of {@code shouldRender} itself (a renderer not affected by culling, the
+	 * distance test), a caster is kept or dropped by two tests.
+	 * {@code LevelRenderer.isSectionCompiledAndVisible}, which Sodium replaces outright
+	 * ({@code mixin/core/render/world/LevelRendererMixin}), answers "built" off the section's own
+	 * state and is moved by nothing. The frustum test of {@code shouldRender} is the one Sodium's
+	 * entity culling reaches into ({@code SodiumWorldRenderer.isEntityVisible}), and that answers
+	 * off the occlusion tree the last walk left in {@code RenderSectionManager.renderTree}. Before
+	 * the light's walk that tree is the camera's, so a mob whose sections the camera's walk did not
+	 * reach, one behind the player first of all, casts nothing; after the walk it is the light's,
+	 * and the test answers for the map being drawn. Sodium spares three things from that tree, and
+	 * they were never missing: a caster whose box touches a section with no geometry in it, one
+	 * that glows or wears a name, and one too large to test. Iris extracts its entities inside its
+	 * shadow scope ({@code shadows/ShadowRenderer.java:549}), where the tree is never the camera's:
+	 * the swap at {@code compat/sodium/mixin/MixinRenderSectionManagerShadow.java:150} installs a
+	 * field nothing assigns, so the tree there is the shadow walk's own on the frames that rebuild
+	 * its lists, and none at all on the others.
 	 * <p>
-	 * <strong>For the block entities the order decides everything</strong>, and they are taken in
-	 * {@link #gatherBlockEntities} instead, which says why.
+	 * The block entities are taken in {@link #gatherBlockEntities} instead, off the light's own
+	 * render lists, which says why.
 	 *
 	 * @param light   the light's own view projection, the matrix the terrain is culled against
 	 * @param camera  where the frame was drawn from, which the map is built around
@@ -477,9 +485,13 @@ public final class ShadowGeometry {
 	 * an axis-aligned cube about the camera cut out of it, and the game's own {@code shouldRender}
 	 * hands both the caster's culling box inflated by half a block ({@code :703} there,
 	 * {@code entity/EntityRenderer.java:73-78}). {@link Reached} is that cube asked of that box.
-	 * What stands beside it is the light's own frustum rather than the sweep, and that is the open
-	 * gap: a caster inside the cube and the light's volume but outside the sweep is kept here and
-	 * dropped there, which costs a draw and never a pixel, the sweep being built so that nothing
+	 * What stands beside it in the planes is the light's own frustum rather than the sweep, but the
+	 * sweep reaches the caster all the same, by Sodium's road: {@code shouldRender} asks the terrain
+	 * renderer's tree, and after the light's walk that tree holds the sections the walk visited
+	 * under {@code ShadowCullFrustum}, so a caster inside the cube and the light's volume but
+	 * outside the sweep is dropped here unless its box touches a section with no geometry in it.
+	 * Iris keeps that caster on the frames its shadow lists are not rebuilt, its tree being none
+	 * then; either way it costs a draw and never a pixel, the sweep being built so that nothing
 	 * outside it can shadow what the camera sees. The other way round is empty: Iris's entity
 	 * frustum never asks the light's volume, so a caster outside it is kept there and dropped here,
 	 * but outside the light's volume is outside the map, and what Iris keeps of it draws nothing.

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -42,12 +42,23 @@ import org.joml.Vector3f;
  * <p>
  * The stage stands at the end of a frame and not at its top, and that placement is the culling
  * design. The world is walked a second time for the light, under the shape
- * {@link ShadowCullFrustum} chooses for it, which reuses the very lists
- * the camera's walk just filled: {@code ChunkRenderList} is one persistent object per region, so
+ * {@link ShadowCullFrustum} chooses for it. <strong>The walk is the light's own</strong>: it is
+ * Sodium's synchronous traversal of every built section, under the light's frustum alone, with no
+ * occlusion and no fog, so nothing the camera can or cannot see decides what the map holds. What
+ * it reuses is the CONTAINERS: {@code ChunkRenderList} is one persistent object per region, so
  * there is nothing to save and restore, only an order to respect. Advancing the frame counter first
  * is what lets the second walk of a frame reset those lists instead of overflowing them, and raising
  * {@code needsRenderListUpdate} afterwards is what makes the camera's walk at the top of the next
  * frame take them back. One extra walk per frame, no bookkeeping.
+ * <p>
+ * The one thing the walk leaves behind for the length of the stage is the occlusion tree Sodium
+ * answers visibility questions from, which is the light's after the walk and the camera's before
+ * it. The entities are gathered AFTER the walk for that reason: Sodium's entity culling asks that
+ * tree, and asked before the walk it drops every caster whose sections the camera's walk did not
+ * reach, a mob behind the player first of all (spared: a box touching a section with no geometry,
+ * a glowing or named mob, a huge one). Iris extracts its entities inside its shadow scope, where
+ * that tree is never the camera's ({@code shadows/ShadowRenderer.java:549}, the swap at
+ * {@code compat/sodium/mixin/MixinRenderSectionManagerShadow.java:150}).
  * <p>
  * <strong>The price is that the shadows are one frame late</strong>, drawn with this frame's sun for
  * the next frame's picture. That is a deliberate divergence from Iris, which culls, draws and reads
@@ -194,12 +205,7 @@ public final class ShadowTerrain {
 		boolean measuring = measured != BlockStateIds.generation();
 		int seen = measuring ? sections(manager.getRenderLists()) : 0;
 
-		// Which entities the light can see is worked out here, and for them the position settles
-		// nothing: they are kept or dropped by a frustum and by a section's own state, neither of
-		// which this walk moves. The block entities are the opposite case and are taken further
-		// down, once the light has render lists of its own.
 		ShadowCasters casters = TerrainDraw.shadowCasters();
-		ShadowGeometry.gather(light, camera, casters);
 
 		// The frame counter first, and it is the piece easiest to miss: the per region lists only
 		// reset themselves for the first walk of a frame, so a second walk under the same number
@@ -224,7 +230,6 @@ public final class ShadowTerrain {
 			}
 		}
 		try {
-			FogParameters fog = ((MixinSodiumWorldRenderer) renderer).vitrail$lastFogParameters();
 			// The shape the pack asked for, and a box around the camera cut out of it wherever a
 			// shadow distance bounds the walk. Distance, default and Advanced keep that box and
 			// no planes. Advanced is the named divergence ShadowCullFrustum.of carries:
@@ -236,15 +241,24 @@ public final class ShadowTerrain {
 			ShadowCullFrustum.Chosen cull = ShadowCullFrustum.of(plan);
 			Viewport viewport = new Viewport(cull.frustum(),
 					new Vector3d(camera.x, camera.y, camera.z));
+			// No fog, whatever the camera's walk was bounded by. With Sodium's fog occlusion on, the
+			// walk stops at the fog's cull distance, and the camera's fog is the wrong bound for the
+			// light: rain or water shortens it, and a hill that still casts into the view would
+			// leave the map with it. Iris turns fog occlusion off for both walks whenever a pack is
+			// loaded (compat/sodium/mixin/MixinRenderSectionManager.java, iris$disableFogOcclusion);
+			// the camera's walk here still keeps its own fog, a gap of the picture and not of the
+			// map, and not this stage's to close.
 			manager.finalizeRenderLists(minecraft.gameRenderer.mainCamera(), viewport,
-					fog == null ? FogParameters.NONE : fog, true);
+					FogParameters.NONE, true);
 
-			// The block entities, HERE and not with the entities above: this is the first line of the
-			// stage at which the light has render lists of its own, and they are what says which
-			// sections to ask. Sodium's door onto them is the one Iris reaches through the game's
-			// extraction (shadows/ShadowRenderer.java:668, cancelled and served by the same mixin);
-			// the game's own visible sections are never filled at all under Sodium, so the walk that
-			// read them found a world with no chests in it.
+			// The entities, now that the tree Sodium answers visibility from is the light's, and the
+			// class note says what asking the camera's would drop. The block entities follow: this
+			// is the first line of the stage at which the light has render lists of its own, and
+			// they are what says which sections to ask. Sodium's door onto them is the one Iris
+			// reaches through the game's extraction (shadows/ShadowRenderer.java:668, cancelled and
+			// served by the same mixin); the game's own visible sections are never filled at all
+			// under Sodium, so the walk that read them found a world with no chests in it.
+			ShadowGeometry.gather(light, camera, casters);
 			ClientLevel level = minecraft.level;
 			if (level != null) {
 				ShadowGeometry.gatherBlockEntities((state, partial) -> renderer.extractBlockEntities(

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -171,12 +171,24 @@ ground under a mob with that map, and the game's oval on top of it would be a se
 author ever saw under their own pack. Under a pack without a map the oval is the only shadow a mob
 has, and it stays, drawn with the translucent entity program as Iris draws it.
 
-The two halves of that second walk are gathered at different moments, and it is not a tidiness.
-The entities are worked out before the light's own walk of the sections, since nothing that decides
-whether one is kept moves with that walk. The block entities can only be gathered after it: what
-says which sections to ask is the set of render lists the walk has just filled, and the terrain
-renderer hands them over off those lists. Asked any earlier, the question has the camera's answer or
-none at all.
+Both halves of that second walk are gathered after the light's own walk of the sections, and the
+order is not a tidiness. What decides whether a moving caster is kept is the terrain renderer's
+entity culling, which answers off the occlusion tree the last walk left behind: before the light's
+walk that tree is the camera's, so a mob behind the player would be dropped from a map its shadow
+belongs in; after it, the tree is the light's. (The terrain renderer never culls a caster whose
+box touches a section with no geometry in it, so a tall mob under open air was never missing.) The
+block entities have the same dependency in a plainer form: what says which sections to ask is the
+set of render lists the walk has just filled, and the terrain renderer hands them over off those
+lists. Asked any earlier, either question has the camera's answer or none at all.
+
+The walk itself is bounded by the render distance and by the pack's shadow distance, and by
+nothing else of the camera's. The
+terrain renderer would also stop it at the fog's cull distance when its fog occlusion is on, which
+is the right bound for the picture and the wrong one for the map: rain or water shortens it, and a
+hill still casting into the view would leave the map with it. The reference turns fog occlusion off
+for both walks whenever a pack is loaded; here the camera's walk still keeps its own fog. That is a
+gap of the picture and not of the map: under a pack whose fog is thinner than the game's, a hill
+past the game's fog distance is drawn there and cut here, and the shadow map is not what closes it.
 
 Which families reach the map at all is the pack's to decide, through six keys of
 `shaders.properties` and one `const float` of its source. Those keys and the trap in two of them


### PR DESCRIPTION
## What changes

The entities the shadow map draws are chosen after the light's own walk of the world, not before it. Sodium's entity culling keeps or drops a caster by asking the occlusion tree the last walk left behind, and before the light's walk that tree is the camera's: a mob standing where the player's view does not reach, behind the player first of all, was dropped from the map even where its shadow fell across the field in front of them, and came back the moment the player turned towards it. Gathered after the walk, the same test answers off the light's tree, which is the map being drawn. Sodium spares a caster whose box touches a section with no geometry in it, a glowing or named one, and a huge one; those were never missing.

The light's walk also stops taking the camera's fog as a bound. With Sodium's fog occlusion on, rain or water shortened the map along with the picture. The walk is now bounded by the render distance and the pack's shadow distance, and the accessor that fetched the camera's fog for it is gone.

## How it differs from the reference, and for what obstacle

On the map it does not. Iris extracts its shadow entities inside its shadow render-list scope (`shadows/ShadowRenderer.java:549`), where the section manager's tree is never the camera's: the scope swaps in a field Iris never assigns (`compat/sodium/mixin/MixinRenderSectionManagerShadow.java:150`), so the tree there is the shadow walk's own on the frames that rebuild its lists, and none on the others, where every caster in reach is kept. Here the light walks every frame, so a caster inside the reach but outside the sweep is dropped on every frame where Iris keeps it on most; the sweep is built so that nothing outside it can shadow what the camera sees, so that costs a draw and never a pixel. Iris also turns Sodium's fog occlusion off whenever a pack is loaded (`compat/sodium/mixin/MixinRenderSectionManager.java:33`), for both walks.

One gap is named rather than closed: Iris turns fog occlusion off for the camera's walk too, and this engine still lets the camera's walk keep its fog. That is a gap of the picture, not of the map: under a pack whose fog is thinner than the game's, a hill past the game's fog distance is drawn there and cut here. Nothing in the 26.2 API prevents closing it; it is a change to the picture with its own frame cost, and not this branch's.

## What proves it

- `gradlew build` green, after the rebase.
- In the game, Fabric bench, Complementary Unbound r5.8.1 at its stock profile, the pinned camera of the frozen world at dawn, the sun low behind the camera. A cow scaled eleven times, fifteen blocks tall, standing on flat ground twenty-eight blocks behind the camera on the sun's side, every section of its box outside the view and inside the pack's reach: under Iris 1.11.2 its band runs across the field in front of the camera, on `dev` the picture does not move when it is summoned, and on this branch the same band appears in the same cells. A cow scaled sixteen times on the same spot casts on all three: its head reaches a section of open air, which Sodium never culls. Mean captures of sixty frames compared in luminance, one game at a time.
- The mechanism itself, from a probe build that logged Sodium's answer for the same caster on the same frame: before the light's walk the tree is the camera's frustum-tested one and the caster behind the player is not visible; after it the tree is the light's and it is.
- Idle frame rate at the same spot, from the engine's own pass timings over thirty-second windows, the bench alone: the same on both jars, about a hundred and fifty-five frames per second over the settled windows, 6.45 ms between frames and 6.1 ms of passes on each. A first run of this branch had two windows a tenth lower while files were being written on the machine; a second run with the machine left alone did not.

## What it leaves owing

The camera's walk keeps its fog occlusion where Iris turns it off, as said above.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
