### PR TITLE
fix(render): hand infinity for chunkFadeTimeInv with chunk fade off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ what the next one holds.
   reads the shader pack again when that changes what is declared, since the symbols decide which
   branch was compiled.
 
+- **`chunkFadeTimeInv` reads infinity with Chunk Fade set to none, as it does under Iris.** It read
+  zero in that setting, so a pack weighting a section by `min(1.0, age * chunkFadeTimeInv)` was held
+  at the start of a fade that never advanced, where under Iris the same expression reads as faded
+  in. Nothing in the packs that fade chunks changes with it: those read the `mc_chunkFade` attribute
+  rather than this uniform, and it is a pack written against the uniform that gets the Iris answer
+  now.
+
 - **A pack that says it cannot bear anisotropic filtering is believed.** BSL and both
   Complementary variants write `breaksAnisotropy` in their `shaders.properties`, and the line was
   read nowhere: with Texture Filtering set to Anisotropic in Video Settings, their terrain showed

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -944,8 +944,16 @@ public final class FrameState implements WorldState {
 			case ANISOTROPIC -> 2;
 		};
 
+		// Divided without a guard, because Chunk Fade set to none is a normal setting and not the
+		// accident a guard would suggest, and because infinity is what Iris hands there
+		// (uniforms/IrisExclusiveUniforms.java:46). A section weighted by
+		// min(1.0, age * chunkFadeTimeInv) then reads as already faded in for every age but nought,
+		// where a zero would hold every section at the start of a fade that never advances. At an
+		// age of nought the product is a NaN and the min is what the driver makes of it, which is
+		// the same hole Iris has: the value is handed as Iris hands it rather than corrected here,
+		// so a pack tuned against one engine reads the same from the other.
 		double fadeMillis = minecraft.options.chunkSectionFadeInTime().get() * 1000.0;
-		this.chunkFadeTimeInv = fadeMillis == 0.0 ? 0.0F : (float) (1.0 / fadeMillis);
+		this.chunkFadeTimeInv = (float) (1.0 / fadeMillis);
 
 		readAtlas(minecraft);
 	}


### PR DESCRIPTION
## What changes

`chunkFadeTimeInv` is handed as infinity when chunk fade is off, as Iris hands it, where this engine handed zero. A pack multiplying a section's age by it read zero forever instead of a finished fade. No shipped pack reads the uniform: the ones that fade chunks read the `mc_chunkFade` attribute instead, so this is parity for a pack written against the name.

## How it differs from the reference, and for what obstacle

It does not. `uniforms/IrisExclusiveUniforms.java:46` divides unguarded, per frame; so does this now. The hole at age zero (zero times infinity) is Iris's too.

## What proves it

- `gradlew build` green.
- Off-game harness `Uniformes` on the corpus, base against branch: the catalogue is the same 143 names and the two name tables are byte-identical; no pack of the nine reads the uniform.
- Not tried in game: nothing a shipped pack would show.

## What it leaves owing

Nothing.


---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.

