### PR TITLE
fix(screen): apply a settings import only on the screen that asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ what the next one holds.
 
 ### Fixed
 
+- **Importing settings no longer acts on a screen you have already left.** The window that asks
+  which file to read is the system's own and does not hold the game, so the settings screen can be
+  closed while it is still up. Picking a file at that point queued its values anyway, into a page
+  nobody was looking at and from the picker's thread rather than the game's, so a pack ended up
+  carrying settings the player had walked away from. A file picked after leaving the screen is now
+  dropped, and one picked while the screen is still up is read on the game's own thread. Exporting
+  was never affected: it copies the settings file of the pack that was open when the button was
+  pressed, and touches nothing on screen.
+
 - **A pack that says it cannot bear anisotropic filtering is believed.** BSL and both
   Complementary variants write `breaksAnisotropy` in their `shaders.properties`, and the line was
   read nowhere: with Texture Filtering set to Anisotropic in Video Settings, their terrain showed

--- a/common/src/main/java/dev/vitrail/screen/OptionList.java
+++ b/common/src/main/java/dev/vitrail/screen/OptionList.java
@@ -372,12 +372,25 @@ public final class OptionList extends WidgetList<OptionList.BaseEntry> {
 			return true;
 		}
 
+		/**
+		 * Queues whatever a settings file the player picked carries, once the platform's window has
+		 * been answered.
+		 * <p>
+		 * <b>Nothing holds the player on this screen while that window is up</b>, and the answer comes
+		 * back on the dialog's own thread, so it is put back on the game's thread and then dropped when
+		 * the screen has walked on. Importing queues values into the page and redraws it; doing that to
+		 * a screen the player has left moves settings nobody asked to move, off the thread that owns
+		 * the widgets. Iris makes the same comparison ({@code ShaderPackOptionList.java:386,399}) and
+		 * makes it from the dialog's thread.
+		 */
 		private boolean importSettings() {
 			ScreenDraw.clickSound();
 			if (!canOpenDialog()) {
 				return false;
 			}
 
+			Minecraft minecraft = Minecraft.getInstance();
+			Screen asking = minecraft.gui.screen();
 			Path origin = this.host.settingsFile();
 			FileDialog
 					.choose(FileDialog.Kind.OPEN, "Import Shader Settings from File", origin)
@@ -388,7 +401,11 @@ public final class OptionList extends WidgetList<OptionList.BaseEntry> {
 							return;
 						}
 
-						chosen.ifPresent(this.host::importSettings);
+						chosen.ifPresent(file -> minecraft.execute(() -> {
+							if (minecraft.gui.screen() == asking) {
+								this.host.importSettings(file);
+							}
+						}));
 					});
 
 			return true;
@@ -398,6 +415,10 @@ public final class OptionList extends WidgetList<OptionList.BaseEntry> {
 		 * Copies this pack's settings file to wherever the player asks for it, which is what Iris does
 		 * and why what is written is the applied settings rather than what is on screen: the file is
 		 * the applied settings.
+		 * <p>
+		 * No screen check and no hop back, unlike {@link #importSettings()}: the file to read is taken
+		 * before the window opens and the answer touches nothing the screen owns, so leaving the screen
+		 * mid-window still writes the pack the player was looking at when they asked.
 		 */
 		private boolean exportSettings() {
 			ScreenDraw.clickSound();


### PR DESCRIPTION
## What changes

Importing a settings file no longer acts on a screen the player has already left. The file dialog is the system's own window and does not hold the game, so the settings screen can be closed while it is up; picking a file at that point queued its values into a page nobody was on, from the dialog's thread. The answer now comes back on the game's thread and is dropped when the current screen is not the one that asked. Export is unchanged: the file it copies is taken before the window opens and the copy touches nothing the screen owns.

## How it differs from the reference, and for what obstacle

It does not. Iris makes the same screen comparison (`ShaderPackOptionList.java:386,399`), from the dialog's thread; here the comparison is made after hopping back to the game's thread, because on 26.2 the current screen is read through the `Gui` rather than a field of `Minecraft`, and the widgets it redraws belong to that thread.

## What proves it

- `gradlew build` green.
- No off-game harness covers `screen/`.
- Not tried in game: the gesture is opening a pack's settings, clicking import, closing the screen while the file window is up, then picking a file. Expected: no exception, no announcement, no value moved; the same gesture without leaving the screen still imports and redraws.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
