### PR TITLE
fix(glsl): pin a lookup without a mip chain to its base level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ what the next one holds.
   that stage read off the wrong slots. An array is now taken apart and put back together the way
   a matrix and a struct are.
 
+- **AstraLex's window panes no longer bloom blue over their walls.** Its glass reflections march
+  a ray across the depth of the world, and on some steps the depth read back was not the image's,
+  so the ray landed on a pixel it never reached and the pane lit up with it, on some frames and
+  not others. A lookup through a sampler that carries no mipmap chain is now asked for the base
+  level of its image outright, which is what the reference's filtering always answered.
+
 - **A mob standing just past the pack's shadow reach for entities keeps its shadow while any
   of it still reaches inside.** A pack that stops its moving casters short of the terrain
   (Complementary does, at an eighth of its shadow distance) had that reach measured on the

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -7,9 +7,11 @@ import dev.vitrail.pack.program.AlphaTest;
 import dev.vitrail.pack.program.ProgramNames;
 import dev.vitrail.pack.program.ProgramStage;
 import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
+import dev.vitrail.pack.target.ConstDirectives;
 import dev.vitrail.pack.target.DrawBuffers;
 import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.SamplerTypes;
+import dev.vitrail.pack.target.TargetName;
 import dev.vitrail.pack.texture.CustomImages;
 import dev.vitrail.pack.texture.CustomStorage;
 import dev.vitrail.pack.texture.VolumeAtlas;
