### PR TITLE
fix(uniform): serve alphaTestRef from the pass's own program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ what the next one holds.
   tests for it was never posed: Bliss took its path without voxel emission, and Complementary
   only kept its two reflection targets at half resolution by the flat read above.
 
+- **`alphaTestRef` carries the alpha reference of the program being drawn**, the pack's own
+  `alphaTest` line or the default of the pass, as it does under Iris. It read nought in every
+  pass, so a program fading against it did so at the wrong threshold; a discard against it
+  was already made at the right one, by the test the translation adds.
+
 - **Photon draws.** Three things stood between its files and its picture. Its atmosphere table
   is a three-dimensional volume of half floats asked to clamp, and the flat atlas that stands in
   for a volume took one byte a texel and a repeating volume only, so the three deferred passes

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -283,6 +283,11 @@ public final class FrameState implements WorldState {
 		this.view.passColour(colour);
 	}
 
+	/** The alpha reference of the program the pass about to write its block draws with. */
+	public void passAlphaTest(float reference) {
+		this.view.passAlphaTest(reference);
+	}
+
 	/** What the pass about to write its block draws. Set beside the three above, and for once. */
 	public void renderStage(RenderStage stage) {
 		this.stage = stage;
@@ -1727,6 +1732,11 @@ public final class FrameState implements WorldState {
 	@Override
 	public Vector4fc passColour() {
 		return this.view.passColour();
+	}
+
+	@Override
+	public float passAlphaTest() {
+		return this.view.passAlphaTest();
 	}
 
 	@Override

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -1821,6 +1821,7 @@ final class GeometryProgram {
 		this.values.modelView(this.modelView, this.bob);
 		this.values.projection(this.projection);
 		this.values.passColour(this.passColour);
+		this.values.passAlphaTest(this.loaded.alphaTest().reference());
 		this.values.renderStage(this.pass.stage());
 
 		try (GpuBufferSlice.MappedView view = this.block.currentBuffer().map(false, true)) {

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -3378,7 +3378,8 @@ public final class PackChain {
 		// this runs. Left standing, every composite of the frame would be told it was drawing the moon.
 		this.values.renderStage(RenderStage.NONE);
 
-		// And the same again for the three values a pass writes beside it. Two geometry families
+		// And the same again for three of the four values a pass writes beside it, the alpha
+		// reference being the one kept, ViewSource.passAlphaTest saying why. Two geometry families
 		// set a matrix of their own: the sky pushes the rotation of the day, and the hand is drawn
 		// under an identity model view and sets a whole projection besides, the head-up volume with
 		// its clip depth squeezed to an eighth. Whichever drew last would

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -266,6 +266,16 @@ public final class PackValues {
 	}
 
 	/**
+	 * What the next block's program discards at, which a pack reads as {@code alphaTestRef}. Set
+	 * beside the colour, and unlike the colour, the matrices and the render stage never dropped by
+	 * the chain: see {@link dev.vitrail.uniform.ViewSource#passAlphaTest} for what a composite
+	 * reads.
+	 */
+	public void passAlphaTest(float reference) {
+		this.state.passAlphaTest(reference);
+	}
+
+	/**
 	 * What the next block is written for, which a pack reads as {@code renderStage} and branches on
 	 * with {@code MC_RENDER_STAGE_*}. Set beside the convention and answering the same kind of
 	 * question, and said by every writer rather than inherited: this one is in the table a full

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -143,6 +143,8 @@ public final class ViewMatrices implements ViewSource {
 	/** The colour the pass modulates its draw by, white until a pass says otherwise. */
 	private static final Vector4f OPAQUE_WHITE = new Vector4f(1.0F, 1.0F, 1.0F, 1.0F);
 	private final Vector4f passColour = new Vector4f(1.0F, 1.0F, 1.0F, 1.0F);
+	/** What the pass's program discards at, nought until a pass says otherwise, never dropped. */
+	private float passAlphaTest;
 	private float far;
 	private int renderDistanceChunks;
 	private boolean seeded;
@@ -550,6 +552,11 @@ public final class ViewMatrices implements ViewSource {
 		this.passColour.set(colour == null ? OPAQUE_WHITE : colour);
 	}
 
+	/** The alpha reference of the program the pass draws with. */
+	void passAlphaTest(float reference) {
+		this.passAlphaTest = reference;
+	}
+
 	/** Called when the world changes, so that no history crosses a dimension. */
 	void reset() {
 		this.seeded = false;
@@ -627,6 +634,11 @@ public final class ViewMatrices implements ViewSource {
 	@Override
 	public Vector4fc passColour() {
 		return this.passColour;
+	}
+
+	@Override
+	public float passAlphaTest() {
+		return this.passAlphaTest;
 	}
 
 	@Override

--- a/common/src/main/java/dev/vitrail/uniform/ViewSource.java
+++ b/common/src/main/java/dev/vitrail/uniform/ViewSource.java
@@ -106,6 +106,24 @@ public interface ViewSource {
 	 */
 	Vector4fc passColour();
 
+	/**
+	 * The alpha reference of the program the pass is drawn with, which a pack reads as
+	 * {@code alphaTestRef}. Iris posts it at every program setup and never clears it
+	 * ({@code pipeline/programs/ExtendedShader.java:179}, {@code SodiumShader.java:181}, into
+	 * {@code uniforms/CapturedRenderingState.java:113}), so each of its composites reads the
+	 * reference of the last program set up before it, and nought before any program has drawn.
+	 * Answered the same way for a geometry pass: set before it writes its block, and left standing.
+	 * <p>
+	 * A full screen pass parts from that by one step, and it is written down rather than served:
+	 * the chain writes ONE block per frame, whichever half asks first
+	 * ({@code render/PackChain.writeBlocks}, mapping it again under commands already recorded
+	 * against it being a write to memory a command holds), so every composite of the frame reads
+	 * the reference held when that block was written, the last geometry program of the early half,
+	 * where Iris would hand the late half the last program before it. What it costs the image:
+	 * nothing on the corpus, the one pack reading the name reading it in geometry programs alone.
+	 */
+	float passAlphaTest();
+
 	Matrix4fc gbufferProjection();
 
 	Matrix4fc gbufferProjectionInverse();

--- a/common/src/main/java/dev/vitrail/uniform/values/DrawValues.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/DrawValues.java
@@ -9,8 +9,8 @@ import org.joml.Matrix4f;
 /**
  * What a pass drawn over a quad gets instead of the fixed function state a program would have had.
  * <p>
- * None of these depends on the world, which is why they are the first thing the catalogue answers
- * and the only thing it answers before the frame state is filled in. A full screen pass has no
+ * The matrices depend on nothing, which is why they are the first thing the catalogue answers
+ * and can be answered before the frame state is filled in. A full screen pass has no
  * model view worth the name: the model view is the identity and the projection is the one that
  * carries the quad onto the screen, so their product is the projection.
  * <p>
@@ -139,6 +139,9 @@ public final class DrawValues {
 		builder.add("entityId", UniformShape.INT, (_, out) -> out.set(0));
 		builder.add("blockEntityId", UniformShape.INT, (_, out) -> out.set(-1));
 		builder.add("currentRenderedItemId", UniformShape.INT, (_, out) -> out.set(-1));
-		builder.add("alphaTestRef", UniformShape.FLOAT, (_, out) -> out.set(0.0F));
+		// What the pass's own program discards at, and in a pass drawn over a quad the reference
+		// held when the chain wrote its one block for the frame: ViewSource.passAlphaTest says
+		// what Iris hands a composite instead, and why the difference reaches no pack.
+		builder.add("alphaTestRef", UniformShape.FLOAT, (world, out) -> out.set(world.passAlphaTest()));
 	}
 }


### PR DESCRIPTION
## What changes

`alphaTestRef` carries the alpha reference of the program the pass is drawn with, the pack's own `alphaTest` line or the default of the pass, where it read a constant nought in every pass. The reference travels like the pass colour: set by every geometry pass before it writes its block, held on the view state, never dropped, and read by the one engine table both kinds of pass share. A program fading against it now does so at the right threshold; a discard against it was already made at the right one by the test the translation adds.

## How it differs from the reference, and for what obstacle

One step, on the full screen passes only. Iris posts the value at every program setup (`pipeline/programs/ExtendedShader.java:179`, `SodiumShader.java:181`, into `uniforms/CapturedRenderingState.java:113`) and never clears it, so each composite reads the last program set up before it. Here the chain writes its block once a frame, whichever half asks first (`render/PackChain.java:2211-2214`, mapping it again under commands already recorded being a write to memory a command holds), so every composite of the frame reads the reference held at that moment, the last geometry program of the early half. What it costs the image: nothing on the corpus, the one pack reading the name (Mellow) reading it in geometry programs alone. Written down in `ViewSource.passAlphaTest` rather than served.

## What proves it

- `gradlew build` green.
- Read against Iris: the two posting sites and the field's default, `AlphaTest.ALWAYS` at nought on both sides, the shadow defaults aligned (`SodiumPrograms.java:78` against `TerrainPass.java:45-60`).
- All seven geometry families write their block through `GeometryProgram.writeBlock`, which is where the reference is set; `alphaTestRef` is registered once in the whole tree and sits in neither gap table.
- Not run in the game, and the out-of-game harness has no reader for a uniform value.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
