### PR TITLE
fix(glsl): refuse a stored translation too large to be one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ what the next one holds.
   was never affected: it copies the settings file of the pack that was open when the button was
   pressed, and touches nothing on screen.
 
+- **A damaged file in the translation cache no longer ends the session.** The cache keeps what a
+  pack's programs came to last time, so that loading that pack again costs less. A file in it far
+  larger than any translation is, damaged where it lies or carried in from another machine, was
+  read whole into memory before anything could ask whether it made sense, and running out of
+  memory reading it stopped the game rather than counting as a miss. Such a file is now refused
+  before it is read, the program is translated as it would have been anyway, and the log names
+  what was refused, once.
+
 - **A pack that says it cannot bear anisotropic filtering is believed.** BSL and both
   Complementary variants write `breaksAnisotropy` in their `shaders.properties`, and the line was
   read nowhere: with Texture Filtering set to Anisotropic in Video Settings, their terrain showed

--- a/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
@@ -25,6 +25,7 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
@@ -61,8 +62,8 @@ import java.util.zip.InflaterOutputStream;
  * vertex format is written into the blob as well as into the key, and read back and compared, so a
  * key that has come apart from its blob is caught rather than believed.
  * <p>
- * Absent, unreadable, corrupt, or of a shape this build cannot read: every one of them is a MISS,
- * and a miss is the translation that would have happened anyway.
+ * Absent, unreadable, corrupt, larger than any translation is, or of a shape this build cannot
+ * read: every one of them is a MISS, and a miss is the translation that would have happened anyway.
  * <p>
  * The store is bounded at a quarter of a gigabyte and bounded per edition, and it is off until
  * somebody installs it. {@code -Dvitrail.translationDir=<path>} installs it outside the game, which