@@ -25,6 +27,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -343,6 +346,12 @@ public final class GlslTranslator {
 	/** What the word sampler is followed by when the declaration asks for a comparison. */
 	private static final String SHADOW_SHAPE = "Shadow";
 
+	/** The level {@link #pinLookupLevels} writes into a lookup, as GLSL text. */
+	private static final String BASE_LEVEL = "0.0";
+
+	/** The suffix of the const directive that asks a chain for a target, {@code TargetDirectives}'s. */
+	private static final String MIPMAP_SUFFIX = "MipmapEnabled";
+
 	/** How far into a sprite a chunk mesh's texture coordinate has to be pulled. */
 	private static final String TEX_SHRINK = "of_TexShrink";
 
@@ -467,6 +476,19 @@ public final class GlslTranslator {
 	 * rewritten from them; they are what {@link #countDepthLookup} measures the blind spot with.
 	 */
 	private final List<Scoped> samplerParameters = new ArrayList<>();
+
+	/**
+	 * Those of {@link #samplerParameters} whose type has no level to pin, a rectangle, a buffer or
+	 * a multisample sampler, so that {@link #pinLookupLevels} leaves a lookup through one alone.
+	 */
+	private final List<Scoped> unlevelledParameters = new ArrayList<>();
+
+	/**
+	 * The same parameters again, each with the function that takes it and its place in that
+	 * function's list, which is what lets {@link #pinLookupLevels} read the call sites and learn
+	 * what a parameter can stand for.
+	 */
+	private final List<SamplerParameter> typedParameters = new ArrayList<>();
 
 	/** Outputs the pack declares itself, by the location it asked for, moved into the header. */
 	private final Map<Integer, Output> packOutputs = new TreeMap<>();
@@ -623,6 +645,16 @@ public final class GlslTranslator {
 
 	private int depthLookups;
 	private int parameterLookups;
+
+	/** Lookups {@link #pinLookupLevels} pinned to the base level of their image. */
+	private int pinnedLookups;
+
+	/**
+	 * Lookups through a sampler the enclosing function was handed that the same pass left as they
+	 * stood, some call of the function handing that parameter something the pass could not read as
+	 * a sampler bound at the base, or the parameter having no level to pin.
+	 */
+	private int unpinnedParameterLookups;
 	private int fragCoordZ;
 	private int fragCoordXyz;
 	private int fragCoordUnhandled;
@@ -796,6 +828,10 @@ public final class GlslTranslator {
 		// have had a chance to wrap.
 		moveCenterDepth();
 		liftUniforms();
+		// After the lifting, which is where the samplers of the file are recorded by name and type,
+		// and after the depth, so that a comparison that road rewrote is under a name of ours by
+		// now and the lookups left standing are the ones that really sample an image.
+		pinLookupLevels();
 		// Decided before the outputs are ordered and applied after: whether the fragment body is
 		// wrapped is what decides where the ascending call goes, and both are settled from the one
 		// answer rather than each asking again.
@@ -1962,6 +1998,10 @@ public final class GlslTranslator {
 	private record Closing(int at, String text, String directive) {
 	}
 
+	/** A sampler parameter, by the function taking it and its position in that function's list. */
+	private record SamplerParameter(String function, int position, Scoped scope) {
+	}
+
 	/**
 	 * One name that means something particular over the lines where it does. A uniform reaches the
 	 * end of the unit and a parameter stops at its own closing brace.
@@ -2135,6 +2175,394 @@ public final class GlslTranslator {
 		} else if (scoped(this.samplerParameters, name, line)) {
 			this.parameterLookups++;
 		}
+	}
+
+	/**
+	 * Pins every lookup through a sampler bound without a mip chain to the base level of its image:
+	 * {@code texture(s, uv)} becomes {@code textureLod(s, uv, 0.0)}, a level the pack wrote out
+	 * becomes nought, and a bias or a pair of derivatives, which only ever chose a level, is
+	 * dropped.
+	 * <p>
+	 * <strong>What it restores is the reference's own filtering.</strong> Iris binds the three
+	 * depth textures nearest and never mipmapped ({@code IrisSamplers.addWorldDepthSamplers} and
+	 * {@code addCompositeSamplers}), the noise linear ({@code addNoiseSampler}), and a colour target
+	 * through the target's own sampler, linear or nearest as its format allows and mipmapped only
+	 * once a program's {@code colortexNMipmapEnabled} turned the chain on
+	 * ({@code CompositeRenderer.setupMipmapping}). Under OpenGL a minification filter without a
+	 * mipmap in its name never selects a level: whatever level of detail a lookup computes from its
+	 * derivatives, or carries as an argument, the base image answers it. Vulkan has no such filter.
+	 * Every sampler selects a level, and the one this engine binds where no chain exists is told to
+	 * stay within a quarter of a level of the base, which ought to come to the same thing.
+	 * Measured, it does not: AstraLex marches a reflection ray across {@code depthtex1} in its
+	 * translucent pass, thirty steps with a {@code break}, reading the depth with {@code texture}
+	 * at a coordinate each step computes, and what came back on some of those steps was not the
+	 * depth, so the ray landed on a pixel it never reached and every glass pane of a village
+	 * bloomed a saturated blue over its wall, on some frames and not others. The same read at an
+	 * explicit level of nought came back right on every frame, as its first composite's re-read of
+	 * the depth at a refracted coordinate did. Whether it is the derivatives of a coordinate made
+	 * under a divergent branch or the clamp itself that the driver answers with something other
+	 * than the base is the driver's to know. Pinning the level is what the reference's filter
+	 * amounts to, and it is decidable here, from the text.
+	 * <p>
+	 * <strong>Which lookups.</strong> In a program drawn over the screen, every sampler declared at
+	 * file scope that the program asks no chain for, the request being read off the same
+	 * {@code colortexNMipmapEnabled} directives {@code TargetDirectives} reads; in a geometry
+	 * program, the names the engine serves out of a colour target, a depth, the noise or the shadow
+	 * map, and never the atlas or a material map, which carry chains and are read through them.
+	 * The shadow map's samplers are pinned with the rest, whatever mipmap directive the pack
+	 * wrote for them, because nothing of this engine fills a chain on the map. A sampler a
+	 * function takes as a parameter has no name to classify, as {@link #countDepthLookup} says,
+	 * so its call sites are read instead: the parameter is pinned when every call of its function
+	 * hands it a sampler already pinned or a parameter already proven, and outright, call sites
+	 * unread, in a program drawn over the screen that asks for no chain at all, since every image
+	 * such a parameter could stand for is read at the base there. A parameter one call hands
+	 * something else, or one that some macro calls its function through, is left as it stood and
+	 * its lookups counted. A comparison sampler is left to {@link #rewriteShadowCompare}, a name
+	 * the pack made a macro of to the preprocessor, and a rectangle, buffer or multisample sampler
+	 * has no levelled lookup to pin.
+	 * <p>
+	 * A pack image laid over the name of a colour target is classified as the target in a geometry
+	 * program, since only the binding knows the difference, and is pinned with it; nothing fills a
+	 * chain on such an image either, so it reads the same.
+	 */
+	private void pinLookupLevels() {
+		if (this.stage != ProgramStage.FRAGMENT || this.program.isEmpty()) {
+			return;
+		}
+
+		boolean fullScreen = fullScreenPass();
+		Set<String> chained = chainedSamplers();
+		Set<String> pinned = new HashSet<>();
+		for (Map.Entry<String, String> sampler : this.samplers.entrySet()) {
+			String name = sampler.getKey();
+			if (chained.contains(name) || !levelled(sampler.getValue())) {
+				continue;
+			}
+
+			if (fullScreen || servedOutOfATarget(name)) {
+				pinned.add(name);
+			}
+		}
+
+		List<Scoped> proven = provenParameters(pinned, fullScreen && chained.isEmpty());
+		int[] lines = lineNumbers();
+		List<Closing> levels = new ArrayList<>();
+
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.kind() != Kind.IDENTIFIER || token.directive() != null || token.macroName()
+					|| !LegacyGlsl.LEVELLED_LOOKUPS.contains(token.text())
+					|| this.packMacros.contains(token.text())) {
+				continue;
+			}
+
+			int open = callOpener(index);
+			int close = matchingBracket(open);
+			int first = significantAfter(open);
+			if (close < 0 || first < 0 || this.tokens.get(first).kind() != Kind.IDENTIFIER) {
+				continue;
+			}
+
+			String name = this.tokens.get(first).text();
+			int line = lines[index];
+			if (this.packMacros.contains(name) || comparisonAt(name, line)
+					|| hardwareComparisonAt(name, line)) {
+				continue;
+			}
+
+			// The parameter first, because a function may name one after a sampler of the file's
+			// and mean its own inside its body.
+			if (scoped(this.samplerParameters, name, line)) {
+				if (!scoped(proven, name, line)) {
+					this.unpinnedParameterLookups++;
+					continue;
+				}
+			} else if (!pinned.contains(name)) {
+				continue;
+			}
+
+			if (pinLookup(index, open, close, levels)) {
+				this.pinnedLookups++;
+			}
+		}
+
+		insertClosings(levels);
+	}
+
+	/**
+	 * The sampler parameters every call site of whose function hands a sampler read at the base:
+	 * a pinned name of the file, or a parameter already proven the same way, until nothing more
+	 * can be proven. On that road a function nothing calls proves nothing, and a call whose
+	 * argument is anything else, an expression, a macro, a name nothing classifies, keeps its
+	 * parameter out.
+	 *
+	 * @param all whether every parameter of a levelled type is proven outright, call sites unread,
+	 *            which is the case of a program drawn over the screen asking for no chain
+	 */
+	private List<Scoped> provenParameters(Set<String> pinned, boolean all) {
+		List<Scoped> proven = new ArrayList<>();
+		if (all) {
+			for (Scoped parameter : this.samplerParameters) {
+				if (!this.unlevelledParameters.contains(parameter)) {
+					proven.add(parameter);
+				}
+			}
+
+			return proven;
+		}
+
+		int[] lines = lineNumbers();
+		boolean grew = true;
+		while (grew) {
+			grew = false;
+			for (SamplerParameter parameter : this.typedParameters) {
+				if (proven.contains(parameter.scope())
+						|| this.unlevelledParameters.contains(parameter.scope())
+						|| !callsHandOver(parameter, pinned, proven, lines)) {
+					continue;
+				}
+
+				proven.add(parameter.scope());
+				grew = true;
+			}
+		}
+
+		return proven;
+	}
+
+	/**
+	 * Whether every call of this parameter's function hands it a sampler read at the base, and
+	 * there is at least one call. A definition or a prototype of the function is told from a call
+	 * by what precedes the name, a builtin type or {@code void}; anything else, an operator, a
+	 * keyword, a struct's name, is read as a call, and a definition read that way refuses the
+	 * parameter, its declaration being no sampler's name. A function named on a preprocessor line
+	 * is called from wherever that macro is used, which no scan of the tokens can see, so such a
+	 * function proves nothing.
+	 */
+	private boolean callsHandOver(SamplerParameter parameter, Set<String> pinned,
+			List<Scoped> proven, int[] lines) {
+		boolean called = false;
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (!token.identifier(parameter.function())) {
+				continue;
+			}
+
+			if (token.directive() != null) {
+				return false;
+			}
+
+			int open = callOpener(index);
+			int before = significantBefore(index);
+			if (open < 0 || (before >= 0 && this.tokens.get(before).kind() == Kind.IDENTIFIER
+					&& returnsAType(this.tokens.get(before).text()))) {
+				continue;
+			}
+
+			int close = matchingBracket(open);
+			if (close < 0) {
+				return false;
+			}
+
+			List<Integer> commas = topLevelCommas(open, close);
+			if (commas.size() < parameter.position()) {
+				return false;
+			}
+
+			int start = parameter.position() == 0 ? open : commas.get(parameter.position() - 1);
+			int end = commas.size() > parameter.position() ? commas.get(parameter.position()) : close;
+			int argument = significantAfter(start);
+			if (argument < 0 || significantAfter(argument) != end
+					|| this.tokens.get(argument).kind() != Kind.IDENTIFIER) {
+				return false;
+			}
+
+			String name = this.tokens.get(argument).text();
+			int line = lines[argument];
+			boolean handed = scoped(this.samplerParameters, name, line)
+					? scoped(proven, name, line)
+					: pinned.contains(name);
+			if (!handed) {
+				return false;
+			}
+
+			called = true;
+		}
+
+		return called;
+	}
+
+	/** Whether a function name preceded by this word is a definition rather than a call. */
+	private static boolean returnsAType(String word) {
+		return LegacyGlsl.TYPE_NAMES.contains(word);
+	}
+
+	/**
+	 * The samplers this program asks a chain for, under the names it declares them by: the targets
+	 * its {@code colortexNMipmapEnabled} directives name, whatever spelling the sampler took. Read
+	 * the way {@code TargetDirectives} reads them, on the live lines of this unit and the last
+	 * declaration winning. The shadow map's own mipmap directives are not read: Iris honours them
+	 * on the map's samplers and this engine fills no chain on the map, so its shadow lookups read
+	 * the base whatever the pack asked, pinned or not, and that is the older gap rather than this
+	 * pass's.
+	 */
+	private Set<String> chainedSamplers() {
+		Set<Integer> targets = new HashSet<>();
+		for (ConstDirectives.Directive directive : ConstDirectives.read(this.unit)) {
+			boolean on = directive.value().equals("true");
+			if (!directive.type().equals("bool") || !(on || directive.value().equals("false"))) {
+				continue;
+			}
+
+			Optional<TargetName.Suffixed> split = TargetName.split(directive.name());
+			if (split.isPresent() && split.get().suffix().equals(MIPMAP_SUFFIX)) {
+				if (on) {
+					targets.add(split.get().index());
+				} else {
+					targets.remove(split.get().index());
+				}
+			}
+		}
+
+		Set<String> chained = new HashSet<>();
+		for (String name : this.samplers.keySet()) {
+			OptionalInt index = TargetName.index(name);
+			if (index.isPresent() && targets.contains(index.getAsInt())) {
+				chained.add(name);
+			}
+		}
+
+		return chained;
+	}
+
+	/**
+	 * Whether a name is one the engine binds an image of its own under in every family and never
+	 * gives a chain to in a geometry program: a colour target, a depth of the world or of the far
+	 * terrain, the noise, or the shadow map's depth and colour, on which nothing of this engine
+	 * fills a chain in any family.
+	 */
+	private static boolean servedOutOfATarget(String name) {
+		return switch (SamplerPlan.classify(name)) {
+			case COLORTEX, DEPTH, NOISE, DISTANT_DEPTH, SHADOW_DEPTH, SHADOW_COLOUR -> true;
+			default -> false;
+		};
+	}
+
+	/**
+	 * Whether a sampler declared so has a level to pin. A rectangle, a buffer and a multisample
+	 * image have one level and no lookup that takes one, and a comparison sampler is another pass's.
+	 *
+	 * @param declaration the type alone, or the declaration {@link #liftUniforms} recorded, which
+	 *                    is the type followed by the name
+	 */
+	private static boolean levelled(String declaration) {
+		for (String word : declaration.split(" ", -1)) {
+			String shape = SamplerTypes.shapeOf(word);
+			if (shape != null) {
+				return !shape.contains("Rect") && !shape.contains("Buffer") && !shape.contains("MS")
+						&& !shape.endsWith(SHADOW_SHAPE);
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * One lookup onto the base level, in whichever spelling it was written, or false for a call
+	 * with fewer arguments than its spelling takes, which the compiler will name for itself.
+	 *
+	 * @param levels where the literal goes when it is a new argument rather than a replaced one,
+	 *               applied once the scan is over so that no index moves under it
+	 */
+	private boolean pinLookup(int index, int open, int close, List<Closing> levels) {
+		List<Integer> commas = topLevelCommas(open, close);
+		String directive = this.tokens.get(index).directive();
+
+		switch (this.tokens.get(index).text()) {
+			case "texture", "textureGrad" -> {
+				if (commas.isEmpty()) {
+					return false;
+				}
+
+				// The bias of the one and the two derivatives of the other are what the level was
+				// computed from, and the level is a literal now.
+				replace(index, "textureLod");
+				dropArgumentsFrom(commas, 2, close);
+				levels.add(new Closing(close, ", " + BASE_LEVEL, directive));
+			}
+			case "textureOffset" -> {
+				if (commas.size() < 2) {
+					return false;
+				}
+
+				replace(index, "textureLodOffset");
+				dropArgumentsFrom(commas, 3, close);
+				levels.add(new Closing(commas.get(1), ", " + BASE_LEVEL, directive));
+			}
+			case "textureGradOffset" -> {
+				if (commas.size() != 4) {
+					return false;
+				}
+
+				// The two derivatives make way for the literal and the offset stays where it is.
+				replace(index, "textureLodOffset");
+				setArgument(commas, 2, close, BASE_LEVEL);
+				dropArgument(commas, 3, close);
+			}
+			default -> {
+				if (commas.size() < 2) {
+					return false;
+				}
+
+				setArgument(commas, 2, close, BASE_LEVEL);
+			}
+		}
+
+		return true;
+	}
+
+	/** The commas that separate a call's arguments, and none of the ones nested inside them. */
+	private List<Integer> topLevelCommas(int open, int close) {
+		List<Integer> commas = new ArrayList<>();
+		int depth = 0;
+
+		for (int scan = open + 1; scan < close; scan++) {
+			Token token = this.tokens.get(scan);
+			if (token.kind() != Kind.OPERATOR) {
+				continue;
+			}
+
+			if (token.operator("(") || token.operator("[") || token.operator("{")) {
+				depth++;
+			} else if (token.operator(")") || token.operator("]") || token.operator("}")) {
+				depth--;
+			} else if (depth == 0 && token.operator(",")) {
+				commas.add(scan);
+			}
+		}
+
+		return commas;
+	}
+
+	/** Blanks the argument at this position, counted from nought, and every one after it. */
+	private void dropArgumentsFrom(List<Integer> commas, int at, int close) {
+		if (commas.size() >= at) {
+			blankRange(commas.get(at - 1), close - 1);
+		}
+	}
+
+	/** Blanks the argument at this position alone, counted from nought, with the comma before it. */
+	private void dropArgument(List<Integer> commas, int at, int close) {
+		int end = commas.size() > at ? commas.get(at) - 1 : close - 1;
+		blankRange(commas.get(at - 1), end);
+	}
+
+	/** Puts a literal in place of the argument at this position, counted from nought. */
+	private void setArgument(List<Integer> commas, int at, int close, String text) {
+		int first = significantAfter(commas.get(at - 1));
+		int end = commas.size() > at ? commas.get(at) - 1 : close - 1;
+		blankRange(commas.get(at - 1) + 1, end);
+		inject(first, text);
 	}
 
 	/**
@@ -4073,17 +4501,21 @@ public final class GlslTranslator {
 		int[] lines = lineNumbers();
 		int depth = 0;
 		int parameters = -1;
+		int position = 0;
 
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (token.directive() == null && token.operator("(")) {
 				if (depth == 0) {
 					parameters = index;
+					position = 0;
 				}
 
 				depth++;
 			} else if (token.directive() == null && token.operator(")")) {
 				depth--;
+			} else if (token.directive() == null && depth == 1 && token.operator(",")) {
+				position++;
 			}
 
 			// Inside a parenthesis and nowhere else, which is what tells a parameter from a
@@ -4096,8 +4528,18 @@ public final class GlslTranslator {
 
 			int name = significantAfter(index);
 			if (name >= 0 && this.tokens.get(name).kind() == Kind.IDENTIFIER) {
-				this.samplerParameters.add(new Scoped(this.tokens.get(name).text(), lines[index],
-						lines[functionEnd(parameters)]));
+				Scoped parameter = new Scoped(this.tokens.get(name).text(), lines[index],
+						lines[functionEnd(parameters)]);
+				this.samplerParameters.add(parameter);
+				if (!levelled(token.text())) {
+					this.unlevelledParameters.add(parameter);
+				}
+
+				int function = significantBefore(parameters);
+				if (function >= 0 && this.tokens.get(function).kind() == Kind.IDENTIFIER) {
+					this.typedParameters.add(new SamplerParameter(this.tokens.get(function).text(),
+							position, parameter));
+				}
 			}
 		}
 	}
@@ -4210,6 +4652,14 @@ public final class GlslTranslator {
 	 * never runs.
 	 */
 	private boolean movesCenterDepth() {
+		return fullScreenPass();
+	}
+
+	/**
+	 * Whether the pass this file is the entry point of is drawn over a quad by this engine: named,
+	 * not a geometry family, and not a shadow composite, which this engine never runs.
+	 */
+	private boolean fullScreenPass() {
 		String family = ProgramNames.familyOf(this.program);
 
 		return !this.program.isEmpty() && !ProgramNames.geometry(family)
@@ -5452,7 +5902,8 @@ public final class GlslTranslator {
 				this.conflicts.size(), this.shadowCalls, this.unwrappedShadowCalls,
 				this.strippedExtensions, this.depthEpilogue ? 1 : 0, this.alphaEpilogue ? 1 : 0,
 				this.covers ? 1 : 0, this.depthLookups,
-				this.parameterLookups, this.fragCoordZ, this.fragCoordXyz,
+				this.parameterLookups, this.pinnedLookups, this.unpinnedParameterLookups,
+				this.fragCoordZ, this.fragCoordXyz,
 				this.fragCoordUnhandled, this.fragDepthWrites, this.fragDepthUnhandled,
 				List.copyOf(this.conflicts), comparedSamplers(), hardwareComparedSamplers(),
 				List.copyOf(this.storageBlocks),
@@ -5502,9 +5953,18 @@ public final class GlslTranslator {
 	/** Empties a range but keeps its line breaks, so error messages still point at the right line. */
 	private void blankRange(int start, int end) {
 		for (int index = start; index <= end; index++) {
-			if (this.tokens.get(index).kind() != Kind.NEWLINE) {
-				this.tokens.set(index, Token.BLANK);
+			Token token = this.tokens.get(index);
+			if (token.kind() == Kind.NEWLINE) {
+				continue;
 			}
+
+			// A comment or a spliced line carries its breaks inside one token, and they are kept
+			// as well: the passes that ask which line a name is on take their numbers once and
+			// read them after blanking, so a break lost here moves every name after it.
+			long breaks = token.text().chars().filter(c -> c == '\n').count();
+			this.tokens.set(index, breaks == 0
+					? Token.BLANK
+					: new Token(Kind.SPACE, "\n".repeat((int) breaks), token.directive()));
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java
+++ b/common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java
@@ -73,6 +73,16 @@ public final class LegacyGlsl {
 			"textureGather", "textureGatherOffset", "textureGatherOffsets");
 
 	/**
+	 * The lookups that select a level of detail, whether they compute it from the derivatives of
+	 * their coordinate or take it as an argument, and so the ones whose level the translator can pin
+	 * to the base. A fetch names its level and a gather has none, so neither is here, and the
+	 * projective forms are left as they stand.
+	 */
+	public static final Set<String> LEVELLED_LOOKUPS = Set.of(
+			"texture", "textureLod", "textureOffset", "textureLodOffset", "textureGrad",
+			"textureGradOffset");
+
+	/**
 	 * Words GLSL 4.60 reserves that packs still use as ordinary names. Renaming them is only safe
 	 * where they are used as a name, which the translator decides; this table only says what they
 	 * become.

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
@@ -33,7 +33,7 @@ import java.util.Map;
 final class TranslatedProgramCodec {
 
 	/** Bumped by hand when the layout changes. It is part of the key, so old blobs go unread. */
-	static final String FORMAT = "vitrail-translation-2";
+	static final String FORMAT = "vitrail-translation-3";
 
 	private TranslatedProgramCodec() {
 	}
@@ -142,6 +142,8 @@ final class TranslatedProgramCodec {
 		out.writeInt(notes.coverage());
 		out.writeInt(notes.depthLookups());
 		out.writeInt(notes.parameterLookups());
+		out.writeInt(notes.pinnedLookups());
+		out.writeInt(notes.unpinnedParameterLookups());
 		out.writeInt(notes.fragCoordZ());
 		out.writeInt(notes.fragCoordXyz());
 		out.writeInt(notes.fragCoordUnhandled());
@@ -162,6 +164,7 @@ final class TranslatedProgramCodec {
 		return new TranslatedUnit.Notes(in.readInt(), in.readInt(), in.readInt(), in.readInt(),
 				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(),
 				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(),
+				in.readInt(), in.readInt(),
 				names(in), names(in), names(in), names(in),
 				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt());
 	}

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedUnit.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedUnit.java
@@ -79,6 +79,14 @@ public record TranslatedUnit(String entry, ProgramStage stage, String text, Note
 	 *                           is the size of the blind spot such a rule would have; the engine
 	 *                           binds an image already in the pack's window rather than rewrite the
 	 *                           ones it can see
+	 * @param pinnedLookups      lookups rewritten onto the base level of their image, because the
+	 *                           sampler they go through is bound without a chain and the reference's
+	 *                           filter never selects a level on one
+	 * @param unpinnedParameterLookups
+	 *                           lookups through a sampler the enclosing function was handed that
+	 *                           were left as they stood, because some call of that function hands
+	 *                           the parameter something the pass could not read as a sampler bound
+	 *                           at the base, or because the parameter's type has no level to pin
 	 * @param fragCoordZ         reads of {@code gl_FragCoord.z} converted
 	 * @param fragCoordXyz       reads of {@code gl_FragCoord.xyz}, where only the third component
 	 *                           is a depth and the rewrite has to rebuild the vector
@@ -122,7 +130,8 @@ public record TranslatedUnit(String entry, ProgramStage stage, String text, Note
 	public record Notes(int fragmentOutputs, int dynamicFragData, int uniformConflicts,
 			int shadowCalls, int unwrappedShadow, int strippedExtensions,
 			int depthEpilogue, int alphaEpilogue, int coverage,
-			int depthLookups, int parameterLookups,
+			int depthLookups, int parameterLookups, int pinnedLookups,
+			int unpinnedParameterLookups,
 			int fragCoordZ, int fragCoordXyz, int fragCoordUnhandled,
 			int fragDepthWrites, int fragDepthUnhandled,
 			List<String> conflictNames, List<String> comparedSamplers,

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -96,6 +96,31 @@ to a function, or written with a compound assignment, cannot be rewritten where 
 are counted rather than guessed at. What the translator never rewrites at all is a **lookup through
 a sampler**. Those are served by converting the *image* instead, once, when the depth is taken.
 
+**A lookup through a sampler bound without a mip chain is pinned to the base level.**
+`texture(s, uv)` becomes `textureLod(s, uv, 0.0)`, a level the pack wrote out becomes nought, and a
+bias or a pair of derivatives, which only ever chose a level, is dropped. The reference binds the
+depth textures nearest and never mipmapped, the noise linear, and a colour target through the
+target's own sampler, mipmapped once a program's `colortexNMipmapEnabled` turned its chain on; under
+OpenGL a filter without a mipmap in its name never selects a level, whatever level of detail the
+lookup computed or carried. Vulkan has no such filter. Every sampler selects a level, the one bound
+where no chain exists is told to stay at the base, and measured on one driver that is not what a
+lookup got: AstraLex marches a reflection ray across the opaque depth in its translucent pass,
+thirty steps with an early exit, reading the depth with `texture` at a coordinate each step
+computes, and on some steps the depth that came back was not the image's, so the ray landed where it
+never reached and every glass pane bloomed a saturated blue over its wall, on some frames and not
+others. The same read at an explicit level of nought was right on every frame. So the level is
+written into the text, which is what the reference's filter amounted to. The rewrite is by the name
+of the sampler, and a sampler a function takes as a parameter, the blind spot the depth conversion
+below describes, is read through its call sites instead: the parameter is pinned when every call
+hands it a sampler already pinned or a parameter already proven, outright in a full screen program
+that asks for no chain at all, and its lookups are counted and left otherwise, a function some macro
+calls included. The shadow map's samplers are pinned with the rest, since nothing here fills a chain
+on the map whatever mipmap directive the pack wrote, which is an older gap of the shadow bindings
+and not of this rewrite. The engine gives a chain to the program that asked for it
+and to that program alone, where the reference keeps the mipmap filter on the target for the rest
+of the frame; that is an older divergence of the bindings, and the rewrite does not change what
+those later programs read.
+
 **One uniform becomes a sampler, because its value never comes back from the card.**
 `centerDepthSmooth` is the depth at the middle of the screen, faded by the pack's own half-life,
 and it is what a depth of field focuses on. It is accumulated in a one-texel image that a pass of


### PR DESCRIPTION
## What changes

A lookup through a sampler that carries no mipmap chain is asked for the base level of its image outright: `texture(s, uv)` becomes `textureLod(s, uv, 0.0)`, a level the pack wrote out becomes nought, and a bias or a pair of derivatives, which only ever chose a level, is dropped. In a program drawn over the screen that is every sampler the program asks no chain for; in a geometry program it is the names the engine serves out of a colour target, a depth, the noise or the shadow map, and never the atlas. A sampler a function takes as a parameter has no name to classify, so its call sites are read: the parameter is pinned when every call of its function hands it a sampler already pinned or a parameter already proven, outright in a full screen program that asks for no chain at all, and its lookups are counted and left otherwise. What a program asks a chain for is read off the same `const` directives the target plan reads; the shadow map's mipmap directives are not, since nothing here fills a chain on the map, which is an older gap of the shadow bindings.

What it closes: under AstraLex, every glass pane of a village bloomed a saturated blue over its wall, on some frames and not others. Its glass reflections march a ray across the opaque depth, thirty steps with an early exit, reading the depth with `texture` at a coordinate each step computes, and on some steps the depth that came back was not the image's, so the ray landed on a pixel it never reached and the pane lit up with what it found there. The same read at an explicit level of nought came back right on every frame.

## How it differs from the reference, and for what obstacle

It does not in effect. Iris binds the depth textures nearest and never mipmapped (`IrisSamplers.addWorldDepthSamplers`, `addCompositeSamplers`), the noise linear (`addNoiseSampler`), and a colour target through the target's own sampler, mipmapped once a program's `colortexNMipmapEnabled` turned the chain on (`CompositeRenderer.setupMipmapping`); under OpenGL a minification filter without a mipmap in its name never selects a level, so the base image answers every lookup whatever level it computed or carried. The obstacle is that Vulkan has no such filter: every sampler selects a level, the one this engine binds where no chain exists is told to stay within a quarter of a level of the base (`PackPass.sampler`, through the game's `SamplerCache`), and on the NVIDIA driver this was measured on a lookup under that sampler still did not read the base inside a divergent loop. Writing the level into the text is the reference's filtering said in words the Vulkan compiler cannot misread. It costs the image nothing: the level was nought under the reference on every lookup this touches.

## What proves it

- `gradlew build` green.
- The off-game harness over the whole corpus of the Fabric bench: all 3026 units compile exactly as before, none gained and none lost, and 296 fragment stages carry pinned reads.
- In the game, AstraLex on its LEX profile at a saved camera in front of a savanna house on the Fabric bench: sixteen captures in two bursts, none blue, where the same camera and the same untouched pack gave two blue captures out of eight with the jar before this. A copy of the pack with that one depth read pinned by hand gave the same sixteen clean captures, which is what named the read.

## What it leaves owing

- A parameter one call hands something the pass cannot read as a sampler at the base, an expression or a macro, keeps its lookups as they were, and the count says how many.
- The projective lookups are not pinned.
- Iris keeps the mipmap filter on a target for the rest of the frame once a program asked for it; this engine gives the chain to that program alone, an older divergence of the bindings that this does not touch.
- Whether the driver's answer comes from the derivatives of a coordinate made under divergent flow or from its clamp is not settled here; pinning the level makes the question moot for every lookup a pack writes.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
