### PR TITLE
fix(glsl): keep a pack's storage block bound off a warm cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@ what the next one holds.
   rather than this uniform, and it is a pack written against the uniform that gets the Iris answer
   now.
 
+- **World-space reflections come back after the first launch.** Complementary Unbound on Ultra
+  gives its reflection pass a buffer the pack declares for itself. On the launch that read the
+  pack for the first time that pass ran; on every launch after it, the translation being reused
+  from the store on disk, the engine stopped recognising the buffer behind the name and dropped
+  the pass. The reflections went with it, two of the targets the pass writes were read by the
+  next one as the clear had left them, and the log named the pass as one it would not run. A
+  pass whose buffer the pack really never declared is still dropped, and still says so.
+
 - **A pack that says it cannot bear anisotropic filtering is believed.** BSL and both
   Complementary variants write `breaksAnisotropy` in their `shaders.properties`, and the line was
   read nowhere: with Texture Filtering set to Anisotropic in Video Settings, their terrain showed

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -13,7 +13,6 @@ import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.SamplerTypes;
 import dev.vitrail.pack.target.TargetName;
 import dev.vitrail.pack.texture.CustomImages;
-import dev.vitrail.pack.texture.CustomStorage;
 import dev.vitrail.pack.texture.VolumeAtlas;
 
 import java.util.ArrayList;
