### PR TITLE
fix(pack): define the texture format a resource pack declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ what the next one holds.
   they are, in the terrain and in the shadow map alike, as they do under Iris, and they say it even
   where the pack gave the fluid no number of its own.
 
+- **A pack is told what convention a resource pack draws its material maps in**, as Iris tells it.
+  `MC_TEXTURE_FORMAT_LAB_PBR`, and the revision beside it, are what a pack written against them
+  branches its labPBR decode on, and neither was ever posed here: such a pack read every install as
+  one where nothing had been declared. Both are posed now, from what `optifine/texture.properties`
+  names, and only where a resource pack really declares the format. Changing the resource packs
+  reads the shader pack again when that changes what is declared, since the symbols decide which
+  branch was compiled.
+
 - **A pack that says it cannot bear anisotropic filtering is believed.** BSL and both
   Complementary variants write `breaksAnisotropy` in their `shaders.properties`, and the line was
   read nowhere: with Texture Filtering set to Anisotropic in Video Settings, their terrain showed

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -80,6 +80,19 @@ public final class EngineDefines {
 	}
 
 	/**
+	 * The convention a resource pack says its material maps are drawn in, named in
+	 * {@code optifine/texture.properties}, with the version of it where the file carries one.
+	 * <p>
+	 * What is carried is the text the resource pack wrote rather than what this engine makes of it:
+	 * the version changes what the channels mean to the PACK and nothing on this side reduces or
+	 * filters differently for it, but a pack branches on the symbol built from it.
+	 *
+	 * @param version null where the file names the convention without one
+	 */
+	public record TextureFormat(String name, String version) {
+	}
+
+	/**
 	 * What the pack is being read for.
 	 *
 	 * @param vendorName      the device's vendor as the driver reports it, classified here
@@ -92,10 +105,21 @@ public final class EngineDefines {
 	 *                        have to come from the same place
 	 * @param biomeCategories the category names, in ordinal order, which is what makes
 	 *                        {@code CAT_DESERT} the number the biome value carries
+	 * @param textureFormat   what the resource pack declares its material maps are drawn in, null
+	 *                        where it declares nothing or names a convention this engine has no
+	 *                        symbol for
 	 */
 	public record Environment(int mcVersion, Os os, String vendorName, String rendererName,
 			int mipmapLevel, boolean distantHorizons, Map<String, Integer> biomes,
-			List<String> biomeCategories) {
+			List<String> biomeCategories, TextureFormat textureFormat) {
+
+		/** What a caller with no resource pack to ask hands over: {@link #of}, and the harness. */
+		public Environment(int mcVersion, Os os, String vendorName, String rendererName,
+				int mipmapLevel, boolean distantHorizons, Map<String, Integer> biomes,
+				List<String> biomeCategories) {
+			this(mcVersion, os, vendorName, rendererName, mipmapLevel, distantHorizons, biomes,
+					biomeCategories, null);
+		}
 
 		public static Environment of(int mcVersion) {
 			return new Environment(mcVersion, Os.WINDOWS, "", "", DEFAULT_MIPMAP_LEVEL, false,
@@ -125,6 +149,23 @@ public final class EngineDefines {
 		defines.put("MC_MIPMAP_LEVEL", Integer.toString(environment.mipmapLevel()));
 		defines.put("MC_NORMAL_MAP", "");
 		defines.put("MC_SPECULAR_MAP", "");
+
+		// What the resource pack says its material maps mean, beside the two names above and where
+		// Iris poses it (gl/shader/StandardMacros.java:107-112, built at
+		// pbr/format/TextureFormat.java:18-33). A pack written against the symbol guards its labPBR
+		// decode on it, and the version symbol tells such a pack which revision of the convention
+		// it is reading. Posed only where a resource pack names a convention in
+		// optifine/texture.properties, so an install where nothing names one sees neither symbol.
+		TextureFormat format = environment.textureFormat();
+		if (format != null) {
+			String symbol = "MC_TEXTURE_FORMAT_"
+					+ format.name().toUpperCase(Locale.ROOT).replace('-', '_');
+			defines.put(symbol, "");
+			if (format.version() != null) {
+				defines.put(symbol + "_" + format.version().replace('.', '_').replace('-', '_'), "");
+			}
+		}
+
 		defines.put("MAX_COLOR_BUFFERS", Integer.toString(MAX_COLOR_BUFFERS));
 
 		// Packs gate their modern paths on this rather than on a feature test. Claiming it is

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -5,6 +5,7 @@ import dev.vitrail.glsl.LoadClock;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.glsl.TranslationCache;
 import dev.vitrail.mixin.GpuDeviceAccessor;
+import dev.vitrail.pack.option.EngineDefines;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.program.TerrainPass;
@@ -1482,6 +1483,11 @@ public final class PackChain {
 			Vitrail.logger().info("Distant Horizons is drawing a far terrain now, or has stopped, so "
 					+ "the pack is read again against DISTANT_HORIZONS: the symbol is what a pack "
 					+ "branches its distant land on, and it cannot be right for both");
+		} else if (PackDefines.textureFormatMoved()) {
+			Vitrail.logger().info("The resource packs {}, so the pack is read again against "
+					+ "MC_TEXTURE_FORMAT_LAB_PBR and the revision beside it: those are what a "
+					+ "pack branches its material decode on, and they cannot be right for both",
+					textureFormatDeclared());
 		} else {
 			Vitrail.logger().info("The world's own registries are here now, reloading the pack so "
 					+ "what names a tag resolves against them");
@@ -1495,6 +1501,21 @@ public final class PackChain {
 		// old one, until somebody asks for a reload. Comparing content rather than a path would cost
 		// more than the report it saves.
 		readAgain(gameDirectory);
+	}
+
+	/**
+	 * How the line above names what the resource packs declare, and it has to name both directions:
+	 * removing the pack that declared it moves the symbols exactly as installing one does.
+	 */
+	private static String textureFormatDeclared() {
+		EngineDefines.TextureFormat format = PbrAtlases.format();
+		if (format == null) {
+			return "declare no texture format any more";
+		}
+
+		String version = format.version() == null ? "" : " " + format.version();
+
+		return "declare " + format.name() + version + " now";
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackDefines.java
+++ b/common/src/main/java/dev/vitrail/render/PackDefines.java
@@ -38,9 +38,10 @@ import java.util.Objects;
  * at {@code :249}). At startup there are none, so the first read of a session still has to be
  * made again when a world arrives, and {@link #stale()}'s registry stamp is what notices that.
  * <p>
- * Distant Horizons is the one thing here a player can change without leaving the world, from that
- * mod's own screen, so {@link #stale()} watches it beside the registry rather than trusting what
- * was true when the pack was read.
+ * Two of these move without the world moving, so {@link #stale()} watches them beside the registry
+ * rather than trusting what was true when the pack was read: Distant Horizons, which the player
+ * switches from that mod's own screen, and the material convention a resource pack declares, which
+ * a resource reload replaces.
  */
 public final class PackDefines {
 
@@ -49,6 +50,9 @@ public final class PackDefines {
 
 	/** And whether the far terrain was there, which the player can change without leaving. */
 	private static volatile boolean distant;
+
+	/** And what the resource packs declared their material maps in, which a reload replaces. */
+	private static volatile EngineDefines.TextureFormat format;
 
 	private PackDefines() {
 	}
@@ -74,6 +78,7 @@ public final class PackDefines {
 	public static void settle() {
 		installed = stamp();
 		distant = DhDepth.present();
+		format = PbrAtlases.format();
 	}
 
 	/**
@@ -81,7 +86,26 @@ public final class PackDefines {
 	 * the one reload nobody can ask for.
 	 */
 	public static boolean stale() {
-		return stamp() != installed || distantHorizonsMoved();
+		return stamp() != installed || distantHorizonsMoved() || textureFormatMoved();
+	}
+
+	/**
+	 * Whether the resource packs now declare a different material convention from the one the pack
+	 * was read against, which is what {@code MC_TEXTURE_FORMAT_LAB_PBR} and its version are posed
+	 * from. Iris asks the same question and answers it the same way, reloading the whole pipeline
+	 * on the difference ({@code pbr/format/TextureFormatLoader.java:28-32}).
+	 * <p>
+	 * It earns its keep at the first read of a NeoForge session as much as at a reload the player
+	 * asks for: client setup runs on a mod loading worker there, before the initial resource reload
+	 * exists, so no atlas has been stitched and the answer is nothing whatever the resource packs
+	 * hold. The stitch that follows is what makes it right.
+	 * <p>
+	 * The value is the one the last stitch read rather than the file, and the stitch keeps the
+	 * record it already holds where the declaration has not changed, so this costs a reference
+	 * comparison per frame and no lookup.
+	 */
+	public static boolean textureFormatMoved() {
+		return !Objects.equals(PbrAtlases.format(), format);
 	}
 
 	/**
@@ -127,8 +151,11 @@ public final class PackDefines {
 		// of the loader's mod list. An installed Distant Horizons this engine cannot get a depth
 		// image or a projection out, or whose own rendering is switched off, leaves the far terrain
 		// flat, and a pack told otherwise would light a picture that has none.
+		// The material convention comes from the last stitch rather than from the file, which is the
+		// same answer the reduction and the sampler already run on: a pack told one thing and a
+		// specular map reduced under another would be two conventions in one picture.
 		return new EngineDefines.Environment(EngineDefines.DEFAULT_MC_VERSION, os(), vendor,
-				renderer, mipmap, DhDepth.present(), biomeIds(), categories());
+				renderer, mipmap, DhDepth.present(), biomeIds(), categories(), PbrAtlases.format());
 	}
 
 	private static Map<String, Integer> biomeIds() {

--- a/common/src/main/java/dev/vitrail/render/PbrAtlases.java
+++ b/common/src/main/java/dev/vitrail/render/PbrAtlases.java
@@ -1,6 +1,7 @@
 package dev.vitrail.render;
 
 import dev.vitrail.Vitrail;
+import dev.vitrail.pack.option.EngineDefines;
 
 import com.mojang.blaze3d.textures.GpuTexture;
 import com.mojang.blaze3d.textures.GpuTextureView;
@@ -14,6 +15,7 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -60,7 +62,10 @@ public final class PbrAtlases {
 	 */
 	private static final Map<Identifier, PbrAtlas> ATLASES = new HashMap<>();
 
-	private static boolean labPbr;
+	/** The one convention this engine knows a symbol and a reduction for. */
+	private static final String LAB_PBR = "lab-pbr";
+
+	private static EngineDefines.TextureFormat format;
 
 	private PbrAtlases() {
 	}
@@ -93,7 +98,16 @@ public final class PbrAtlases {
 		}
 
 		ResourceManager resources = minecraft.getResourceManager();
-		labPbr = labPbr(resources);
+
+		// The record already held is kept where the file still names the same thing, rather than
+		// replaced by an equal one. What asks whether this moved is
+		// PackDefines#textureFormatMoved(), which runs once a frame: given the same object it stops
+		// at the reference, where a fresh record each stitch would have it compare two strings for
+		// the whole session.
+		EngineDefines.TextureFormat declared = format(resources);
+		if (!Objects.equals(declared, format)) {
+			format = declared;
+		}
 
 		PbrAtlas previous = ATLASES.remove(atlas);
 		if (previous != null) {
@@ -101,7 +115,7 @@ public final class PbrAtlases {
 		}
 
 		try {
-			PbrAtlas read = PbrAtlas.read(atlas, texture, sprites, resources, labPbr);
+			PbrAtlas read = PbrAtlas.read(atlas, texture, sprites, resources, labPbr());
 			if (read != null) {
 				ATLASES.put(atlas, read);
 			}
@@ -157,9 +171,27 @@ public final class PbrAtlases {
 	/**
 	 * Whether the resource pack declares the labPBR convention, which decides how the specular map is
 	 * reduced and how it is filtered. Read once per stitch and answered from there.
+	 * <p>
+	 * A declaration at all is a labPBR declaration: {@link #format} keeps nothing else, because
+	 * {@code lab-pbr} is the only convention Iris registers a factory for either
+	 * ({@code pbr/format/TextureFormatRegistry.java:12}).
 	 */
 	static boolean labPbr() {
-		return labPbr;
+		return format != null;
+	}
+
+	/**
+	 * What the resource pack declares, for the symbols the pack branches on. Null where it declares
+	 * nothing.
+	 * <p>
+	 * Answered from the last stitch rather than from the file, which is Iris's moment translated:
+	 * it refreshes the same answer at the tail of the texture manager's own reload
+	 * ({@code mixin/texture/MixinTextureManager.java:32}) and reloads the whole pipeline when it
+	 * comes back different ({@code pbr/format/TextureFormatLoader.java:28-32}). Here the stitch is
+	 * the reload, and {@link PackDefines#textureFormatMoved()} is the reload that follows.
+	 */
+	static EngineDefines.TextureFormat format() {
+		return format;
 	}
 
 	/**
@@ -172,20 +204,21 @@ public final class PbrAtlases {
 	}
 
 	/**
-	 * Whether {@code optifine/texture.properties} names labPBR.
+	 * What {@code optifine/texture.properties} names, or null where the resource pack ships no such
+	 * file, names no convention in it, or names one this engine has nothing to say about.
 	 * <p>
-	 * Only the name of the format is read and the version after the slash is not: the two versions
-	 * differ in what the channels mean to the PACK, which is the pack's business, and not in
-	 * anything this engine does with them. Iris keeps the version and asks one thing of it, which
-	 * this engine has no use for: {@code LabPBRTextureFormat.equals} compares it
-	 * ({@code pbr/format/LabPBRTextureFormat.java:34-44}) and
-	 * {@code pbr/format/TextureFormatLoader.java:28-32} reloads the whole pack when it changes,
-	 * where here a resource reload restitches the atlases and rebuilds these anyway.
+	 * The version after the slash is kept although nothing here reduces or filters differently for
+	 * it: the two versions differ in what the channels mean to the PACK, which is the pack's
+	 * business, and the pack reaches that business through {@code MC_TEXTURE_FORMAT_LAB_PBR_1_3},
+	 * built from this string ({@code pbr/format/TextureFormat.java:25-30}). Iris keeps it for the
+	 * same reason and for one more, which is comparing it to decide a reload
+	 * ({@code pbr/format/LabPBRTextureFormat.java:34-44}); {@link PackDefines#textureFormatMoved()}
+	 * is where that comparison lands here.
 	 */
-	static boolean labPbr(ResourceManager resources) {
+	static EngineDefines.TextureFormat format(ResourceManager resources) {
 		Optional<Resource> resource = resources.getResource(FORMAT);
 		if (resource.isEmpty()) {
-			return false;
+			return null;
 		}
 
 		Properties properties = new Properties();
@@ -195,12 +228,27 @@ public final class PbrAtlases {
 			Vitrail.logger().warn("{} could not be read, so the material maps are reduced and "
 					+ "filtered as if it named no format", FORMAT, e);
 
-			return false;
+			return null;
 		}
 
-		String format = properties.getProperty("format", "").trim();
-		int slash = format.indexOf('/');
+		String declared = properties.getProperty("format", "").trim();
+		int slash = declared.indexOf('/');
+		if (!LAB_PBR.equals(slash < 0 ? declared : declared.substring(0, slash))) {
+			return null;
+		}
 
-		return "lab-pbr".equals(slash < 0 ? format : format.substring(0, slash));
+		return new EngineDefines.TextureFormat(LAB_PBR, version(declared, slash));
+	}
+
+	/** The field between the first slash and the next, or null where there is nothing between. */
+	private static String version(String declared, int slash) {
+		if (slash < 0) {
+			return null;
+		}
+
+		int next = declared.indexOf('/', slash + 1);
+		String version = declared.substring(slash + 1, next < 0 ? declared.length() : next);
+
+		return version.isEmpty() ? null : version;
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/PbrMap.java
+++ b/common/src/main/java/dev/vitrail/render/PbrMap.java
@@ -30,9 +30,8 @@ import java.util.function.IntUnaryOperator;
  * subsurface amount above it. Averaging across that boundary invents a material that is in neither
  * class, so those channels are averaged only among the texels of the class that wins the quad
  * ({@code pbr/format/LabPBRTextureFormat.java:13-18}). That only applies where the resource pack
- * declares the format, which is what {@code labPbr} carries down from
- * {@link PbrAtlases#labPbr(net.minecraft.server.packs.resources.ResourceManager)}: with no
- * declaration Iris falls back to the plain average for both maps
+ * declares the format, which is what {@code labPbr} carries down from {@link PbrAtlases#labPbr()}:
+ * with no declaration Iris falls back to the plain average for both maps
  * ({@code pbr/loader/AtlasPBRLoader.java:188-198}).
  * <p>
  * <strong>Those three thresholds sit on the channels labPBR puts them on, and that is a divergence

--- a/docs/internals/material-maps.md
+++ b/docs/internals/material-maps.md
@@ -58,6 +58,15 @@ across one of those boundaries invents a material that is in neither class: a ha
 stone that bleeds light. So those channels are averaged only among the texels of the class that wins
 the quad. With no declaration, both maps take the plain average.
 
+The declaration is told to the shader pack as well, and not only to the reduction. Iris poses
+`MC_TEXTURE_FORMAT_LAB_PBR`, and `MC_TEXTURE_FORMAT_LAB_PBR_1_3` beside it where the file names a
+revision, and a pack written against them guards its labPBR decode on them. Both are posed here for
+such a pack. What decides them is `optifine/texture.properties` and nothing else: a resource pack
+that ships `_n` and `_s` maps without that file declares no format, and a pack reading the symbols
+then takes its undeclared path over maps drawn in the convention after all. The symbols are settled
+when the shader pack is read, which is why a resource reload that changes what is declared reads it
+again: a symbol that decided which branch was compiled cannot be corrected any other way.
+
 The same reasoning should decide how the map is **filtered**, and here it only gets half way. A
 sampler that blends two texels of it does at draw time exactly what the reduction refuses to do at
 load, so the specular map is read with nearest filtering under labPBR. Nearest *inside* a mip level


### PR DESCRIPTION
## What changes

The texture format a resource pack declares in `optifine/texture.properties` is handed to the pack as Iris hands it: `MC_TEXTURE_FORMAT_LAB_PBR`, and the revision macro beside it when the declaration carries one. Neither was ever defined here. A resource reload that changes the declared format reads the shader pack again, and the log says which way it moved.

## How it differs from the reference, and for what obstacle

It does not. Iris reads the file in `pbr/format/TextureFormatLoader`, refreshes it from its texture manager mixin and injects the macros in `gl/shader/StandardMacros.java:107-112`; the spelling of the revision macro follows `TextureFormat.java`, one per version string.

## What proves it

- `gradlew build` green.
- Off-game harness `Traduction` on the whole corpus, base against branch, byte-identical: no pack of the corpus reads the symbol, so nothing moves at default.
- A probe over the define table: nothing declared gives no macro, `format=lab-pbr` gives the one, `format=lab-pbr/1.3` gives both.
- Not tried in game: a resource pack declaring the format is the gesture, and the reload line in the log is what witnesses it.

## What it leaves owing

Nothing.


---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.

