### PR TITLE
fix: settle the filter of a custom image and honour breaksAnisotropy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,11 @@ what the next one holds.
   being LINEAR whatever it says, and it still applies to everything a pack does not draw.
 
   An empty file `vitrail/legacy-terrain-filter` in the instance, or
-  `-Dvitrail.legacyTerrainFilter=true`, puts the old filtered sampler back on both the terrain and
-  its shadow, so the two states can be compared in one world by reloading the pack with the
+  `-Dvitrail.legacyTerrainFilter=true`, puts the game's filtered sampler back on the terrain the
+  camera sees. The shadow map stays unfiltered either way: what the switch restores is the sampler
+  the chunk renderer was handed, and the shadow draw hands it one of its own that is unfiltered
+  already, so a comparison taken with the switch is a comparison of the camera's half alone. The
+  two states can be compared in one world by reloading the pack with the
   Reload Shaders key (R by default) rather than by swapping builds. F3 + T does not read the
   pack again and leaves the state as it was. The log names the state once per pack load, at the
   first terrain the pack draws.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ what the next one holds.
 
 ### Fixed
 
+- **A texture a pack ships is read by a compute pass as the pack asked for it**, the blurring and
+  the wrapping written in the `.mcmeta` beside the file included, which is how a full-screen pass
+  already read it. A compute naming such a texture found no image behind the name at all: one
+  spelled like a colour target was answered with the target instead of the pack's own file, and
+  under any other spelling that one compute did nothing at all, leaving a line in the log while
+  the pass it belongs to drew on without whatever the compute was there to prepare.
+
 - **A volume a pack fills for itself is read the same way from every pass.** An image declared
   with an `image.` line is filtered by its format, smoothly unless it holds whole numbers, which
   is the one thing Iris settles on the image and every reader then inherits. Here the answer was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack that says it cannot bear anisotropic filtering is believed.** BSL and both
+  Complementary variants write `breaksAnisotropy` in their `shaders.properties`, and the line was
+  read nowhere: with Texture Filtering set to Anisotropic in Video Settings, their terrain showed
+  a strip of the neighbouring sprite along a block edge seen from low down, where the same packs
+  under Iris do not. Their terrain and their shadow map now read the block atlas without
+  anisotropy whatever the setting says, as Iris reads them. Everything the pack does not draw
+  keeps the player's value, and so does the number the pack itself reads for the setting.
+
 - **A texture a pack ships is read by a compute pass as the pack asked for it**, the blurring and
   the wrapping written in the `.mcmeta` beside the file included, which is how a full-screen pass
   already read it. A compute naming such a texture found no image behind the name at all: one
@@ -56,8 +64,7 @@ what the next one holds.
   atlas through the game's own chunk sampler and its shadow map through a cache sampler without
   anisotropy, both LINEAR for min and mag, where
   Iris throws that sampler away and binds NEAREST for every terrain draw. Both halves now bind
-  the same sampler Iris does, mipmaps and the player's anisotropy kept, short of the one thing
-  Iris adds for packs that declare they cannot bear anisotropy, which is not read yet. What a
+  the same sampler Iris does, mipmaps and the player's anisotropy kept. What a
   filter can decide on cutout foliage is whether a fragment survives its alpha test, so the two
   states can only differ where a leaf's edge falls inside a texel; compared against Iris on one
   scene at three camera heights, the two engines shade the trees alike in both states, so this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ what the next one holds.
 
 ### Fixed
 
+- **A volume a pack fills for itself is read the same way from every pass.** An image declared
+  with an `image.` line is filtered by its format, smoothly unless it holds whole numbers, which
+  is the one thing Iris settles on the image and every reader then inherits. Here the answer was
+  decided in three places and only the geometry programs had it right: a full-screen pass and a
+  compute pass read every such image unfiltered. So the geometry half of a pack's lighting was
+  smooth and the full-screen half was not, whatever the settings. Photon's deferred shading and
+  Bliss's composites interpolate their light volumes, and showed the light in bricks the size of
+  a voxel with a hard edge; a pack that reads its volume texel by texel never saw it, no filter
+  reaching that kind of read.
+
 - **The block outline is drawn by the pack, as Iris draws it.** The thin box around the block
   aimed at was left to the game's own shader and painted into a layer this engine composes onto
   the pack's picture at the spot where the pack blends its water; where a pack keeps something

