### PR TITLE
fix(render): set the fluid bit on a fluid quad's block id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ what the next one holds.
   sees the fire as an entity it never named, as it is under Iris, where before the fire read as
   the mob it wraps.
 
+- **A pack can tell water and lava from the blocks around them.** Half of the number a chunk quad
+  carries says whether the quad is a fluid, and it said no on every quad in the world, so a pack
+  that draws fluid surfaces apart drew them like stone. Both Complementary variants read it to hold
+  the mip level down on flowing lava, which their own comment says comes out broken without it, and
+  that guard is compiled in only with Anisotropic Filtering on 8 or 16, not on the 0 they ship nor
+  on 4: there the guard never fired and the lava kept the broken level. Fluid quads now say what
+  they are, in the terrain and in the shadow map alike, as they do under Iris, and they say it even
+  where the pack gave the fluid no number of its own.
+
 - **A pack that says it cannot bear anisotropic filtering is believed.** BSL and both
   Complementary variants write `breaksAnisotropy` in their `shaders.properties`, and the line was
   read nowhere: with Texture Filtering set to Anisotropic in Video Settings, their terrain showed

--- a/common/src/main/java/dev/vitrail/mixin/DefaultFluidRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/DefaultFluidRendererMixin.java
@@ -24,8 +24,9 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
- * Gives a fluid quad the number {@code block.properties} gave the fluid, which is what tells a pack
- * that water is water.
+ * Gives a fluid quad the number {@code block.properties} gave the fluid, and under it the bit that
+ * says the quad is a fluid at all, which is what tells a pack that water is water even where the
+ * pack named no fluid. {@link BlockStateIds#packedFluid} is the entry the block path does not take.
  * <p>
  * Fluids never went through {@code BlockRenderer} at all: they have a renderer of their own, and its
  * push takes a {@code Material} rather than the int the block path hands over, so there was nowhere
@@ -77,7 +78,7 @@ public abstract class DefaultFluidRendererMixin {
 			ChunkModelBuilder builder, Material material, ColorProvider<FluidState> colours,
 			FluidModel model, CallbackInfo callback) {
 		BlockState fluidBlock = fluidState == null ? null : fluidState.createLegacyBlock();
-		this.vitrail$id = fluidBlock == null ? BlockStateIds.NONE : BlockStateIds.packed(fluidBlock);
+		this.vitrail$id = BlockStateIds.packedFluid(fluidBlock);
 
 		// The fluid's own light and not that of the block sharing its position, for the reason the
 		// class comment gives about the id: a waterlogged stair is two things to draw, and these

--- a/common/src/main/java/dev/vitrail/render/BlockStateIds.java
+++ b/common/src/main/java/dev/vitrail/render/BlockStateIds.java
@@ -55,11 +55,20 @@ public final class BlockStateIds {
 
 	/**
 	 * The largest number a declaration may carry. The encoder keeps {@link #PACKED_MASK} of what
-	 * {@link #packedFrom} produced, and that is even, so the last id whose packed form survives
-	 * whole is one below half the mask: 4194302 packs as 0x7FFFFE and 4194303 packs as 0x800000,
-	 * which the mask takes away entirely.
+	 * {@link #packedFrom} produced, which shifts the id over the {@link #FLUID} bit and leaves that
+	 * bit clear, so the value is even and the last id whose packed form survives whole is one below
+	 * half the mask: 4194302 packs as 0x7FFFFE and 4194303 packs as 0x800000, which the mask takes
+	 * away entirely.
 	 */
 	private static final int MAX_ID = (PACKED_MASK >> 1) - 1;
+
+	/**
+	 * The bit under the number, which is what a pack reads as {@code mc_Entity.y}: one on a quad the
+	 * fluid renderer drew and nought on every other quad in the world. Iris packs it in the same
+	 * place ({@code sodium/terrain/XHFPTerrainVertex.java:197}) and the shader side here is
+	 * written against that, building it as {@code a_BlockId & 1u}.
+	 */
+	private static final int FLUID = 1;
 
 	private static volatile Object2IntMap<BlockState> table = empty();
 
@@ -185,17 +194,28 @@ public final class BlockStateIds {
 
 	/**
 	 * The number to put on the mesh for one block state, packed the way the shader unpacks it:
-	 * {@code ((id + 1) << 1) | isFluid}.
-	 * <p>
-	 * <strong>The fluid bit is nought on every quad in the world.</strong> The fluid renderer comes
-	 * through this same method ({@code mixin/DefaultFluidRendererMixin.java:80}) rather than pushing
-	 * a number of its own, and {@link #packedFrom} sets no bit, so a pack reading {@code mc_Entity.y}
-	 * cannot tell water from any other block. That is issue 108 and it is not corrected here.
+	 * {@code ((id + 1) << 1) | isFluid}. The bit is nought here, which is what every quad but a
+	 * fluid's carries; the fluid renderer asks {@link #packedFluid} instead.
 	 */
 	public static int packed(BlockState state) {
 		int id = table.getInt(state);
 
 		return id < 0 ? NONE : packedFrom(id);
+	}
+
+	/**
+	 * The same number for a quad the fluid renderer drew, carrying the bit that tells a pack water
+	 * from any other block.
+	 * <p>
+	 * {@code null} for a fluid naming no block state, which still carries the bit: what the quad is
+	 * does not depend on the pack having named it, and Iris answers the same 1 there, its build task
+	 * handing an unmatched id straight on ({@code sodium/mixin/MixinChunkMeshBuildTask.java:70}).
+	 * <p>
+	 * <strong>The number travels on the vertex.</strong> Sections already meshed keep the bit they
+	 * were built with, so what shows this is a world built again and never a pack loaded again.
+	 */
+	public static int packedFluid(BlockState state) {
+		return (state == null ? NONE : packed(state)) | FLUID;
 	}
 
 	/**


### PR DESCRIPTION
## What changes

A water or lava quad carries the fluid bit in its block id, as Iris packs it: `((id + 1) << 1) | fluid`. The bit was never set here, so a pack testing `mc_Entity.y` could not tell a fluid quad from any other block. Terrain and shadow map share the same chunk meshes, so one write serves both. A pack change does not rebuild meshes: the value shows after a world rebuild.

## How it differs from the reference, and for what obstacle

It does not. Iris hands `1` for a fluid and `0` for a block in its chunk build task (`compat/sodium/mixin/MixinChunkMeshBuildTask.java:63,70`) and packs it in `vertices/sodium/terrain/XHFPTerrainVertex.java:197`; an unmatched fluid id still carries the bit, here as there.

## What proves it

- `gradlew build` green.
- Off-game harness `Terrain` on the eleven packs of the bench, base against branch, sorted output identical, 264 of 264 compiled both times: the vertex format and the terrain family are untouched. The harness does not compile the vertex writer itself, so the new value is proven by reading only.
- Corpus read in place: both Complementary builds read `mc_Entity.y`, behind their anisotropic filtering guard at 8 or 16.
- Not tried in game: flowing lava under Complementary with Anisotropic Filtering at 8, after a world rebuild.

## What it leaves owing

Nothing.


---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.