@@ -86,6 +87,14 @@ public final class TranslationCache {
 	/** SHA-256, sitting behind the blob in every file and answering for it. */
 	private static final int DIGEST_BYTES = 32;
 
+	/**
+	 * How large one file may be before it is refused unread. A translated program comes to a
+	 * quarter of a megabyte before it is squeezed, so this is two orders of magnitude of room; what
+	 * it is really for is a file that grew for a reason nothing here can name, which would
+	 * otherwise be read whole into the heap before anything got the chance to refuse it.
+	 */
+	private static final long MOST_BYTES = 64L * 1024L * 1024L;
+
 	private static final long CEILING_BYTES = 256L * 1024L * 1024L;
 	private static final long SWEEP_TARGET = CEILING_BYTES / 4L * 3L;
 
@@ -94,6 +103,9 @@ public final class TranslationCache {
 	private static final AtomicLong SERVED = new AtomicLong();
 	private static final AtomicLong TRANSLATED = new AtomicLong();
 	private static final AtomicLong BYTES = new AtomicLong();
+
+	/** The one blob refused rather than served this run, waiting for whoever has a logger. */
+	private static final AtomicReference<String> REFUSAL = new AtomicReference<>("");
 
 	/** Held for the one scan at install and for every sweep. */
 	private static final Object LOCK = new Object();
@@ -104,6 +116,9 @@ public final class TranslationCache {
 
 	/** How long a sweep that could not finish stays out of the way of the next write. */
 	private static volatile long nextSweepNanos;
+
+	/** Raised by the first refusal of the run and never lowered, which is what makes it one a run. */
+	private static volatile boolean refused;
 
 	static {
 		// Inside the try and not beside it: Path.of refuses a name Windows will not have, and an
@@ -171,6 +186,33 @@ public final class TranslationCache {
 		return directory != null;
 	}
 
+	/**
+	 * The one blob this run refused rather than served, taken and cleared, or empty when there was
+	 * none and empty for the rest of the run once it has been taken.
+	 * <p>
+	 * Taken rather than read, because there is no logger to reach from here: this package names
+	 * nothing a game brings, which is what lets the whole translator be run over the corpus without
+	 * starting one. The pack chain takes it at the end of a load, which is late by up to a load: a
+	 * load that turned back before it, or a family that translates on a worker after it, leaves the
+	 * note for the load after. Installed from {@code vitrail.translationDir} instead, nothing takes
+	 * it at all and a refusal there is silent, which is what running without a game costs.
+	 */
+	public static String takeRefusal() {
+		return REFUSAL.getAndSet("");
+	}
+
+	/**
+	 * Keeps the first refusal of the run and no other: the ones after it are the same story told
+	 * again. The latch stays up once it is raised, so a refusal in a later load finds the note
+	 * already said rather than saying it a second time.
+	 */
+	private static void refuse(String what) {
+		if (!refused) {
+			refused = true;
+			REFUSAL.set(what);
+		}
+	}
+
 	public static long served() {
 		return SERVED.get();
 	}
@@ -200,10 +242,25 @@ public final class TranslationCache {
 		Path file = root.resolve(key + SUFFIX);
 		byte[] raw;
 		try {
+			// Asked before the read and not after it: the digest sits behind the blob, so nothing
+			// can answer for a file that is not already whole in the heap, and a file that grew
+			// past what a translation is would be read before anything could refuse it.
+			if (Files.size(file) > MOST_BYTES) {
+				refuse("a stored translation is larger than any translation is");
+
+				return null;
+			}
+
 			raw = Files.readAllBytes(file);
 		} catch (IOException e) {
 			// Absent is the ordinary case and unreadable the rare one. What follows either way is
 			// the translation that would have happened anyway.
+			return null;
+		} catch (OutOfMemoryError e) {
+			// The size was asked for above, so this is a heap that was already at its edge rather
+			// than a file that lied about itself. It is still a miss and never a dead load.
+			refuse("there was no room to read a stored translation");
+
 			return null;
 		}
 
@@ -217,6 +274,14 @@ public final class TranslationCache {
 			byte[] blob = inflate(raw, length);
 			program = TranslatedProgramCodec.read(blob, blob.length, inputs);
 		} catch (IOException | RuntimeException e) {
+			return null;
+		} catch (OutOfMemoryError e) {
+			// Not the damaged file: the digest above answers for the bytes on disk, so damage is
+			// already a miss by the time the inflate begins. What the digest says nothing about is
+			// what those bytes unpack to, which leaves a file written to inflate far past the size
+			// it was refused on, or a heap that was already at its edge.
+			refuse("a stored translation did not fit the heap once it was unpacked");
+
 			return null;
 		}
 

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -961,6 +961,17 @@ public final class PackChain {
 				Vitrail.logger().info("Translation cache: {} programs served from disk, {} "
 								+ "translated, counted at the same point of the load as the line "
 								+ "above", TranslationCache.served(), TranslationCache.translated());
+				// Said from here and not from there: the cache lives in a package that names
+				// nothing the game brings, so it keeps the note and this takes it. Once a run is
+				// the cache's own latch and not this take. Here is also as early as a load can
+				// say it and no earlier: a load that turned back above, or a family translating
+				// on the worker started below, leaves the note for the load after this one.
+				String refused = TranslationCache.takeRefusal();
+				if (!refused.isEmpty()) {
+					Vitrail.logger().warn("In the translation cache, {}, so it was translated "
+							+ "instead. Said once a run: nothing about it stops a pack loading",
+							refused);
+				}
 			}
 
 			active.startFamilyPrefetch();


### PR DESCRIPTION
## What changes

The translation store on disk asked whether a file made sense only after reading it whole, so a damaged or foreign blob in `vitrail/translations` went into the heap first, and the `OutOfMemoryError` that came out ended the session: the pack load catches `IOException` and `RuntimeException`, not an `Error`. The store now asks the file's size first and refuses anything larger than a translation can be, unread; it also catches the `Error` on both ends of the read, since the digest answers for the bytes on disk and not for what they inflate to. A refusal is a miss like any other, the program is translated again, and the log says so once a run.

## How it differs from the reference, and for what obstacle

It does not: Iris has no translation store. The shape is the module store's beside it, which already asked the size first.

## What proves it

- `gradlew build` green.
- Off-game: a probe under a 64 MiB heap against a 65 MiB file placed in a store, built from the base commit and from this branch. Before: `OutOfMemoryError` escapes `TranslationCache.lookup`. After: the lookup returns a miss and the refusal note reads as expected.
- The real store of the Fabric bench holds 339 blobs, the largest under 200 KiB, so the cap is two orders of magnitude above anything legitimate.
- Not tried in game: nothing a launch on a healthy store would show.

## What it leaves owing

The note is said at the end of the load that follows the refusal, so a refusal from a family translating on a worker is reported one load late. Installed outside the game through `vitrail.translationDir`, nothing takes the note and a refusal there is silent.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
