### PR TITLE
fix(sodium): give the shadow draw cached batches of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ what the next one holds.
 
 ### Fixed
 
+- **Leaves keep the same self-shadow wherever the camera stands.** The shadow map is drawn
+  with Sodium's chunk renderer, which keeps one filled batch of draw commands per region and
+  pass and only refills it when the region's sections change or the camera crosses a section
+  boundary in or next to the region. The camera's draw fills that batch without the faces the
+  camera cannot see, and where the light and the camera kept the same sections the shadow draw
+  took the camera's batch as it stood: the faces between the sun and the leaves were missing
+  from the map, and a canopy's self-shadow came and went region by region as the player walked,
+  every tree lighter or darker according to where they stood, where Iris showed one shadow. The
+  shadow draw now keeps filled batches of its own, as Iris does.
+
 - **Photon draws.** Three things stood between its files and its picture. Its atmosphere table
   is a three-dimensional volume of half floats asked to clamp, and the flat atlas that stands in
   for a volume took one byte a texel and a repeating volume only, so the three deferred passes

--- a/common/src/main/java/dev/vitrail/mixin/MixinRenderRegion.java
+++ b/common/src/main/java/dev/vitrail/mixin/MixinRenderRegion.java
@@ -1,0 +1,81 @@
+package dev.vitrail.mixin;
+
+import dev.vitrail.render.TerrainDraw;
+
+import net.caffeinemc.mods.sodium.client.gpu.device.batch.MultiDrawBatch;
+import net.caffeinemc.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import net.caffeinemc.mods.sodium.client.render.chunk.region.RenderRegion;
+import net.caffeinemc.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/**
+ * Gives the shadow draw cached draw batches of its own, beside the ones the camera's draw fills.
+ * <p>
+ * The chunk renderer keeps one filled batch per region and pass and reuses it until the region's
+ * render list changes or the camera crosses a section boundary inside the region, or steps into
+ * or out of it ({@code render/chunk/lists/ChunkRenderList.prepareForRender}, the camera section
+ * clamped to one past the region on each axis). Which faces a batch draws is decided when it is
+ * filled, from the position of whoever filled it, and the face culling {@code
+ * MixinDefaultChunkRenderer} turns off for the shadow draw only lands on a fill the shadow draw
+ * makes itself: a region whose list is the same for the camera and for the light is never
+ * refilled between the two, so the shadow draw found the camera's batch standing and drew the map
+ * with the camera's face culling in it. The faces the camera cannot see are the ones between the
+ * sun and the leaves, so a canopy's self-shadow came and went with where the camera stood, region
+ * by region, refilled at the section boundaries the camera crossed inside the tree's own region.
+ * <p>
+ * Iris keeps a second render list and a second map of batches for its shadow pass and swaps both
+ * into Sodium's fields around it ({@code compat/sodium/mixin/MixinRenderRegion.java}). Here the
+ * light's walk replaces the camera's lists rather than swapping them, so only the batches need a
+ * second home: the shadow draw takes its batch from this map, and the map is emptied wherever
+ * Sodium empties its own, pass for pass, which is what keeps a batch from outliving the list or
+ * the geometry it was filled from. What it costs is one more batch per region and pass the map
+ * draws, a few tens of kilobytes each, freed with the region.
+ */
+@Mixin(value = RenderRegion.class, remap = false)
+public abstract class MixinRenderRegion {
+
+	@Unique
+	private final Map<TerrainRenderPass, MultiDrawBatch> vitrail$shadowBatches =
+			new IdentityHashMap<>();
+
+	@Inject(method = "getCachedBatch", at = @At("HEAD"), cancellable = true)
+	private void vitrail$shadowBatch(TerrainRenderPass pass,
+			CallbackInfoReturnable<MultiDrawBatch> cir) {
+		if (TerrainDraw.drawingShadow()) {
+			cir.setReturnValue(this.vitrail$shadowBatches.computeIfAbsent(pass,
+					_ -> MultiDrawBatch.newBatch(ModelQuadFacing.COUNT * RenderRegion.REGION_SIZE + 1)));
+		}
+	}
+
+	@Inject(method = "clearAllCachedBatches", at = @At("HEAD"))
+	private void vitrail$clearAll(CallbackInfo ci) {
+		for (MultiDrawBatch batch : this.vitrail$shadowBatches.values()) {
+			batch.clear();
+		}
+	}
+
+	@Inject(method = "clearCachedBatchFor", at = @At("HEAD"))
+	private void vitrail$clearFor(TerrainRenderPass pass, CallbackInfo ci) {
+		MultiDrawBatch batch = this.vitrail$shadowBatches.get(pass);
+		if (batch != null) {
+			batch.clear();
+		}
+	}
+
+	@Inject(method = "delete", at = @At("HEAD"))
+	private void vitrail$delete(CallbackInfo ci) {
+		for (MultiDrawBatch batch : this.vitrail$shadowBatches.values()) {
+			batch.delete();
+		}
+
+		this.vitrail$shadowBatches.clear();
+	}
+}

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -60,6 +60,7 @@
 		"RenderPassMixin",
 		"RenderPipelineAccessor",
 		"RenderPipelineMixin",
