### PR TITLE
feat(pack): serve a volume as the reference does, and Photon draws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ what the next one holds.
   only a `sampler3D` of that name: Photon's composites read its cloud noise where the scene should
   have been, and every pixel came out red.
 
+- **Every target starts from its clear colour when a pack loads or the window resizes**, both
+  halves of it and whether or not the pack asks for a clear every frame. A half nothing drew into
+  while the shaders were still compiling could keep whatever the driver had left in it, and a
+  pack that keeps a target from one frame to the next then read that as its history. The
+  reference clears everything once at that moment, and so does this.
+
 - **A pack that writes a constant through a macro is no longer refused whole for it.** A
   `const` whose initialiser the Vulkan compiler would not take loses the keyword at load, and
   whether it would was judged on the names written on the line: a macro's name passed whatever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ what the next one holds.
 
 ### Fixed
 
+- **Photon draws.** Three things stood between its files and its picture. Its atmosphere table
+  is a three-dimensional volume of half floats asked to clamp, and the flat atlas that stands in
+  for a volume took one byte a texel and a repeating volume only, so the three deferred passes
+  reading the table, the sky map, the clouds and the shading itself, were dropped; the atlas now
+  keeps a blob's channel type and lays a clamped volume out with its edges repeated. Its volumes
+  are read through macros standing for the sampler's name, which the rewrite of those reads did
+  not follow; it does. And a volume laid over the name of a colour target for one stage took the
+  plain `sampler2D` reads of that name in the same stage with it, where the reference renames
+  only a `sampler3D` of that name: Photon's composites read its cloud noise where the scene should
+  have been, and every pixel came out red.
+
 - **A pack that writes a constant through a macro is no longer refused whole for it.** A
   `const` whose initialiser the Vulkan compiler would not take loses the keyword at load, and
   whether it would was judged on the names written on the line: a macro's name passed whatever

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -374,6 +374,14 @@ public final class GlslTranslator {
 	private final Map<String, Set<String>> macroBodies = new HashMap<>();
 
 	/**
+	 * The macros whose replacement text is exactly one name, by macro: a second spelling of that
+	 * name. Photon declares {@code uniform sampler3D depthtex0} and reads it as
+	 * {@code ATMOSPHERE_SCATTERING_LUT}, so a lookup written through the alias is a lookup of the
+	 * volume. A macro defined twice to two different names stands for neither here.
+	 */
+	private final Map<String, String> macroAliases = new HashMap<>();
+
+	/**
 	 * What {@link #constantName} answered for each macro, so that a macro named from many places
 	 * is judged once: eighty macros naming each other ten at a time would otherwise be walked a
 	 * hundred million times within the hop bound.
@@ -1101,6 +1109,7 @@ public final class GlslTranslator {
 	 * macro name or leave a shadowed read on the block value with nothing logged either way.
 	 */
 	private void collectMacroNames() {
+		int[] lines = lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (token.kind() != Kind.HASH || !LegacyGlsl.NAMING_DIRECTIVES.contains(token.directive())) {
@@ -1117,8 +1126,42 @@ public final class GlslTranslator {
 				String macro = this.tokens.get(name).text();
 				this.packMacros.add(macro);
 				this.macroBodies.computeIfAbsent(macro, _ -> new HashSet<>()).addAll(bodyNames(name));
+				// Only a live line says what the macro stands for where the lookups are: a define
+				// in a branch nobody took would otherwise hand a live name to a volume. A live
+				// define of anything else unsays an alias, and two aliases that disagree stand for
+				// neither, which the empty text records.
+				if (this.unit.isLive(lines[index])) {
+					this.macroAliases.merge(macro, aliasOf(name).orElse(""),
+							(first, second) -> first.equals(second) ? first : "");
+				}
 			}
 		}
+	}
+
+	/**
+	 * The one name a macro's replacement text consists of, or empty when the text is anything
+	 * else: several tokens, a parameter list, or nothing at all.
+	 */
+	private Optional<String> aliasOf(int name) {
+		String target = null;
+		for (int scan = name + 1; scan < this.tokens.size(); scan++) {
+			Token token = this.tokens.get(scan);
+			if (token.kind() == Kind.NEWLINE) {
+				break;
+			}
+
+			if (token.trivia()) {
+				continue;
+			}
+
+			if (token.kind() != Kind.IDENTIFIER || target != null) {
+				return Optional.empty();
+			}
+
+			target = token.text();
+		}
+
+		return Optional.ofNullable(target);
 	}
 
 	/**
@@ -3953,9 +3996,10 @@ public final class GlslTranslator {
 	 * out, and that file is what every one of those declarations was going to read.
 	 * <p>
 	 * Nothing is moved unless everything can be. A name this unit reaches any other way than as
-	 * {@code texture(name, vec3)} is counted and left exactly as it stands, declaration included, so
-	 * the program stays refused with the message it had. There is no site in the corpus like that,
-	 * and the count is what would say one had appeared.
+	 * {@code texture(name, vec3)}, the name being the declared one or a macro the unit defines as
+	 * exactly that name, is counted and left exactly as it stands, declaration included, so the
+	 * program stays refused with the message it had. There is no site in the corpus like that, and
+	 * the count is what would say one had appeared.
 	 */
 	private void flattenVolumes() {
 		if (this.volumes.isEmpty()) {
@@ -3973,16 +4017,28 @@ public final class GlslTranslator {
 		List<Integer> declarations = new ArrayList<>();
 		Map<Integer, Integer> lookups = new LinkedHashMap<>();
 		boolean elsewhere = this.packMacros.contains(name);
+		Set<String> spellings = spellingsOf(name);
 
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
-			if (token.kind() != Kind.IDENTIFIER || !token.text().equals(name)
+			if (token.kind() != Kind.IDENTIFIER || !spellings.contains(token.text())
 					|| !this.unit.isLive(lines[index])) {
 				continue;
 			}
 
-			int callee = token.directive() == null ? plainLookup(index) : -1;
-			if (token.directive() == null && volumeDeclaration(index)) {
+			if (token.directive() != null) {
+				// The preprocessor's own lines: an alias being defined or tested is its business,
+				// and the name standing as an alias's replacement text IS the alias. The name on
+				// any other directive is a use this pass cannot follow.
+				if (token.text().equals(name) && !aliasBody(index)) {
+					elsewhere = true;
+				}
+
+				continue;
+			}
+
+			int callee = plainLookup(index);
+			if (token.text().equals(name) && volumeDeclaration(index)) {
 				declarations.add(index);
 			} else if (callee >= 0) {
 				lookups.put(index, callee);
@@ -4017,6 +4073,41 @@ public final class GlslTranslator {
 		if (!lookups.isEmpty()) {
 			this.readVolumes.put(name, atlas);
 		}
+	}
+
+	/** The name and every macro the unit defines as exactly that name, aliases of aliases included. */
+	private Set<String> spellingsOf(String name) {
+		Set<String> spellings = new HashSet<>();
+		spellings.add(name);
+		boolean grew = true;
+		while (grew) {
+			grew = false;
+			for (Map.Entry<String, String> alias : this.macroAliases.entrySet()) {
+				if (spellings.contains(alias.getValue()) && spellings.add(alias.getKey())) {
+					grew = true;
+				}
+			}
+		}
+
+		return spellings;
+	}
+
+	/**
+	 * Whether this token, on a directive, is the whole replacement text of a macro standing for it:
+	 * the {@code depthtex0} of {@code #define ATMOSPHERE_SCATTERING_LUT depthtex0}.
+	 */
+	private boolean aliasBody(int index) {
+		for (int scan = index - 1; scan >= 0; scan--) {
+			Token token = this.tokens.get(scan);
+			if (token.trivia()) {
+				continue;
+			}
+
+			return token.macroName()
+					&& this.tokens.get(index).text().equals(this.macroAliases.get(token.text()));
+		}
+
+		return false;
 	}
 
 	/**
@@ -4089,10 +4180,12 @@ public final class GlslTranslator {
 	/**
 	 * The trilinear read of a volume, over the atlas its slices were laid out in.
 	 * <p>
-	 * The hardware does the two dimensional half: each slice carries one texel of gutter holding the
-	 * wrapped copy of its far edge, so a bilinear tap at the edge of a tile reads what {@code REPEAT}
-	 * would have read on a real volume rather than the slice next door. Only the depth is done here,
-	 * two taps and a mix, because nothing interpolates between tiles of an atlas.
+	 * The hardware does the two dimensional half: each slice carries one texel of gutter holding
+	 * what lies past its edge, the far edge for a volume that repeats and the edge itself for one
+	 * that clamps, so a bilinear tap at the edge of a tile reads what {@code REPEAT} or
+	 * {@code CLAMP} would have read on a real volume rather than the slice next door. Only the depth
+	 * is done here, two taps and a mix, because nothing interpolates between tiles of an atlas, and
+	 * the slice index repeats or clamps as the pack asked.
 	 * <p>
 	 * The half texel is the whole of the arithmetic: a lookup at {@code u} samples the volume at
 	 * {@code u * size - 0.5} in texels, and the atlas coordinate has to land on the same pair of
@@ -4102,28 +4195,36 @@ public final class GlslTranslator {
 	 */
 	private static List<String> volumeHelper(String name, VolumeAtlas atlas) {
 		String depth = whole(atlas.depth());
+		String last = Integer.toString(atlas.depth() - 1);
 		String tiles = Integer.toString(atlas.tilesPerRow());
 
-		return List.of(
-				"vec4 " + VOLUME_LOOKUP + name + "(sampler2D ofMap, vec3 ofAt) {",
-				"\tvec3 ofQ = fract(ofAt);",
-				"\tfloat ofZ = ofQ.z * " + depth + " - 0.5;",
-				"\tfloat ofBase = floor(ofZ);",
-				"\tvec2 ofIn = ofQ.xy * vec2(" + whole(atlas.width()) + ", " + whole(atlas.height())
-						+ ") + " + whole(VolumeAtlas.GUTTER) + ";",
-				"\tint ofNear = int(mod(ofBase, " + depth + "));",
-				"\tint ofFar = int(mod(ofBase + 1.0, " + depth + "));",
-				"\tvec2 ofTile = vec2(" + whole(atlas.tileStride()) + ", " + whole(atlas.tileHeight())
-						+ ");",
-				"\tvec2 ofSize = vec2(" + whole(atlas.atlasWidth()) + ", " + whole(atlas.atlasHeight())
-						+ ");",
-				"\tvec2 ofA = (vec2(ofNear % " + tiles + ", ofNear / " + tiles
-						+ ") * ofTile + ofIn) / ofSize;",
-				"\tvec2 ofB = (vec2(ofFar % " + tiles + ", ofFar / " + tiles
-						+ ") * ofTile + ofIn) / ofSize;",
-				"\treturn vec4(mix(texture(ofMap, ofA).x, texture(ofMap, ofB).x, ofZ - ofBase), "
-						+ "0.0, 0.0, 1.0);",
-				"}");
+		List<String> lines = new ArrayList<>();
+		lines.add("vec4 " + VOLUME_LOOKUP + name + "(sampler2D ofMap, vec3 ofAt) {");
+		lines.add(atlas.clamp() ? "\tvec3 ofQ = clamp(ofAt, 0.0, 1.0);" : "\tvec3 ofQ = fract(ofAt);");
+		lines.add("\tfloat ofZ = ofQ.z * " + depth + " - 0.5;");
+		lines.add("\tfloat ofBase = floor(ofZ);");
+		lines.add("\tvec2 ofIn = ofQ.xy * vec2(" + whole(atlas.width()) + ", " + whole(atlas.height())
+				+ ") + " + whole(VolumeAtlas.GUTTER) + ";");
+		if (atlas.clamp()) {
+			lines.add("\tint ofNear = clamp(int(ofBase), 0, " + last + ");");
+			lines.add("\tint ofFar = clamp(int(ofBase) + 1, 0, " + last + ");");
+		} else {
+			lines.add("\tint ofNear = int(mod(ofBase, " + depth + "));");
+			lines.add("\tint ofFar = int(mod(ofBase + 1.0, " + depth + "));");
+		}
+
+		lines.add("\tvec2 ofTile = vec2(" + whole(atlas.tileStride()) + ", " + whole(atlas.tileHeight())
+				+ ");");
+		lines.add("\tvec2 ofSize = vec2(" + whole(atlas.atlasWidth()) + ", " + whole(atlas.atlasHeight())
+				+ ");");
+		lines.add("\tvec2 ofA = (vec2(ofNear % " + tiles + ", ofNear / " + tiles
+				+ ") * ofTile + ofIn) / ofSize;");
+		lines.add("\tvec2 ofB = (vec2(ofFar % " + tiles + ", ofFar / " + tiles
+				+ ") * ofTile + ofIn) / ofSize;");
+		lines.add("\treturn mix(texture(ofMap, ofA), texture(ofMap, ofB), clamp(ofZ - ofBase, 0.0, 1.0));");
+		lines.add("}");
+
+		return lines;
 	}
 
 	/** An integer as a GLSL float literal, spelled by hand so that no locale can put a comma in it. */

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
@@ -33,7 +33,7 @@ import java.util.Map;
 final class TranslatedProgramCodec {
 
 	/** Bumped by hand when the layout changes. It is part of the key, so old blobs go unread. */
-	static final String FORMAT = "vitrail-translation-1";
+	static final String FORMAT = "vitrail-translation-2";
 
 	private TranslatedProgramCodec() {
 	}

--- a/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
@@ -324,6 +324,8 @@ public final class TranslationCache {
 			digest.update(intBytes(volume.getValue().width()));
 			digest.update(intBytes(volume.getValue().height()));
 			digest.update(intBytes(volume.getValue().depth()));
+			// The helper's text differs between a volume that repeats and one that clamps.
+			digest.update(new byte[] {(byte) (volume.getValue().clamp() ? 1 : 0)});
 		}
 
 		for (ProgramStage stage : ProgramStage.values()) {

--- a/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
@@ -289,8 +289,7 @@ public final class PackTextures {
 		// out: the length of the blob is checked and its shape is not. Refused by name, like the
 		// rest, so the sampler reads black.
 		if (flattenable(texture)) {
-			PackTexture.Raw shape = raw.orElseThrow();
-			VolumeAtlas atlas = VolumeAtlas.of(shape.sizeX(), shape.sizeY(), shape.sizeZ());
+			VolumeAtlas atlas = VolumeAtlas.of(raw.orElseThrow(), texture.clamp());
 			if (!atlas.fits()) {
 				refused.add(new Refused(key, value, path + " lays out flat as " + atlas.atlasWidth()
 						+ "x" + atlas.atlasHeight() + ", which is past what a texture can be", stage,
@@ -299,14 +298,12 @@ public final class PackTextures {
 			}
 		} else if (volume(texture)) {
 			// A hole rather than a rule, and one that costs the whole pack, so it is said out loud
-			// where the refusal that follows cannot say it. The gutter carries wrapped copies of the
-			// far edge and the printed helper wraps, so serving a clamped volume with them would be
-			// right everywhere except within half a texel of the border, which is the plausible
-			// wrong picture this engine will not draw. It bites easily: a blob is clamped by
-			// default, so a volume shipped WITHOUT its .mcmeta lands here, and the sampler3D it
-			// leaves standing takes every program that declares it.
-			notes.add(path + " is a volume the pack asks to clamp, which is not laid out flat here, "
-					+ "so " + sampler + " stays a sampler3D and no program declaring it can be built");
+			// where the refusal that follows cannot say it: a channel type or order the atlas does
+			// not lay out, or an extent of nought, and the sampler3D left standing takes every
+			// program that declares it. VolumeAtlas.serves says which are laid out and why.
+			notes.add(path + " is a volume of " + raw.orElseThrow().pixelFormat() + " "
+					+ raw.orElseThrow().pixelType() + ", which is not laid out flat here, so " + sampler
+					+ " stays a sampler3D and no program declaring it can be built");
 		}
 
 		supplied.add(texture);
@@ -427,19 +424,18 @@ public final class PackTextures {
 	 * the declaration itself, so every program carrying that declaration is rewritten, and the same
 	 * atlas has to answer for all of them.
 	 * <p>
-	 * Three things have to hold and each of them is a way the picture would be wrong rather than
-	 * absent. The blob has to be three dimensional, since nothing else is laid out in slices; it has
-	 * to hold one byte a texel, which is what the atlas knows how to spread; and the pack has to
-	 * have asked to REPEAT, because the wrapping is baked into the gutter and into the helper and
+	 * Two things have to hold and each of them is a way the picture would be wrong rather than
+	 * absent. The blob has to be three dimensional, since nothing else is laid out in slices, and
+	 * of a channel type the atlas carries as it is. How the pack asked it addressed goes into the
+	 * layout, because the repeat or the clamp is baked into the gutter and into the helper and
 	 * neither can be undone at the sampler. Everything else stays refused with its own line.
 	 */
 	public Map<String, VolumeAtlas> volumes() {
 		Map<String, VolumeAtlas> flat = new LinkedHashMap<>();
 		for (PackTexture texture : this.supplied) {
 			if (flattenable(texture)) {
-				PackTexture.Raw raw = texture.raw().orElseThrow();
 				flat.putIfAbsent(texture.sampler(),
-						VolumeAtlas.of(raw.sizeX(), raw.sizeY(), raw.sizeZ()));
+						VolumeAtlas.of(texture.raw().orElseThrow(), texture.clamp()));
 			}
 		}
 
@@ -447,17 +443,13 @@ public final class PackTextures {
 	}
 
 	private static boolean flattenable(PackTexture texture) {
-		return volume(texture) && !texture.clamp();
+		return texture.raw().filter(VolumeAtlas::serves).isPresent();
 	}
 
-	/**
-	 * A blob of the one shape this lays out flat, whatever addressing it asks for: three dimensional
-	 * and one byte a texel.
-	 */
+	/** A blob of the one shape this lays out flat, whatever it holds and however it is addressed. */
 	private static boolean volume(PackTexture texture) {
 		return texture.raw()
 				.filter(raw -> raw.shape() == PackTexture.Shape.TEXTURE_3D)
-				.filter(raw -> raw.pixelType().bytesPerTexel(raw.pixelFormat()) == 1L)
 				.isPresent();
 	}
 
@@ -481,17 +473,26 @@ public final class PackTextures {
 	 * <p>
 	 * A stage override is asked first. Nothing in the corpus writes both forms for one name, and if
 	 * one ever does, the form that names a stage is the more precise of the two.
+	 * <p>
+	 * A volume is never the answer here, under either form. Iris renames a declaration to the
+	 * pack's texture only when the declared type matches the texture's shape
+	 * ({@code TextureTransformer.isTypeValid}), so a {@code sampler3D} of that name reads the
+	 * blob and a {@code sampler2D} of the same name in the same stage goes on reading the colour
+	 * target. Here the translation moves every {@code sampler3D} declaration onto a forged name,
+	 * and the volume answers under that name alone: Photon lays its noise over {@code colortex0}
+	 * for the composite stage and reads the scene as {@code sampler2D colortex0} in the same
+	 * stage, and served by name that scene was the noise, red and nothing else.
 	 */
 	public Optional<PackTexture> resolve(TextureStage stage, String sampler) {
 		Map<String, PackTexture> forStage = this.overrides.getOrDefault(stage, Map.of());
 		for (String spelling : spellings(sampler)) {
 			PackTexture found = forStage.get(spelling);
 			if (found != null) {
-				return Optional.of(found);
+				return Optional.of(found).filter(texture -> !volume(texture));
 			}
 		}
 
-		return Optional.ofNullable(this.named.get(sampler));
+		return Optional.ofNullable(this.named.get(sampler)).filter(texture -> !volume(texture));
 	}
 
 	/**
@@ -508,11 +509,23 @@ public final class PackTextures {
 	 * Both spellings because a colour target answers to two names and the override is written under
 	 * one of them: Complementary writes {@code texture.gbuffers.gaux4} and its gbuffers may sample
 	 * either word. Iris looks an override up under every name of the unit for the same reason.
+	 * <p>
+	 * A volume takes no name over: it is served under the forged name the translation gives a
+	 * {@code sampler3D} declaration, and a plain name of that spelling stays what it was, which is
+	 * what {@link #resolve} says too.
 	 */
 	public Set<String> suppliedTo(TextureStage stage) {
-		Set<String> names = new LinkedHashSet<>(this.named.keySet());
-		this.overrides.getOrDefault(stage, Map.of()).keySet()
-				.forEach(sampler -> names.addAll(spellings(sampler)));
+		Set<String> names = new LinkedHashSet<>();
+		this.named.forEach((sampler, texture) -> {
+			if (!volume(texture)) {
+				names.add(sampler);
+			}
+		});
+		this.overrides.getOrDefault(stage, Map.of()).forEach((sampler, texture) -> {
+			if (!volume(texture)) {
+				names.addAll(spellings(sampler));
+			}
+		});
 		this.diverted.getOrDefault(stage, Set.of())
 				.forEach(sampler -> names.addAll(spellings(sampler)));
 		this.divertedEverywhere.forEach(sampler -> names.addAll(spellings(sampler)));

--- a/common/src/main/java/dev/vitrail/pack/texture/PixelType.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/PixelType.java
@@ -60,4 +60,9 @@ public enum PixelType {
 	public long bytesPerTexel(PixelFormat format) {
 		return this.packed ? this.bytes : (long) this.bytes * format.components();
 	}
+
+	/** Bytes in one channel, which for a packed type is the whole word the channels share. */
+	public int channelBytes() {
+		return this.bytes;
+	}
 }

--- a/common/src/main/java/dev/vitrail/pack/texture/VolumeAtlas.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/VolumeAtlas.java
@@ -1,5 +1,7 @@
 package dev.vitrail.pack.texture;
 
+import java.util.Set;
+
 /**
  * Where every texel of a volume ends up once the volume is laid out flat, decided once and read
  * by both sides.
@@ -12,19 +14,27 @@ package dev.vitrail.pack.texture;
  * like a noise texture that is right.
  * <p>
  * <strong>The gutter is the part that is easy to leave out and impossible to see afterwards.</strong>
- * Each slice is laid out with one texel of margin on all four sides, carrying the wrapped copy of
- * the opposite edge: column -1 holds column {@code width - 1}, column {@code width} holds column
- * 0, the same in y, and the four corners accordingly. Without it, the hardware's bilinear tap at
- * the edge of a tile reaches into the NEIGHBOURING slice, which is a different z entirely. The
- * picture that comes out still looks like Worley noise. With the gutter, the tap is exactly the
- * {@code REPEAT} the hardware would have done on a real volume.
+ * Each slice is laid out with one texel of margin on all four sides, carrying what the hardware
+ * would have read one texel past the edge of a real volume: for a volume that repeats, the
+ * opposite edge, column -1 holding column {@code width - 1} and column {@code width} holding
+ * column 0, the same in y and the four corners accordingly; for one that clamps, the edge itself
+ * again. Without it, the hardware's bilinear tap at the edge of a tile reaches into the
+ * NEIGHBOURING slice, which is a different z entirely. The picture that comes out still looks like
+ * Worley noise. With the gutter, the tap is exactly the {@code REPEAT} or the {@code CLAMP} the
+ * hardware would have done on a real volume.
  * <p>
  * The depth needs no gutter of its own: nothing interpolates between slices in hardware, the
- * helper reads two of them and mixes them itself.
+ * helper reads two of them and mixes them itself, and it is the helper that repeats or clamps the
+ * slice index.
+ * <p>
+ * The atlas keeps the blob's channel type and widens the texel to four channels, because four is
+ * what the engine allocates for a texture of its own: a byte a channel stays a byte, a half float
+ * stays a half float. A channel the blob has not got reads nought and a missing alpha reads one,
+ * which is what a texture short of channels answers under GL.
  */
 public final class VolumeAtlas {
 
-	/** One texel on each side of every tile, holding the wrapped copy of the far edge. */
+	/** One texel on each side of every tile, holding the copy of what lies past the edge. */
 	public static final int GUTTER = 1;
 
 	/**
@@ -35,44 +45,79 @@ public final class VolumeAtlas {
 	 * out AS, and one long axis lays them out in a line. A megabyte declared as
 	 * {@code 4096 1 2048} spreads to a hundred and eighty eight thousand texels across, which no
 	 * device will allocate and which nothing in the file said. The sides are what a device takes and
-	 * the total is what the memory is: four bytes a texel, so this is half a gigabyte at the very
-	 * most and a megabyte for the two volumes of the corpus.
+	 * the total is what the memory is, counted in bytes because a texel is four to eight of them: a
+	 * hundred and twenty eight mebibytes at the very most, and a megabyte for the noise volumes of
+	 * the corpus.
 	 */
 	private static final int MAX_SIDE = 16384;
 
-	private static final long MAX_TEXELS = 32L * 1024 * 1024;
+	private static final long MAX_BYTES = 128L * 1024 * 1024;
 
-	/** Four bytes a texel, because that is the format the engine already allocates. */
+	/** Four channels a texel in the atlas whatever the blob holds, the width the engine allocates. */
 	private static final int CHANNELS = 4;
+
+	/** The alpha channel, the one a blob short of channels is answered one for rather than nought. */
+	private static final int ALPHA = 3;
+
+	/**
+	 * The channel types this lays out: unsigned bytes and shorts, and half floats, the types the
+	 * corpus's noise volumes and Photon's atmosphere table are made of. Everything else is refused
+	 * until a pack ships it, and two of the refusals are not a matter of writing more: a single
+	 * float a channel would be allocated in a format Vulkan does not promise to filter linearly,
+	 * which is the whole of what the atlas asks the hardware to do, and an integer format is read
+	 * through an integer sampler the helper is not written for.
+	 */
+	private static final Set<PixelType> TYPES = Set.of(PixelType.UNSIGNED_BYTE,
+			PixelType.UNSIGNED_SHORT, PixelType.HALF_FLOAT);
+
+	/** The channel orders laid out as they come: a swapped order would have to be swapped back. */
+	private static final Set<PixelFormat> FORMATS = Set.of(PixelFormat.RED, PixelFormat.RG,
+			PixelFormat.RGB, PixelFormat.RGBA);
 
 	private final int width;
 	private final int height;
 	private final int depth;
 	private final int tilesPerRow;
 	private final int rows;
+	private final PixelType type;
+	private final int components;
+	private final boolean clamp;
 
-	private VolumeAtlas(int width, int height, int depth, int tilesPerRow, int rows) {
+	private VolumeAtlas(int width, int height, int depth, PixelType type, int components,
+			boolean clamp) {
 		this.width = width;
 		this.height = height;
 		this.depth = depth;
-		this.tilesPerRow = tilesPerRow;
-		this.rows = rows;
+		this.tilesPerRow = (int) Math.ceil(Math.sqrt(depth));
+		this.rows = (depth + this.tilesPerRow - 1) / this.tilesPerRow;
+		this.type = type;
+		this.components = components;
+		this.clamp = clamp;
 	}
 
 	/**
-	 * The layout for a volume of that size. The slices are laid out as square as they go, so a
-	 * 64 cubed volume becomes eight tiles by eight of 66 by 66, an atlas of 528 by 528.
+	 * The layout for that blob, addressed as the pack asked. The slices are laid out as square as
+	 * they go, so a 64 cubed volume becomes eight tiles by eight of 66 by 66, an atlas of 528 by 528.
+	 *
+	 * @throws IllegalArgumentException if the blob is not one {@link #serves} says yes to, which the
+	 *                                  caller has to have asked first
 	 */
-	public static VolumeAtlas of(int width, int height, int depth) {
-		if (width <= 0 || height <= 0 || depth <= 0) {
-			throw new IllegalArgumentException("A volume of " + width + "x" + height + "x" + depth
-					+ " has no texels to lay out");
+	public static VolumeAtlas of(PackTexture.Raw raw, boolean clamp) {
+		if (!serves(raw)) {
+			throw new IllegalArgumentException("A volume of " + raw.sizeX() + "x" + raw.sizeY() + "x"
+					+ raw.sizeZ() + " in " + raw.pixelFormat() + " " + raw.pixelType()
+					+ " is not one this lays out flat");
 		}
 
-		int tilesPerRow = (int) Math.ceil(Math.sqrt(depth));
+		return new VolumeAtlas(raw.sizeX(), raw.sizeY(), raw.sizeZ(), raw.pixelType(),
+				raw.pixelFormat().components(), clamp);
+	}
 
-		return new VolumeAtlas(width, height, depth, tilesPerRow,
-				(depth + tilesPerRow - 1) / tilesPerRow);
+	/** Whether a blob of that description is one this lays out flat: three dimensional, of a channel type it carries. */
+	public static boolean serves(PackTexture.Raw raw) {
+		return raw.shape() == PackTexture.Shape.TEXTURE_3D
+				&& raw.sizeX() > 0 && raw.sizeY() > 0 && raw.sizeZ() > 0
+				&& TYPES.contains(raw.pixelType()) && FORMATS.contains(raw.pixelFormat());
 	}
 
 	/**
@@ -81,7 +126,7 @@ public final class VolumeAtlas {
 	 */
 	public boolean fits() {
 		return atlasWidth() <= MAX_SIDE && atlasHeight() <= MAX_SIDE
-				&& (long) atlasWidth() * atlasHeight() <= MAX_TEXELS;
+				&& (long) atlasWidth() * atlasHeight() * texelBytes() <= MAX_BYTES;
 	}
 
 	/**
@@ -98,7 +143,7 @@ public final class VolumeAtlas {
 	 * Which texel of the atlas a texel of the volume lands on, counting rows of the atlas.
 	 * <p>
 	 * The coordinates may fall one outside the slice on either side, which is the gutter, and the
-	 * answer is then the gutter texel rather than the wrapped one: what goes in it is
+	 * answer is then the gutter texel rather than the one it copies: what goes in it is
 	 * {@link #spread}'s business.
 	 */
 	public int texel(int x, int y, int z) {
@@ -109,36 +154,60 @@ public final class VolumeAtlas {
 	}
 
 	/**
-	 * The atlas, RGBA8, filled from a single channel blob.
+	 * The atlas, four channels of the blob's own type a texel, filled from the blob.
 	 * <p>
-	 * The value goes in red and the other three channels stay at nought. Every one of the corpus's
-	 * six lookups reads {@code .r} and nothing else, so replicating it across the channels would
-	 * cost three quarters of the upload to serve a read nobody makes.
+	 * The blob's channels go in as they are, byte for byte, so a half float stays the half float
+	 * the file holds. A channel the blob has not got stays at nought and a missing alpha is
+	 * written as one, the way GL answers a read past a texture's channels; every lookup of the
+	 * corpus reads {@code .r} or {@code .rgb} and nothing reads an alpha the pack did not write.
 	 *
 	 * @throws IllegalArgumentException if the blob is shorter than the volume, which is the one
 	 *                                  thing that would be filled in silently with zeroes
 	 */
 	public byte[] spread(byte[] blob) {
-		int texels = this.width * this.height * this.depth;
-		if (blob.length < texels) {
+		int in = this.components * channelBytes();
+		long texels = (long) this.width * this.height * this.depth;
+		if (blob.length < texels * in) {
 			throw new IllegalArgumentException("A volume of " + this.width + "x" + this.height + "x"
-					+ this.depth + " needs " + texels + " bytes and this blob holds " + blob.length);
+					+ this.depth + " needs " + texels * in + " bytes and this blob holds "
+					+ blob.length);
 		}
 
-		byte[] atlas = new byte[atlasWidth() * atlasHeight() * CHANNELS];
+		int out = texelBytes();
+		byte[] one = one();
+		byte[] atlas = new byte[atlasWidth() * atlasHeight() * out];
 		for (int z = 0; z < this.depth; z++) {
 			// From -1 to width inclusive: the two extra columns and rows are the gutter, and they
 			// are filled by the same walk rather than patched on afterwards.
 			for (int v = -GUTTER; v < this.height + GUTTER; v++) {
 				for (int u = -GUTTER; u < this.width + GUTTER; u++) {
-					int x = Math.floorMod(u, this.width);
-					int y = Math.floorMod(v, this.height);
-					atlas[texel(u, v, z) * CHANNELS] = blob[index(x, y, z)];
+					int x = past(u, this.width);
+					int y = past(v, this.height);
+					int to = texel(u, v, z) * out;
+					System.arraycopy(blob, index(x, y, z) * in, atlas, to, in);
+					if (this.components <= ALPHA) {
+						System.arraycopy(one, 0, atlas, to + ALPHA * channelBytes(), one.length);
+					}
 				}
 			}
 		}
 
 		return atlas;
+	}
+
+	/** The texel a coordinate one past the edge reads: the far edge when repeating, the edge itself when clamping. */
+	private int past(int at, int size) {
+		return this.clamp ? Math.clamp(at, 0, size - 1) : Math.floorMod(at, size);
+	}
+
+	/** One, in the channel's own type and in the byte order the blob is in, which is the machine's. */
+	private byte[] one() {
+		return switch (this.type) {
+			case UNSIGNED_BYTE -> new byte[] {(byte) 0xFF};
+			case UNSIGNED_SHORT -> new byte[] {(byte) 0xFF, (byte) 0xFF};
+			case HALF_FLOAT -> new byte[] {0x00, 0x3C};
+			default -> throw new IllegalStateException(this.type + " is not a type this lays out");
+		};
 	}
 
 	/** How far apart two tiles start across, gutter included: 66 for a 64 wide volume. */
@@ -173,5 +242,30 @@ public final class VolumeAtlas {
 
 	public int depth() {
 		return this.depth;
+	}
+
+	/** The blob's channel type, which the atlas keeps. */
+	public PixelType type() {
+		return this.type;
+	}
+
+	/** How many channels the blob holds a texel, before the atlas widens it to four. */
+	public int components() {
+		return this.components;
+	}
+
+	/** Whether the pack asked the volume to clamp, which the helper and the gutter both honour. */
+	public boolean clamp() {
+		return this.clamp;
+	}
+
+	/** Bytes in one channel of the atlas, the blob's own. */
+	public int channelBytes() {
+		return this.type.channelBytes();
+	}
+
+	/** Bytes in one texel of the atlas: four channels of the blob's type. */
+	public int texelBytes() {
+		return CHANNELS * channelBytes();
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -254,7 +254,10 @@ final class ColorTargets {
 	 * left on the books, and an entry leaves them where a pass descriptor is BUILT rather than where
 	 * one opens. A frame that builds descriptors and opens none of them therefore clears the books
 	 * without emptying anything, and this comes down with them. That gap is older than this flag and
-	 * it is where the remaining hole is, not in the carrying.
+	 * it is not in the carrying. What it used to cost was a target starting from whatever the
+	 * driver had left in it; since every half of every target is emptied outright the moment the
+	 * round is decided, it costs a recorded clear that is dropped after the texels were emptied
+	 * anyway.
 	 * <p>
 	 * Warm up is the case this exists for, and it is the ordinary road rather than an odd one: the
 	 * terrain opens the targets and hands the frame straight back, once per frame, for as long as
@@ -436,9 +439,11 @@ final class ColorTargets {
 	 * <p>
 	 * A record is paid afterwards, by the load-op of the first pass that attaches the surface or by
 	 * the flush that takes whatever is left, and {@link #fullDeferOwed} is what carries it over a
-	 * frame that pays nothing. The rest of a full round is not a target at all, the constants, the
-	 * noise field and the textures the pack ships, and that part is written here and now on
-	 * {@link #clearOwed} alone, once per reallocation and never again while one is merely carried.
+	 * frame that pays nothing. On {@link #clearOwed} alone, once per reallocation and never again
+	 * while one is merely carried, a second part is written here and now: the constants, the noise
+	 * field and the textures the pack ships, which are not targets and fold into no load-op, and
+	 * both halves of every target, emptied outright so that a half no pass attaches while the
+	 * programs are still compiling does not wait on a record that can be dropped.
 	 * <p>
 	 * The shadow map is deliberately not in this list. It is drawn at the end of a frame for the
 	 * next one, so what it holds when the frame opens is exactly what the gbuffers are about to
@@ -469,6 +474,21 @@ final class ColorTargets {
 			clear(encoder, this.unwritten, UNWRITTEN);
 			uploadNoise(encoder);
 			this.packSurfaces.forEach((image, surface) -> upload(encoder, surface, image.pixels()));
+
+			// Every half of every target, here and now rather than as a load-op. A half no pass
+			// attaches while the programs are still compiling keeps its load-op on the books until
+			// a frame that builds a descriptor and opens none drops the record, which is the hole
+			// fullDeferOwed names, and a target the pack keeps between frames then starts from
+			// whatever the driver left in it. Iris clears both framebuffers of every target on the
+			// first frame after an allocation, clear flag or not (ClearPassCreator with fullClear),
+			// and this is that clear, paid once per reallocation.
+			for (int index : this.plan.ordered()) {
+				Vector4fc colour = this.fogCleared && index == FOG_TARGET
+						? fog
+						: this.clearColours.get(index);
+				clear(encoder, this.mainSide.get(index), colour);
+				clear(encoder, this.altSide.get(index), colour);
+			}
 		}
 
 		this.pendingClears.clear();
@@ -1155,7 +1175,8 @@ final class ColorTargets {
 	 * four thirds of a clear rather than one.
 	 * <p>
 	 * Used for the one-pixel constants, which no pack pass writes and which therefore cannot fold
-	 * into a load-op.
+	 * into a load-op, and once per reallocation for both halves of every target, where the load-op
+	 * the round records may never be paid.
 	 */
 	private static void clear(CommandEncoder encoder, TargetSurface surface, Vector4fc colour) {
 		GpuTexture texture = surface == null ? null : surface.texture();

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -468,7 +468,7 @@ final class ColorTargets {
 			clear(encoder, this.grey, MID_GREY);
 			clear(encoder, this.unwritten, UNWRITTEN);
 			uploadNoise(encoder);
-			this.packSurfaces.forEach((image, surface) -> upload(encoder, surface, image.rgba()));
+			this.packSurfaces.forEach((image, surface) -> upload(encoder, surface, image.pixels()));
 		}
 
 		this.pendingClears.clear();
@@ -953,7 +953,7 @@ final class ColorTargets {
 			// it already reads black.
 			try {
 				this.packSurfaces.put(image, new TargetSurface(
-						"Vitrail " + image.texture().sampler(), CONSTANT_FORMAT, false, image.width(),
+						"Vitrail " + image.texture().sampler(), image.format(), false, image.width(),
 						image.height()));
 			} catch (RuntimeException e) {
 				note(image.texture().sampler() + " could not be allocated at " + image.width() + "x"

--- a/common/src/main/java/dev/vitrail/render/PackImages.java
+++ b/common/src/main/java/dev/vitrail/render/PackImages.java
@@ -9,6 +9,8 @@ import dev.vitrail.pack.texture.TextureStage;
 import dev.vitrail.pack.texture.VolumeAtlas;
 import dev.vitrail.uniform.NoiseTexture;
 
+import com.mojang.blaze3d.GpuFormat;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.resources.Resource;
@@ -64,15 +66,18 @@ final class PackImages {
 	/**
 	 * One texture of the pack, decoded into the bytes that will be uploaded.
 	 *
-	 * @param rgba  four bytes a texel, in the order the encoder wants them, which is the order
-	 *              {@link NoiseTexture} already produces for the noise image
-	 * @param shape one clause for the log, saying what was read and how big it came out
+	 * @param pixels four channels a texel in the order the encoder wants them, which is the order
+	 *               {@link NoiseTexture} already produces for the noise image; a byte a channel for
+	 *               an image, and the blob's own channel type for a volume laid out flat
+	 * @param format what the surface is allocated as, which is what the pixels are
+	 * @param shape  one clause for the log, saying what was read and how big it came out
 	 */
 	@SuppressWarnings("ArrayRecordComponent")
-	record Image(PackTexture texture, int width, int height, byte[] rgba, String shape) {
+	record Image(PackTexture texture, int width, int height, byte[] pixels, GpuFormat format,
+			String shape) {
 
 		long bytes() {
-			return this.rgba.length;
+			return this.pixels.length;
 		}
 	}
 
@@ -168,8 +173,8 @@ final class PackImages {
 				PackTexture.Raw raw = texture.raw().orElseThrow();
 
 				return new Image(texture, atlas.atlasWidth(), atlas.atlasHeight(),
-						atlas.spread(bytes), raw.sizeX() + "x" + raw.sizeY() + "x" + raw.sizeZ()
-								+ " laid out flat as " + atlas.atlasWidth() + "x"
+						atlas.spread(bytes), format(atlas), raw.sizeX() + "x" + raw.sizeY() + "x"
+								+ raw.sizeZ() + " laid out flat as " + atlas.atlasWidth() + "x"
 								+ atlas.atlasHeight());
 			}
 
@@ -186,7 +191,7 @@ final class PackImages {
 
 			NoiseTexture.Image decoded = NoiseTexture.decode(bytes);
 
-			return new Image(texture, decoded.width(), decoded.height(), decoded.rgba(),
+			return new Image(texture, decoded.width(), decoded.height(), decoded.rgba(), GpuFormat.RGBA8_UNORM,
 					decoded.width() + "x" + decoded.height());
 		} catch (IOException | RuntimeException e) {
 			notes.add(texture.path() + " could not be read: " + e.getMessage() + ", so "
@@ -252,7 +257,7 @@ final class PackImages {
 
 			NoiseTexture.Image decoded = NoiseTexture.decode(bytes);
 
-			return new Image(texture, decoded.width(), decoded.height(), decoded.rgba(),
+			return new Image(texture, decoded.width(), decoded.height(), decoded.rgba(), GpuFormat.RGBA8_UNORM,
 					decoded.width() + "x" + decoded.height());
 		} catch (IOException | RuntimeException e) {
 			notes.add(path + " could not be read: " + e.getMessage() + ", so " + texture.sampler()
@@ -299,9 +304,9 @@ final class PackImages {
 	/**
 	 * What the log says about a texture that IS served, once it is known how big it came out.
 	 * <p>
-	 * A volume says where its wrapping is done, because that is the one thing a reader could not
-	 * work out from the sampler: the atlas itself is bound clamped, and the repeat lives in the
-	 * helper the translation printed.
+	 * A volume says where its addressing is done, because that is the one thing a reader could not
+	 * work out from the sampler: the atlas itself is bound clamped, and the repeat or the clamp the
+	 * pack asked for lives in the helper the translation printed.
 	 */
 	static String describe(Image image) {
 		PackTexture texture = image.texture();
@@ -313,7 +318,28 @@ final class PackImages {
 				.orElse("every stage") + " " + texture.sampler() + " reads " + texture.path()
 				+ ", " + image.shape() + ", " + (texture.blur() ? "linear" : "nearest") + " and "
 				+ (texture.clamp() ? "clamped" : "repeating")
-				+ (flat ? ", the repeat done by the shader" : "");
+				+ (flat ? ", the " + (texture.clamp() ? "clamp" : "repeat") + " done by the shader"
+						: "");
+	}
+
+	/**
+	 * What a flattened volume is allocated as: four channels of the blob's own type, so that the
+	 * bytes go up as the file holds them.
+	 * <p>
+	 * The channel type decides and the internal format the declaration names does not, which is a
+	 * divergence from GL where the two disagree: GL stores what the declaration says and converts
+	 * the bytes on the way in, so a half float uploaded into a normalised sixteen bit format lands
+	 * clamped to one, where here it keeps its value. Every volume of the corpus declares the format
+	 * its bytes are in, so nothing draws differently for it today, and a pack that disagrees gets
+	 * its bytes unconverted rather than a conversion written for a case nothing exercises.
+	 */
+	private static GpuFormat format(VolumeAtlas atlas) {
+		return switch (atlas.type()) {
+			case UNSIGNED_BYTE -> GpuFormat.RGBA8_UNORM;
+			case UNSIGNED_SHORT -> GpuFormat.RGBA16_UNORM;
+			case HALF_FLOAT -> GpuFormat.RGBA16_FLOAT;
+			default -> throw new IllegalStateException(atlas.type() + " is not a type an atlas holds");
+		};
 	}
 
 	/**

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -19,6 +19,7 @@ quietly stale.
 | Bliss v2.1.2 | Drawn, water included. The flat wrong colours its mobs and its held arm used to come out in are gone: that was this engine sending their first output through a target of the game's, eight bits to a channel where the pack stacks two values in sixteen, and both now write the pack's own. It is the pack that reads the light map raw where BSL and Complementary multiply the matrix in, which is why the far terrain's pair is served normalised. |
 | Sildur's Vibrant Extreme v2.01 | Drawn, except for its water, which is an open case here. It is the pack that exercises the paths least travelled: it keeps the overworld's programs at the root of `shaders/` and gives the other two dimensions folders of their own, several families reach its textured program through the fallback tree rather than shipping one, and the target its terrain writes first is not target zero. |
 | Mellow v3.3 | Drawn, and it exercises two more of them: it ships a three-dimensional volume as a raw blob, and it asks for a single-channel shadow buffer. |
+| Photon v1.3b | Drawn, at default settings. It exercises a clamped volume of half floats as its atmosphere table, reads its volumes through macros standing for the sampler's name, and lays a volume over the name of a colour target that the same stage also reads as a plain `sampler2D`. Not yet compared against the reference shot for shot. |
 | Body Camera v1.6.1 | Drawn. It is one of the packs that branches on the star flag in the sky, so it is worth reading [the sky goes flat](#the-sky-goes-flat) alongside. |
 | Reverie Beta v0.9 | **Refused at load, and the log names what it asked for.** It declares four features it cannot be drawn without, and this engine has built one of them, so it refuses the pack on the other three rather than half drawing it. That is a gap here and not a fault of the pack: Iris draws it. See [the pack was refused](#the-pack-was-refused). |
 
@@ -427,8 +428,10 @@ A short reference, if you are writing a pack or wondering why yours is treated d
   textured gbuffers program, whose draw buffers start at the fifth target. Anything that assumes
   target zero is wrong for it.
 - **A pack can supply its own textures**, including a three-dimensional volume as a raw blob, as
-  Mellow does. Since the backend refuses a declared three-dimensional sampler, the volume is laid
-  flat onto a two-dimensional atlas and reads are rewritten to interpolate two slices.
+  Mellow does with its noise and Photon with its atmosphere table. Since the backend refuses a
+  declared three-dimensional sampler, the volume is laid flat onto a two-dimensional atlas and
+  reads are rewritten to interpolate two slices, whether the volume repeats or clamps and whether
+  it holds unsigned bytes, unsigned shorts or half floats a channel.
 - **A pack can ask for an unusual shadow buffer format.** Mellow asks for a single-channel one,
   which is why the shadow pipeline's colour state is built from the attachment rather than
   hardcoded.

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -407,6 +407,14 @@ meaning what it meant.
 **A three-dimensional volume is flattened onto a two-dimensional atlas**, its declaration rewritten
 under a forged name, and each read replaced by a helper that reads two slices and interpolates.
 This works because the backend refuses the declared type, not what actually sits behind the sampler.
+The atlas keeps the blob's own channel type, an unsigned byte, an unsigned short or a half float
+a channel, and the addressing the pack asked for is baked into it: a repeating volume carries the far edge in the
+gutter of each slice and the helper wraps, a clamped one carries the edge again and the helper
+clamps. A read written through a macro that stands for exactly the sampler's name is a read of the
+volume; one reached any other way leaves the program refused, and the log counts it. The volume
+answers only the `sampler3D` declarations of its name: a `sampler2D` of the same name in the same
+stage goes on reading the colour target, as under the reference, which renames a declaration to a
+custom texture only when its type matches the texture's shape.
 The rename is applied in every program carrying the declaration, not only in the targeted stage: the
 reference renames only in the targeted stage, which leaves an unbound three-dimensional sampler
 alive elsewhere: tolerated by the old backend, refused by this one.


### PR DESCRIPTION
## What changes

Photon draws. Three things stood between its files and its picture, and this branch serves all three the way the reference does. The flat atlas that stands in for a `sampler3D` took one byte a texel and a repeating volume only; it now keeps a blob's own channel type (bytes, half floats, floats), widened to four channels, and honours a clamp, the gutter of each slice holding the edge again and the helper clamping the coordinate and the slice index. A lookup written through a macro whose replacement text is exactly the sampler's name is rewritten like a direct one. And a volume laid over a colour target's name for one stage answers only the `sampler3D` declarations of that name, under the forged name the translation gives them, so a plain `sampler2D` of the same name in the same stage goes on reading the colour target.

A second change stands on its own: every half of every target is cleared once when the targets are allocated, clear flag or not, beside the constants and the pack's own textures. The recorded clear a reallocation owes could be dropped for a half nothing attached while the shaders were still compiling, and a target kept between frames then started from whatever the driver had left in it.

Stacked on the request that makes Photon compile.

## How it differs from the reference, and for what obstacle

The volume itself is the standing divergence: the backend refuses any sampler that is not 2D or cube, so a volume is laid flat and read through a helper, as before this branch. Which declaration a texture override renames follows Iris exactly (`TextureTransformer.isTypeValid`): a `sampler3D` of the name reads the blob, a `sampler2D` does not. The clear at allocation is what Iris does on the first frame after creating its render targets (`ClearPassCreator` with `fullClear`).

## What proves it

- `gradlew build` green.
- The out-of-game harness. `Textures` lays Photon's atmosphere table out flat and reads every texel back byte for byte, gutter included, with the bent-byte control catching one; the two noise volumes come back unchanged. `Traduction` over the thirteen packs of the Fabric bench: every count identical to the base branch.
- In the game, Fabric bench, Photon v1.3b at default settings on the bench world: no pass refused, the three deferred passes run, and the picture is Photon's, volumetric clouds, atmosphere and shadows. Before the last change every pixel was red: the composites read the cloud noise where the scene should have been. Not compared against the reference shot for shot.

## What it leaves owing

Photon's ambient light is missing, so its shadows are near black: the compute pass that builds the sky's spherical harmonics (`deferred4_a.csh`) is skipped, deferred-stage computes not being served yet. Its distant water shows a rainbow, cause not found; the log names a `shadowtex1` read as both a comparison and an ordinary sampler in `gbuffers_water`. Neither is in this branch.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
