### PR TITLE
feat(render): dispatch the computes a pass hangs off, before it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ what the next one holds.
   under one of those, so the include the switches guard was skipped and its terrain and shadow
   programs compiled against a function that was not there.
 
+- **Photon's shadows are lit again.** The compute programs a pack attaches to its full screen
+  passes were named in the log and skipped, so whatever they prepared for the pass after them was
+  never there: Photon computes its sky lighting in one, and everything in shadow, the hand first,
+  was black for the lack of it. Those programs now run, right before the pass they belong to. A
+  compute whose pass the pack ships no fragment program for, and one attached to a setup program,
+  are still skipped, and the log still names them.
+
 - **A mob standing just past the pack's shadow reach for entities keeps its shadow while any
   of it still reaches inside.** A pack that stops its moving casters short of the terrain
   (Complementary does, at an eighth of its shadow distance) had that reach measured on the

--- a/common/src/main/java/dev/vitrail/mixin/VulkanConstMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanConstMixin.java
@@ -1,0 +1,33 @@
+package dev.vitrail.mixin;
+
+import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.vulkan.VulkanConst;
+import dev.vitrail.render.TextureUsage;
+import org.lwjgl.vulkan.VK10;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Lets a colour target be written by a compute shader.
+ * <p>
+ * A pack's compute pass may write a colour target directly, {@code layout(rgba16f) uniform image2D
+ * colorimg4} in Photon's sky harmonics, and Vulkan refuses a storage descriptor on an image created
+ * without {@code VK_IMAGE_USAGE_STORAGE_BIT}. The game's conversion knows four usages and never
+ * this one, so the bit is added on the way out whenever {@link TextureUsage} says the texture being
+ * created on this thread asked for it. No other texture takes the bit: the flag is raised by the
+ * engine's own surfaces for one call each, on their own thread, and lowered right after.
+ */
+@Mixin(VulkanConst.class)
+public abstract class VulkanConstMixin {
+
+	@Inject(method = "textureUsageToVk(ILcom/mojang/blaze3d/GpuFormat;)I", at = @At("RETURN"),
+			cancellable = true)
+	private static void vitrail$storageUsage(int usage, GpuFormat format,
+			CallbackInfoReturnable<Integer> info) {
+		if (TextureUsage.storageRequested()) {
+			info.setReturnValue(info.getReturnValueI() | VK10.VK_IMAGE_USAGE_STORAGE_BIT);
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/program/ProgramNames.java
+++ b/common/src/main/java/dev/vitrail/pack/program/ProgramNames.java
@@ -36,6 +36,14 @@ public final class ProgramNames {
 	/** Families that stand alone. */
 	private static final Set<String> SIMPLE = Set.of("shadow", "final");
 
+	/**
+	 * The full screen families whose passes a compute may hang off, which is every family the
+	 * chain draws. Setup is the one left out: Iris runs it once at load and this engine has no
+	 * such moment yet.
+	 */
+	private static final Set<String> CHAINED = Set.of("begin", "prepare", "deferred", "composite",
+			"final");
+
 	/** Highest slot the format allows on a numbered family. */
 	private static final int MAX_SLOT = 99;
 
@@ -125,6 +133,30 @@ public final class ProgramNames {
 	/** The family a program belongs to, {@code composite} for {@code composite4}. */
 	public static String familyOf(String baseName) {
 		return parse(baseName).map(ProgramName::family).orElse(baseName);
+	}
+
+	/**
+	 * The full screen pass a compute file hangs off, {@code deferred4} for {@code deferred4_a} and
+	 * for {@code deferred4} itself: Iris reads the letter-less file first and the lettered ones
+	 * after it, stopping at the first letter missing ({@code ProgramSet.readComputeArray}), all
+	 * off the same pass. Empty for a file that hangs off nothing this engine runs as a pass,
+	 * setup among them. Whether the pass itself runs, and whether the letter follows on from the
+	 * one before, is the plan's to say.
+	 *
+	 * @param file the compute file's name without its extension, which is a name of its own
+	 */
+	public static Optional<String> computeBase(String file) {
+		return parse(file)
+				.filter(name -> CHAINED.contains(name.family()))
+				.map(ProgramName::baseName);
+	}
+
+	/**
+	 * The letter that orders the computes of one pass, the letter-less file first and then
+	 * {@code a} before {@code b}.
+	 */
+	public static String computeLetter(String file) {
+		return parse(file).map(ProgramName::computeSuffix).orElse("");
 	}
 
 	public static Optional<ProgramName> parse(String baseName) {

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -222,18 +223,47 @@ public final class TargetPlan {
 			String file = key.file();
 			int dot = file.lastIndexOf('.');
 			String path = dot < 0 ? file : file.substring(0, dot);
-			String name = key.name().baseName();
+			// The file, letter included, relative to the place: deferred4_a and deferred4 are two
+			// computes of one pass, run in that order, and the stage that runs them opens each
+			// under its own name.
+			String prefix = draft.place.isEmpty() ? "" : draft.place + "/";
+			String stem = path.startsWith(prefix) ? path.substring(prefix.length()) : path;
 			if (Boolean.FALSE.equals(toggles.get(path))) {
-				off.put(name, conditions.getOrDefault(path, "shaders.properties"));
+				off.put(stem, conditions.getOrDefault(path, "shaders.properties"));
 				continue;
 			}
 
-			kept.add(name);
+			kept.add(stem);
 		}
 
-		// Several files answer for one name once the letter is off it, and the name runs as soon
-		// as one of them is on: what the plan carries downstream is the name.
-		off.keySet().removeAll(kept);
+		// Iris reads the letters of one name in order and stops at the first one missing
+		// (ProgramSet.readComputeArray), so a deferred4_b shipped without a deferred4_a is a file
+		// it never opens, and neither does this.
+		Map<String, List<String>> byBase = new LinkedHashMap<>();
+		for (String stem : kept) {
+			byBase.computeIfAbsent(ProgramNames.parse(stem)
+					.map(ProgramNames.ProgramName::baseName)
+					.orElse(stem), _ -> new ArrayList<>()).add(stem);
+		}
+
+		for (List<String> stems : byBase.values()) {
+			Set<String> letters = new HashSet<>();
+			for (String stem : stems) {
+				letters.add(ProgramNames.computeLetter(stem));
+			}
+
+			for (String stem : stems) {
+				String letter = ProgramNames.computeLetter(stem);
+				for (char c = 'a'; c < (letter.isEmpty() ? 'a' : letter.charAt(0)); c++) {
+					if (!letters.contains(String.valueOf(c))) {
+						kept.remove(stem);
+						draft.unreachableComputes.add(stem);
+						break;
+					}
+				}
+			}
+		}
+
 		draft.computes = List.copyOf(kept);
 		draft.disabledComputes.putAll(off);
 	}
@@ -547,8 +577,11 @@ public final class TargetPlan {
 	}
 
 	/**
-	 * Compute entry points this place ships, by bare name. Shadowcomp is dispatched after the
-	 * shadow map; the rest are named in {@link #notes()} until a stage exists for them.
+	 * Compute entry points this place ships and keeps on, by file name without the extension,
+	 * letter included: {@code deferred4_a} and {@code deferred4} are two of them. Shadowcomp is
+	 * dispatched at the head of the frame, a compute hanging off a begin, prepare, deferred,
+	 * composite or final pass right before that pass, and the rest are named in {@link #notes()}
+	 * until a stage exists for them.
 	 */
 	public List<String> computes() {
 		return this.computes;
@@ -689,16 +722,43 @@ public final class TargetPlan {
 			List<String> shadow = draft.computes.stream()
 					.filter(name -> ProgramNames.shadowComposite(ProgramNames.familyOf(name)))
 					.toList();
-			List<String> other = draft.computes.stream()
+			// Hanging off a pass this place draws: the chain dispatches them before it. Iris also
+			// runs a compute whose pass has no fragment program, as a pass of its own
+			// (CompositeRenderer.java:135-141), and the chain has no step for that yet.
+			List<String> chained = draft.computes.stream()
 					.filter(name -> !ProgramNames.shadowComposite(ProgramNames.familyOf(name)))
+					.filter(name -> ProgramNames.computeBase(name)
+							.filter(draft.running::contains).isPresent())
+					.toList();
+			List<String> orphaned = draft.computes.stream()
+					.filter(name -> !shadow.contains(name) && !chained.contains(name))
+					.filter(name -> ProgramNames.computeBase(name).isPresent())
+					.toList();
+			List<String> other = draft.computes.stream()
+					.filter(name -> !shadow.contains(name) && !chained.contains(name)
+							&& !orphaned.contains(name))
 					.toList();
 			if (!shadow.isEmpty()) {
 				notes.add("shadow compute served: " + shadow);
 			}
 
+			if (!chained.isEmpty()) {
+				notes.add("compute programs dispatched before the pass they hang off: " + chained);
+			}
+
+			if (!orphaned.isEmpty()) {
+				notes.add("compute programs skipped, the pass they hang off does not run here and "
+						+ "the reference runs them as a pass of their own: " + orphaned);
+			}
+
 			if (!other.isEmpty()) {
 				notes.add("compute programs skipped, no stage exists for them yet: " + other);
 			}
+		}
+
+		if (!draft.unreachableComputes.isEmpty()) {
+			notes.add("compute programs past a gap in their letters, which the reference never "
+					+ "opens: " + draft.unreachableComputes);
 		}
 
 		// Named apart from the passes the engine leaves out, because nothing here is missing: the
@@ -825,6 +885,9 @@ public final class TargetPlan {
 		private final List<String> running = new ArrayList<>();
 		private final Map<String, String> disabled = new LinkedHashMap<>();
 		private final Map<String, String> disabledComputes = new LinkedHashMap<>();
+
+		/** Compute files past a gap in their letters, which the reference never opens. */
+		private final List<String> unreachableComputes = new ArrayList<>();
 		private final Set<String> shadowComposites = new TreeSet<>();
 		private final Set<Integer> written = new TreeSet<>();
 		private final Set<Integer> sampled = new TreeSet<>();

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -31,6 +31,7 @@ import org.joml.Vector4fc;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -265,6 +266,16 @@ final class ColorTargets {
 	 * rewrite every constant and re-upload every texture the pack ships on each one of them.
 	 */
 	private boolean fullDeferOwed;
+
+	/**
+	 * The targets a compute of the pack writes as {@code colorimgN}, which have to be created with
+	 * the storage usage: the bit is baked into the image, so it is known before the first
+	 * allocation and never added to one.
+	 */
+	private Set<Integer> storageTargets = Set.of();
+
+	/** The targets a compute asked to store into and the device refused, each said once. */
+	private final Set<Integer> storageRefused = new HashSet<>();
 
 	private boolean broken;
 
@@ -644,6 +655,16 @@ final class ColorTargets {
 		return device == null
 				? ASSUMED_COLOR_ATTACHMENTS
 				: Math.max(1, device.getDeviceInfo().limits().maxColorAttachments());
+	}
+
+	/**
+	 * Names the targets a compute of the pack writes as an image, before any of them is allocated.
+	 * Whether the device makes a storage image of a target's format is asked at its allocation, on
+	 * the render thread where a device exists, and a refusal is said there: the target is
+	 * allocated as it was and the compute naming it is refused at its first dispatch.
+	 */
+	void storageTargets(Set<Integer> targets) {
+		this.storageTargets = Set.copyOf(targets);
 	}
 
 	/**
@@ -1061,15 +1082,22 @@ final class ColorTargets {
 		if (surface == null) {
 			GpuFormat format = this.formats.get(index);
 			TargetDirectives directives = this.plan.directives();
+			boolean storage = this.storageTargets.contains(index) && GpuFormats.storageCapable(format);
+			if (this.storageTargets.contains(index) && !storage && this.storageRefused.add(index)) {
+				Vitrail.logger().warn("{} is written by a compute as an image, and this device makes "
+						+ "no storage image of {}, so that compute is not dispatched", name, format);
+			}
 			// Named before it is allocated, on purpose. RG11B10_FLOAT as a colour attachment is
 			// not something the Vulkan specification guarantees and nothing in the game asks the
 			// driver whether it has it, so the last line written has to name the format asked for.
 			// The declaration comes with it, because a wrong image starts at a wrong declaration
 			// and reading it off the picture is what has to stop being necessary.
-			Vitrail.logger().info("Allocating {} as {} at {}x{}, {} level(s), declared {} at {}", name,
+			Vitrail.logger().info("Allocating {} as {} at {}x{}, {} level(s), declared {} at {}{}", name,
 					format, width, height, TargetSurface.levelsFor(mipped, width, height),
-					directives.format(index).declared(), directives.formatSource(index));
-			side.put(index, new TargetSurface("Vitrail " + name, format, mipped, width, height));
+					directives.format(index).declared(), directives.formatSource(index),
+					storage ? ", writable from a compute" : "");
+			side.put(index, new TargetSurface("Vitrail " + name, format, mipped, storage, width,
+					height));
 		} else {
 			surface.resize(width, height);
 		}

--- a/common/src/main/java/dev/vitrail/render/GpuFormats.java
+++ b/common/src/main/java/dev/vitrail/render/GpuFormats.java
@@ -1,9 +1,17 @@
 package dev.vitrail.render;
 
+import dev.vitrail.mixin.GpuDeviceAccessor;
 import dev.vitrail.pack.target.TargetFormat;
 
 import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.vulkan.VulkanConst;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.VK10;
+import org.lwjgl.vulkan.VkFormatProperties;
 
 /**
  * The one place a pack's colour format becomes a device format.
@@ -78,5 +86,29 @@ final class GpuFormats {
 	/** An integer format carries no filtering, and asking a sampler for it is invalid on Vulkan. */
 	static FilterMode filterFor(TargetFormat format) {
 		return format.integer() ? FilterMode.NEAREST : FilterMode.LINEAR;
+	}
+
+	/**
+	 * Whether this device makes a storage image of that format, which is what a compute writing a
+	 * colour target as {@code colorimgN} needs. Asked of the device rather than read off a table,
+	 * the way the attachment count is: the specification's required set is short and a card
+	 * offers well past it, and a target created without the bit on a device that would have taken
+	 * it costs the compute for nothing. Iris asks nothing here because GL decides it at bind time.
+	 * False with no Vulkan device to ask, which is no device to store into either.
+	 */
+	static boolean storageCapable(GpuFormat format) {
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (device == null
+				|| !(((GpuDeviceAccessor) device).vitrail$backend() instanceof VulkanDevice vulkan)) {
+			return false;
+		}
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			VkFormatProperties properties = VkFormatProperties.calloc(stack);
+			VK10.vkGetPhysicalDeviceFormatProperties(vulkan.vkDevice().getPhysicalDevice(),
+					VulkanConst.toVk(format), properties);
+
+			return (properties.optimalTilingFeatures() & VK10.VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT) != 0;
+		}
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -76,6 +76,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -475,8 +476,15 @@ public final class PackChain {
 		// on the frames DH really draws a far terrain.
 		this.distant = new DistantDraw(this, packPath, chain.place(), chosen, profile, values,
 				this.load, chain.chain(), chain.targets(), chainWanted, this.targets);
+		// The passes the chain will draw, read off the plan: the pass objects themselves are only
+		// built on the render thread, after this constructor.
 		this.compute = PackCompute.load(opened, chain.place(), chain.targets().computes(), this.load,
-				values.shadowGeometryCatalog());
+				values.shadowGeometryCatalog(), values.catalog(),
+				ordered(chain.chain()).stream().map(ChainPlan.Pass::program)
+						.collect(Collectors.toSet()));
+		// Before the first frame allocates a target: the usage a compute needs is baked into the
+		// image at creation, and nothing can add it afterwards.
+		this.targets.storageTargets(this.compute.storageTargets());
 	}
 
 	/**
@@ -2252,6 +2260,28 @@ public final class PackChain {
 
 			PackPass pass = this.programs.get(at);
 
+			boolean emptying = this.targets.hasPendingClears();
+			if (this.compute.hangsOff(pass.program())) {
+				// The frame's clears are paid before the computes and not inside the draw after
+				// them, where the first pass of the frame pays them: a compute storing into a
+				// target still owed its clear would have its stores emptied by the very pass it
+				// hangs off.
+				if (emptying) {
+					this.targets.flushPending(encoder);
+				}
+
+				// The computes hanging off this pass run right before it, on the halves it reads,
+				// as Iris does, and before the chains below are filled, as Iris fills them after
+				// its dispatch (CompositeRenderer.java:287-313): a compute storing into a target
+				// the pass reads at a lod is what the chain has to be built from. Outside any
+				// render pass: a dispatch is a command of its own, and the barriers around it are
+				// what let the pass sample what the compute stored.
+				this.compute.dispatchBefore(pass.program(), encoder, device, this.values,
+						this.targets, this.chain.targets().schedule().step(pass.program())
+								.orElse(null), ready.main().width, ready.main().height);
+				this.currentChains.clear();
+			}
+
 			// Right before the first program that reads them after a write: a chain is only true
 			// of the level nought it was built from, and every pass between the two may have
 			// written it. The reduction opens render passes of its own, which is why this is here
@@ -2267,7 +2297,6 @@ public final class PackChain {
 				}
 			}
 
-			boolean emptying = this.targets.hasPendingClears();
 			GpuBufferSlice uniforms = buffer.slice(pass.uniformOffset(), pass.uniformSize());
 			if (pass == this.last) {
 				pass.drawFinal(encoder, ready.mainView(), this.targets, depth, distant, this.quad,

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -10,6 +10,8 @@ import dev.vitrail.pack.program.ProgramNames;
 import dev.vitrail.pack.program.ProgramStage;
 import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.source.OpenedPack;
+import dev.vitrail.pack.target.TargetName;
+import dev.vitrail.pack.target.TargetSchedule;
 import dev.vitrail.pack.texture.CustomImages;
 import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.UniformCatalog;
@@ -58,22 +60,36 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * The pack's shadow compute passes, dispatched at the head of the frame, in the parity of the
- * gbuffers that read what they propagate; the volumes they read are the previous frame's
- * shadow-geometry writes, one frame late like the shadow map itself.
+ * The pack's compute passes: the shadow computes, dispatched at the head of the frame, and the
+ * computes hanging off a full screen pass, dispatched right before that pass.
  * <p>
- * Complementary's floodfill lives in {@code shadowcomp.csh}. The Java facade has no compute, so
- * the pipeline is built the way the storage probe was: shaderc kind 2, a VMA storage image,
- * push descriptors. Iris runs it inside its shadow render ({@code ShadowRenderer.java:631-632},
- * the debug group and the {@code compositeRenderer.renderAll()} under it), before its gbuffers in
- * the SAME frame. Under this engine's deferred shadow stage, the head of the frame is that
- * moment's translation.
+ * The shadow computes run in the parity of the gbuffers that read what they propagate; the
+ * volumes they read are the previous frame's shadow-geometry writes, one frame late like the
+ * shadow map itself. Complementary's floodfill lives in {@code shadowcomp.csh}. Iris runs it
+ * inside its shadow render ({@code ShadowRenderer.java:631-632}, the debug group and the
+ * {@code compositeRenderer.renderAll()} under it), before its gbuffers in the SAME frame. Under
+ * this engine's deferred shadow stage, the head of the frame is that moment's translation.
+ * <p>
+ * The chained computes, {@code deferred4_a.csh} for {@code deferred4}, run where Iris runs them:
+ * in a loop right before their pass, with a memory barrier after ({@code CompositeRenderer.java:287-297}),
+ * reading and storing the colour targets on the halves that pass reads. Photon builds its sky
+ * lighting in one, and without it everything in shadow was black.
+ * <p>
+ * The Java facade has no compute, so the pipeline is built the way the storage probe was: shaderc
+ * kind 2, push descriptors, and a storage image that is either the pack's own through VMA or a
+ * colour target created with the usage for it.
  *
  * @see <a href="https://github.com/IrisShaders/Iris">Iris ComputeProgram, LGPL-3.0</a>
  */
@@ -98,30 +114,80 @@ final class PackCompute implements AutoCloseable {
 	 */
 	private static final int PUSH_DESCRIPTORS = 32;
 
+	/** The pattern of a colour target written as an image, {@code colorimg4} for {@code colortex4}. */
+	private static final Pattern COLOUR_IMAGE = Pattern.compile("\\bcolorimg(\\d+)\\b");
+
+	/** The shadow computes, dispatched at the head of the frame. */
 	private final List<Pass> passes;
+
+	/**
+	 * The computes hanging off a full screen pass, by that pass, each list in letter order. Iris
+	 * dispatches them right before the pass ({@code CompositeRenderer.java:287-297}, the loop over
+	 * {@code compositePass.computes} with a memory barrier after), and so does the chain here.
+	 */
+	private final Map<String, List<Pass>> chained;
+
+	/** The targets some compute writes as {@code colorimgN}, which are created writable for it. */
+	private final Set<Integer> storageTargets;
+
 	private boolean announced;
 
-	private PackCompute(List<Pass> passes) {
+	/** The passes whose computes have been announced once, which is once per pass and not per frame. */
+	private final Set<String> announcedChains = new LinkedHashSet<>();
+
+	private PackCompute(List<Pass> passes, Map<String, List<Pass>> chained,
+			Set<Integer> storageTargets) {
 		this.passes = List.copyOf(passes);
+		this.chained = Map.copyOf(chained);
+		this.storageTargets = Set.copyOf(storageTargets);
 	}
 
 	static PackCompute none() {
-		return new PackCompute(List.of());
+		return new PackCompute(List.of(), Map.of(), Set.of());
+	}
+
+	/** The targets to create writable from a compute, read before the first allocation. */
+	Set<Integer> storageTargets() {
+		return this.storageTargets;
+	}
+
+	/** Whether any compute hangs off that full screen pass. */
+	boolean hangsOff(String program) {
+		return this.chained.containsKey(program);
 	}
 
 	/**
-	 * Reads every shadow compute the pack ships, out of the opening the load already holds.
+	 * Reads every compute the pack ships and the plan kept, out of the opening the load already
+	 * holds: the shadow computes for the head of the frame, and the computes hanging off a pass of
+	 * the chain for the moment before that pass.
 	 * <p>
 	 * The opening is handed in and not taken here, and this loop is why it matters: read a program
 	 * at a time from a pack path, each turn mounted the archive again and walked every source file
-	 * of it to rebuild the same index of the same settings, so a pack with four shadow computes
-	 * paid for four whole readings of itself to translate four files.
+	 * of it to rebuild the same index of the same settings, so a pack with four computes paid for
+	 * four whole readings of itself to translate four files.
+	 *
+	 * @param running the programs the chain draws, which is where a chained compute can hang. A
+	 *                compute whose pass is not among them is read by Iris and dispatched with no
+	 *                fragment stage at all ({@code CompositeRenderer.java:135-141}); here it is
+	 *                named and left, since the chain has no step to hang it off yet
 	 */
 	static PackCompute load(OpenedPack pack, String place, List<String> computes, int load,
-			UniformCatalog catalog) {
+			UniformCatalog shadowCatalog, UniformCatalog chainCatalog, Set<String> running) {
 		List<Pass> passes = new ArrayList<>();
+		Map<String, List<Pass>> chained = new LinkedHashMap<>();
+		Set<Integer> storageTargets = new LinkedHashSet<>();
 		for (String name : computes) {
-			if (!ProgramNames.shadowComposite(ProgramNames.familyOf(name))) {
+			boolean shadow = ProgramNames.shadowComposite(ProgramNames.familyOf(name));
+			Optional<String> base = ProgramNames.computeBase(name);
+			// Setup has no moment in this frame yet. The plan already names it.
+			if (!shadow && base.isEmpty()) {
+				continue;
+			}
+
+			if (!shadow && !running.contains(base.get())) {
+				Vitrail.logger().warn("compute {} hangs off {}, which this chain does not draw, so "
+						+ "it is not dispatched: the reference runs it as a pass of its own",
+						name, base.get());
 				continue;
 			}
 
@@ -138,22 +204,98 @@ final class PackCompute implements AutoCloseable {
 				// as one where the shader means sixteen, the guess asks for a group per pixel and
 				// stalls the frame instead of drawing it wrong.
 				if (!compute.get().sized()) {
-					Vitrail.logger().warn("shadow compute {} is not dispatched: it leaves its work "
+					Vitrail.logger().warn("compute {} is not dispatched: it leaves its work "
 							+ "group count to the engine and writes its local size as something "
 							+ "other than a number, so how much work it asks for cannot be read",
 							path);
 					continue;
 				}
 
-				passes.add(new Pass(compute.get(), catalog, load, path));
-				Vitrail.logger().info("Loaded shadow compute {} ({})", path, sizing(compute.get()));
+				Pass pass = new Pass(compute.get(), shadow ? shadowCatalog : chainCatalog, load,
+						path, shadow ? null : base.get());
+				if (shadow) {
+					passes.add(pass);
+					Vitrail.logger().info("Loaded shadow compute {} ({})", path, sizing(compute.get()));
+				} else {
+					chained.computeIfAbsent(base.get(), _ -> new ArrayList<>()).add(pass);
+					storageTargets.addAll(colourImagesOf(compute.get()));
+					Vitrail.logger().info("Loaded compute {} before {} ({})", path, base.get(),
+							sizing(compute.get()));
+				}
 			} catch (IOException | RuntimeException e) {
-				Vitrail.logger().warn("shadow compute {} could not be translated: {}", path,
-						e.toString());
+				Vitrail.logger().warn("compute {} could not be translated: {}", path, e.toString());
 			}
 		}
 
-		return new PackCompute(passes);
+		chained.values().forEach(list -> list.sort(
+				Comparator.comparing(pass -> ProgramNames.computeLetter(pass.name))));
+
+		return new PackCompute(passes, chained, storageTargets);
+	}
+
+	/** The colour targets a compute names as an image, read off its translated text. */
+	private static Set<Integer> colourImagesOf(PackProgram.Compute compute) {
+		Set<Integer> indices = new LinkedHashSet<>();
+		TranslatedUnit unit = compute.loaded().program().stages().get(ProgramStage.COMPUTE);
+		if (unit == null) {
+			return indices;
+		}
+
+		Matcher matcher = COLOUR_IMAGE.matcher(unit.text());
+		while (matcher.find()) {
+			indices.add(Integer.parseInt(matcher.group(1)));
+		}
+
+		return indices;
+	}
+
+	/**
+	 * Dispatches the computes hanging off that full screen pass, right before it, as Iris does.
+	 * Nothing happens for a pass with none, which is every pass of most packs.
+	 *
+	 * @param step the halves that pass reads and writes, which is where its computes read a colour
+	 *             target from and write one to: Iris binds both the sampler and the image on the
+	 *             flipped state of that moment ({@code IrisImages.addRenderTargetImages})
+	 */
+	void dispatchBefore(String program, CommandEncoder encoder, GpuDevice device, PackValues values,
+			ColorTargets targets, TargetSchedule.Bound step, int width, int height) {
+		List<Pass> attached = this.chained.get(program);
+		if (attached == null || attached.isEmpty()) {
+			return;
+		}
+
+		// The hold first, as the head-of-frame dispatch does: the first pass of a chain half can
+		// still have the geometry's render pass object open over it, and ending the pass
+		// underneath would leave that object to close a pass the encoder no longer has.
+		GeometryHold.flush(() -> "the compute dispatch before " + program);
+		GpuRecording.endPass(encoder);
+		VkCommandBuffer commands = commands(encoder);
+		VulkanDevice vulkan = vulkan(device);
+		if (commands == null || vulkan == null) {
+			return;
+		}
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			beforeChainCompute(commands, stack);
+		}
+
+		for (Pass pass : attached) {
+			try {
+				pass.dispatch(vulkan, commands, values, targets, width, height, step);
+			} catch (RuntimeException e) {
+				if (pass.failed.add(e.toString())) {
+					Vitrail.logger().warn("compute {} failed: {}", pass.path, e.toString());
+				}
+			}
+		}
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			afterChainCompute(commands, stack);
+		}
+
+		if (this.announcedChains.add(program)) {
+			Vitrail.logger().info("Dispatched {} compute pass(es) before {}", attached.size(), program);
+		}
 	}
 
 	void dispatch(PackValues values, ColorTargets targets) {
@@ -200,7 +342,7 @@ final class PackCompute implements AutoCloseable {
 		int height = main == null ? 0 : main.height;
 		for (Pass pass : this.passes) {
 			try {
-				pass.dispatch(vulkan, commands, values, targets, width, height);
+				pass.dispatch(vulkan, commands, values, targets, width, height, null);
 			} catch (RuntimeException e) {
 				if (pass.failed.add(e.toString())) {
 					Vitrail.logger().warn("shadow compute {} failed: {}", pass.path, e.toString());
@@ -320,6 +462,37 @@ final class PackCompute implements AutoCloseable {
 						| VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT);
 	}
 
+	/**
+	 * Makes what the passes before this point drew, colour writes and storage writes alike, visible
+	 * to a compute that samples or stores it. The render pass has already closed on the game's own
+	 * barrier, which orders graphics against graphics; this names the compute stage as the reader.
+	 */
+	private static void beforeChainCompute(VkCommandBuffer commands, MemoryStack stack) {
+		shaderBarrier(commands, stack, VK13.VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT,
+				VK13.VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT
+						| VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT,
+				VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+				VK13.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT
+						| VK13.VK_ACCESS_2_SHADER_STORAGE_READ_BIT
+						| VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT);
+	}
+
+	/**
+	 * Makes a compute's image stores visible to the pass that follows, which samples them, and to
+	 * the attachment writes a later pass makes to the same target. Iris's memory barrier after its
+	 * loop, {@code CompositeRenderer.java:297}: image access, texture fetch and shader storage.
+	 */
+	private static void afterChainCompute(VkCommandBuffer commands, MemoryStack stack) {
+		shaderBarrier(commands, stack, VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+				VK13.VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT,
+				VK13.VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT
+						| VK13.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+				VK13.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT
+						| VK13.VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT
+						| VK13.VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT
+						| VK13.VK_ACCESS_2_SHADER_STORAGE_READ_BIT);
+	}
+
 	private static void shaderBarrier(VkCommandBuffer commands, MemoryStack stack, long srcStage,
 			long srcAccess, long dstStage, long dstAccess) {
 		VkMemoryBarrier2.Buffer barrier = VkMemoryBarrier2.calloc(1, stack).sType$Default();
@@ -337,6 +510,11 @@ final class PackCompute implements AutoCloseable {
 		private final PackProgram.Compute compute;
 		private final PackUniforms uniforms;
 		private final String path;
+		private final String name;
+
+		/** The full screen pass this compute hangs off, or null for a shadow compute. */
+		private final String program;
+
 		private final String label;
 		private final Set<String> failed = new LinkedHashSet<>();
 		private MappableRingBuffer block;
@@ -347,15 +525,22 @@ final class PackCompute implements AutoCloseable {
 		private List<VulkanBindGroupLayout.Entry> entries = List.of();
 		private boolean compiled;
 
-		private Pass(PackProgram.Compute compute, UniformCatalog catalog, int load, String path) {
+		private Pass(PackProgram.Compute compute, UniformCatalog catalog, int load, String path,
+				String program) {
 			this.compute = compute;
 			this.path = path;
+			this.name = path.substring(path.lastIndexOf('/') + 1);
+			this.program = program;
 			this.label = "pack/" + load + "/" + path + "/compute";
 			this.uniforms = new PackUniforms(compute.loaded().program().uniforms(), catalog);
 		}
 
+		/**
+		 * @param step the halves of the pass this compute hangs off, or null for a shadow compute,
+		 *             which reads no colour target
+		 */
 		private void dispatch(VulkanDevice vulkan, VkCommandBuffer commands, PackValues values,
-				ColorTargets targets, int width, int height) {
+				ColorTargets targets, int width, int height, TargetSchedule.Bound step) {
 			if (!this.compiled) {
 				compile(vulkan);
 			}
@@ -368,7 +553,7 @@ final class PackCompute implements AutoCloseable {
 			try (MemoryStack stack = MemoryStack.stackPush()) {
 				VulkanCommandEncoder.memoryBarrier(commands, stack);
 				VK12.vkCmdBindPipeline(commands, VK12.VK_PIPELINE_BIND_POINT_COMPUTE, this.pipeline);
-				pushDescriptors(commands, stack, targets);
+				pushDescriptors(commands, stack, targets, step);
 				// The screen and not the shadow map: Iris sizes a shadow composite's compute off
 				// the main render target, ShadowCompositeRenderer.java:212, and the resolution of
 				// the shadow map is what it sizes the shadow GEOMETRY computes off instead,
@@ -436,12 +621,12 @@ final class PackCompute implements AutoCloseable {
 					// pushed set, and going past it is undefined rather than slow. Said here, once,
 					// so that a driver error later has a line in the log that predicted it.
 					if (this.entries.size() > PUSH_DESCRIPTORS) {
-						Vitrail.logger().warn("shadow compute {} pushes {} descriptors in one set, "
+						Vitrail.logger().warn("compute {} pushes {} descriptors in one set, "
 								+ "past the {} a device commonly allows at once", this.path,
 								this.entries.size(), PUSH_DESCRIPTORS);
 					}
 				} catch (Exception e) {
-					Vitrail.logger().warn("shadow compute {} SPIR-V failed: {}", this.path,
+					Vitrail.logger().warn("compute {} SPIR-V failed: {}", this.path,
 							e.toString());
 					return;
 				}
@@ -458,11 +643,11 @@ final class PackCompute implements AutoCloseable {
 				createPipeline(vulkan, stack);
 			} catch (RuntimeException e) {
 				destroy(vulkan);
-				Vitrail.logger().warn("shadow compute {} pipeline failed: {}", this.path, e.toString());
+				Vitrail.logger().warn("compute {} pipeline failed: {}", this.path, e.toString());
 			}
 
 			if (this.pipeline != 0L) {
-				Vitrail.logger().info("Compiled shadow compute {} ({})", this.path,
+				Vitrail.logger().info("Compiled compute {} ({})", this.path,
 						sizing(this.compute));
 			}
 		}
@@ -488,7 +673,7 @@ final class PackCompute implements AutoCloseable {
 						filename, entry, options);
 				int status = Shaderc.shaderc_result_get_compilation_status(result);
 				if (status != 0) {
-					Vitrail.logger().warn("shadow compute shaderc: {}",
+					Vitrail.logger().warn("compute shaderc: {}",
 							Shaderc.shaderc_result_get_error_message(result));
 					return null;
 				}
@@ -517,7 +702,8 @@ final class PackCompute implements AutoCloseable {
 			for (int i = 0; i < this.entries.size(); i++) {
 				VulkanBindGroupLayout.Entry entry = this.entries.get(i);
 				boolean storage = CustomImages.storage(entry.name())
-						|| StorageImages.storageBinding(entry.name());
+						|| StorageImages.storageBinding(entry.name())
+						|| COLOUR_IMAGE.matcher(entry.name()).matches();
 				int type;
 				if (entry.type() == VulkanBindGroupLayout.VulkanBindGroupEntryType.UNIFORM_BUFFER) {
 					type = StorageBuffers.named(entry.name())
@@ -539,7 +725,7 @@ final class PackCompute implements AutoCloseable {
 			LongBuffer layoutPtr = stack.callocLong(1);
 			VulkanUtils.crashIfFailure(vulkan,
 					VK12.vkCreateDescriptorSetLayout(vulkan.vkDevice(), layoutInfo, null, layoutPtr),
-					"shadow compute set layout");
+					"compute set layout");
 			this.setLayout = layoutPtr.get(0);
 			LongBuffer setLayouts = stack.callocLong(1).put(0, this.setLayout);
 			VkPipelineLayoutCreateInfo pipelineLayoutInfo = VkPipelineLayoutCreateInfo.calloc(stack)
@@ -549,7 +735,7 @@ final class PackCompute implements AutoCloseable {
 			VulkanUtils.crashIfFailure(vulkan,
 					VK12.vkCreatePipelineLayout(vulkan.vkDevice(), pipelineLayoutInfo, null,
 							pipelineLayoutPtr),
-					"shadow compute pipeline layout");
+					"compute pipeline layout");
 			this.pipelineLayout = pipelineLayoutPtr.get(0);
 		}
 
@@ -568,7 +754,7 @@ final class PackCompute implements AutoCloseable {
 			LongBuffer pipelinePtr = stack.callocLong(1);
 			VulkanUtils.crashIfFailure(vulkan,
 					VK12.vkCreateComputePipelines(vulkan.vkDevice(), 0L, infos, null, pipelinePtr),
-					"shadow compute pipeline");
+					"compute pipeline");
 			this.pipeline = pipelinePtr.get(0);
 		}
 
@@ -587,7 +773,7 @@ final class PackCompute implements AutoCloseable {
 		}
 
 		private void pushDescriptors(VkCommandBuffer commands, MemoryStack stack,
-				ColorTargets targets) {
+				ColorTargets targets, TargetSchedule.Bound step) {
 			if (this.entries.isEmpty()) {
 				return;
 			}
@@ -628,6 +814,11 @@ final class PackCompute implements AutoCloseable {
 
 				StorageImages.Bound bound = StorageImages.bound(entry.name());
 				VkDescriptorImageInfo.Buffer imageInfo = VkDescriptorImageInfo.calloc(1, stack);
+				if (bound == null && step != null && colourTarget(write, imageInfo, entry.name(),
+						targets, step, this.program)) {
+					continue;
+				}
+
 				if (bound == null) {
 					// The samplers the engine serves every pack program, noisetex and the shadow
 					// set among them: shadowcomp reads them the way a composite does, and only a
@@ -656,6 +847,63 @@ final class PackCompute implements AutoCloseable {
 
 			KHRPushDescriptor.vkCmdPushDescriptorSetKHR(commands,
 					VK12.VK_PIPELINE_BIND_POINT_COMPUTE, this.pipelineLayout, 0, writes);
+		}
+
+		/**
+		 * A colour target, read as {@code colortexN} or written as {@code colorimgN}, on the half
+		 * the pass this compute hangs off reads: Iris binds both off the same flipped state
+		 * ({@code IrisSamplers.addRenderTargetSamplers}, {@code IrisImages.addRenderTargetImages}),
+		 * so a compute stores into the very half the pass after it will sample.
+		 *
+		 * @param program the pass this compute hangs off, whose lod reads say whether the target
+		 *                is sampled through its chain
+		 * @return whether the name was one, and the write filled
+		 */
+		private static boolean colourTarget(VkWriteDescriptorSet write,
+				VkDescriptorImageInfo.Buffer imageInfo, String name, ColorTargets targets,
+				TargetSchedule.Bound step, String program) {
+			Matcher image = COLOUR_IMAGE.matcher(name);
+			if (image.matches()) {
+				int index = Integer.parseInt(image.group(1));
+				TargetSurface surface = targets.surface(index, step.read(index));
+				if (surface == null || !surface.storage()
+						|| !(surface.storageView() instanceof VulkanGpuTextureView view)) {
+					throw new IllegalStateException(name + " is not a target created writable from "
+							+ "a compute");
+				}
+
+				imageInfo.sampler(0L);
+				imageInfo.imageView(view.vkImageView());
+				imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+				write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
+				write.pImageInfo(imageInfo);
+				return true;
+			}
+
+			OptionalInt index = TargetName.index(name);
+			if (index.isEmpty()) {
+				return false;
+			}
+
+			TargetSurface surface = targets.surface(index.getAsInt(), step.read(index.getAsInt()));
+			if (surface == null || !(surface.view() instanceof VulkanGpuTextureView view)) {
+				throw new IllegalStateException(name + " is not an allocated colour target");
+			}
+
+			// Clamped, filtered and mipmapped the way the pass this hangs off binds the same
+			// target: the pack's own indexing stays inside the image, an integer format takes no
+			// filtering, and the chain is only in reach once something has written it and the
+			// pass reads the target at a lod. Iris has one texture with one set of parameters
+			// for both, so a compute and its pass sample it the same way.
+			boolean mipmaps = surface.chainWritten()
+					&& targets.lodReads(program).contains(index.getAsInt());
+			imageInfo.sampler(((VulkanGpuSampler) PackPass.sampler(false,
+					targets.filter(index.getAsInt()), mipmaps)).vkSampler());
+			imageInfo.imageView(view.vkImageView());
+			imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+			write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+			write.pImageInfo(imageInfo);
+			return true;
 		}
 
 		private void close() {

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -284,6 +284,11 @@ final class PackPass {
 		return this.path;
 	}
 
+	/** The program name alone, {@code composite3}, which is what the schedule and the computes key on. */
+	String program() {
+		return this.pass.program();
+	}
+
 	int uniformOffset() {
 		return this.offset;
 	}

--- a/common/src/main/java/dev/vitrail/render/TargetSurface.java
+++ b/common/src/main/java/dev/vitrail/render/TargetSurface.java
@@ -40,6 +40,9 @@ final class TargetSurface implements AutoCloseable {
 	private final GpuFormat format;
 	private final boolean mipped;
 
+	/** Whether a compute of the pack writes this target as an image, which is a usage bit at creation. */
+	private final boolean storage;
+
 	private GpuTexture texture;
 	private GpuTextureView view;
 
@@ -71,9 +74,19 @@ final class TargetSurface implements AutoCloseable {
 	 *               level and one view, exactly as before there were chains at all
 	 */
 	TargetSurface(String label, GpuFormat format, boolean mipped, int width, int height) {
+		this(label, format, mipped, false, width, height);
+	}
+
+	/**
+	 * @param storage whether a compute of the pack writes this target as a storage image, which
+	 *                has to be said at creation: the usage is baked into the image
+	 */
+	TargetSurface(String label, GpuFormat format, boolean mipped, boolean storage, int width,
+			int height) {
 		this.label = label;
 		this.format = format;
 		this.mipped = mipped;
+		this.storage = storage;
 		allocate(width, height);
 	}
 
@@ -133,6 +146,22 @@ final class TargetSurface implements AutoCloseable {
 	}
 
 	/**
+	 * The base level alone, which is what a storage descriptor takes: Vulkan binds an image view of
+	 * exactly one level there, and a compute writes level nought. The same object as {@link #view}
+	 * on a surface with no chain, where the whole view is one level already.
+	 */
+	GpuTextureView storageView() {
+		GpuTextureView base = levelView(0);
+
+		return base == null ? this.view : base;
+	}
+
+	/** Whether this surface was created writable from a compute, which nothing can add afterwards. */
+	boolean storage() {
+		return this.storage;
+	}
+
+	/**
 	 * One level on its own, for the reduction to draw into. A render pass attaches a view and writes
 	 * whatever it covers, so a view of one level is how a single level is written without touching
 	 * the rest of the chain.
@@ -178,8 +207,17 @@ final class TargetSurface implements AutoCloseable {
 		// gets it back. The chain makes this real rather than theoretical, since one surface now
 		// creates up to a dozen views instead of one.
 		try {
-			this.texture = device.createTexture(this.label, USAGE, this.format, width, height, 1,
-					levels);
+			// The flag is read by the mixin on the game's usage conversion, inside this one call,
+			// and lowered whatever the call did: a throw that left it up would mark the next
+			// texture anybody creates.
+			TextureUsage.requestStorage(this.storage);
+			try {
+				this.texture = device.createTexture(this.label, USAGE, this.format, width, height, 1,
+						levels);
+			} finally {
+				TextureUsage.requestStorage(false);
+			}
+
 			this.view = device.createTextureView(this.texture);
 
 			if (levels > 1) {

--- a/common/src/main/java/dev/vitrail/render/TextureUsage.java
+++ b/common/src/main/java/dev/vitrail/render/TextureUsage.java
@@ -1,0 +1,32 @@
+package dev.vitrail.render;
+
+/**
+ * Whether the texture about to be created has to be writable from a compute shader.
+ * <p>
+ * The game's texture facade has no such usage: {@code VulkanConst.textureUsageToVk} maps the four
+ * bits {@code GpuTexture} knows and never sets {@code VK_IMAGE_USAGE_STORAGE_BIT}, and a usage bit
+ * the facade does not know would be dropped on the same road. So a colour target a pack's compute
+ * writes as {@code colorimgN} is asked for here, in the instant between deciding to allocate it
+ * and the call that does, and the mixin on that conversion reads the flag and adds the bit. The
+ * flag is held per thread, so the one creation that raised it is the only one that reads it, and
+ * a texture another thread creates in that same instant stays what it asked for. Iris allocates
+ * every render target with GL, where a texture is a storage image the moment
+ * {@code glBindImageTexture} says so.
+ */
+public final class TextureUsage {
+
+	private static final ThreadLocal<Boolean> STORAGE_REQUESTED = ThreadLocal.withInitial(() -> false);
+
+	private TextureUsage() {
+	}
+
+	/** Read by the mixin on {@code VulkanConst.textureUsageToVk}, on the creating thread. */
+	public static boolean storageRequested() {
+		return STORAGE_REQUESTED.get();
+	}
+
+	/** Raised for one creation and lowered right after it, by the surface that asked. */
+	static void requestStorage(boolean requested) {
+		STORAGE_REQUESTED.set(requested);
+	}
+}

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -75,6 +75,7 @@
 		"VulkanBindGroupLayoutMixin",
 		"VulkanCommandEncoderAccessor",
 		"VulkanCommandEncoderMixin",
+		"VulkanConstMixin",
 		"VulkanDeviceMixin",
 		"VulkanQueueSubmitMixin",
 		"VulkanRenderPassMixin",

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -251,15 +251,22 @@ which has a compute kind the game never passes only because the Java enumeration
 for it. None of that needs a mixin: those methods are public.
 
 What does need going around is texture creation. The usage-bit mapping never sets the Vulkan
-storage bit, so a storage image has to be allocated through VMA rather than through
-`createTexture`. That is an extension of how the device is used, not of the device class.
+storage bit, so a storage image of the pack's own has to be allocated through VMA rather than
+through `createTexture`. That is an extension of how the device is used, not of the device class.
+A colour target a compute writes as `colorimgN` is a different case: it has to stay the texture
+the passes attach and sample, so the bit is added to what that mapping returns, by a mixin on it,
+for the one creation that asks for it and only in a format the device makes a storage image of,
+asked of the device.
 
 None of this is inference. A compute shader built with that shaderc, dispatched against a storage
 image allocated through VMA, writes texels the same frame reads back unchanged: the road is open,
 and nothing of it was ever in the backend's way. The stage that walks it is `PackCompute`, which
-compiles a pack's `shadowcomp` and dispatches it at the head of the frame. Which programs it serves,
-including the pack's own switch deciding whether it serves any at all, and why that moment rather
-than beside the shadow map that feeds it, is answered where the pack's chain is.
+compiles a pack's `shadowcomp` and dispatches it at the head of the frame, and compiles the
+computes hanging off a full screen pass and dispatches them right before that pass, between two
+barriers of its own since the game's render pass boundary orders graphics against graphics only.
+Which programs it serves, including the pack's own switch deciding whether it serves any at all,
+and why the shadow moment rather than beside the shadow map that feeds it, is answered where the
+pack's chain is.
 
 ## Small things that cost a lot to rediscover
 

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -50,10 +50,13 @@ zero to the first empty slot drops real programs.
 
 A compute program hangs a single-letter suffix off a name that has to be valid without it, and the
 suffix is recognised on the numbered families and on two of the unnumbered names, not on the
-geometry names. Vitrail reads those files and names them in the log. One family of them runs, the
-shadow compute, translated like any other unit and dispatched once a frame wherever the pack's own
-toggle keeps it. The rest are named and go no further, so what their order among themselves would
-be is the reference's business and not this engine's yet.
+geometry names. Vitrail reads those files and names them in the log. The shadow compute runs,
+translated like any other unit and dispatched once a frame wherever the pack's own toggle keeps
+it, and so does a compute hanging off a pass the chain draws, begin, prepare, deferred,
+composite or final: dispatched right before that pass, the letter-less file first and then the
+letters in order, as the reference runs them. The reference stops at the first letter missing,
+and so does this: a `_b` shipped without its `_a` is named and never opened. A compute hanging
+off setup is named and goes no further, setup having no moment in this engine's frame yet.
 
 Stages are never paired or cross-checked. A compute program and a fragment program with the same
 slot name coexist as independent entries, which is a real case.
@@ -131,7 +134,8 @@ every pack with an unusual dimension name.
 name by a single letter, so `world0/composite21_a` is a key of its own and a pack switching off
 `world0/composite21` has said nothing about it. The reference keeps such a compute and runs it
 with no fragment stage at all, which is why the lookup cannot fall back to the name the letter
-came off.
+came off. This engine keeps it too, and then has no pass to hang it off: it is named in the log
+as skipped, and its dispatch is a gap still owed.
 
 Both an empty value and a non-evaluable expression mean enabled: this file is read fail-open.
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -318,18 +318,25 @@ for that path, three different mechanisms, and it is worth knowing which:
   a vertex stage and a fragment stage and nothing else, and the device exposes no way to precompile
   anything but a render pipeline. The Vulkan backend behind that facade already has a compute-capable
   queue, a public `VkDevice`, and the shaderc the game embeds, whose compute kind the facade never
-  passes. That path has been made to dispatch and to write, and a pack's own shadowcomp goes down
-  it: translated like any other unit, compiled by the same shaderc, dispatched at the head of the
-  frame. Only where the pack keeps it, and a pack that switches the program off takes with it the
-  declarations that program reads, so one switched off does not draw nothing, it does not compile.
-  The other compute names are named in the log and go no further, translation included.
+  passes. That path has been made to dispatch and to write, and a pack's computes go down it:
+  translated like any other unit, compiled by the same shaderc. A shadowcomp is dispatched at the
+  head of the frame, and a compute hanging off a pass the chain draws, begin, prepare, deferred,
+  composite or final, right before that pass, the letter-less file first and then in letter
+  order, reading and writing the colour targets on the halves the pass itself reads, which is the
+  reference's moment and side for it. Only where the pack keeps it, and a pack that switches the
+  program off takes with it the declarations that program reads, so one switched off does not
+  draw nothing, it does not compile. A setup compute, and a compute whose pass the chain does not
+  draw, which the reference runs as a pass of its own, are named in the log and go no further,
+  translation included.
 - **Storage buffers and storage images are worse than refused on the facade: they are ignored.**
   Reflection asks for uniform buffers, sampled images, outputs and inputs, and never enumerates
   them. On the facade's own walk they pass compilation and are bound to nothing, so the walk is
   widened around it: the reflected entries gain those names, the layout emits a storage type for
-  them, and the descriptor written at bind time carries the handle. The image itself is allocated
-  through VMA and bound as a push descriptor, because the game's texture usage bits never set the
-  Vulkan storage flag and `createTexture` therefore cannot be that image.
+  them, and the descriptor written at bind time carries the handle. An image of the pack's own is
+  allocated through VMA and bound as a push descriptor, because the game's texture usage bits
+  never set the Vulkan storage flag on their own; a colour target a compute stores into has to
+  stay the texture the passes attach, so there the flag is added to what that conversion returns,
+  for the one creation that asks.
 
 No amount of translation work makes a pack compute unit or a pack storage image pass through the
 facade. Vulkan itself supports all of them. The layer above does not, and the backend below it


### PR DESCRIPTION
## What changes

A compute program hanging off a begin, prepare, deferred, composite or final pass was named at load and skipped, so whatever it computed for the pass that follows was never there. Photon builds its sky lighting in `deferred4_a`, and everything in shadow, the hand first, came out black for the lack of it. The plan now keeps those files by name, letter included, in the reference's order: the letter-less file first, then the letters, stopping at the first one missing. The chain dispatches them right before their pass, outside its render pass and between two barriers of the compute stage's own, after the frame's owed clears and before the pass's mip chains are filled. The `colortexN` they sample and the `colorimgN` they store into both bind on the half that pass reads. A colour target a compute stores into is created with the storage usage, which the game's usage conversion never sets, so a mixin on that conversion adds the bit for the one creation that asks for it, when the device makes a storage image of that format, asked of the device.

## How it differs from the reference, and for what obstacle

It does not, where it runs. Iris dispatches a pass's computes in a loop right before the pass, puts one memory barrier after them and generates the pass's mipmaps after that (`CompositeRenderer.java:287-313`), reads the compute files letter-less first and stops at the first letter missing (`ProgramSet.java:190-204`), and binds their images and samplers off the same flipped snapshot as the pass (`CompositeRenderer.java:130-152`, `IrisImages.java:29-35`). The two barriers here are the same ordering said in Vulkan's terms: the render pass boundary orders graphics against graphics only, so the compute stage has to be named as the reader before and as the writer after.

One thing the chain already did differently and these computes inherit: this engine runs a pack's begin and prepare passes after the opaque world where Iris runs them before its shadow pass, a divergence documented where the chain folds the opaque depth before its first half (`PackChain.java`, the note beside `sampleCenterDepth`). A compute hanging off begin or prepare therefore runs at that later moment too, after the shadow computes of the frame rather than before them.

Two things Iris does that this branch does not yet:

- A compute whose pass has no fragment program of its own, or whose pass the pack switched off, still runs in Iris, as a compute-only pass (`CompositeRenderer.java:135-141`). Here the chain has no step to hang it off, so it is not dispatched, and the log names it as skipped for that reason.
- Computes hanging off `setup` have no moment in this engine's frame yet. Named at load, as before.

## What proves it

- `gradlew build` green.
- The off-game harness, Traduction over the whole corpus of the Fabric bench: the same units translate and compile before and after, to the unit.
- The mixin target checked on the game jar with `javap`: `public static int textureUsageToVk(int, GpuFormat)`.
- In the game, Photon on the Fabric bench, overworld: the load log carries "Loaded compute world0/deferred4_a before deferred4", `colortex4` is allocated "writable from a compute", the plan's note says the compute is dispatched before the pass it hangs off and no longer that it is skipped, and the frame reports one compute dispatched before `deferred4` with no failure. The picture draws with its sky lighting in; whether the hand in shadow matches Iris to the eye is still to be looked at side by side.

## What it leaves owing

The two gaps above. And Photon's distant water and ground still draw in a flat magenta, which is a separate defect this branch does not touch: the pack reconstructs those far positions wrongly and fogs them, and the compute stage plays no part in it.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