+		"MixinRenderRegion",
 		"RenderSectionManagerAccessor",
 		"RenderTargetAccessor",
 		"RenderTypeFeatureRendererGroupMixin",

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -258,6 +258,17 @@ Finally, per-face batch culling has to be disabled for the shadow pass, and the 
 not enough to do it: batches choose which faces to submit before any pipeline exists, and a face
 the camera cannot see is exactly the face standing between the sun and the ground.
 
+Disabling it at the point where a batch is filled is still not enough, because Sodium keeps the
+filled batch. One batch per region and pass survives until the region's render list changes or the
+camera crosses a section boundary inside the region or steps into or out of it, and whoever fills it
+decides the faces it holds. Where the light and the camera keep the same sections of a region, which
+is every region fully in view, nothing refills the batch between the camera's draw and the shadow
+draw, so the shadow draw took the camera's batch with the camera's holes in it. The symptom was a
+canopy whose self-shadow came and went as the player walked, one region at a time, refilled at the
+section boundaries crossed inside the tree's region. The shadow draw therefore keeps batches of its
+own, as Iris does with a second render list and a second batch map it swaps in for its shadow pass,
+and the second map is emptied wherever Sodium empties its own.
+
 ### The shape the light measures a section against
 
 The obvious shape is the box the map is drawn in, and it is the wrong one. The map only ever gets


### PR DESCRIPTION
## What changes

The shadow map is drawn with Sodium's chunk renderer, which keeps one filled draw batch per region and pass and reuses it until the region's render list changes or the camera crosses a section beside the region. The faces a batch draws are chosen when it is filled, from the position of whoever filled it, and the camera's draw leaves out the faces the camera cannot see. This engine already turns Sodium's face culling off for the shadow draw, but that switch is only reached on a fill the shadow draw makes itself: every region whose sections were the same for the camera and for the light, which is every region fully in view, was never refilled between the two draws, so the shadow draw took the camera's batch as it stood and drew the map with the camera's holes in it. The faces between the sun and the leaves were missing from the map, and a canopy's self-shadow came and went region by region as the player walked, every tree lighter or darker according to where they stood. The shadow draw now takes its batches from a second map of its own, emptied wherever Sodium empties its own.

## How it differs from the reference, and for what obstacle

It does not. Iris keeps a second batch map for its shadow pass and swaps it in with its shadow render lists (`compat/sodium/mixin/MixinRenderRegion.java`, `compat/sodium/mixin/MixinRenderRegionManager.java`). Here the light's walk replaces the camera's lists rather than swapping them, so only the batches need a second home; the clears reach both maps the way Iris's do.

## What proves it

- `gradlew build` green.
- In the game, Complementary Unbound on the Fabric bench, walking towards oak and acacia canopies with the sun low: with the switch off, the shadow draw took between sixty and a hundred batches filled by the camera on every section crossing, counted at the point where it asks the region for its batch; with it on, the trees kept one self-shadow from twenty blocks to under the canopy, where before each one flipped between lit-through and shaded at a section boundary. The same walk under Iris on the same world shows the stable shadow.
- The off-game harness has nothing to say about draw batches.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
