### PR TITLE
build: name a dev build after the version it is heading for

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -26,10 +26,17 @@ types='feat|fix|perf|refactor|docs|test|build|ci|chore'
 subject_re="^($types)(\([a-z0-9-]+\))?!?: [a-z].*[^.]$"
 # `release` is a branch prefix and not a commit type: what lands from such a branch is the version
 # bump, which is a `build`, that line of gradle.properties being the build's own. The version itself
-# is the name, so this is the one branch carrying dots.
+# is the name, so this is one of the two branches carrying dots.
 # Three numbers, then either `-alpha`, or `-beta`, or nothing: a counted pre-release is refused here
 # rather than at the tag, where the repair costs a branch already pushed under the wrong name.
-branch_re="^(($types)/[a-z0-9]+(-[a-z0-9]+)*|release/[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta))?)$"
+#
+# `build/open-<version>-dev` is the other, and it is the same branch read backwards: `release/` takes
+# the `-dev` suffix off the version for the tag, and this one puts the next version and its suffix
+# back the moment that tag is out. The version is again the whole of what the name has to say, and
+# the shape is written out here rather than left to the general rule because the general rule would
+# have to admit a dot everywhere to admit it here.
+semver='[0-9]+\.[0-9]+\.[0-9]+'
+branch_re="^(($types)/[a-z0-9]+(-[a-z0-9]+)*|release/$semver(-(alpha|beta))?|build/open-$semver-dev)$"
 
 die() {
 	echo "commit-msg: $1" >&2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,11 @@ dashes, saying what the branch does rather than which class it opens.
     fix/hand-bob-frame
     ci/commit-and-branch-format
 
-`release/0.5.0-beta` is the one shape that departs from it, the version being the whole of the
-name: such a branch carries the version bump and nothing else. No name records who wrote the
-branch, or when, or which issue it answers. That last one is a choice rather than an absence: the
+`release/0.5.0-beta` is one of the two shapes that depart from it, the version being the whole of
+the name: such a branch carries the version bump and nothing else. `build/open-0.6.0-dev` is the
+other, and it is that branch read backwards, carrying the commit that opens the next version once
+the tag is out. Those two are the only branch names with a dot in them. No name records who wrote
+the branch, or when, or which issue it answers. That last one is a choice rather than an absence: the
 commit that does the work names the issue it closes, and a branch name carrying the number would
 say it in the one place nothing reads it back from.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,6 +251,21 @@ workflow refuses it when the two disagree rather than publishing a jar named aft
 from the other. The target Minecraft version is in the artifact name and comes from the same file.
 A tag is pushed on `main` and on nothing else, which is what keeps that sentence true.
 
+Between two releases that line does not hold the version that went out, and it does not hold a
+version at all in the sense above: it holds the next one with `-dev` after it, `0.10.0-dev` once
+`0.9.0-beta` is published. The shape is deliberately one nothing will tag, and that is the point of
+it. No `-dev` version is ever tagged and none is ever published, the `release/<version>` branch is
+what takes the suffix off in the bump that is the whole of that branch, and the commit that opens
+the next version, the first to land on `dev` after a release, is what puts it back.
+
+A build off a topic branch appends that branch's name to the suffix, so a jar built on
+`fix/shadow-band` calls itself `0.10.0-dev.fix.shadow-band` and is not to be confused with anyone
+else's. Nothing about it is committed: the root `build.gradle` asks git which branch is checked
+out, and everything that states a version reads that one answer, so the jar name, both metadata
+files, the F3 line, the settings screen and the line the engine logs at load all say the same
+thing. `dev`, `main` and a detached head, which is what a release build is, are left with the bare
+suffix, and a version without `-dev` is not touched at all.
+
 Publishing, in order: rewrite the pack table at the head of
 [docs/compatibility.md](docs/compatibility.md) against whatever has been seen since the last one,
 bump `mod_version`, land those commits on `main` the way every other commit lands, push `main`,

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,79 @@ plugins {
 	id "net.ltgt.errorprone" version "4.1.0" apply false
 }
 
+// Between two releases `dev` carries the version being written towards, suffixed `-dev`, so that
+// nothing built before a release can be read as that release. One ambiguity survives that suffix:
+// every topic branch open at the same time builds the same 0.10.0-dev, and a jar, a log line or a
+// screenshot out of one is indistinguishable from another's. So a build off a topic branch appends
+// the branch name to the suffix. It is appended here and committed nowhere, because the answer
+// depends on which branch is checked out and a committed one would be wrong on every other.
+//
+// This is the one place the number is decided, and everything that states it reads this: the jar
+// names, the two metadata files the loaders parse, and through them the F3 line, the settings
+// screen and the line the engine logs at load. They agree because there is nothing left for them
+// to disagree about.
+//
+// A version that does not end in `-dev` is never touched, which is the whole of what leaves a
+// release exactly what gradle.properties says. `.github/workflows/release.yml` compares the tag
+// against that line and refuses a mismatch, and it checks a tag out, so its head is detached and
+// carries no branch name to append anyway. `dev` and `main` are left bare for the other half of
+// the reason: there is nothing there to tell one build from another.
+def effectiveVersion = project.mod_version
+
+if (effectiveVersion.endsWith("-dev")) {
+	def branch = null
+
+	try {
+		def git = new ProcessBuilder("git", "rev-parse", "--abbrev-ref", "HEAD")
+				.directory(rootDir)
+				.redirectErrorStream(true)
+				.start()
+		def said = git.inputStream.getText("UTF-8").trim()
+
+		if (git.waitFor() == 0) {
+			branch = said
+		}
+	} catch (IOException ignored) {
+		// No git on the path, or no repository under this directory. A build out of a tarball is
+		// a legitimate build, and the bare suffix is the right answer for it rather than a stop.
+	}
+
+	// "HEAD" is what a detached head answers, which is what continuous integration checks out and
+	// what a release build therefore is.
+	if (branch != null && !(branch in ["dev", "main", "HEAD"])) {
+		// Where this ends up is a semantic version pre-release string, a run of identifiers of
+		// [-0-9A-Za-z] separated by dots: that is what Fabric Loader's SemanticVersionImpl matches
+		// everything after the first dash against, and a jar it refuses there does not load at
+		// all. So a slash becomes a dot, and anything outside the set is dropped rather than
+		// replaced, a replacement being only another character to justify. Empty identifiers go
+		// with them, because a name made entirely of dropped characters would otherwise leave a
+		// trailing dot, which is one of the strings that parser refuses.
+		//
+		// NeoForge asks something weaker, worth naming since the same string is handed to both:
+		// ModInfo takes any Maven version whose first character is a digit, and the major number
+		// in front satisfies that whatever follows it.
+		def slug = branch.replace("/", ".")
+				.replaceAll("[^0-9A-Za-z.-]", "")
+				.split("\\.")
+				.findAll { !it.isEmpty() }
+				.join(".")
+
+		if (!slug.isEmpty()) {
+			effectiveVersion = "${effectiveVersion}.${slug}"
+		}
+	}
+}
+
+// Put back on the project because both loader modules read it too, each of them naming it in the
+// metadata it expands and in the name of the jar it writes.
+ext.effectiveVersion = effectiveVersion
+
 subprojects {
 	apply plugin: "java"
 	apply plugin: "net.ltgt.errorprone"
 
 	group = project.group_id
-	version = project.mod_version
+	version = rootProject.effectiveVersion
 
 	repositories {
 		mavenCentral()
@@ -221,7 +288,7 @@ tasks.register("mergedJar", Jar) {
 	description = "Assembles the one jar that runs under either loader."
 
 	archiveBaseName = "vitrail"
-	archiveVersion = "${project.mod_version}+mc${project.minecraft_version}"
+	archiveVersion = "${project.effectiveVersion}+mc${project.minecraft_version}"
 
 	// Aimed at build/libs itself, because the base plugin's home for a root archive is
 	// build/distributions, and everything this build makes is read out of one directory.

--- a/common/src/main/java/dev/vitrail/Vitrail.java
+++ b/common/src/main/java/dev/vitrail/Vitrail.java
@@ -26,6 +26,35 @@ public final class Vitrail {
 		return LOGGER;
 	}
 
+	/**
+	 * The declared version with the branch name cut off it, which is what the two compiled stores
+	 * name their edition after and key their entries by.
+	 * <p>
+	 * A build made off a topic branch declares that branch in its version,
+	 * {@code 0.10.0-dev.fix.shadow-band} where {@code dev} declares {@code 0.10.0-dev}, so that a
+	 * jar, a log line and a screenshot say which branch made them. A cache edition must not follow
+	 * it there. Both stores delete every edition but their own when they open, so a bench swapping
+	 * between two branch builds would throw the other one's store away on every swap and compile
+	 * every pack from cold again: on this machine that is most of a gigabyte of work bought by a
+	 * name. What a version says in a cache key is a claim about the translator and the compiler,
+	 * and neither of them changes because a branch does, so every build between two releases goes
+	 * on sharing one folder exactly as it did before there was a suffix to share it despite.
+	 * <p>
+	 * The cut is at the first dot after the dash, which is where the build appends and the only
+	 * place a dot can follow: a version is three numbers and then {@code -alpha}, {@code -beta},
+	 * {@code -dev} or nothing at all, so a released one comes back unchanged.
+	 */
+	public static String cacheVersion() {
+		String version = platform().modVersion();
+		int dash = version.indexOf('-');
+		if (dash < 0) {
+			return version;
+		}
+
+		int dot = version.indexOf('.', dash);
+		return dot < 0 ? version : version.substring(0, dot);
+	}
+
 	public static VitrailPlatform platform() {
 		if (platform == null) {
 			throw new IllegalStateException("Vitrail has not been initialised by a loader module");

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -84,6 +84,9 @@ public final class EngineStages {
 	 * a RELEASE takes its predecessor's folder away rather than filling a second one beside it.
 	 * Two builds declaring one version share the folder and every key in it, which is every build
 	 * made between two releases; what answers that in the workshop is deleting the folder by hand.
+	 * The branch a build was made on is cut out of the version first, by
+	 * {@link Vitrail#cacheVersion()}, so that a topic build is one of those two builds and not the
+	 * owner of a folder of its own.
 	 * The loader is not in the name, and does not need to be: the two loaders run the same
 	 * translator over the same text, and what does differ between them is in the key of every
 	 * entry.
@@ -91,7 +94,7 @@ public final class EngineStages {
 	private static void openTranslationCache() {
 		TranslationCache.install(
 				Vitrail.platform().gameDirectory().resolve(Vitrail.MOD_ID),
-				Vitrail.platform().modVersion() + "+mc" + Vitrail.platform().minecraftVersion());
+				Vitrail.cacheVersion() + "+mc" + Vitrail.platform().minecraftVersion());
 
 		if (!TranslationCache.installed()) {
 			Vitrail.logger().warn("No translation cache this run, so every pack load translates "

--- a/common/src/main/java/dev/vitrail/render/ModuleCache.java
+++ b/common/src/main/java/dev/vitrail/render/ModuleCache.java
@@ -307,7 +307,7 @@ public final class ModuleCache {
 		MessageDigest digest = sha256();
 
 		feed(digest, FORMAT);
-		feed(digest, Vitrail.platform().modVersion());
+		feed(digest, Vitrail.cacheVersion());
 		feed(digest, Vitrail.platform().minecraftVersion());
 		feed(digest, Vitrail.platform().loaderName());
 		feed(digest, Vitrail.platform().loaderVersion());
@@ -649,9 +649,13 @@ public final class ModuleCache {
 		}
 	}
 
-	/** What names a whole set of keys at once, and therefore what names their directory. */
+	/**
+	 * What names a whole set of keys at once, and therefore what names their directory. The version
+	 * is the one {@link Vitrail#cacheVersion()} answers, so that a build off a topic branch shares
+	 * this folder with every other build between the same two releases rather than emptying it.
+	 */
 	private static String edition() {
-		return plain(Vitrail.platform().modVersion()) + "+mc"
+		return plain(Vitrail.cacheVersion()) + "+mc"
 				+ plain(Vitrail.platform().minecraftVersion());
 	}
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 tasks.named("processResources", ProcessResources).configure {
 	def metadata = [
 		mod_id: project.mod_id,
-		mod_version: project.mod_version,
+		mod_version: rootProject.effectiveVersion,
 		minecraft_version: project.minecraft_version,
 		fabric_loader_version: project.fabric_loader_version
 	]
@@ -61,7 +61,7 @@ tasks.named("processResources", ProcessResources).configure {
 }
 
 tasks.named("jar", Jar).configure {
-	archiveVersion = "${project.mod_version}+mc${project.minecraft_version}"
+	archiveVersion = "${rootProject.effectiveVersion}+mc${project.minecraft_version}"
 	from project(":common").sourceSets.main.output
 
 	// The licence has to reach whoever receives the program, and what they receive is this jar.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.9.0-beta
+mod_version=0.10.0-dev
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 tasks.named("processResources", ProcessResources).configure {
 	def metadata = [
 		mod_id: project.mod_id,
-		mod_version: project.mod_version,
+		mod_version: rootProject.effectiveVersion,
 		minecraft_version: project.minecraft_version,
 		neoforge_version: project.neoforge_version
 	]
@@ -48,7 +48,7 @@ tasks.named("processResources", ProcessResources).configure {
 }
 
 tasks.named("jar", Jar).configure {
-	archiveVersion = "${project.mod_version}+mc${project.minecraft_version}"
+	archiveVersion = "${rootProject.effectiveVersion}+mc${project.minecraft_version}"
 	from project(":common").sourceSets.main.output
 
 	// The licence has to reach whoever receives the program, and what they receive is this jar.


### PR DESCRIPTION
## What changes

`mod_version` held `0.9.0-beta` between releases, the number already out there, so every build off
`dev` and off a topic branch named itself after a release it was not: the jar, the mod metadata,
the F3 line, the settings screen and the line logged at load all said the published version, and a
screenshot could not be told from the real one. The line now holds the version being written
towards, `0.10.0-dev`, and the build appends the checked-out branch to a `-dev` version, so
`fix/shadow-band` builds `vitrail-0.10.0-dev.fix.shadow-band+mc26.2.jar` and those six places read
one value rather than six copies of a property.

Nothing is committed by the suffix, and a version without `-dev` is not touched, which leaves a
release exactly what `gradle.properties` says: `release.yml` compares the tag with that line and is
untouched here. `dev`, `main` and a detached head, which is what a release build is, keep the bare
suffix, and git missing or failing leaves the version alone rather than stopping the build.

The two compiled stores read that version with the branch cut back off. Both name their edition
after the declared version and delete every other edition when they open, so a branch in that name
would have given each branch a store of its own and made a bench that swaps builds throw the other
one away and compile every pack from cold.

`CONTRIBUTING.md` now says what the line holds on the days nothing is being released, and the
branch rule admits `build/open-<version>-dev`, which puts the suffix back once a tag is out.

## How it differs from the reference, and for what obstacle

It does not. Nothing here reaches the engine or anything a pack can say.

## What proves it

- `gradlew build` green. The jars in `build/libs` are named
  `0.10.0-dev.build.dev-version-suffix`, and `fabric.mod.json` and `neoforge.mods.toml` inside the
  merged jar carry that same string.
- The same tree detached builds `vitrail-0.10.0-dev+mc26.2.jar`. A branch named `dev` or `main`
  answers the same, and a name that survives the character filter as nothing at all leaves the bare
  suffix rather than a trailing dot.
- Fabric Loader 0.19.3 accepts `0.10.0-dev.build.dev-version-suffix` and refuses `0.10.0-dev.fix.`,
  the shape dropping empty identifiers exists to prevent; `ModInfo` asks only for a Maven version
  starting with a digit.
- The cut the two stores key on gives `0.10.0-dev` for `0.10.0-dev.fix.shadow-band` and returns
  `0.9.0-beta`, `0.9.0-alpha` and `0.9.0` unchanged, so no bench swap empties a store.

## What it leaves owing

`build/libs` accumulates one jar per branch name built in a tree, where every build used to
overwrite one name. It grows until it is emptied by hand.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
