### PR TITLE
fix(pack): read blend, size, flip and end flash lines conditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ what the next one holds.
   Complementary's water blend and its weather target's `off` held whatever the define or the
   setting around them said.
 
+- **Packs are told the block emission attribute is there**, as Iris tells them. The chunk
+  mesh already carried a block's own light beside its mid-block offset, but the flag a pack
+  tests for it was never posed: Bliss took its path without voxel emission, and Complementary
+  only kept its two reflection targets at half resolution by the flat read above.
+
 - **Photon draws.** Three things stood between its files and its picture. Its atmosphere table
   is a three-dimensional volume of half floats asked to clamp, and the flat atlas that stands in
   for a volume took one byte a texel and a repeating volume only, so the three deferred passes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ what the next one holds.
   pack again and leaves the state as it was. The log names the state once per pack load, at the
   first terrain the pack draws.
 
+- **Blend overrides, target sizes, flips and `endFlashShadows` follow the pack's own settings.**
+  Those four families of `shaders.properties` lines were read whether or not the `#if` around
+  them held, so a line the pack had switched off still applied. Photon's two low-resolution
+  cloud targets took the size of the last of its four choices whichever was picked, and
+  Complementary's water blend and its weather target's `off` held whatever the define or the
+  setting around them said.
+
 - **Photon draws.** Three things stood between its files and its picture. Its atmosphere table
   is a three-dimensional volume of half floats asked to clamp, and the flat atlas that stands in
   for a volume took one byte a texel and a repeating volume only, so the three deferred passes

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -139,6 +139,14 @@ public final class EngineDefines {
 			defines.put("IRIS_FEATURE_CUSTOM_IMAGES", "");
 		}
 
+		// The block emission attribute is served: the chunk element carries the block's own light
+		// in the fourth component of at_midBlock, on the terrain and in the shadow map alike
+		// (SodiumVertex.MID_BLOCK). Iris poses the flag whatever the hardware
+		// (features/FeatureFlags.java:20), and packs decide more than a vertex read on it:
+		// Complementary sizes its two reflection targets under it, Bliss writes its voxel
+		// emission under it.
+		defines.put("IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE", "");
+
 		// The rest of IRIS_FEATURE_ stays unposted until each capability is served. See
 		// ShaderProperties.optionalFeatures for the other half of the answer, and PackChain for
 		// what a pack requiring one is told.