@@ -453,8 +452,8 @@ public final class GlslTranslator {
 	 */
 	private String centerDepthTexel;
 
-	/** Storage blocks this unit declares at file scope, by the name the block is written under. */
-	private final List<String> storageBlocks = new ArrayList<>();
+	/** Storage blocks this unit declares at file scope, each under the binding it was written at. */
+	private final List<TranslatedUnit.StorageBlock> storageBlocks = new ArrayList<>();
 
 	/** The volumes this unit reads, and so the helpers its header owes, by the pack's own name. */
 	private final Map<String, VolumeAtlas> readVolumes = new LinkedHashMap<>();
@@ -5083,23 +5082,29 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			String block = this.tokens.get(name).text();
 			int binding = layoutBinding(index);
-			if (!this.storageBlocks.contains(block)) {
-				this.storageBlocks.add(block);
-			}
-
-			CustomStorage.declare(block, binding);
+			note(this.tokens.get(name).text(), binding);
 			int close = matchingBracket(brace);
 			int instance = close < 0 ? -1 : significantAfter(close);
 			if (instance >= 0 && this.tokens.get(instance).kind() == Kind.IDENTIFIER) {
-				String instanceName = this.tokens.get(instance).text();
-				if (!this.storageBlocks.contains(instanceName)) {
-					this.storageBlocks.add(instanceName);
-				}
-
-				CustomStorage.declare(instanceName, binding);
+				note(this.tokens.get(instance).text(), binding);
 			}
+		}
+	}
+
+	/**
+	 * Both spellings of one block, the block name and the instance name, share its binding, and the
+	 * first spelling filed keeps it.
+	 * <p>
+	 * Which of two would win is a question no pack that compiles can ask: two live declarations of
+	 * one block name at file scope are a redeclaration, so the only name that can reach here twice
+	 * is one block's instance name standing as another block's name, and neither of the two bindings
+	 * is then the right one. Iris never has the choice to make at all, binding a buffer by the index
+	 * in its layout qualifier and never by the name.
+	 */
+	private void note(String name, int binding) {
+		if (this.storageBlocks.stream().noneMatch(block -> block.name().equals(name))) {
+			this.storageBlocks.add(new TranslatedUnit.StorageBlock(name, binding));
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -150,6 +150,7 @@ public final class PackProgram {
 		public List<String> storageBlocks() {
 			return this.program.stages().values().stream()
 					.flatMap(stage -> stage.notes().storageBlocks().stream())
+					.map(TranslatedUnit.StorageBlock::name)
 					.distinct()
 					.toList();
 		}
@@ -1392,6 +1393,7 @@ public final class PackProgram {
 						.filter(sampler -> SamplerTypes.refused(sampler.type()))
 						.forEach(sampler -> found.putIfAbsent(sampler.name(), sampler));
 				stage.notes().storageBlocks().stream()
+						.map(TranslatedUnit.StorageBlock::name)
 						.filter(block -> !storage.contains(block))
 						.filter(block -> !CustomStorage.named(block))
 						.forEach(storage::add);

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -3,6 +3,7 @@ package dev.vitrail.glsl;
 import dev.vitrail.pack.program.AlphaTest;
 import dev.vitrail.pack.program.ProgramStage;
 import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
+import dev.vitrail.pack.texture.CustomStorage;
 import dev.vitrail.pack.texture.VolumeAtlas;
 
 import java.util.ArrayList;
@@ -197,17 +198,38 @@ public final class ProgramTranslator {
 					program, volumes);
 			TranslatedProgram served = TranslationCache.lookup(key, inputs);
 			if (served != null) {
-				return served;
+				return declared(served);
 			}
 
 			TranslatedProgram built =
 					translated(units, inputs, boundElements, alphaTest, coverage, program, volumes);
 			TranslationCache.store(key, built);
 
-			return built;
+			return declared(built);
 		} finally {
 			LoadClock.translation(System.nanoTime() - began);
 		}
+	}
+
+	/**
+	 * Files this program's storage blocks with the bindings they were written at, and hands it back.
+	 * <p>
+	 * Here rather than where the text is read, and that is the whole point: a program served out of
+	 * {@link TranslationCache} never goes near the translator, so a table filled while the tokens
+	 * were walked would hold the blocks of the programs this run happened to translate and not the
+	 * ones the pack declares. What reads it is
+	 * {@link dev.vitrail.pack.texture.CustomStorage#named}, which decides whether a program keeps
+	 * its place in the chain and, for one that does, whether the bind group layout declares its slot
+	 * a storage buffer rather than a uniform one. A draw's descriptor write does not ask it at all,
+	 * taking its buffer from {@code StorageBuffers.bound}, and only a compute dispatch asks the name
+	 * again to type its own write. Answered off a warm cache the question refused Complementary's
+	 * world-space reflection composite and left the targets it writes on their clear.
+	 */
+	private static TranslatedProgram declared(TranslatedProgram program) {
+		program.stages().values().forEach(stage -> stage.notes().storageBlocks()
+				.forEach(block -> CustomStorage.declare(block.name(), block.binding())));
+
+		return program;
 	}
 
 	private static TranslatedProgram translated(Map<ProgramStage, ExpandedUnit> units,

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
@@ -33,7 +33,7 @@ import java.util.Map;
 final class TranslatedProgramCodec {
 
 	/** Bumped by hand when the layout changes. It is part of the key, so old blobs go unread. */
-	static final String FORMAT = "vitrail-translation-3";
+	static final String FORMAT = "vitrail-translation-4";
 
 	private TranslatedProgramCodec() {
 	}
@@ -152,7 +152,7 @@ final class TranslatedProgramCodec {
 		names(out, notes.conflictNames());
 		names(out, notes.comparedSamplers());
 		names(out, notes.hardwareCompared());
-		names(out, notes.storageBlocks());
+		storageBlocks(out, notes.storageBlocks());
 		out.writeInt(notes.volumeLookups());
 		out.writeInt(notes.volumesLeftAlone());
 		out.writeInt(notes.trigCalls());
@@ -165,8 +165,27 @@ final class TranslatedProgramCodec {
 				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(),
 				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(),
 				in.readInt(), in.readInt(),
-				names(in), names(in), names(in), names(in),
+				names(in), names(in), names(in), storageBlocks(in),
 				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt());
+	}
+
+	private static void storageBlocks(DataOutputStream out,
+			List<TranslatedUnit.StorageBlock> blocks) throws IOException {
+		out.writeInt(blocks.size());
+		for (TranslatedUnit.StorageBlock block : blocks) {
+			text(out, block.name());
+			out.writeInt(block.binding());
+		}
+	}
+
+	private static List<TranslatedUnit.StorageBlock> storageBlocks(DataInputStream in)
+			throws IOException {
+		List<TranslatedUnit.StorageBlock> blocks = new ArrayList<>();
+		for (int left = in.readInt(); left > 0; left--) {
+			blocks.add(new TranslatedUnit.StorageBlock(text(in), in.readInt()));
+		}
+
+		return List.copyOf(blocks);
 	}
 
 	private static void uniforms(DataOutputStream out, List<TranslatedUnit.Uniform> uniforms)

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedUnit.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedUnit.java
@@ -43,6 +43,19 @@ public record TranslatedUnit(String entry, ProgramStage stage, String text, Note
 	}
 
 	/**
+	 * One storage block a unit declares at file scope, with the {@code layout(..., binding = N)} it
+	 * carried, or {@code -1} when the pack wrote none.
+	 * <p>
+	 * The binding travels with the name because it is the only thing that ties a nameless
+	 * {@code bufferObject.N} to a block: Complementary writes {@code blockDataBuffer} at binding 0
+	 * and declares {@code bufferObject.0} with no name at all. Carried on the notes rather than
+	 * filed away as the text is read, so that a program served out of {@link TranslationCache}
+	 * answers for its blocks exactly like one that was just translated.
+	 */
+	public record StorageBlock(String name, int binding) {
+	}
+
+	/**
 	 * What the translation did to one file, counted, so a run over a corpus can be read.
 	 *
 	 * @param fragmentOutputs    how many fragment outputs the header declares, counting both the
@@ -106,9 +119,10 @@ public record TranslatedUnit(String entry, ProgramStage stage, String text, Note
 	 *                           binding owes each a comparison sampler and the lookup is the
 	 *                           hardware's. The rest are declared ordinary, with the comparison
 	 *                           made in arithmetic where each lookup stood
-	 * @param storageBlocks      the storage blocks this unit declares at file scope. A
-	 *                           {@code bufferObject} that matches one is bound; the rest refuse
-	 *                           the program that carries them
+	 * @param storageBlocks      the storage blocks this unit declares at file scope, each with the
+	 *                           binding it was written at. A {@code bufferObject} that matches one
+	 *                           by name or by binding is bound; the rest refuse the program that
+	 *                           carries them
 	 * @param volumeLookups      lookups on a volume the pack ships, moved onto the flat atlas it was
 	 *                           laid out in
 	 * @param volumesLeftAlone   volumes this unit reaches some way the rewrite does not cover, and
@@ -135,7 +149,7 @@ public record TranslatedUnit(String entry, ProgramStage stage, String text, Note
 			int fragCoordZ, int fragCoordXyz, int fragCoordUnhandled,
 			int fragDepthWrites, int fragDepthUnhandled,
 			List<String> conflictNames, List<String> comparedSamplers,
-			List<String> hardwareCompared, List<String> storageBlocks,
+			List<String> hardwareCompared, List<StorageBlock> storageBlocks,
 			int volumeLookups, int volumesLeftAlone, int trigCalls, int gameTextureMatrix,
 			int gameModelView) {
 	}

--- a/common/src/main/java/dev/vitrail/pack/texture/CustomStorage.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/CustomStorage.java
@@ -18,10 +18,11 @@ public final class CustomStorage {
 	private static volatile BufferObject.Reading declared = BufferObject.Reading.empty();
 
 	/**
-	 * The block names the translator saw, which is the one half of this class that does not replace
-	 * itself. {@link #install} hands the whole of {@link #declared} over at each load, while this is
-	 * filled a name at a time and would otherwise carry every name of every pack read this session.
-	 * Emptied by {@link #clear} at the head of a load, and the answers below say what that buys.
+	 * The block names the pack's own programs declare, which is the one half of this class that does
+	 * not replace itself. {@link #install} hands the whole of {@link #declared} over at each load,
+	 * while this is filled a name at a time and would otherwise carry every name of every pack read
+	 * this session. Emptied by {@link #clear} at the head of a load, and the answers below say what
+	 * that buys.
 	 */
 	private static final Map<String, Integer> bindings = new ConcurrentHashMap<>();
 
@@ -48,8 +49,11 @@ public final class CustomStorage {
 	}
 
 	/**
-	 * Records a storage block the translator just saw, with the {@code layout(..., binding = N)}
-	 * it carried, or {@code -1} when the pack wrote none.
+	 * Records a storage block one of the pack's programs declares, with the
+	 * {@code layout(..., binding = N)} it carried, or {@code -1} when the pack wrote none.
+	 * <p>
+	 * Called for every program handed out and not for every text read, so that a program restored
+	 * from the translation store files its blocks exactly like one that was just translated.
 	 */
 	public static void declare(String name, int binding) {
 		if (name == null || name.isEmpty()) {


### PR DESCRIPTION
## What changes

A pack's storage block stays bound when its program comes back from the translation store rather than from a fresh translation. The binding a block declares was filed only while the translator walked the tokens, so on a warm store the engine no longer knew that `blockDataBuffer` sat at binding 0, found no name to match against a `bufferObject.0` written without one, and refused the program. Under Complementary's Ultra profile that program is the world-space reflection composite, and with it gone the two targets the next pass reads held only their clear colour. The binding now travels with the block name inside the stored translation, and the store's format number moves so older files are translated again rather than read.

## How it differs from the reference, and for what obstacle

It does not. Iris binds a storage block by the index in its layout qualifier and never by name; this engine has to carry that index through its store.

## What proves it

- `gradlew build` green.
- Off-game, through the engine's own load road under `vitrail.translationDir`: with Complementary Unbound at `COLORED_LIGHTING=512 WORLD_SPACE_REFLECTIONS=1`, a cold run kept the composite and a warm run refused it before the change; both keep it after. Negative control at `COLORED_LIGHTING=64`, where the pack declares the block and no `bufferObject`: still refused, same sentence. Harness `Chaine` on BSL and Bliss byte-identical.
- In game, Fabric bench, Complementary Unbound at the Ultra profile on a warm store: the log went from seven full-screen passes and `world0/composite is not run` to eight passes and `world0/composite writes colortex7 alt, colortex1 alt`.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
