### PR TITLE
feat(render): draw the block outline with the pack's line program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ what the next one holds.
 
 ### Fixed
 
+- **The block outline is drawn by the pack, as Iris draws it.** The thin box around the block
+  aimed at was left to the game's own shader and painted into a layer this engine composes onto
+  the pack's picture at the spot where the pack blends its water; where a pack keeps something
+  other than its picture there, the box landed in it and came back as a faint ghost, a bright
+  refraction of the block behind under Photon. The pack now
+  draws the lines itself with its `gbuffers_line` program, or `gbuffers_basic` where it ships
+  none, under the outline render stage, so a pack's own selection box comes through: the
+  colour or rainbow Complementary offers for it, the box mode of Photon, the plain dark
+  outline of the rest.
+
 - **Leaves keep the same self-shadow wherever the camera stands.** The shadow map is drawn
   with Sodium's chunk renderer, which keeps one filled batch of draw commands per region and
   pass and only refills it when the region's sections change or the camera crosses a section

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -619,6 +619,12 @@ public final class GlslTranslator {
 	 */
 	private boolean entityWrapped;
 
+	/**
+	 * Whether the pack's main is run twice and its clip position widened, which is what a lines
+	 * mesh asks of its vertex stage. {@link LinesVertex} says why the mesh needs it.
+	 */
+	private boolean linesWrapped;
+
 	/** Whether this stage really makes the overlay colour, which only the whole program can say. */
 	private boolean makesOverlayColour;
 
@@ -1165,6 +1171,19 @@ public final class GlslTranslator {
 		if (this.used.contains(LegacyGlsl.CAMERA_BOB)) {
 			block.add(TranslatedUnit.Uniform.of(LegacyGlsl.CAMERA_BOB,
 					"mat4 " + LegacyGlsl.CAMERA_BOB));
+		}
+
+		// The screen size the lines wrapper widens with, supplied under the pack's own two names
+		// wherever the pack did not declare them itself; declared ones come through liftUniforms.
+		// Declared anywhere: collectDeclarations does not know a scope, so a pack naming a local
+		// viewWidth would keep the member out and leave the wrapper reading a name nobody
+		// declared, the trap LegacyGlsl records for projectionMatrix. No pack of the corpus does.
+		if (this.linesWrapped) {
+			for (String name : List.of("viewWidth", "viewHeight")) {
+				if (!this.declaredNames.contains(name)) {
+					block.add(TranslatedUnit.Uniform.of(name, "float " + name));
+				}
+			}
 		}
 
 		block.addAll(asUniforms(this.blockMembers));
@@ -3220,7 +3239,8 @@ public final class GlslTranslator {
 		boolean distant = this.inputs == VertexInputs.DISTANT;
 		boolean depth = namesClipPosition();
 		boolean overlay = this.inputs.overlay();
-		if (!terrain && !distant && !depth && !overlay) {
+		boolean lines = this.inputs == VertexInputs.LINES;
+		if (!terrain && !distant && !depth && !overlay && !lines) {
 			return;
 		}
 
@@ -3233,6 +3253,14 @@ public final class GlslTranslator {
 		this.terrainPrologue = terrain;
 		this.distantPrologue = distant;
 		this.entityWrapped = overlay;
+		this.linesWrapped = lines;
+		if (lines) {
+			// The widening reads the screen size off the two uniforms a pack may read and often
+			// does not declare in this program; naming them here is what has the block supply them.
+			this.injectedNames.add("viewWidth");
+			this.injectedNames.add("viewHeight");
+		}
+
 		if (terrain) {
 			takeTexShrink();
 		}
@@ -5297,6 +5325,10 @@ public final class GlslTranslator {
 						EntityVertex.prologue(this.used, this.synthesized, this.inputs.fullbright()));
 				case GLINT -> lines.addAll(GlintVertex.prologue(this.used, this.synthesized));
 				case CRUMBLING -> lines.addAll(CrumblingVertex.prologue(this.used, this.synthesized));
+				case LINES -> {
+					lines.addAll(LinesVertex.prologue(this.used, this.synthesized));
+					lines.addAll(LinesVertex.widen());
+				}
 				case PARTICLE -> lines.addAll(ParticleVertex.prologue(this.used, this.synthesized));
 				case SKY -> lines.addAll(SkyVertex.prologue(this.bound, this.used, this.synthesized));
 				case CLOUDS -> lines.addAll(CloudVertex.prologue(this.used, this.synthesized));
@@ -5539,9 +5571,21 @@ public final class GlslTranslator {
 		// The pack's body is concatenated after the header, so its own main is only a name here and
 		// has to be declared before it can be called.
 		if (this.depthEpilogue || this.terrainPrologue || this.distantPrologue || this.entityWrapped
-				|| wrapsFragment() || owesInitialisers() || !this.splitMatrices.isEmpty()
-				|| !this.splitStructs.isEmpty() || !this.splitArrays.isEmpty()) {
+				|| this.linesWrapped || wrapsFragment() || owesInitialisers()
+				|| !this.splitMatrices.isEmpty() || !this.splitStructs.isEmpty()
+				|| !this.splitArrays.isEmpty()) {
 			lines.add("void " + PACK_MAIN + "();");
+			// The lines mesh runs the pack's main twice, the far end of the edge first and the
+			// vertex itself second, so that every varying holds the vertex's own value when the
+			// epilogues below read them, and widens between the two clip positions: Iris's own
+			// order (VanillaTransformer.java:214-222). The depth conversion still lands after,
+			// on the widened position, whose z the widening leaves alone.
+			String body = this.linesWrapped
+					? LinesVertex.OFFSET + " = Normal.xyz; " + PACK_MAIN + "(); vec4 of_LineEnd = "
+							+ "gl_Position; gl_Position = vec4(0.0); " + LinesVertex.OFFSET
+							+ " = vec3(0.0); " + PACK_MAIN + "(); " + LinesVertex.WIDEN
+							+ "(gl_Position, of_LineEnd);"
+					: PACK_MAIN + "();";
 			// The mask goes last of all, after the discard: a fragment the alpha test threw away
 			// covered nothing, and marking it covered would leave a hole where a leaf was.
 			lines.add("void main() { "
@@ -5555,7 +5599,7 @@ public final class GlslTranslator {
 					+ matrixPrologue()
 					+ structPrologue()
 					+ arrayPrologue()
-					+ PACK_MAIN + "();"
+					+ body
 					+ matrixEpilogue()
 					+ structEpilogue()
 					+ arrayEpilogue()

--- a/common/src/main/java/dev/vitrail/glsl/LinesVertex.java
+++ b/common/src/main/java/dev/vitrail/glsl/LinesVertex.java
@@ -1,0 +1,143 @@
+package dev.vitrail.glsl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What the mesh the game's lines are drawn from carries, the block outline first among them, and
+ * how the names a pack reads are made out of it.
+ * <p>
+ * {@code DefaultVertexFormat.POSITION_COLOR_NORMAL_LINE_WIDTH} holds four elements: {@code
+ * Position} as three floats, {@code Color} as four normalised bytes, {@code Normal} as four
+ * normalised bytes of which three are read, {@code LineWidth} as one float. The game emits every
+ * edge as two vertices carrying the same normal, which is the edge's own direction, writes each of
+ * them twice into the buffer ({@code BufferBuilder.endLastVertex} under the lines topology) and
+ * indexes every four as two triangles ({@code PrimitiveTopology.indexCount}), so an edge reaches
+ * the vertex stage as a degenerate quad. Its {@code rendertype_lines} stage opens it: each vertex
+ * is pushed off the line by half the width, one way for an even vertex and the other for an odd
+ * one, along the screen normal of the edge's projection ({@code core/rendertype_lines.vsh}). The
+ * mesh itself is thin; the width is made in the vertex stage or it is not made at all.
+ * <p>
+ * <strong>Iris keeps that widening and puts it AROUND the pack's own main</strong>
+ * ({@code transform/transformer/VanillaTransformer.java:188-222}): the pack's main runs twice,
+ * once with the edge's direction added to the position, which projects the far end, and once
+ * without, which projects the vertex itself, and the two clip positions are widened the way the
+ * game's stage widens them, short of the 255/256 shrink towards the eye the game's stage applies
+ * to both before projecting them, which Iris leaves to the pack and so does this. {@code
+ * gl_Normal} is answered with the constant a mesh without a normal gets, plus Z, since the
+ * element it comes from is a direction and not a surface normal ({@code :143-148}); {@code
+ * vaNormal} keeps the element, which is what a pack written for Iris reads when it widens by
+ * itself. {@link GlslTranslator} writes the same wrapper, and this head declares what it reads:
+ * {@link #OFFSET}, the direction added to the position on the first run, and {@link #WIDEN}, the
+ * function that pushes the vertex off the line.
+ * <p>
+ * <strong>One guard Iris has not got, and it is a divergence written out in the three parts one
+ * owes.</strong> What Iris does: it normalises the screen direction between the two clip positions
+ * whatever they are ({@code VanillaTransformer.java:203}). What makes that wrong here: a pack that
+ * widens by itself reads {@code vaPosition}, which carries no offset under Iris either
+ * ({@code VanillaCoreTransformer.java:100}), so its two runs hand back one position, and
+ * normalising nought is a NaN that lands in the clip position; Complementary and Photon both
+ * widen by themselves. What it costs the image: nothing that Iris draws, since a NaN draws
+ * nothing; {@link #WIDEN} leaves such an edge where the pack put it instead.
+ * <p>
+ * The light map is answered at full light, which is what Iris hands a mesh without a light
+ * element ({@code VanillaTransformer.java:103-105}), the sampler behind it staying the real light
+ * map, and {@code vaUV2} with nought, which is what an attribute Iris declares and nothing fills
+ * reads there ({@code VanillaCoreTransformer.java:119}); the texture coordinate is the centre of
+ * a texel, the first file's answer for a mesh without one ({@code :86-88}).
+ */
+public final class LinesVertex {
+
+	/** The elements of the lines mesh, in the format's own order. */
+	public static final List<String> ATTRIBUTES = List.of("Position", "Color", "Normal", "LineWidth");
+
+	/** The names a pack written for Iris reads straight off the mesh, answered here as macros. */
+	public static final Set<String> ANSWERED = Set.of("vaPosition", "vaNormal", "vaColor");
+
+	/** The direction the wrapper adds to the position on its first run, nought on the second. */
+	public static final String OFFSET = "of_LineOffset";
+
+	/** The function the wrapper calls with the two clip positions, which widens the edge. */
+	public static final String WIDEN = "of_WidenLine";
+
+	private LinesVertex() {
+	}
+
+	/**
+	 * The head of a lines vertex stage: the four elements, the names a pack reads made out of
+	 * them, and constants for everything the mesh has not got.
+	 *
+	 * @param used        every name the rewritten body mentions, so that nothing is declared for a
+	 *                    pack that never asks
+	 * @param synthesized the vertex inputs the pack declared for itself and that were taken out of
+	 *                    the body, by name and with the type the pack gave them
+	 */
+	public static List<String> prologue(Set<String> used, Map<String, String> synthesized) {
+		List<String> lines = new ArrayList<>();
+
+		for (String attribute : ATTRIBUTES) {
+			lines.add("in " + VertexPrologue.elementType(attribute) + " " + attribute + ";");
+		}
+
+		lines.add("vec3 " + OFFSET + " = vec3(0.0);");
+		lines.add("#define of_Vertex vec4(Position + " + OFFSET + ", 1.0)");
+		lines.add("#define of_Color Color");
+		lines.add("#define of_MultiTexCoord0 vec4(0.5, 0.5, 0.0, 1.0)");
+		lines.add("#define of_MultiTexCoord1 " + EntityVertex.FULL_LIGHT);
+		lines.add("#define of_MultiTexCoord2 " + EntityVertex.FULL_LIGHT);
+		lines.addAll(VertexPrologue.blankTexCoords());
+
+		// The element is the edge's direction and not a surface normal, so what a pack takes for
+		// the normal is the constant every mesh without one gets, which is Iris's own answer for
+		// this mesh (VanillaTransformer.java:146-147).
+		lines.add("#define of_Normal vec3(0.0, 0.0, 1.0)");
+
+		VertexPrologue.globals(used, synthesized, Map.of()).forEach((name, type) -> lines.add(
+				ANSWERED.contains(name)
+						? "#define " + name + " " + answer(name)
+						: VertexPrologue.declaration(name, type)));
+
+		return List.copyOf(lines);
+	}
+
+	/**
+	 * The widening, declared after the head and before the wrapper that calls it. The screen size
+	 * comes from the two uniforms every pack may read, which the translation supplies where the
+	 * pack did not declare them. An edge whose two ends project to one point is left where the
+	 * pack put it: a pack that widened the edge by itself hands both runs the same position, and a
+	 * direction normalised out of nought would carry a NaN into the position.
+	 */
+	public static List<String> widen() {
+		return List.of(
+				"void " + WIDEN + "(inout vec4 lineStart, vec4 lineEnd) {",
+				"    vec2 screenSize = vec2(viewWidth, viewHeight);",
+				"    vec3 ndc1 = lineStart.xyz / lineStart.w;",
+				"    vec3 ndc2 = lineEnd.xyz / lineEnd.w;",
+				"    vec2 along = (ndc2.xy - ndc1.xy) * screenSize;",
+				"    if (dot(along, along) < 1.0e-12) {",
+				"        return;",
+				"    }",
+				"    vec2 lineScreenDirection = normalize(along);",
+				"    vec2 lineOffset = vec2(-lineScreenDirection.y, lineScreenDirection.x) * LineWidth"
+						+ " / screenSize;",
+				"    if (lineOffset.x < 0.0) {",
+				"        lineOffset *= -1.0;",
+				"    }",
+				"    if (gl_VertexIndex % 2 == 0) {",
+				"        lineStart = vec4((ndc1 + vec3(lineOffset, 0.0)) * lineStart.w, lineStart.w);",
+				"    } else {",
+				"        lineStart = vec4((ndc1 - vec3(lineOffset, 0.0)) * lineStart.w, lineStart.w);",
+				"    }",
+				"}");
+	}
+
+	private static String answer(String name) {
+		return switch (name) {
+			case "vaPosition" -> "Position";
+			case "vaNormal" -> "Normal.xyz";
+			default -> "Color";
+		};
+	}
+}

--- a/common/src/main/java/dev/vitrail/glsl/VertexInputs.java
+++ b/common/src/main/java/dev/vitrail/glsl/VertexInputs.java
@@ -97,6 +97,14 @@ public enum VertexInputs {
 	CRUMBLING,
 
 	/**
+	 * The game's lines mesh, the block outline first among them: four elements out of which the
+	 * names a {@code gbuffers_line} program reads are made, and a wrapper around the pack's main
+	 * that widens each edge on the screen the way the game's own stage does. {@link LinesVertex}
+	 * carries the decode and the widening, and says what the mesh has not got.
+	 */
+	LINES,
+
+	/**
 	 * The game's own sky meshes. Alone among these, it is not one format: {@code SkyRenderer} binds
 	 * four between its eight passes, so the elements to declare come from the pass rather than from
 	 * this constant. {@link SkyVertex} carries the renaming and says what the sky has not got.
@@ -213,6 +221,7 @@ public enum VertexInputs {
 			case ENTITY, ENTITY_FULLBRIGHT -> EntityVertex.ATTRIBUTES;
 			case GLINT -> GlintVertex.ATTRIBUTES;
 			case CRUMBLING -> CrumblingVertex.ATTRIBUTES;
+			case LINES -> LinesVertex.ATTRIBUTES;
 			case PARTICLE -> ParticleVertex.ATTRIBUTES;
 			case SKY -> SkyVertex.ATTRIBUTES;
 			case CLOUDS -> CloudVertex.ATTRIBUTES;

--- a/common/src/main/java/dev/vitrail/glsl/VertexPrologue.java
+++ b/common/src/main/java/dev/vitrail/glsl/VertexPrologue.java
@@ -148,6 +148,7 @@ public final class VertexPrologue {
 			case "UV0", EntityVertex.MID_TEX_COORD -> "vec2";
 			case "UV1", "UV2" -> "ivec2";
 			case EntityVertex.IDENTIFIERS -> "uvec4";
+			case "LineWidth" -> "float";
 			default -> "vec4";
 		};
 	}

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -164,6 +164,16 @@ public final class ChainPlan {
 					// Not counted, on the hand's argument: a crack is drawn where somebody is mining
 					// a block, which is a per frame answer no per place map may carry.
 					new NamedProgram("gbuffers_damagedblock", true, false, NOT_EVERYWHERE),
+					// The game's lines, the block outline first among them, drawn among the
+					// translucent features beside the overlay and on the same side of the stage.
+					// The same entry the overlay owed: without it the line program resolved to no
+					// attachment, its one output went to the game's cleared target, and what
+					// reached the picture of it came through the seed's depth cut, a partial line
+					// fighting the face it lies on, or nothing where the seed does not run.
+					//
+					// Not counted, on the hand's argument: an outline is drawn where somebody is
+					// aiming at a block, a per frame answer no per place map may carry.
+					new NamedProgram("gbuffers_line", true, false, NOT_EVERYWHERE),
 					// The hand's two passes, which straddle the stage as the particles do and for the
 					// same kind of reason: the solid one is drawn among the game's opaque features and
 					// the blending one at the end of the level. Not counted, and not by a switch:

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -1,6 +1,7 @@
 package dev.vitrail.render;
 
 import dev.vitrail.glsl.LegacyGlsl;
+import dev.vitrail.glsl.LinesVertex;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.glsl.TranslatedUnit;
 import dev.vitrail.glsl.VertexInputs;
@@ -241,8 +242,9 @@ public final class EntityDraw {
 	 *                      carries false here
 	 * @param fullbright    whether the game draws this piece at full light, so that the light map
 	 *                      names are answered with a constant and the sampler behind them with one
-	 *                      white texel. True for the three rows of {@link #FIXED} and no other so
-	 *                      far.
+	 *                      white texel. True for the eyes and the crumbling rows of {@link #FIXED}
+	 *                      and no other so far; the lines rows there answer their light with the
+	 *                      constant and keep the real light map behind it, as Iris does.
 	 *                      <strong>A column of the row and not a reading of the program name</strong>,
 	 *                      which is where Iris keeps it as well: its lighting model hangs off the
 	 *                      {@code ShaderKey} ({@code pipeline/programs/ShaderKey.java:44,45}), and
@@ -309,8 +311,20 @@ public final class EntityDraw {
 		}
 
 		/**
+		 * Whether this piece is drawn from the game's lines mesh, the block outline first among
+		 * them. Asked of the PIPELINE like the two above and for the same reason: what it answers
+		 * differently is its mesh and the wrapper that mesh needs, which {@link LinesVertex} carries.
+		 */
+		@SuppressWarnings("ReferenceEquality")
+		boolean lines() {
+			return this.pipeline == RenderPipelines.LINES
+					|| this.pipeline == RenderPipelines.LINES_TRANSLUCENT
+					|| this.pipeline == RenderPipelines.SECONDARY_BLOCK_OUTLINE;
+		}
+
+		/**
 		 * The format this piece is drawn from, which is the entity mesh for every row but the glint's
-		 * four and the crumbling's one.
+		 * four, the crumbling's one and the three lines rows.
 		 * <p>
 		 * Derived from {@link #glint} and {@link #crumbling} rather than tabulated beside them, so
 		 * that a row and its format cannot drift: a row whose format did not match the pipeline it
@@ -327,6 +341,10 @@ public final class EntityDraw {
 		VertexFormat format() {
 			if (glint()) {
 				return DefaultVertexFormat.POSITION_TEX;
+			}
+
+			if (lines()) {
+				return DefaultVertexFormat.POSITION_COLOR_NORMAL_LINE_WIDTH;
 			}
 
 			return crumbling() ? DefaultVertexFormat.BLOCK : EntityMesh.format();
@@ -357,6 +375,10 @@ public final class EntityDraw {
 				return VertexInputs.CRUMBLING;
 			}
 
+			if (lines()) {
+				return VertexInputs.LINES;
+			}
+
 			return this.fullbright ? VertexInputs.ENTITY_FULLBRIGHT : VertexInputs.ENTITY;
 		}
 
@@ -372,6 +394,10 @@ public final class EntityDraw {
 
 			if (crumbling()) {
 				return "block breaking";
+			}
+
+			if (lines()) {
+				return "block outline";
 			}
 
 			return hand() ? "hand" : "entities";
@@ -556,6 +582,13 @@ public final class EntityDraw {
 	 * {@code shaderpack/loading/ProgramId.java:33}.
 	 */
 	private static final String DAMAGED_BLOCK = "gbuffers_damagedblock";
+
+	/**
+	 * What Iris asks for a lines draw, {@code ProgramId.Line}, whose fallback is {@code
+	 * gbuffers_basic} ({@code shaderpack/loading/ProgramId.java:22}); {@code ProgramFallbacks}
+	 * carries the same parent.
+	 */
+	private static final String LINE = "gbuffers_line";
 
 	/**
 	 * What the glowing eyes of a mob ask for, and the one name of this class that answers whatever
@@ -912,8 +945,13 @@ public final class EntityDraw {
 	 */
 	private static void shadowTwins(Map<RenderPipeline, Element> from) {
 		from.values().stream()
+				// No twin for the lines either, on the crumbling's argument: Iris keys two of the
+				// three to SHADOW_LINES (pipeline/IrisPipelines.java:116,118) and its shadow stage
+				// replays only what it submits itself, so the key sits unused there, and the light's
+				// walk here submits the same two families (ShadowGeometry.walk). A twin would be a
+				// compiled module nothing selects.
 				.filter(mob -> mob.pipeline() != RenderPipelines.ENTITY_SHADOW
-						&& mob.pipeline() != RenderPipelines.CRUMBLING)
+						&& mob.pipeline() != RenderPipelines.CRUMBLING && !mob.lines())
 				.map(mob -> new Element(mob.pipeline(), "shadow_" + mob.element(), SHADOW_ENTITIES,
 						CUTOUT, RenderStage.ENTITIES, false))
 				.forEach(element -> SHADOW_ELEMENTS.put(element.pipeline(), element));
@@ -1130,6 +1168,21 @@ public final class EntityDraw {
 		// reading renderStage here reads what it reads there.
 		FIXED.put(RenderPipelines.CRUMBLING, new Element(RenderPipelines.CRUMBLING, "crumbling",
 				DAMAGED_BLOCK, CUTOUT, RenderStage.NONE, false, true));
+		// The three lines pipelines Iris keys to the line program (pipeline/IrisPipelines.java:40-42),
+		// no alpha test (ShaderKey.java:72). The fourth built on the same snippet, LINES_DEPTH_BIAS
+		// (RenderPipelines.java:574-580), Iris keys to nothing and neither does this. Under
+		// OUTLINE, which Iris poses on the block outline alone through the render type it wraps
+		// around that one draw (mixin/MixinLevelRenderer.java:270-274): here every lines draw of
+		// the window carries it, and the others riding these pipelines are the gizmos and the debug
+		// shapes, drawn by nobody playing. The side flag is an entity row's, so false and unread:
+		// the three pipelines blend, and blended() is what puts them after the deferred stage.
+		FIXED.put(RenderPipelines.LINES, new Element(RenderPipelines.LINES, "lines", LINE,
+				AlphaTest.OFF, RenderStage.OUTLINE, false, false));
+		FIXED.put(RenderPipelines.LINES_TRANSLUCENT, new Element(RenderPipelines.LINES_TRANSLUCENT,
+				"lines_translucent", LINE, AlphaTest.OFF, RenderStage.OUTLINE, false, false));
+		FIXED.put(RenderPipelines.SECONDARY_BLOCK_OUTLINE,
+				new Element(RenderPipelines.SECONDARY_BLOCK_OUTLINE, "outline_secondary", LINE,
+						AlphaTest.OFF, RenderStage.OUTLINE, false, false));
 	}
 
 	static {
@@ -1509,8 +1562,9 @@ public final class EntityDraw {
 		// ten draws in a hand pass.
 		boolean inMoment = (element != null && element.hand()) ? HandDraw.wanted()
 				: wanted && element != null && inWindow(element);
-		// And the mesh has to be carrying, whatever the moment says. Every row but the glint's and the
-		// crumbling's is read against EntityMesh.format, so a draw served before the mesh settled
+		// And the mesh has to be carrying, whatever the moment says. Every row but the glint's, the
+		// crumbling's and the lines' is read against EntityMesh.format, so a draw served before the
+		// mesh settled
 		// would bind fifty-six bytes of layout over a vertex of thirty-six. It lasts from the load
 		// that asked until the extract that rebuilds the world, which is one frame in the ordinary
 		// case.
@@ -1975,7 +2029,12 @@ public final class EntityDraw {
 			// buffers; put in with the entities, a place that could not answer for that one file
 			// would take every mob and every chest down with it. Apart, the worst it can paint is a
 			// mob the pack lit wearing eyes the game drew, which is the smaller of the two pictures.
-			groups.add(eyes);
+			//
+			// And the lines apart from the eyes, on the same argument one step further: the line
+			// program walks its own chain too, and a place that could not answer for it would
+			// otherwise take the eyes and the breaking overlay back to the game with the outline.
+			groups.add(eyes.stream().filter(element -> !element.lines()).toList());
+			groups.add(eyes.stream().filter(Element::lines).toList());
 		}
 
 		if (HandDraw.wanted()) {
@@ -2044,9 +2103,10 @@ public final class EntityDraw {
 	 * <p>
 	 * The vertex head declares the elements of that format BY NAME, and an element the stage does not
 	 * declare shifts the location of every one after it without a word being said: the picture stays a
-	 * picture and reads its texture coordinates out of the light map. Three formats come in by this
-	 * door now, the entity mesh, the glint's two elements and the block one the crumbling is drawn
-	 * from, so the claim is the piece's and the check is against the game's own binding.
+	 * picture and reads its texture coordinates out of the light map. Four formats come in by this
+	 * door now, the entity mesh, the glint's two elements, the block one the crumbling is drawn
+	 * from and the lines one the block outline is, so the claim is the piece's and the check is
+	 * against the game's own binding.
 	 * <p>
 	 * It is also what keeps two of the families beside the eyes out of these tables, and that is a
 	 * fact about this engine rather than about them: the lightning and the dragon rays bind
@@ -2090,7 +2150,7 @@ public final class EntityDraw {
 				.toList();
 	}
 
-	/** The fixed rows this engine can decode the mesh of, which today is all three of them. */
+	/** The fixed rows this engine can decode the mesh of, which today is all six of them. */
 	private static List<Element> fixed() {
 		return FIXED.values().stream().filter(EntityDraw::decodable).toList();
 	}

--- a/common/src/main/java/dev/vitrail/render/EntityProgram.java
+++ b/common/src/main/java/dev/vitrail/render/EntityProgram.java
@@ -1,6 +1,7 @@
 package dev.vitrail.render;
 
 import dev.vitrail.glsl.EntityVertex;
+import dev.vitrail.glsl.LinesVertex;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.program.ProgramFallbacks;
 import dev.vitrail.pack.program.RenderStage;
@@ -105,14 +106,19 @@ final class EntityProgram implements DumpedProgram {
 	 * in by this same door with a mesh of its own: {@code POSITION_TEX}, two elements, out of which
 	 * {@code GlintVertex} makes every other name with a constant. A set fixed here would have the log
 	 * tell a reader that the glint's mesh carries a tangent, and telling a reader which names are
-	 * real is the whole of what that line is for.
+	 * real is the whole of what that line is for. The lines rows come in the same way with a mesh
+	 * of their own, and {@code LinesVertex} says which of the names it really carries.
 	 * <p>
 	 * {@code mc_Entity} is in neither answer and is the one worth naming, since the chunk mesh does
 	 * carry it: an entity is not a block state and has no id to travel on, so a pack branching on it
 	 * here is branching on a constant.
 	 */
 	private static Set<String> answered(EntityDraw.Element element) {
-		return element.glint() ? Set.of() : EntityVertex.ANSWERED;
+		if (element.glint()) {
+			return Set.of();
+		}
+
+		return element.lines() ? LinesVertex.ANSWERED : EntityVertex.ANSWERED;
 	}
 
 	private final GeometryProgram body;

--- a/docs/internals/entities.md
+++ b/docs/internals/entities.md
@@ -346,6 +346,25 @@ alpha. The crumbling multiplies instead, so left there it multiplies against the
 cracks come out opaque black rather than darkening the face they lie on. Served, the multiply lands
 on the picture, which is where the game meant to put it.
 
+**The block outline** is the third piece drawn from a mesh of the game's, the lines format, and it
+is the one the full-screen layer could not carry at all rather than carry flat. The layer is composed
+onto the first target the pack's translucent pass writes, which is the scene colour for most packs
+and, for a pack that forward-shades its translucents into a target of their own, something else
+entirely: Photon writes refraction data there, and the outline composed into it came back as a faint
+refraction of the block behind. The reference never composes it: it draws the lines with the pack's
+`gbuffers_line`, falling back to `gbuffers_basic`, into whatever that program writes, and marks the
+draw with the outline stage, which is how a pack recolours or hides its selection box. The same is
+done here, from the same four elements, with one thing the mesh cannot carry made in the vertex
+stage: the game emits every edge as two vertices sharing the edge's direction as their normal, each
+written twice and indexed as two triangles, and its own vertex stage opens that degenerate quad on
+the screen, so the pack's main is run twice, once with the direction added to the position and once
+without, and the two clip positions are widened between them the way the game's stage does it, short
+of the slight shrink towards the eye the game applies first and Iris leaves to the pack. A pack that
+widens by itself, reading the direction off `vaNormal` as Complementary and Photon do, hands both
+runs one position and is left alone, where Iris would normalise nought. The width is
+the game's own, carried on the vertex, and the screen size comes from the two uniforms every pack may
+read, supplied where the pack did not declare them.
+
 Three families in this window stay the game's, and are carried in flat by the full-screen layer: the
 beacon beam, the lightning, and the text of a name plate or a sign. The lightning and the text bind
 a mesh this door cannot decode. The beam binds the block format, which the door now reads, and what


### PR DESCRIPTION
## What changes

The block outline, and every other line the game draws in the world, is drawn by the pack's own `gbuffers_line` program, falling back to `gbuffers_basic`, under the outline render stage, into the targets that program writes on the far side of the deferred stage. Before, the lines were left to the game's shader inside the translucent feature window, which this engine catches in a layer and composes onto the first target of the pack's translucent pass: right where that target is the picture, wrong where it is anything else, and Photon keeps refraction data there, so its outline came back as a faint refraction of the block behind. A pack's own selection box now comes through: the rainbow or the colour Complementary offers, the box mode of Photon, the plain dark line of the others. The lines mesh carries no width, the game's vertex stage makes it, so the translation wraps a line program's main to run twice and widen the edge between the two clip positions the way the game's stage does, and a pack that widens by itself is left as it stands. No shadow twin: the light's walk never replays the outline, here as in the reference.

## How it differs from the reference, and for what obstacle

One guard. Iris normalises the screen direction between the two runs whatever they are (`transform/transformer/VanillaTransformer.java:203`); a pack that widens by itself hands both runs one position, since `vaPosition` carries no offset under Iris either (`transform/transformer/VanillaCoreTransformer.java:100`), and a normalised nought is a NaN in the clip position, which draws nothing. Here such an edge is left where the pack put it. What it costs the image: nothing Iris draws. Otherwise it does not: the three lines pipelines are keyed as Iris keys them (`pipeline/IrisPipelines.java:40-42`, `:116,118`), the outline stage is posed where Iris poses it on the block outline (`mixin/MixinLevelRenderer.java:270-274`), and every lines draw of the window carries it here where Iris marks the outline alone, the others being the gizmos and the debug shapes.

## What proves it

- `gradlew build` green.
- The off-game harness, `Lines`, over the whole corpus: every `gbuffers_line`, `gbuffers_basic` and shadow program translated under the lines mesh, the four elements declared and kept in the SPIR-V of every vertex stage, all of them compiled by the game's own compiler options but Reverie's, which fails the same way under every tool for a reason of its own.
- In the game, on the Fabric bench: Photon draws a thin dark outline around the block aimed at where it drew a faint refraction before; Complementary draws its rainbow selection box, which never reached the screen before. Both compared with the same scenes under Iris.

## What it leaves owing

The outline of a translucent block, glass, ice or water, which the game draws after its water rather than among its translucent features: that draw falls outside the window this engine serves, so it stays the game's and goes through the layer as before. Photon's own draws after the deferred stage still come out wrong for reasons this branch does not touch: its breaking cracks bright, its bubbles yellow, its name tags and floating text composed into its refraction buffer by the same layer this branch takes the outline out of.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
