### PR TITLE
fix(render): hand Sodium the NEAREST shadow sampler, settle the switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,17 +35,18 @@ what the next one holds.
   every tree lighter or darker according to where they stood, where Iris showed one shadow. The
   shadow draw now keeps filled batches of its own, as Iris does.
 
-- **A pack's terrain reads the block atlas unfiltered, as Iris binds it.** The terrain and its
-  shadow map read the atlas through the game's own chunk sampler, LINEAR for min and mag, where
+- **A pack's terrain reads the block atlas unfiltered, as Iris binds it.** The terrain read the
+  atlas through the game's own chunk sampler and its shadow map through a cache sampler without
+  anisotropy, both LINEAR for min and mag, where
   Iris throws that sampler away and binds NEAREST for every terrain draw. Both halves now bind
   the same sampler Iris does, mipmaps and the player's anisotropy kept, short of the one thing
   Iris adds for packs that declare they cannot bear anisotropy, which is not read yet. What a
   filter can decide on cutout foliage is whether a fragment survives its alpha test, so the two
   states can only differ where a leaf's edge falls inside a texel; compared against Iris on one
   scene at three camera heights, the two engines shade the trees alike in both states, so this
-  is parity and not the cure of anything seen so far. Of the Texture Filtering setting, only the
-  anisotropy still reaches a pack's terrain; the filter itself still applies to everything a pack
-  does not draw.
+  is parity and not the cure of anything seen so far. Of the Texture Filtering setting, the
+  anisotropy reaches a pack's terrain as it did; its filter never did, the game's chunk sampler
+  being LINEAR whatever it says, and it still applies to everything a pack does not draw.
 
   An empty file `vitrail/legacy-terrain-filter` in the instance, or
   `-Dvitrail.legacyTerrainFilter=true`, puts the old filtered sampler back on both the terrain and

--- a/common/src/main/java/dev/vitrail/render/LegacyTerrainFilter.java
+++ b/common/src/main/java/dev/vitrail/render/LegacyTerrainFilter.java
@@ -2,9 +2,8 @@ package dev.vitrail.render;
 
 import dev.vitrail.Vitrail;
 
-import net.minecraft.client.Minecraft;
-
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Whether a pack's terrain reads the block atlas through the game's filtered sampler, as this
@@ -32,10 +31,14 @@ public final class LegacyTerrainFilter {
 
 	private static final String ARM_FILE = "legacy-terrain-filter";
 
-	/** Null until first asked after a pack load, so the file is read once per load and not per pass. */
-	private static Boolean armed;
+	/**
+	 * Settled at the head of each pack load, like {@link DriverTrig}, and volatile for the reason
+	 * {@code RenderScale.percent} gives: the load may run on a loading worker while every reader
+	 * is the render thread.
+	 */
+	private static volatile boolean armed;
 
-	private static boolean announced;
+	private static volatile boolean announced;
 
 	private LegacyTerrainFilter() {
 	}
@@ -46,30 +49,19 @@ public final class LegacyTerrainFilter {
 	 * @return true while the file or the property asks for the old filter
 	 */
 	public static boolean armed() {
-		if (PROPERTY) {
-			announce(true);
-
-			return true;
-		}
-
-		if (armed == null) {
-			Minecraft minecraft = Minecraft.getInstance();
-			if (minecraft == null || minecraft.gameDirectory == null) {
-				return false;
-			}
-
-			armed = Files.isRegularFile(minecraft.gameDirectory.toPath()
-					.resolve("vitrail").resolve(ARM_FILE));
-		}
-
 		announce(armed);
 
 		return armed;
 	}
 
-	/** A new pack is being read, so the file is worth looking at again. */
-	public static void reset() {
-		armed = null;
+	/**
+	 * Read at the head of a pack load, so the file is looked at once per load and not per pass.
+	 * The game directory is handed in rather than asked of the game, as {@link DriverTrig#read}
+	 * takes it: the load already knows where it is reading from.
+	 */
+	public static void read(Path gameDirectory) {
+		armed = PROPERTY
+				|| Files.isRegularFile(gameDirectory.resolve(Vitrail.MOD_ID).resolve(ARM_FILE));
 		announced = false;
 	}
 

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -660,7 +660,7 @@ public final class PackChain {
 		// Taken before anything reads the folder, so that the count printed at the end of the load
 		// covers every opening the load made and not only the translation's.
 		int openings = ShaderPackSource.openings();
-		LegacyTerrainFilter.reset();
+		LegacyTerrainFilter.read(gameDirectory);
 		session = null;
 		lastError = null;
 		removed = List.of();

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -309,10 +309,11 @@ public final class ShadowTerrain {
 		// half binds the same NEAREST sampler as the gbuffer half or the game's under the legacy
 		// switch, either way through TerrainSampler and LegacyTerrainFilter and never through this
 		// argument. What this argument reaches is Sodium's own shader, on a pass handed back to it,
-		// which keeps the game's filtering there as it does in the gbuffers. Iris hands a sampler down
-		// the same road (shadows/ShadowRenderer.java:389) and its SodiumShader.setupState binds its
-		// own instead (pipeline/programs/SodiumShader.java:131).
-		GpuSampler sampler = RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR, true);
+		// and there Iris hands NEAREST down the same road (shadows/ShadowRenderer.java:389), where
+		// the gbuffers hand it the game's LINEAR: NEAREST here too, so that the one pass Sodium
+		// draws itself filters as it does under Iris. Iris's SodiumShader.setupState binds its own
+		// instead (pipeline/programs/SodiumShader.java:131), and so does ours.
+		GpuSampler sampler = RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST, true);
 
 		ShadowCasters casters = TerrainDraw.shadowCasters();
 


### PR DESCRIPTION
## What changes

Three loose ends of the unfiltered terrain sampler. The sampler handed to Sodium for the shadow draw is NEAREST, as Iris hands it (`shadows/ShadowRenderer.java:389`), where a LINEAR one was passed with a comment presenting it as the same gesture; it only reaches a pass Sodium draws itself, so nothing this engine's programs draw changes. The legacy-filter switch is read once at the head of a pack load from the directory the load already knows, like the trig switch beside it, on volatile statics, instead of lazily from the game on the render thread. The changelog entry no longer implies the Texture Filtering setting ever delivered a filter to a pack's terrain, and names the shadow's old sampler for what it was.

## How it differs from the reference, and for what obstacle

It does not. The one remaining gap is the per-pack anisotropy override Iris applies, already named in the entry.

## What proves it

- `gradlew build` green.
- Read against Iris: `ShadowRenderer.java:389` builds CLAMP_TO_EDGE, NEAREST, mipmapped, and hands it at `:510`; `LevelRenderer.java:430-434` hardcodes LINEAR for the game's chunk sampler whatever the setting says.
- Not run in the game: the sampler change reaches only a pass handed back to Sodium, and the switch keeps the same two states and the same log line.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
