### PR TITLE
fix(render): guard the release a pack reload makes

### DIFF
--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -31,6 +31,7 @@ import dev.vitrail.screen.ScreenText;
 import dev.vitrail.HostReport;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.buffers.Std140Builder;
@@ -1562,7 +1563,38 @@ public final class PackChain {
 		disabled = false;
 
 		if (previous != null) {
-			previous.release();
+			// Guarded like the same call in leaveWorld, and the three lines below are why this road
+			// needs it more than that one: the load and both settle() calls stand after it, and a
+			// throw leaving here skips all three, which leaves a session drawing no pack at all with
+			// the reload still asked for. Where the throw goes then depends on which caller asked.
+			// The world moving under the pack reaches this from the first line of draw(), which
+			// stands outside its try; the settings screen, the pack key and the shadow map scale
+			// reach it from their own event, outside any frame. None of the four is under a catch.
+			//
+			// Nothing is disabled here, where leaveWorld's catch disables: that one keeps the chain
+			// it failed to free and has to stop it being drawn, while this one has already dropped
+			// its chain and is about to read a pack the failure says nothing about.
+			try {
+				previous.release();
+			} catch (GpuDeviceLossException e) {
+				// The one thing a failed free can raise that is not about the free. The game's
+				// Vulkan backend raises it wherever a call comes back VK_ERROR_DEVICE_LOST
+				// (VulkanUtils.crashIfFailure) and catches it in no place at all, which is what
+				// makes it the end of the session rather than the end of a release: the load below
+				// would allocate its targets against a device that is gone. Rethrown as it stands,
+				// so the report names the driver rather than a line about video memory.
+				throw e;
+			} catch (RuntimeException e) {
+				// Said here rather than left to whatever comes next, and said once: the chain is
+				// unreachable by the time this is caught, so nothing frees the rest of it later and
+				// no other line would ever name what it still holds. What it holds is buffers and
+				// images; the pipelines and shader modules of that load are not part of it, since
+				// the next resource reload empties the device cache whether a release reached them
+				// or not.
+				Vitrail.logger().error("Vitrail could not hand back everything the pack being "
+						+ "replaced held, so the buffers and images its release had not reached "
+						+ "stay allocated until the game is closed", e);
+			}
 		}
 		load(gameDirectory);
 		// Taken whatever the load did with them. A pack that cannot be read at all settled nothing,


### PR DESCRIPTION
## What changes

Freeing the outgoing chain when a pack is reloaded ran unguarded, ahead of the load that replaces it and of both settle calls. A throw out of it left the session drawing no pack with the reload still asked for, and climbed out to whichever caller asked. The free is now caught the way the same call already is when a world is left, logged once with its cause, and the load proceeds. A lost device is rethrown: the game ends the session on it wherever it lands, and a load against a device that is gone would only allocate into the void.

## How it differs from the reference, and for what obstacle

It does not: this is the engine's own lifecycle, Iris has no equivalent free.

## What proves it

- `gradlew build` green.
- Read against the game's Vulkan utilities: `GpuDeviceLossException` is raised on `VK_ERROR_DEVICE_LOST` and caught nowhere in the game, so rethrowing it keeps the session's end where the game puts it.
- No off-game harness covers `render/`, and no throw can be forced from outside: nothing a launch on a healthy session shows.

## What it leaves owing

Nothing a player sees changes today, so no changelog entry. The chain is still released from seven catch blocks that leave it as the active one, so a later reload releases it a second time; every site walked twice is a no-op today, and that is left as it is.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
