### PR TITLE
fix(render): read the block atlas unfiltered, as Iris binds it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@ what the next one holds.
   every tree lighter or darker according to where they stood, where Iris showed one shadow. The
   shadow draw now keeps filled batches of its own, as Iris does.
 
+- **A pack's terrain reads the block atlas unfiltered, as Iris binds it.** The terrain and its
+  shadow map read the atlas through the game's own chunk sampler, LINEAR for min and mag, where
+  Iris throws that sampler away and binds NEAREST for every terrain draw. Both halves now bind
+  the same sampler Iris does, mipmaps and the player's anisotropy kept, short of the one thing
+  Iris adds for packs that declare they cannot bear anisotropy, which is not read yet. What a
+  filter can decide on cutout foliage is whether a fragment survives its alpha test, so the two
+  states can only differ where a leaf's edge falls inside a texel; compared against Iris on one
+  scene at three camera heights, the two engines shade the trees alike in both states, so this
+  is parity and not the cure of anything seen so far. Of the Texture Filtering setting, only the
+  anisotropy still reaches a pack's terrain; the filter itself still applies to everything a pack
+  does not draw.
+
+  An empty file `vitrail/legacy-terrain-filter` in the instance, or
+  `-Dvitrail.legacyTerrainFilter=true`, puts the old filtered sampler back on both the terrain and
+  its shadow, so the two states can be compared in one world by reloading the pack with the
+  Reload Shaders key (R by default) rather than by swapping builds. F3 + T does not read the
+  pack again and leaves the state as it was. The log names the state once per pack load, at the
+  first terrain the pack draws.
+
 - **Photon draws.** Three things stood between its files and its picture. Its atmosphere table
   is a three-dimensional volume of half floats asked to clamp, and the flat atlas that stands in
   for a volume took one byte a texel and a repeating volume only, so the three deferred passes

--- a/common/src/main/java/dev/vitrail/mixin/MixinShaderChunkRenderer.java
+++ b/common/src/main/java/dev/vitrail/mixin/MixinShaderChunkRenderer.java
@@ -2,7 +2,9 @@ package dev.vitrail.mixin;
 
 import dev.vitrail.sodium.SodiumPasses;
 import dev.vitrail.pack.program.TerrainPass;
+import dev.vitrail.render.LegacyTerrainFilter;
 import dev.vitrail.render.TerrainDraw;