--- a/common/src/main/java/dev/vitrail/mixin/MixinShaderChunkRenderer.java
+++ b/common/src/main/java/dev/vitrail/mixin/MixinShaderChunkRenderer.java
@@ -62,12 +62,15 @@ public abstract class MixinShaderChunkRenderer {
 	 * draw, so a pack, which is written against Iris, expects NEAREST. What that filter decides on
 	 * cutout foliage is the silhouette rather than the colour, the fragment being discarded on the
 	 * atlas's alpha, and {@link TerrainSampler} carries the whole of it with the references on both
-	 * sides. {@link LegacyTerrainFilter} puts the game's back, terrain and shadow alike, for a
-	 * comparison. The choice is made where the pack is known to be drawing, so that a pass with no
-	 * pack behind it neither asks nor announces anything.
+	 * sides. {@link LegacyTerrainFilter} hands back whatever this road was given, for a comparison,
+	 * which is the game's LINEAR under the camera and NEAREST in the shadow map: what the switch
+	 * moves is the gbuffer half alone. The choice is made where the pack is known to be drawing, so
+	 * that a pass with no pack behind it neither asks nor announces anything.
 	 * <p>
-	 * Every pass comes through here, the shadow map's included: the light's draw hands the game's
-	 * sampler down the same road, and the pack's shadow programs bind what is settled here.
+	 * Every pass comes through here, the shadow map's included: the light's draw hands a sampler of
+	 * its own down the same road, NEAREST rather than the game's
+	 * ({@code sodium/ShadowTerrain.java:323}), and the pack's shadow programs bind what is settled
+	 * here.
 	 */
 	@Inject(method = "begin", at = @At("HEAD"))
 	private void vitrail$sampler(TerrainRenderPass pass, FogParameters parameters,

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -110,6 +110,10 @@ public final class ShaderProperties {
 	// lines like every other directive of this file, and the note on RAIN_DEPTH says why that is
 	// what the reference does too.
 	private static final Pattern SEPARATE_AO = Pattern.compile("^\\s*separateAo\\s*=\\s*(.*)$");
+	// Whether the pack declares that anisotropy breaks the way it reads the block atlas. Read on the
+	// live lines and on separateAo's rule in every respect, and answered the same way.
+	private static final Pattern BREAKS_ANISOTROPY =
+			Pattern.compile("^\\s*breaksAnisotropy\\s*=\\s*(.*)$");
 	private static final Pattern SIZE_BUFFER = Pattern.compile("^\\s*size\\.buffer\\.([^=\\s.]+)\\s*=\\s*(.*)$");
 	private static final Pattern SKY_ELEMENT = Pattern.compile("^\\s*(sun|moon|stars|sky)\\s*=\\s*(.*)$");
 	// The fifth word of that family, kept apart because it is the one that takes neither a yes nor a
@@ -394,6 +398,12 @@ public final class ShaderProperties {
 		// author that nothing looks at a line which had just overruled the one before it.
 		Matcher separateAo = SEPARATE_AO.matcher(line);
 		if (separateAo.matches()) {
+			return;
+		}
+
+		// On that same rule, and read for the same reason: a word this cannot read leaves the
+		// default standing rather than being stepped over.
+		if (BREAKS_ANISOTROPY.matcher(line).matches()) {
 			return;
 		}
 
@@ -1556,6 +1566,30 @@ public final class ShaderProperties {
 	public boolean separateAo(Map<String, String> defines) {
 		Boolean asked = null;
 		for (Matcher line : live(SEPARATE_AO, defines)) {
+			asked = truth(line.group(1).trim());
+		}
+
+		return Boolean.TRUE.equals(asked);
+	}
+
+	/**
+	 * Whether the pack declares that anisotropic filtering breaks the way it reads the block atlas,
+	 * live lines only, off unless it says otherwise.
+	 * <p>
+	 * A pack that asks for it is not asking for a look: it is saying that neighbouring sprites bleed
+	 * into each other at grazing angles once the sampler averages across their border, which is a
+	 * strip of the wrong texture along a block edge seen from low down. BSL and both Complementary
+	 * variants write it. Iris reads it into its directives
+	 * ({@code shaderpack/properties/ShaderProperties.java:212}) and forces the anisotropy of the
+	 * terrain sampler to one where it holds, whatever the player set
+	 * ({@code samplers/IrisSamplers.java:250}).
+	 * <p>
+	 * Read through {@link #live} and answered like {@link #separateAo}, whose note carries why the
+	 * last live line decides even when it carries a word this cannot read.
+	 */
+	public boolean breaksAnisotropy(Map<String, String> defines) {
+		Boolean asked = null;
+		for (Matcher line : live(BREAKS_ANISOTROPY, defines)) {
 			asked = truth(line.group(1).trim());
 		}
 

--- a/common/src/main/java/dev/vitrail/render/BlockStateIds.java
+++ b/common/src/main/java/dev/vitrail/render/BlockStateIds.java
@@ -185,8 +185,12 @@ public final class BlockStateIds {
 
 	/**
 	 * The number to put on the mesh for one block state, packed the way the shader unpacks it:
-	 * {@code ((id + 1) << 1) | isFluid}. The fluid bit is nought here, since every quad this is asked
-	 * for comes from the block renderer and the fluid renderer pushes its own.
+	 * {@code ((id + 1) << 1) | isFluid}.
+	 * <p>
+	 * <strong>The fluid bit is nought on every quad in the world.</strong> The fluid renderer comes
+	 * through this same method ({@code mixin/DefaultFluidRendererMixin.java:80}) rather than pushing
+	 * a number of its own, and {@link #packedFrom} sets no bit, so a pack reading {@code mc_Entity.y}
+	 * cannot tell water from any other block. That is issue 108 and it is not corrected here.
 	 */
 	public static int packed(BlockState state) {
 		int id = table.getInt(state);

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -2182,9 +2182,12 @@ final class GeometryProgram {
 		// The shadow DEPTH is LINEAR too, and the reason a reader reaches for to keep it NEAREST
 		// does not hold: where the compare mode is on, a sampler averages the RESULTS of the
 		// four tests and never the depths, so nothing is ever compared against a surface that exists
-		// nowhere. Iris filters this LINEAR whatever the pack asks, its SamplingSettings starting at
-		// nearest=false, and adds GL_COMPARE_REF_TO_TEXTURE on top only where the pack writes
-		// shadowHardwareFiltering. The manual PCF loops packs write are the whole point either way,
+		// nowhere. Iris filters this LINEAR unless the pack asks otherwise, its SamplingSettings
+		// starting at nearest=false and shadowtexNearest with its per-index spellings turning that
+		// round (shadows/ShadowRenderer.java:267-280), and adds GL_COMPARE_REF_TO_TEXTURE on top
+		// only where the pack writes shadowHardwareFiltering. Those three names are not read here
+		// and no pack of the corpus writes one, which is what PackPass says of the same bind two
+		// files away. The manual PCF loops packs write are the whole point either way,
 		// since every tap of such a loop rides on this filter. It has to match PackPass, which binds
 		// the same name for the full screen passes: the two halves of one frame reading one map
 		// through two filters is a difference nothing would ever explain.

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -12,7 +12,6 @@ import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.DrawBuffers;
 import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.TargetName;
-import dev.vitrail.pack.texture.CustomImages;
 import dev.vitrail.pack.texture.TextureStage;
 import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.TextSink;
@@ -2189,15 +2188,12 @@ final class GeometryProgram {
 		// since every tap of such a loop rides on this filter. It has to match PackPass, which binds
 		// the same name for the full screen passes: the two halves of one frame reading one map
 		// through two filters is a difference nothing would ever explain.
-		// A custom image follows its format, which is Iris's rule (GlImage filters a non-integer
-		// image LINEAR): the floodfill volumes are rgba16f and the light they carry is continuous,
-		// so NEAREST turns every voxel into a lit brick with a hard edge. An integer volume keeps
-		// NEAREST, since ids do not average.
+		// A custom image follows its format, and it is asked of one place for the same reason the
+		// shadow map is: a volume read one way here and another from a composite is a difference
+		// nothing would ever explain. PackPass.customImageFilter is that place.
 		return switch (binding.kind()) {
 			case NOISE, SHADOW_COLOUR, SHADOW_DEPTH -> FilterMode.LINEAR;
-			case CUSTOM_IMAGE -> CustomImages.image(sampler)
-					.map(image -> image.internalFormat().used().integer())
-					.orElse(true) ? FilterMode.NEAREST : FilterMode.LINEAR;
+			case CUSTOM_IMAGE -> PackPass.customImageFilter(sampler);
 			default -> FilterMode.NEAREST;
 		};
 	}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -657,6 +657,10 @@ public final class PackChain {
 		// stops between two families once the chain is released, which leaves the one family already
 		// under way, and that is the whole of what can still land here.
 		CustomStorage.clear();
+		// Down before the folder is read rather than raised only where a pack asks for it: every
+		// road out of this method below has to leave the terrain sampler answering for the pack
+		// that will draw, and most of them draw no pack at all.
+		TerrainSampler.breaksAnisotropy(false);
 		// Taken before anything reads the folder, so that the count printed at the end of the load
 		// covers every opening the load made and not only the translation's.
 		int openings = ShaderPackSource.openings();
@@ -886,6 +890,12 @@ public final class PackChain {
 				String world = PackPlace.world();
 
 				PackValues values = PackValues.read(opened, place);
+				// The terrain sampler is a static that outlives any one chain, and this is the
+				// first point in the load where the pack's own answer exists. It has to be in force
+				// before a chunk pass begins rather than when the chain is installed: the sampler is
+				// settled from the renderer's begin, which the world's first draw reaches, and a
+				// pack that cannot bear anisotropy would otherwise read one frame with it.
+				TerrainSampler.breaksAnisotropy(values.breaksAnisotropy());
 
 				long began = System.nanoTime();
 				Optional<PackProgram.Chain> read =
@@ -3616,6 +3626,10 @@ public final class PackChain {
 		}
 
 		CustomImages.clear();
+		// Beside it, and said here as well as at the head of a load: leaving a world releases the
+		// chain without replacing it, so this is the moment the pack's declaration stops holding,
+		// whether or not another load ever follows.
+		TerrainSampler.breaksAnisotropy(false);
 		this.compute.close();
 		this.targets.release();
 		if (this.features != null) {

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -13,6 +13,7 @@ import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.target.TargetName;
 import dev.vitrail.pack.target.TargetSchedule;
 import dev.vitrail.pack.texture.CustomImages;
+import dev.vitrail.pack.texture.TextureStage;
 import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.UniformCatalog;
 import dev.vitrail.Vitrail;
@@ -521,6 +522,13 @@ final class PackCompute implements AutoCloseable {
 		/** The full screen pass this compute hangs off, or null for a shadow compute. */
 		private final String program;
 
+		/**
+		 * Which stage a {@code texture.<stage>.<sampler>} line has to name for this compute to read
+		 * the file behind it. A shadow compute is the {@code shadowcomp} stage by construction: it
+		 * hangs off no pass, so there is nothing else it could be.
+		 */
+		private final TextureStage textureStage;
+
 		private final String label;
 		private final Set<String> failed = new LinkedHashSet<>();
 		private MappableRingBuffer block;
@@ -537,6 +545,9 @@ final class PackCompute implements AutoCloseable {
 			this.path = path;
 			this.name = path.substring(path.lastIndexOf('/') + 1);
 			this.program = program;
+			this.textureStage = program == null
+					? TextureStage.SHADOWCOMP
+					: TextureStage.of(program).orElse(null);
 			this.label = "pack/" + load + "/" + path + "/compute";
 			this.uniforms = new PackUniforms(compute.loaded().program().uniforms(), catalog);
 		}
@@ -820,6 +831,26 @@ final class PackCompute implements AutoCloseable {
 
 				StorageImages.Bound bound = StorageImages.bound(entry.name());
 				VkDescriptorImageInfo.Buffer imageInfo = VkDescriptorImageInfo.calloc(1, stack);
+
+				// A texture the pack ships answers here exactly as it answers a full screen pass:
+				// which image, how it is filtered and how it is addressed outside zero to one are
+				// all the pack's to say, in one directive and the .mcmeta beside the file. Asked
+				// BEFORE the colour targets for the reason PackPass asks it first as well: a pack
+				// may lay a lookup table over the name of a real target for one stage, and reading
+				// the name first would hand the compute a copy of the scene as a lookup table.
+				ColorTargets.PackBinding supplied = bound == null
+						? targets.packTexture(this.textureStage, entry.name())
+						: null;
+				if (supplied != null && supplied.view() instanceof VulkanGpuTextureView served) {
+					imageInfo.sampler(((VulkanGpuSampler) PackPass.sampler(supplied.repeat(),
+							supplied.filter(), false)).vkSampler());
+					imageInfo.imageView(served.vkImageView());
+					imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+					write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+					write.pImageInfo(imageInfo);
+					continue;
+				}
+
 				if (bound == null && step != null && colourTarget(write, imageInfo, entry.name(),
 						targets, step, this.program)) {
 					continue;

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -421,13 +421,19 @@ final class PackCompute implements AutoCloseable {
 	 * The same sampler state the graphics passes bind for the name. The noise field repeats and
 	 * is filtered, Iris's choice: a pack indexes it in texels well past one, and clamped it reads
 	 * the same edge row for the whole volume. The shadow set is filtered the way Iris filters its
-	 * shadow samplers. A pack's own image stays NEAREST and clamped, on the pack's own indexing.
+	 * shadow samplers. A volume the pack declared follows its format, through the one place that
+	 * answers that for every road, so a compute reads it exactly as the composite after it will.
 	 */
 	private static long samplerFor(String name) {
 		boolean noise = "noisetex".equals(name);
 		boolean shadow = name.startsWith("shadowtex") || name.startsWith("shadowcolor");
-		return ((VulkanGpuSampler) PackPass.sampler(noise,
-				noise || shadow ? FilterMode.LINEAR : FilterMode.NEAREST, false)).vkSampler();
+		// Every other name keeps the answer this line gave before there was one place to ask:
+		// customImageFilter is NEAREST for a name no image directive declared.
+		FilterMode filter = noise || shadow
+				? FilterMode.LINEAR
+				: PackPass.customImageFilter(name);
+
+		return ((VulkanGpuSampler) PackPass.sampler(noise, filter, false)).vkSampler();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -7,6 +7,7 @@ import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.TargetName;
 import dev.vitrail.pack.target.TargetSchedule;
+import dev.vitrail.pack.texture.CustomImages;
 import dev.vitrail.pack.texture.TextureStage;
 import dev.vitrail.uniform.TextSink;
 import dev.vitrail.uniform.WorldState;
@@ -633,9 +634,13 @@ final class PackPass {
 			//
 			// The three names that would ask for NEAREST back - shadowtexNearest, shadowtexNNearest
 			// and shadowNMinMagNearest - are not read: no pack of the corpus writes one.
+			//
+			// A custom image is the image's own answer and not this pass's, which is why it is
+			// asked of one place rather than decided here: see customImageFilter.
 			FilterMode filter = supplied != null ? supplied.filter() : switch (binding.kind()) {
 				case COLORTEX -> targets.filter(binding.index());
 				case NOISE, SHADOW_COLOUR, SHADOW_DEPTH -> FilterMode.LINEAR;
+				case CUSTOM_IMAGE -> customImageFilter(sampler);
 				default -> FilterMode.NEAREST;
 			};
 
@@ -720,6 +725,29 @@ final class PackPass {
 	 */
 	static GpuSampler sampler(SamplerPlan.Kind kind, FilterMode filter, boolean mipmaps) {
 		return sampler(kind == SamplerPlan.Kind.NOISE, filter, mipmaps);
+	}
+
+	/**
+	 * How a custom image is filtered, which its FORMAT decides and not the pass reading it.
+	 * <p>
+	 * Iris settles this once and on the image itself, when it allocates it
+	 * ({@code gl/image/GlImage.java:51-53}): LINEAR unless the format is integer, and every
+	 * consumer then reads it through that one setting. There is no such place here, an image being
+	 * bound with a sampler of the caller's choosing, so this method is that place instead: the
+	 * geometry programs, the full screen passes and the compute passes all ask it, and a pack
+	 * therefore reads one volume the same way wherever it reads it from.
+	 * <p>
+	 * The floodfill volumes are {@code rgba16f} and the light they carry is continuous, so NEAREST
+	 * turns every voxel into a lit brick with a hard edge for the packs that interpolate them.
+	 * Most read them with {@code texelFetch}, which no filter reaches, which is why only some show
+	 * it. The format's half of the answer is {@link GpuFormats#filterFor}, which the colour targets
+	 * already go through; what is this method's own is the default for a name no {@code image.}
+	 * directive declared, and that is NEAREST.
+	 */
+	static FilterMode customImageFilter(String sampler) {
+		return CustomImages.image(sampler)
+				.map(image -> GpuFormats.filterFor(image.internalFormat().used()))
+				.orElse(FilterMode.NEAREST);
 	}
 
 	/** The same, where the addressing is the pack's own answer rather than the name's. */

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -93,6 +93,7 @@ public final class PackValues {
 	private ShadowCullState shadowCull = ShadowCullState.DEFAULT;
 
 	private boolean separateAo;
+	private boolean breaksAnisotropy;
 	private Optional<String> particleOrdering = Optional.empty();
 	private NoiseTexture.Image noiseImage;
 	private PackImages packImages = PackImages.none();
@@ -138,6 +139,7 @@ public final class PackValues {
 		values.dhShadow = properties.dhShadow(settings.globalDefines(options));
 		values.shadowCull = properties.shadowCull(settings.globalDefines(options));
 		values.separateAo = properties.separateAo(settings.globalDefines(options));
+		values.breaksAnisotropy = properties.breaksAnisotropy(settings.globalDefines(options));
 		values.particleOrdering = properties.particleOrdering(settings.globalDefines(options));
 		values.declare(properties, settings.globalDefines(options));
 		values.readNoise(properties, source, settings.globalDefines(options));
@@ -586,6 +588,16 @@ public final class PackValues {
 	 */
 	public boolean separateAo() {
 		return this.separateAo;
+	}
+
+	/**
+	 * Whether this pack declared that anisotropy breaks the way it reads the block atlas. What
+	 * answers it is the SAMPLER and not the translation: {@code TerrainSampler} asks for an
+	 * anisotropy of one while it holds, and the {@code anisotropicFiltering} uniform still carries
+	 * the player's value, which is the number a pack reads to know what it is up against.
+	 */
+	public boolean breaksAnisotropy() {
+		return this.breaksAnisotropy;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PbrAtlases.java
+++ b/common/src/main/java/dev/vitrail/render/PbrAtlases.java
@@ -41,8 +41,11 @@ import java.util.Properties;
  * Only the geometry programs are served, which is Iris's shape: {@code normals} and
  * {@code specular} are added by {@code IrisSamplers.addLevelSamplers} and by nothing else
  * ({@code samplers/IrisSamplers.java:215-216}). What a composite declaring one of the names reads
- * is NOT the same on both sides and this file does not claim it is: here it reads a flat texel,
- * where Iris leaves the sampler unassigned and it falls to whatever texture unit nought holds.
+ * is NOT the same on both sides and this file does not claim it is: here the full screen binding
+ * resolves such a name to one black pixel ({@code render/PackPass.java:610}), where Iris leaves the
+ * sampler unassigned and it falls to whatever texture unit nought holds. The flat texel this class
+ * falls back on answers a different question, which is a GEOMETRY program reading a sprite the
+ * resource pack ships no map for.
  */
 public final class PbrAtlases {
 

--- a/common/src/main/java/dev/vitrail/render/TerrainSampler.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainSampler.java
@@ -35,9 +35,13 @@ import java.util.OptionalDouble;
  * <p>
  * The anisotropy is the player's, read the way the game and Iris both read it, and the cache is
  * keyed by it so that changing the setting builds one more sampler rather than reusing a stale one.
- * Iris additionally forces it to one for a pack that cannot bear it, which this engine has no
- * equivalent of and does not pretend to. Released when the client closes, the one moment the device
- * is known to be going away with it.
+ * A pack that declares {@code breaksAnisotropy} is asked for one instead, whatever the player set,
+ * which is what Iris does at the same point ({@code samplers/IrisSamplers.java:250}): such a pack
+ * says that averaging across a sprite's border bleeds its neighbour into it, and that is a strip of
+ * the wrong texture along a block edge rather than a matter of taste. What the pack reads to know
+ * the setting is the {@code anisotropicFiltering} uniform, and that keeps the player's value on both
+ * engines ({@code uniforms/CommonUniforms.java:166-172}). Released when the client closes, the one
+ * moment the device is known to be going away with it.
  */
 public final class TerrainSampler {
 
@@ -47,7 +51,23 @@ public final class TerrainSampler {
 	 */
 	private static final Map<Integer, GpuSampler> BY_ANISOTROPY = new HashMap<>();
 
+	/**
+	 * Whether the pack now loaded declared that anisotropy breaks it. A static because this sampler
+	 * is one, and volatile because the pack that sets it is read on the loading worker while the
+	 * draws that ask for it run on the render thread.
+	 */
+	private static volatile boolean breaksAnisotropy;
+
 	private TerrainSampler() {
+	}
+
+	/**
+	 * Told what the pack about to be drawn declared, and told again with false when no pack is
+	 * drawn: this outlives any one chain, so a pack that could not bear anisotropy would otherwise
+	 * go on refusing it for the pack picked after it.
+	 */
+	public static void breaksAnisotropy(boolean breaks) {
+		breaksAnisotropy = breaks;
 	}
 
 	/**
@@ -65,7 +85,8 @@ public final class TerrainSampler {
 			return null;
 		}
 
-		int anisotropy = minecraft.options.textureFiltering().get() == TextureFilteringMethod.ANISOTROPIC
+		int anisotropy = !breaksAnisotropy
+				&& minecraft.options.textureFiltering().get() == TextureFilteringMethod.ANISOTROPIC
 				? minecraft.options.maxAnisotropyValue()
 				: 1;
 

--- a/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
+++ b/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
@@ -130,8 +130,14 @@ public final class ConfigEntry implements ConfigEntryPoint {
 				//
 				// Asked through UPDATE_ON_REBUILD rather than read once, so the list follows a pack
 				// loaded or dropped while the game is up rather than the state the screen was first
-				// built under. A stored RGSS is not carried around the gap: Sodium falls back to the
-				// option's default for a value its own allowed set no longer holds.
+				// built under.
+				//
+				// A stored RGSS survives the narrowing, and that is not something this overlay can
+				// change from here. Sodium answers a value its allowed set no longer holds with the
+				// option's default (EnumOption.validateValue), and its default for this option is
+				// RGSS itself (SodiumConfigBuilder.java:511), so the fall back lands on the value it
+				// was meant to replace: the selector opens on a name outside the set it offers, and
+				// the player cannot cycle back to it once they have moved off.
 				.registerOptionOverlay(FILTERING,
 						builder.createEnumOption(FILTERING, TextureFilteringMethod.class)
 								.setAllowedValuesProvider(

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -306,9 +306,16 @@ public final class ShadowTerrain {
 		// The game's own chunk sampler, mipmapped and clamped, and it is NOT what the pack's shadow
 		// programs read the atlas through: the renderer hands this to begin, where the chunk
 		// renderer mixin settles the pack's sampler for every pass, this one included, so the shadow
-		// half binds the same NEAREST sampler as the gbuffer half or the game's under the legacy
-		// switch, either way through TerrainSampler and LegacyTerrainFilter and never through this
-		// argument. What this argument reaches is Sodium's own shader, on a pass handed back to it,
+		// half binds the same NEAREST sampler as the gbuffer half, through TerrainSampler and never
+		// through this argument.
+		//
+		// The legacy switch does NOT part the two halves the way it reads: it puts the game's LINEAR
+		// back through LegacyTerrainFilter, which is the sampler the renderer hands begin, and the
+		// argument on this line is NEAREST rather than the game's. So the gbuffer half gets the
+		// game's filter back and the shadow half stays NEAREST either way, and an A/B taken with
+		// the switch measures the gbuffer change alone.
+		//
+		// What this argument reaches is Sodium's own shader, on a pass handed back to it,
 		// and there Iris hands NEAREST down the same road (shadows/ShadowRenderer.java:389), where
 		// the gbuffers hand it the game's LINEAR: NEAREST here too, so that the one pass Sodium
 		// draws itself filters as it does under Iris. Iris's SodiumShader.setupState binds its own


### PR DESCRIPTION
## What changes

Three things a pack says about how its images are read are now believed. A volume declared with an
`image.` line is filtered by its format wherever it is read: the answer was written in three places
and only the geometry programs had it right, so one volume came back smooth in a gbuffer and in
voxel-sized bricks from a composite. Photon's deferred shading and Bliss's light propagation
composites interpolate theirs and showed it. A compute pass gained the row it never had for a
texture the pack ships, so the blur and the wrapping of the `.mcmeta` reach it as they reach a
full-screen pass, instead of a name spelled like a colour target reading the target and any other
spelling leaving that one compute skipped with a warning while its pass drew on without what the
compute was there to prepare. And `breaksAnisotropy` is parsed and published:
BSL and both Complementary variants declare it, and with Texture Filtering on Anisotropic their
terrain bled the neighbouring sprite along a block edge seen from low down. Their shadow map takes
the same road, every chunk pass settling its sampler where the chunk renderer begins, so both
halves lose the anisotropy together. Five comments and a changelog line describing behaviour the
code does not have are corrected with them, no code moving.

## How it differs from the reference, and for what obstacle

It does not. Iris sets the filter on the image at allocation (`gl/image/GlImage.java:51-53`); there
is no image-side setting here, a sampler being bound by the caller, so the same rule lives in one
method the three roads call. It forces the terrain anisotropy to one for a pack that declares it
(`samplers/IrisSamplers.java:250`) and leaves the `anisotropicFiltering` uniform carrying the
player's value (`uniforms/CommonUniforms.java:166-172`); both hold here.

## What proves it

- `gradlew build` green.
- The harness, on the eleven entries of the corpus: `Harness`, `Cles` and `Echantillonneurs` print
  byte for byte what they print on `dev`, so no sampler classification and no pack key moved. None
  of them measures a filter mode or a directive boolean, so they say the fixes broke nothing they
  see rather than that the fixes work. A probe on the same tree reads `breaksAnisotropy` true for
  five of the eleven, BSL plus Reimagined and Unbound in both the forms the folder holds of each,
  and false for the other six, which is the set expected.
- Not looked at in the game. What to look at: Photon or Bliss, a light volume in a deferred pass,
  which should hold no voxel-sized bricks; Complementary with Anisotropic Filtering at 8, along a
  block edge seen from low down, which should show no strip of the neighbouring texture.

## What it leaves owing

`shadowtexNearest` and its per-index spellings stay unread, so a pack asking for an unfiltered
shadow map does not get one; no pack of the corpus writes one. The compute road's pack-texture row
follows the full-screen one line for line, and no corpus pack exercises it.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
