### PR TITLE
fix(render): zero a pack's storage buffer whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,15 @@ what the next one holds.
   next one as the clear had left them, and the log named the pass as one it would not run. A
   pass whose buffer the pack really never declared is still dropped, and still says so.
 
+- **A buffer a pack asks for starts empty, whatever its size.** Only the small ones were emptied,
+  and anything past four mebibytes was handed over holding whatever the driver had last left in
+  that memory. Complementary reads a cell of one before anything has written it and takes a zero
+  for "no surface here", so at its Ultra profile, which turns World-Space Reflections on and
+  Advanced Color Tracing up to 16 chunks and asks for 773 MiB on that account, the reflections of
+  the first seconds could carry scraps of unrelated blocks, and the pack mixes what it reads back
+  in, which drags them out over several more. Every such buffer is now emptied whole the moment it
+  is allocated, which is before the pack has drawn anything into it.
+
 - **A pack that says it cannot bear anisotropic filtering is believed.** BSL and both
   Complementary variants write `breaksAnisotropy` in their `shaders.properties`, and the line was
   read nowhere: with Texture Filtering set to Anisotropic in Video Settings, their terrain showed

--- a/NOTICE
+++ b/NOTICE
@@ -152,6 +152,14 @@ GNU Lesser General Public License version 3
   targets are made with the map where Iris builds each one the first time a framebuffer names it,
   lines 127 and 136, which changes when memory is taken and nothing a pack can read.
 
+  common/src/main/java/dev/vitrail/render/StorageBuffers.java keeps the rule that a bufferObject
+  starts life at zero, which net.irisshaders.iris.gl.buffer.ShaderStorageBuffer applies at line 79
+  for an absolute buffer and at line 64 every time a relative one is rebuilt. Packs are written
+  against it: Complementary tells a face it never voxelised from one it did by the cell reading
+  zero, having no written flag of its own. Line 79 sits in the else of a test on inline content,
+  which Iris uploads in place of the clear when a pack gave any; the clear is unconditional here
+  because the bufferObject grammar this engine reads carries no content.
+
   common/src/main/java/dev/vitrail/render/PackPass.java binds what a full screen pass samples with
   Iris's filters, the packs blurring and interpolating against them: the noise image LINEAR, a
   shadow colour LINEAR outright, net.irisshaders.iris.samplers.IrisSamplers.addShadowSamplers, and

--- a/common/src/main/java/dev/vitrail/render/StorageBuffers.java
+++ b/common/src/main/java/dev/vitrail/render/StorageBuffers.java
@@ -188,10 +188,33 @@ public final class StorageBuffers implements AutoCloseable {
 	}
 
 	/**
-	 * Zeros storage buffers small enough to fill on this command buffer. Complementary Ultra's
-	 * {@code bufferObject.0} is hundreds of megabytes; {@code vkCmdFillBuffer} of that size on
-	 * the frame that also draws the world trips Windows TDR ({@code VK_ERROR_DEVICE_LOST} two
-	 * seconds later). The pack writes the cells it uses.
+	 * Zeros every buffer {@link #ensure} has just made, whole and in one fill.
+	 * <p>
+	 * <strong>A pack reads a cell it never wrote and expects zero.</strong> Complementary indexes
+	 * {@code blockDataSSBO.data[]} by face rather than by voxel, and its reader tests the cell it
+	 * gets rather than a written flag: {@code lib/materials/materialMethods/worldSpaceRef.glsl:69}
+	 * drops the reflection when {@code faceData.textureBounds.z < 1e-6}, and that field is only ever
+	 * zero because nothing wrote the cell. Its writer reads too, at
+	 * {@code lib/voxelization/reflectionVoxelData.glsl:61}, before any store of the frame and at the
+	 * previous camera anchor, then mixes what it read back in at 99 percent. Uninitialised memory
+	 * passes the first test and is fed to the atlas as a texture coordinate, and the second carries
+	 * it forward for a hundred frames. Nothing in the pack clears the buffer at Ultra either: its
+	 * {@code clearSSBOs()} touches {@code playerVerticesSSBO} alone and sits under
+	 * {@code WORLD_SPACE_PLAYER_REF == 1}, which ships at -1.
+	 * <p>
+	 * <strong>What Iris does.</strong> It clears the whole allocation the moment it makes it, both
+	 * for an absolute buffer ({@code gl/buffer/ShaderStorageBuffer.java:79}) and on every rebuild of
+	 * a relative one ({@code :64}), and never again. The same holds here: this runs at the tail of
+	 * {@link #ensure}, which makes the absolute buffers once per pack load and the relative ones
+	 * again on every resize, and the fill goes on the command buffer there, ahead of everything the
+	 * frame that made them goes on to draw.
+	 * <p>
+	 * <strong>It is one fill and not a spread of them.</strong> The pack's shadow vertex stage
+	 * stores into the buffer from the first frame the world is drawn
+	 * ({@code lib/voxelization/reflectionVoxelData.glsl:80} and {@code :83}), and a fill carried
+	 * over to a later frame would erase what those stores put there. Filling 773 MiB is one
+	 * bandwidth-bound write with no per-cell work behind it, and it lands on the frame that
+	 * allocates the buffer rather than on one drawing a world.
 	 */
 	private void zero(GpuDevice device) {
 		CommandEncoder encoder = device.createCommandEncoder();
@@ -207,14 +230,11 @@ public final class StorageBuffers implements AutoCloseable {
 				continue;
 			}
 
-			if (buffer.bytes > 4L * 1024 * 1024) {
-				buffer.zeroed = true;
-				continue;
-			}
-
 			VK12.vkCmdFillBuffer(commands, buffer.buffer, 0L, buffer.bytes, 0);
 			buffer.zeroed = true;
 			filled = true;
+			Vitrail.logger().info("storage buffer {} zeroed whole at {} bytes",
+					buffer.declared.describe(), buffer.bytes);
 		}
 
 		if (filled) {


### PR DESCRIPTION
## What changes

A pack's storage buffer is zeroed whole when it is allocated, as Iris zeroes it. Above four megabytes the buffer was marked zeroed and left with whatever the allocator handed back, and Complementary's world-space reflections read a zero cell as "never written": on the Ultra profile the 773 MiB buffer started full of leftovers, so reflections could sample unrelated block textures for the first seconds and the pack's own history blend kept them around. One fill command now covers the whole allocation at creation, and again when a relative buffer is rebuilt.

## How it differs from the reference, and for what obstacle

It does not. Iris clears the whole buffer at creation (`gl/buffer/ShaderStorageBuffer.java:79`) and on every rebuild of a relative one (`:64`). The one difference is that Iris uploads inline content instead of clearing when the pack ships some, and this engine's `bufferObject` grammar carries no content, so the clear is unconditional here.

## What proves it

- `gradlew build` green.
- Read in the pack: the reflection reader rejects a cell on its zero bound, and the writer reads the old cell back and blends it at 99 percent, so garbage both passes the test and persists.
- In game, Fabric bench, Complementary Unbound at the Ultra profile: the log carries `storage buffer 0 ... zeroed whole at 810549248 bytes` on both loads of the session, no device loss, the world drawn.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