--- a/common/src/main/java/dev/vitrail/pack/source/PackReport.java
+++ b/common/src/main/java/dev/vitrail/pack/source/PackReport.java
@@ -90,7 +90,7 @@ public final class PackReport {
 					PREFIX, properties.directiveCount(), properties.continuationCount(),
 					properties.profiles().size(), properties.customUniformTypes().size(),
 					properties.screenTokens().size(), properties.sliders().size(),
-					properties.blend().size(), pack.disabledPrograms().size());
+					properties.blendCount(), pack.disabledPrograms().size());
 
 			logIfAny("  keys not read", properties.ignoredPrefixes());
 		} else {

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -1625,8 +1625,9 @@ public final class ShaderProperties {
 	/**
 	 * What the pack would use if it were there, and takes another path without. It is the list Iris
 	 * turns into {@code IRIS_FEATURE_} defines for the GLSL. This engine poses
-	 * {@code IRIS_FEATURE_CUSTOM_IMAGES} when the storage-image pipe is served, and none of the
-	 * others, which is what tells a pack to take the other path for those.
+	 * {@code IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE}, and {@code IRIS_FEATURE_CUSTOM_IMAGES} when
+	 * the storage-image pipe is served, and none of the others, which is what tells a pack to
+	 * take the other path for those.
 	 * <p>
 	 * Nothing in the engine reads this list, and that is deliberate rather than an oversight: there
 	 * is nothing here to decide from it. What taking the line out of the ignored keys buys is

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -165,15 +165,12 @@ public final class ShaderProperties {
 	private final List<String> sliders;
 	private final List<String> requiredFeatures;
 	private final List<String> optionalFeatures;
-	private final List<BlendDirective> blend;
-	private final Map<String, String> sizeBuffers;
-	private final List<FlipDirective> flips;
 	private final Map<String, String> malformedAlphaTests;
 	private final Map<String, Integer> ignoredPrefixes;
 	private final int directiveCount;
+	private final int blendCount;
 	private final int continuationCount;
 	private final boolean present;
-	private final boolean endFlashShadows;
 
 	private ShaderProperties(Builder builder) {
 		this.lines = List.copyOf(builder.lines);
@@ -192,15 +189,12 @@ public final class ShaderProperties {
 		this.sliders = List.copyOf(builder.sliders);
 		this.requiredFeatures = List.copyOf(builder.requiredFeatures);
 		this.optionalFeatures = List.copyOf(builder.optionalFeatures);
-		this.blend = List.copyOf(builder.blend);
-		this.sizeBuffers = Map.copyOf(builder.sizeBuffers);
-		this.flips = List.copyOf(builder.flips);
 		this.malformedAlphaTests = Map.copyOf(builder.malformedAlphaTests);
 		this.ignoredPrefixes = Map.copyOf(builder.ignoredPrefixes);
 		this.directiveCount = builder.directiveCount;
+		this.blendCount = builder.blendCount;
 		this.continuationCount = builder.continuationCount;
 		this.present = builder.present;
-		this.endFlashShadows = builder.endFlashShadows;
 	}
 
 	public static ShaderProperties parse(ShaderPackSource source) throws IOException {
@@ -300,15 +294,17 @@ public final class ShaderProperties {
 			return;
 		}
 
-		Matcher blend = BLEND.matcher(line);
-		if (blend.matches()) {
-			builder.blend.add(new BlendDirective(blend.group(1), blend.group(2), blend.group(3).trim()));
+		// Consumed here for the census only; the values come out of blend, which walks the
+		// conditionals for the reason alphaTests gives just below.
+		if (BLEND.matcher(line).matches()) {
+			builder.blendCount++;
 			return;
 		}
 
 		// Consumed here for the census only; the values come out of alphaTests, which walks the
 		// conditionals, because the reference reads this family off its preprocessed copy of the
-		// file. Not every family: it reads the screens and the sliders off the raw one.
+		// file. Not every family: it reads the screens, the sliders, the profiles and the feature
+		// lists off the raw one.
 		Matcher alpha = ALPHA_TEST.matcher(line);
 		if (alpha.matches()) {
 			String value = alpha.group(2).trim();
@@ -354,12 +350,9 @@ public final class ShaderProperties {
 			return;
 		}
 
-		// Whether the pack means its shadows to follow the End flash. Off unless the pack says so,
-		// which is what decides where the shadow light points in that one dimension, and no pack of
-		// the corpus writes it.
-		Matcher endFlash = END_FLASH_SHADOWS.matcher(line);
-		if (endFlash.matches()) {
-			builder.endFlashShadows = endFlash.group(1).trim().equalsIgnoreCase("true");
+		// Consumed here for the census only; the value comes out of endFlashShadows, which walks
+		// the conditionals.
+		if (END_FLASH_SHADOWS.matcher(line).matches()) {
 			return;
 		}
 
@@ -404,12 +397,9 @@ public final class ShaderProperties {
 			return;
 		}
 
-		// The value is kept exactly as written. It is often not a number at all but the name of
-		// one of the pack's own settings, and substituting it needs those settings resolved,
-		// which this class deliberately knows nothing about.
-		Matcher size = SIZE_BUFFER.matcher(line);
-		if (size.matches()) {
-			builder.sizeBuffers.put(size.group(1), size.group(2).trim());
+		// Consumed here for the census only; the values come out of sizeBuffers, which walks the
+		// conditionals.
+		if (SIZE_BUFFER.matcher(line).matches()) {
 			return;
 		}
 
@@ -463,14 +453,12 @@ public final class ShaderProperties {
 			return;
 		}
 
+		// Consumed here for the census only, and only when the value is a boolean: the lines come
+		// out of flips, which walks the conditionals, and anything else falls through to the
+		// ignored keys.
 		Matcher flip = FLIP.matcher(line);
-		if (flip.matches()) {
-			String value = flip.group(3).trim();
-			if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
-				builder.flips.add(new FlipDirective(flip.group(1), flip.group(2),
-						value.equalsIgnoreCase("true")));
-				return;
-			}
+		if (flip.matches() && flipValue(flip) != null) {
+			return;
 		}
 
 		// Consumed here for the census only; the path comes out of noiseTexturePath, which walks
@@ -1019,10 +1007,9 @@ public final class ShaderProperties {
 	 * order.
 	 * <p>
 	 * Shared rather than written once per caller: what counts as live is the whole subtlety of it,
-	 * and two walks that agree today are two walks that can be edited on different days. Three
-	 * methods read it, the sky's four words and the fifth about the clouds, the weather's two and
-	 * the particles' ordering; two of the three call it twice, the sky for that fifth word and the
-	 * particles for their two spellings.
+	 * and two walks that agree today are two walks that can be edited on different days. Every
+	 * family the reference reads off its preprocessed copy comes through here, one reader each;
+	 * some call it twice, the sky for its fifth word and the particles for their two spellings.
 	 */
 	private List<Matcher> live(Pattern pattern, Map<String, String> defines) {
 		List<Matcher> matched = new ArrayList<>();
@@ -1391,12 +1378,22 @@ public final class ShaderProperties {
 	}
 
 	/**
-	 * Whether the pack asked for its shadows to follow the End flash, off unless it says otherwise.
-	 * It is the pack opting in, so it decides where the shadow light points in the End and nothing
-	 * else; the flash's own position is published either way.
+	 * Whether the pack asked for its shadows to follow the End flash, off unless it says otherwise,
+	 * under the conditionals. It is the pack opting in, so it decides where the shadow light points
+	 * in the End and nothing else; the flash's own position is published either way. A line
+	 * whose value is not one of the four boolean words leaves the previous one standing, which
+	 * is what the reference does with it. No pack of the corpus writes it.
 	 */
-	public boolean endFlashShadows() {
-		return this.endFlashShadows;
+	public boolean endFlashShadows(Map<String, String> defines) {
+		boolean asked = false;
+		for (Matcher line : live(END_FLASH_SHADOWS, defines)) {
+			Boolean value = truth(line.group(1).trim());
+			if (value != null) {
+				asked = value;
+			}
+		}
+
+		return asked;
 	}
 
 	/**
@@ -1641,22 +1638,59 @@ public final class ShaderProperties {
 		return this.optionalFeatures;
 	}
 
-	public List<BlendDirective> blend() {
-		return this.blend;
+	/**
+	 * The blend overrides the pack writes, in file order, under the conditionals. Conditionally
+	 * for the reason {@link #alphaTests} gives: Complementary writes its water blend under
+	 * {@code DISTANT_HORIZONS} and a weather target's {@code off} under a setting of its own, and
+	 * read flat both would hold whatever the define or the setting said.
+	 */
+	public List<BlendDirective> blend(Map<String, String> defines) {
+		List<BlendDirective> directives = new ArrayList<>();
+		for (Matcher line : live(BLEND, defines)) {
+			directives.add(new BlendDirective(line.group(1), line.group(2), line.group(3).trim()));
+		}
+
+		return directives;
 	}
 
 	/**
-	 * The size a pack asks a colour target to be, by the name it wrote, raw. The two tokens are
-	 * often settings rather than numbers, so reading them needs {@link TargetSize} and the
-	 * resolved settings.
+	 * The size a pack asks a colour target to be, by the name it wrote, raw, the last live line
+	 * for a name winning. The two tokens are often settings rather than numbers, so reading them
+	 * needs {@link TargetSize} and the resolved settings.
+	 * <p>
+	 * Under the conditionals, and this family is where a flat read costs the most: Photon writes
+	 * the size of two targets four times in the four arms of one setting, so a flat read hands
+	 * every choice the size of the last arm.
 	 */
-	public Map<String, String> sizeBuffers() {
-		return this.sizeBuffers;
+	public Map<String, String> sizeBuffers(Map<String, String> defines) {
+		Map<String, String> sizes = new LinkedHashMap<>();
+		for (Matcher line : live(SIZE_BUFFER, defines)) {
+			sizes.put(line.group(1), line.group(2).trim());
+		}
+
+		return sizes;
 	}
 
-	/** Where a pack takes the ping pong into its own hands. One line in the whole corpus. */
-	public List<FlipDirective> flips() {
-		return this.flips;
+	/**
+	 * Where a pack takes the ping pong into its own hands, under the conditionals. One line in the
+	 * whole corpus, and a line whose value is not one of the four boolean words is not one of
+	 * these, which is where the reference leaves it too.
+	 */
+	public List<FlipDirective> flips(Map<String, String> defines) {
+		List<FlipDirective> directives = new ArrayList<>();
+		for (Matcher line : live(FLIP, defines)) {
+			Boolean value = flipValue(line);
+			if (value != null) {
+				directives.add(new FlipDirective(line.group(1), line.group(2), value));
+			}
+		}
+
+		return directives;
+	}
+
+	/** The boolean a {@code flip} line carries, or null for a value that is not one. */
+	private static Boolean flipValue(Matcher flip) {
+		return truth(flip.group(3).trim());
 	}
 
 	/**
@@ -1710,6 +1744,11 @@ public final class ShaderProperties {
 
 	public int directiveCount() {
 		return this.directiveCount;
+	}
+
+	/** How many blend lines the file carries, live or not: a census, where {@link #blend} answers. */
+	public int blendCount() {
+		return this.blendCount;
 	}
 
 	public int continuationCount() {
@@ -1871,14 +1910,11 @@ public final class ShaderProperties {
 		private final List<String> sliders = new ArrayList<>();
 		private List<String> requiredFeatures = List.of();
 		private List<String> optionalFeatures = List.of();
-		private final List<BlendDirective> blend = new ArrayList<>();
-		private final Map<String, String> sizeBuffers = new LinkedHashMap<>();
-		private final List<FlipDirective> flips = new ArrayList<>();
 		private final Map<String, String> malformedAlphaTests = new LinkedHashMap<>();
 		private final Map<String, Integer> ignoredPrefixes = new LinkedHashMap<>();
 		private int directiveCount;
+		private int blendCount;
 		private int continuationCount;
 		private boolean present;
-		private boolean endFlashShadows;
 	}
 }

--- a/common/src/main/java/dev/vitrail/pack/target/TargetDirectives.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetDirectives.java
@@ -128,7 +128,7 @@ public final class TargetDirectives {
 		public Builder accept(ShaderProperties properties, Map<String, String> defines) {
 			Map<Integer, String> wanted = new TreeMap<>();
 
-			properties.sizeBuffers().forEach((buffer, value) -> {
+			properties.sizeBuffers(defines).forEach((buffer, value) -> {
 				Optional<Integer> index = boxed(buffer);
 				if (index.isEmpty()) {
 					this.notes.add("size.buffer." + buffer + " names no target we know of, ignored");

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -184,6 +184,7 @@ public final class TargetPlan {
 		List<ProgramSet.ProgramKey> entries = programs.fragmentsOf(draft.place);
 
 		Map<String, String> defines = settings.globalDefines(options);
+		draft.blend = properties.blend(defines);
 		read(source, options, settings, properties, entries, draft);
 		walk(properties, options, defines, entries, filter, draft);
 		computes(properties, options, defines, programs, draft);
@@ -343,7 +344,7 @@ public final class TargetPlan {
 			draft.geometryAt = draft.running.size();
 		}
 
-		draft.schedule = TargetSchedule.of(steps, properties.flips());
+		draft.schedule = TargetSchedule.of(steps, properties.flips(defines));
 	}
 
 	/**
@@ -699,7 +700,7 @@ public final class TargetPlan {
 					+ directives.mipmapRequests());
 		}
 
-		List<String> unreadable = draft.properties.blend().stream()
+		List<String> unreadable = draft.blend.stream()
 				.filter(directive -> directive.buffer() == null)
 				.filter(directive -> BlendMode.parse(directive.value()).isEmpty())
 				.map(directive -> directive.program() + "=" + directive.value())
@@ -709,7 +710,7 @@ public final class TargetPlan {
 					+ "keep the blending the engine would have used: " + unreadable);
 		}
 
-		List<String> perBuffer = draft.properties.blend().stream()
+		List<String> perBuffer = draft.blend.stream()
 				.filter(directive -> directive.buffer() != null)
 				.map(directive -> directive.program() + "." + directive.buffer())
 				.toList();
@@ -849,7 +850,7 @@ public final class TargetPlan {
 	 */
 	private static Map<String, BlendMode> blendOf(Draft draft) {
 		Map<String, BlendMode> blend = new LinkedHashMap<>();
-		for (ShaderProperties.BlendDirective directive : draft.properties.blend()) {
+		for (ShaderProperties.BlendDirective directive : draft.blend) {
 			if (directive.buffer() != null) {
 				continue;
 			}
@@ -898,6 +899,7 @@ public final class TargetPlan {
 		private String dimension;
 		private String place;
 		private ShaderProperties properties;
+		private List<ShaderProperties.BlendDirective> blend = List.of();
 		private TargetDirectives directives;
 		private TargetSchedule schedule;
 		private List<String> computes = List.of();

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -831,8 +831,10 @@ public final class PackChain {
 			// Read from the one file rather than from the report above, because a refusal has to
 			// hold at every load and the report is taken once.
 			List<String> required = new ArrayList<>(PackLoader.properties(pack).requiredFeatures());
-			// Only the names this engine has not built refuse the pack: custom images are served
-			// now, so a pack that cannot draw without them is simply right about what it needs.
+			// Only the names this engine has not built refuse the pack: the block emission
+			// attribute rides in the chunk element, and custom images are served now, so a pack
+			// that cannot draw without either is simply right about what it needs.
+			required.remove("BLOCK_EMISSION_ATTRIBUTE");
 			if (CustomImages.served()) {
 				required.remove("CUSTOM_IMAGES");
 			}

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -130,7 +130,7 @@ public final class PackValues {
 		SettingSet settings = pack.settings();
 
 		values.state.directives(PackDirectives.read(source, settings, dimension));
-		values.state.endFlashShadows(properties.endFlashShadows());
+		values.state.endFlashShadows(properties.endFlashShadows(settings.globalDefines(options)));
 		values.skyElements = properties.skyElements(settings.globalDefines(options));
 		values.weather = properties.weather(settings.globalDefines(options));
 		values.rainDepth = properties.rainDepth(settings.globalDefines(options));

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -61,11 +61,12 @@ can declare the features it cannot be drawn without, and Reverie declares severa
 before any of its programs is translated, so the refusal names what the pack asked for and did not
 get, the log listing them, rather than the symptom that would have come later.
 
-**Any name this engine has not built refuses the declaration.** One name is built and served
-today, `CUSTOM_IMAGES`, so a pack that requires it alone loads; every other name still refuses
-the pack, with the list in the log. The served flag is also the one `IRIS_FEATURE_` define a
-pack finds, `IRIS_FEATURE_CUSTOM_IMAGES`: a capability define is a promise, so each appears the
-day its feature is served and not before, and the optional declarations keep reading the truth.
+**Any name this engine has not built refuses the declaration.** Two names are built and served
+today, `BLOCK_EMISSION_ATTRIBUTE` and `CUSTOM_IMAGES`, so a pack that requires those alone
+loads; every other name still refuses the pack, with the list in the log. The served flags are
+also the only `IRIS_FEATURE_` defines a pack finds: a capability define is a promise, so each
+appears the day its feature is served and not before, and the optional declarations keep
+reading the truth.
 
 Iris draws Reverie. It refuses a required flag only when the name is unknown to it or the hardware
 cannot serve it, and it has built every one of the ones Reverie asks for: some outright, some
@@ -100,8 +101,8 @@ message is one of its passes, and it is drawn because a capability test in its c
 
 The test reads capability defines. This engine announces itself the way Iris does, but a
 capability define is a promise, so it defines only what the backend actually serves, which today
-is `IRIS_FEATURE_CUSTOM_IMAGES` and nothing else; the section above says why the features behind
-the other names are closed. A pack that finds the announcement without the capability it wants
+is `IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE` and `IRIS_FEATURE_CUSTOM_IMAGES` and nothing else; the
+section above says why the features behind the other names are closed. A pack that finds the announcement without the capability it wants
 concludes it is running on OptiFine, the only renderer in that position when the pack was
 written, and words its message for it. Read "OptiFine" as "not Iris" and the message is accurate.
 


### PR DESCRIPTION
## What changes

Four families of `shaders.properties` lines, `blend.`, `flip.`, `size.buffer.` and `endFlashShadows`, are read under the pack's own preprocessor conditionals instead of flat, the way `alphaTest` already was. A line the pack switches off with one of its settings no longer applies. The two boolean families take the four words the reference takes (`true`, `false`, `1`, `0`), and a value that is none of them leaves the previous line standing rather than answering false.

The second commit poses `IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE`. The chunk element has carried a block's own light in the fourth byte of `at_midBlock` since the mesh was widened, on the terrain and in the shadow map alike, but the flag was left unposted. Bliss writes its voxel emission under it, and Complementary sizes its two reflection targets to half resolution under it: reading that line conditionally without the flag would have handed Complementary two full-size targets Iris never gives it.

## How it differs from the reference, and for what obstacle

It does not. Iris reads every family off its preprocessed copy except the screens, the sliders, the profiles and the feature lists (`shaderpack/properties/ShaderProperties.java:132-152` for the preprocessed loop, `:600-622` for the raw one), takes `1` and `0` as booleans and warns on anything else (`:626-647`), and poses the block emission flag whatever the hardware (`features/FeatureFlags.java:20`).

## What proves it

- `gradlew build` green on both commits.
- The out-of-game harness over the eight packs of the bench, `Cibles` and `Chaine` built from `dev` and from this branch and diffed. `Chaine` is identical. `Cibles` differs on exactly the lines the pack's conditionals decide: Complementary with Euphoria Patches loses `size.buffer.colortex9`, which sits under `defined PHOTONICS`, a symbol the Photonics mod injects and that no file of the pack defines, so Iris without that mod never reads the line either. Complementary's own two half-resolution targets stay, which is the second commit: without the flag they went full size, the difference the harness showed first.
- Photon's four-arm size lines read the arm its setting picks; at the default the arm is the last one, so the flat read and the conditional read agree there and nothing changes at default.
- `Traduction` on Bliss from both builds, since posing the flag sends its shadow and voxel programs down the emission path.
- Not run in the game.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