+import dev.vitrail.render.TerrainSampler;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.textures.GpuSampler;
@@ -51,13 +53,21 @@ public abstract class MixinShaderChunkRenderer {
 	protected VertexFormat vertexFormat;
 
 	/**
-	 * Takes the sampler the game configured for the block atlas, which {@code begin} is handed and
-	 * {@code compileProgram} is not.
+	 * Settles which sampler a pack's terrain reads the block atlas through, at the one point that is
+	 * handed the game's: {@code begin} has it and {@code compileProgram} does not. {@code begin}
+	 * calls {@code compileProgram}, so this always lands first.
 	 * <p>
-	 * Worth the second hook rather than settling for a sampler of our own: the game's is mipmapped
-	 * and ours was not, and a block atlas sampled without mipmaps shimmers at distance and bleeds
-	 * between sprites at their edges. {@code begin} calls {@code compileProgram}, so this always
-	 * lands first.
+	 * <strong>What the pack binds is ours and not the game's, and that is a correction rather than a
+	 * preference.</strong> The game filters the atlas LINEAR and Iris binds NEAREST for every terrain
+	 * draw, so a pack, which is written against Iris, expects NEAREST. What that filter decides on
+	 * cutout foliage is the silhouette rather than the colour, the fragment being discarded on the
+	 * atlas's alpha, and {@link TerrainSampler} carries the whole of it with the references on both
+	 * sides. {@link LegacyTerrainFilter} puts the game's back, terrain and shadow alike, for a
+	 * comparison. The choice is made where the pack is known to be drawing, so that a pass with no
+	 * pack behind it neither asks nor announces anything.
+	 * <p>
+	 * Every pass comes through here, the shadow map's included: the light's draw hands the game's
+	 * sampler down the same road, and the pack's shadow programs bind what is settled here.
 	 */
 	@Inject(method = "begin", at = @At("HEAD"))
 	private void vitrail$sampler(TerrainRenderPass pass, FogParameters parameters,

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -10,6 +10,7 @@ import dev.vitrail.render.PbrTextures;
 import dev.vitrail.render.RenderScale;
 import dev.vitrail.render.ShadowGeometry;
 import dev.vitrail.render.TerrainDraw;
+import dev.vitrail.render.TerrainSampler;
 import dev.vitrail.sodium.EntityMeshSerializer;
 import dev.vitrail.screen.SettingsKey;
 import dev.vitrail.sodium.ShadowTerrain;
@@ -272,6 +273,11 @@ public final class EngineStages {
 		// The render scale's scaled world and its quad belong to the session too: they outlive
 		// every pack on purpose, so the end of the session is the one caller that frees them.
 		RenderScale.close();
+
+		// The block atlas sampler a pack's terrain binds, one per anisotropy the player asked for.
+		// Same lifetime and same reason: it belongs to the device rather than to any pack, and a
+		// sampler outliving its device is a handle into freed memory.
+		TerrainSampler.release();
 
 		// And the material maps, which belong to the resource pack rather than to any shader pack:
 		// nothing in a pack's lifetime touches them, so nothing but the end of the session does. Both

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -1428,9 +1428,11 @@ final class GeometryProgram {
 	}
 
 	/**
-	 * The sampler the game configured for the block atlas, which is mipmapped and filtered as the
-	 * user's own settings say. Worth taking rather than making one: a block atlas read without
-	 * mipmaps shimmers at distance, and the sprites bleed into each other at their edges.
+	 * The sampler this pack's terrain reads the block atlas through, mipmapped and carrying the
+	 * player's anisotropy, and NEAREST where the game's own is LINEAR. {@link TerrainSampler} is
+	 * where it is built and why: what an interpolated filter decides on cutout foliage is the
+	 * silhouette rather than the colour. Mipmaps are not the thing that changed and are still what
+	 * keeps a block atlas from shimmering at distance and bleeding between sprites at their edges.
 	 */
 	void sampler(GpuSampler sampler) {
 		this.atlasSampler = sampler;

--- a/common/src/main/java/dev/vitrail/render/LegacyTerrainFilter.java
+++ b/common/src/main/java/dev/vitrail/render/LegacyTerrainFilter.java
@@ -1,0 +1,100 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+
+import net.minecraft.client.Minecraft;
+
+import java.nio.file.Files;
+
+/**
+ * Whether a pack's terrain reads the block atlas through the game's filtered sampler, as this
+ * engine did before it bound Iris's unfiltered one.
+ * <p>
+ * <strong>It exists so that the difference can be SEEN rather than argued about.</strong> A filter
+ * decides the silhouette of cutout foliage, and whatever that changes on screen is exactly the kind
+ * of thing an eye judges badly across two launches minutes apart, and badly again across two jars.
+ * One jar and one keypress puts both states in the same window, the same world and the same second,
+ * with one variable between them.
+ * <p>
+ * A file {@code vitrail/legacy-terrain-filter} in the game directory, or
+ * {@code -Dvitrail.legacyTerrainFilter=true}. Read again at every pack load, so the Reload Shaders
+ * key is the whole gesture. F3 and T is not one: a resource reload rebuilds the pipelines and does
+ * not read the pack again, so it leaves the state where it was. The state is written to the log
+ * BOTH WAYS, once per pack load at the first terrain the pack draws, so a reading taken afterwards
+ * can always say which of the two it belongs to.
+ * <p>
+ * It is not a setting anybody should keep on. The filtered sampler is what this engine had wrong,
+ * and Iris has never bound it.
+ */
+public final class LegacyTerrainFilter {
+
+	private static final boolean PROPERTY = Boolean.getBoolean("vitrail.legacyTerrainFilter");
+
+	private static final String ARM_FILE = "legacy-terrain-filter";
+
+	/** Null until first asked after a pack load, so the file is read once per load and not per pass. */
+	private static Boolean armed;
+
+	private static boolean announced;
+
+	private LegacyTerrainFilter() {
+	}
+
+	/**
+	 * Whether a pack's terrain is to read the atlas through the game's own filtered sampler.
+	 *
+	 * @return true while the file or the property asks for the old filter
+	 */
+	public static boolean armed() {
+		if (PROPERTY) {
+			announce(true);
+
+			return true;
+		}
+
+		if (armed == null) {
+			Minecraft minecraft = Minecraft.getInstance();
+			if (minecraft == null || minecraft.gameDirectory == null) {
+				return false;
+			}
+
+			armed = Files.isRegularFile(minecraft.gameDirectory.toPath()
+					.resolve("vitrail").resolve(ARM_FILE));
+		}
+
+		announce(armed);
+
+		return armed;
+	}
+
+	/** A new pack is being read, so the file is worth looking at again. */
+	public static void reset() {
+		armed = null;
+		announced = false;
+	}
+
+	/**
+	 * Said once per pack load, and said BOTH WAYS on purpose. A line that only appears in one of the
+	 * two states makes every load without one ambiguous, and an ambiguous reading is worth nothing.
+	 */
+	private static void announce(boolean on) {
+		if (announced) {
+			return;
+		}
+
+		announced = true;
+		if (on) {
+			Vitrail.logger().warn("A pack's terrain reads the block atlas through the GAME's "
+					+ "filtered sampler, asked for by vitrail/{} or by "
+					+ "-Dvitrail.legacyTerrainFilter. That is what this engine bound before and what "
+					+ "Iris never binds. Remove it and reload the pack to go back",
+					ARM_FILE);
+			return;
+		}
+
+		Vitrail.logger().info("A pack's terrain reads the block atlas unfiltered, as it does under "
+				+ "Iris. vitrail/{} would put the game's filtered sampler back, and this line is "
+				+ "said either way so that a reading can name the state it was taken under",
+				ARM_FILE);
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -660,6 +660,7 @@ public final class PackChain {
 		// Taken before anything reads the folder, so that the count printed at the end of the load
 		// covers every opening the load made and not only the translation's.
 		int openings = ShaderPackSource.openings();
+		LegacyTerrainFilter.reset();
 		session = null;
 		lastError = null;
 		removed = List.of();

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -799,12 +799,23 @@ public final class TerrainDraw {
 		}
 	}
 
-	/** The sampler the game configured for the block atlas, taken where a chunk pass begins. */
-	public static void sampler(GpuSampler sampler) {
+	/**
+	 * Settles the sampler this pack's terrain reads the block atlas through, where a chunk pass
+	 * begins. Ours rather than the game's, and {@link TerrainSampler} says why; the game's under
+	 * {@link LegacyTerrainFilter}, and the game's again before a device exists to build ours on,
+	 * which no pass drawn by a pack reaches. Nothing is asked or announced while no pack draws.
+	 *
+	 * @param game the sampler the game configured for its own chunk draws
+	 */
+	public static void sampler(GpuSampler game) {
 		TerrainDraw draw = PackChain.terrain();
-		if (draw != null) {
-			draw.programs.values().forEach(program -> program.sampler(sampler));
+		if (draw == null) {
+			return;
 		}
+
+		GpuSampler ours = LegacyTerrainFilter.armed() ? null : TerrainSampler.get();
+		GpuSampler bound = ours == null ? game : ours;
+		draw.programs.values().forEach(program -> program.sampler(bound));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/TerrainProgram.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainProgram.java
@@ -270,7 +270,8 @@ public final class TerrainProgram implements DumpedProgram {
 	}
 
 	/**
-	 * Takes the sampler the game configured for the block atlas, mipmaps and filtering included.
+	 * Takes the sampler this pack's terrain reads the block atlas through, mipmaps, filtering and
+	 * anisotropy included.
 	 *
 	 * @see GeometryProgram#sampler(GpuSampler)
 	 */

--- a/common/src/main/java/dev/vitrail/render/TerrainSampler.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainSampler.java
@@ -1,0 +1,88 @@
+package dev.vitrail.render;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.AddressMode;
+import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.textures.GpuSampler;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.TextureFilteringMethod;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalDouble;
+
+/**
+ * The block atlas sampler a pack's terrain is drawn with, in the gbuffers and in the shadow map
+ * alike, and it is NEAREST where the game's own is LINEAR.
+ * <p>
+ * <strong>The game filters the atlas, and a pack cannot afford it.</strong> The game builds
+ * {@code chunkLayerSampler} as CLAMP_TO_EDGE on both axes, LINEAR for min and mag, and the
+ * player's anisotropy, in {@code LevelRenderer} where it draws the chunk layers. Iris throws that
+ * away and binds its own for every terrain draw: the same sampler in every respect but NEAREST for
+ * min and mag ({@code pipeline/programs/SodiumShader.java:131}, built by
+ * {@code samplers/IrisSamplers.java:249-254}). Packs are written against Iris, so NEAREST is what
+ * they expect, and this engine was passing the game's straight through.
+ * <p>
+ * <strong>What the filter can decide is a silhouette, not a colour.</strong> Foliage is cutout: the
+ * fragment is discarded on the atlas's alpha, so interpolating that alpha makes whether a fragment
+ * survives depend on where a sample falls INSIDE a texel rather than on which texel it falls in.
+ * That is the whole of what the two samplers can differ by, and measured against Iris on one scene
+ * at three camera heights the two engines shaded the trees alike under either: this is parity with
+ * what Iris binds, not the cure of a picture anybody has seen. Mipmaps stay on and both backends of
+ * the game blend between levels under a NEAREST min filter, so what goes is the blend within one
+ * level and nothing else.
+ * <p>
+ * The anisotropy is the player's, read the way the game and Iris both read it, and the cache is
+ * keyed by it so that changing the setting builds one more sampler rather than reusing a stale one.
+ * Iris additionally forces it to one for a pack that cannot bear it, which this engine has no
+ * equivalent of and does not pretend to. Released when the client closes, the one moment the device
+ * is known to be going away with it.
+ */
+public final class TerrainSampler {
+
+	/**
+	 * One sampler per anisotropy the player has asked for. Small and bounded: the option offers a
+	 * handful of values and nothing else reaches this map.
+	 */
+	private static final Map<Integer, GpuSampler> BY_ANISOTROPY = new HashMap<>();
+
+	private TerrainSampler() {
+	}
+
+	/**
+	 * The sampler every terrain draw of a pack binds, built once per anisotropy.
+	 * <p>
+	 * Null before there is a device to build one on, which the callers already handle by falling
+	 * back to what the game handed them: an atlas filtered the game's way is wrong, and no atlas at
+	 * all is a black world.
+	 *
+	 * @return the sampler, or null before the device exists
+	 */
+	public static GpuSampler get() {
+		Minecraft minecraft = Minecraft.getInstance();
+		if (minecraft == null || RenderSystem.tryGetDevice() == null) {
+			return null;
+		}
+
+		int anisotropy = minecraft.options.textureFiltering().get() == TextureFilteringMethod.ANISOTROPIC
+				? minecraft.options.maxAnisotropyValue()
+				: 1;
+
+		return BY_ANISOTROPY.computeIfAbsent(anisotropy, asked ->
+				RenderSystem.getDevice().createSampler(AddressMode.CLAMP_TO_EDGE,
+						AddressMode.CLAMP_TO_EDGE, FilterMode.NEAREST, FilterMode.NEAREST, asked,
+						OptionalDouble.empty()));
+	}
+
+	/**
+	 * Closes what was built, at the one moment the device is going away with it.
+	 * <p>
+	 * A sampler outliving its device is a handle into freed memory, and the map is static, so
+	 * nothing else would ever drop these.
+	 */
+	public static void release() {
+		BY_ANISOTROPY.values().forEach(GpuSampler::close);
+		BY_ANISOTROPY.clear();
+	}
+}

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -303,9 +303,15 @@ public final class ShadowTerrain {
 				((GameRendererStorage) minecraft.gameRenderer).sodium$getProjectionMatrix();
 		ChunkRenderMatrices matrices = new ChunkRenderMatrices(projection, MODEL_VIEW);
 
-		// Mipmapped and clamped, which is the game's own chunk sampler short of its anisotropy. It
-		// matters here rather than being tidiness: the cutout half of the shadow discards on the
-		// atlas's alpha, and a leaf sampled without mipmaps casts a shadow that crawls at distance.
+		// The game's own chunk sampler, mipmapped and clamped, and it is NOT what the pack's shadow
+		// programs read the atlas through: the renderer hands this to begin, where the chunk
+		// renderer mixin settles the pack's sampler for every pass, this one included, so the shadow
+		// half binds the same NEAREST sampler as the gbuffer half or the game's under the legacy
+		// switch, either way through TerrainSampler and LegacyTerrainFilter and never through this
+		// argument. What this argument reaches is Sodium's own shader, on a pass handed back to it,
+		// which keeps the game's filtering there as it does in the gbuffers. Iris hands a sampler down
+		// the same road (shadows/ShadowRenderer.java:389) and its SodiumShader.setupState binds its
+		// own instead (pipeline/programs/SodiumShader.java:131).
 		GpuSampler sampler = RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR, true);
 
 		ShadowCasters casters = TerrainDraw.shadowCasters();

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -262,6 +262,16 @@ game's full memory barrier and sends the mip chain back to a pass per level. It 
 cannot be the cause of a wrong image, so it is the first thing to ask of a machine that draws one
 this one does not.
 
+**The block atlas filter can be put back the way it was.** An empty file
+`vitrail/legacy-terrain-filter` in the instance, or `-Dvitrail.legacyTerrainFilter=true`, sends a
+pack's terrain and its shadow back through the game's filtered sampler, which is what this engine
+bound before it took Iris's unfiltered one. It exists because what a filter can change is the
+silhouette of cutout foliage, and an eye judges that badly across two launches and worse across
+two builds. One world, one variable, and the Reload Shaders key between the two states: F3 + T
+rebuilds the pipelines without reading the pack again, so it does not switch. The state is written
+to the log once per pack load, at the first terrain the pack draws, whether the file is there or
+not, so a reading always names the state it belongs to.
+
 **The sine substitution can be taken off.** Every `sin` and `cos` a pack writes is replaced at load
 time by a reduced-argument helper of the translation's own, whatever the argument. An empty file
 `vitrail/driver-trig` in the instance, or `-Dvitrail.driverTrig=true` among the JVM arguments,


### PR DESCRIPTION
## What changes

A pack's terrain, in the gbuffers and in the shadow map, now reads the block atlas through the sampler Iris binds for every terrain draw: clamped, NEAREST for min and mag, mipmapped, with the player's anisotropy. Before, both halves went through the game's own chunk sampler, which filters LINEAR. On cutout foliage the filter decides whether a fragment survives its alpha test, so it decides the leaf silhouette rather than a colour. An empty file `vitrail/legacy-terrain-filter` in the instance, or `-Dvitrail.legacyTerrainFilter=true`, puts the game's filtered sampler back on both halves at the next pack load, and the log names the state at every load whichever it is, so the two states can be compared in one world with the Reload Shaders key between them.

## How it differs from the reference, and for what obstacle

It does not. Iris ignores the sampler Sodium hands it and binds `IrisSamplers.getTerrainCache` (`pipeline/programs/SodiumShader.java:131`, built at `samplers/IrisSamplers.java:249-254`): the same sampler in every respect. The one thing Iris does that this does not is force the anisotropy to one for packs that cannot bear it, which this engine has no equivalent of yet.

## What proves it

- `gradlew build` green.
- In the game, Complementary Unbound on the Fabric bench: the same scene at three camera heights, mean of sixty frames each, compared against Iris on the same world and pack. The two engines shade the trees alike in both states, filtered and unfiltered. This lands as parity with what Iris binds, not as the cure of a darkening anybody has seen: the tree darkening it was first written for, canopies that darken as the camera comes down on them, the reference reproduces to the unit.
- The switch was exercised both ways in one session, the log naming the state at each pack load.

## What it leaves owing

The per-pack anisotropy override Iris applies. And the off-game harness has nothing to say about a sampler, so the proof is the in-game comparison above.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
