### PR TITLE
feat(shadow): serve the hardware-compared shadow depth names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ what the next one holds.
 
 ## Unreleased
 
+### Added
+
+- **A pack can read the shadow map under a second, hardware-compared name.** `shadowtex0HW` and
+  `shadowtex1HW` are bound now, to the same two depth images as `shadowtex0` and `shadowtex1`,
+  and each is compared by the hardware where the pack declares it that way. Both names read back
+  black before, and a pack declaring it cannot be drawn without `SEPARATE_HARDWARE_SAMPLERS` was
+  refused at load over that name alone. That name refuses nothing now, though a pack that also
+  requires a name this engine has not built is still refused, the log listing what it asked for.
+  Nothing changes for a pack that never writes the two names.
+
 ### Fixed
 
 - **Importing settings no longer acts on a screen you have already left.** The window that asks

--- a/NOTICE
+++ b/NOTICE
@@ -51,7 +51,12 @@ GNU Lesser General Public License version 3
   keeps its overrides for the whole frame; and the final rides with the composites, which is where
   net.irisshaders.iris.shaderpack.texture.TextureStage puts it. The stage each program falls in is
   worked out from this engine's own plan rather than from the flip snapshots Iris takes at link
-  time.
+  time. The pair shadowtex0HW and shadowtex1HW is the second name of each depth image that
+  SEPARATE_HARDWARE_SAMPLERS gives a pack, lines 179 to 183 of the former, read on 5 September
+  2026, and each reads the image its plain twin reads. The gate is not reproduced: Iris binds
+  them only where the pack poses the flag and asks for hardware filtering on that index, while
+  here every pack spelling them gets them, the comparison following the type the pack declared
+  rather than a directive.
 
   common/src/main/java/dev/vitrail/render/ColorTargets.java empties colortex0 to the frame's fog
   colour with an alpha of one, which is what net.irisshaders.iris.targets.ClearPass.execute does

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -188,6 +188,11 @@ public final class EngineDefines {
 		// emission under it.
 		defines.put("IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE", "");
 
+		// shadowtex0HW and shadowtex1HW are bound, the same two depth images as the plain pair and
+		// compared where the pack declares them so (SamplerPlan.SHADOW_DEPTH). Iris poses this one
+		// whatever the hardware, features/FeatureFlags.java:12.
+		defines.put("IRIS_FEATURE_SEPARATE_HARDWARE_SAMPLERS", "");
+
 		// The rest of IRIS_FEATURE_ stays unposted until each capability is served. See
 		// ShaderProperties.optionalFeatures for the other half of the answer, and PackChain for
 		// what a pack requiring one is told.

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -1658,10 +1658,10 @@ public final class ShaderProperties {
 
 	/**
 	 * What the pack would use if it were there, and takes another path without. It is the list Iris
-	 * turns into {@code IRIS_FEATURE_} defines for the GLSL. This engine poses
-	 * {@code IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE}, and {@code IRIS_FEATURE_CUSTOM_IMAGES} when
-	 * the storage-image pipe is served, and none of the others, which is what tells a pack to
-	 * take the other path for those.
+	 * turns into {@code IRIS_FEATURE_} defines for the GLSL. A flag is posed the day the capability
+	 * behind it is served and not before, a define being a promise, and every other name stays
+	 * unposed, which is what tells a pack to take the other path for it. Which names those are
+	 * today is written where they are posed, {@code EngineDefines.table}.
 	 * <p>
 	 * Nothing in the engine reads this list, and that is deliberate rather than an oversight: there
 	 * is nothing here to decide from it. What taking the line out of the ignored keys buys is

--- a/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
@@ -32,8 +32,31 @@ import java.util.Set;
 public final class SamplerPlan {
 
 	private static final Set<String> DEPTH = Set.of("depthtex0", "depthtex1", "depthtex2", "gdepthtex");
-	private static final Set<String> SHADOW_DEPTH =
-			Set.of("shadowtex0", "shadowtex1", "shadow", "watershadow");
+
+	/**
+	 * The names that read the light's own depth. The two spelled {@code HW} are the same two images
+	 * as {@code shadowtex0} and {@code shadowtex1}, under a second name, and that is the whole of
+	 * what SEPARATE_HARDWARE_SAMPLERS is: Iris hands the plain names the texture's own state and the
+	 * {@code HW} names a sampler carrying GL_COMPARE_REF_TO_TEXTURE
+	 * ({@code samplers/IrisSamplers.java:147-152} and {@code :179-183}), so a pack can read one map
+	 * both compared and plain in the one program, which one name never could.
+	 * <p>
+	 * Which of the two roads a name takes is settled here by the pack's own declaration and not by a
+	 * flag, because that is already this engine's rule: the comparison rides the binding wherever the
+	 * pack spelled the type {@code sampler2DShadow} over a name of the shadow map's, which is what
+	 * {@code GlslTranslator.collectComparisonSamplers} decides and {@code render/ShadowCompare} then
+	 * carries. A pack posing the flag declares the plain pair {@code sampler2D} and the {@code HW}
+	 * pair {@code sampler2DShadow}, so it gets Iris's arrangement out of its own text, with nothing
+	 * to switch.
+	 * <p>
+	 * The divergence that leaves is which packs see the names at all. Iris binds an {@code HW} name
+	 * only where the pack both poses the flag and asks for hardware filtering on that index; here
+	 * both are served to anyone who spells them. What that costs is a pack reading a real shadow map
+	 * where Iris would have left the sampler unbound, and nothing else: the plain pair is untouched,
+	 * and a pack that never writes the names cannot tell the difference.
+	 */
+	private static final Set<String> SHADOW_DEPTH = Set.of("shadowtex0", "shadowtex1", "shadow",
+			"watershadow", "shadowtex0HW", "shadowtex1HW");
 
 	/**
 	 * The depth Distant Horizons keeps apart from the game's, kept apart here as well, which is
@@ -452,7 +475,8 @@ public final class SamplerPlan {
 	/**
 	 * Whether a shadow depth name reads the map as it stood before the translucents.
 	 * <p>
-	 * {@code shadowtex1} is always that one and {@code shadowtex0} is never it. The pair is the whole
+	 * {@code shadowtex1} is always that one and {@code shadowtex0} is never it, and the {@code HW}
+	 * spelling of each reads the image its plain twin reads. The pair is the whole
 	 * of what a coloured shadow rests on: a point occluded in nought and clear in one has something
 	 * translucent between it and the light, and the tint comes from {@code shadowcolor}.
 	 * <p>
@@ -468,7 +492,8 @@ public final class SamplerPlan {
 	 * would move {@code shadow} here and not there. No pack of the corpus writes the name at all.
 	 */
 	public boolean withoutTranslucents(String name) {
-		return name.equals("shadowtex1") || (this.waterShadow && name.equals("shadow"));
+		return name.equals("shadowtex1") || name.equals("shadowtex1HW")
+				|| (this.waterShadow && name.equals("shadow"));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -841,6 +841,8 @@ public final class PackChain {
 			// attribute rides in the chunk element, and custom images are served now, so a pack
 			// that cannot draw without either is simply right about what it needs.
 			required.remove("BLOCK_EMISSION_ATTRIBUTE");
+			// The second shadow depth name of each map is bound too, SamplerPlan.SHADOW_DEPTH.
+			required.remove("SEPARATE_HARDWARE_SAMPLERS");
 			if (CustomImages.served()) {
 				required.remove("CUSTOM_IMAGES");
 			}

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -405,8 +405,12 @@ final class PackCompute implements AutoCloseable {
 		ShadowTargets shadow = targets.shadow();
 		return switch (name) {
 			case "noisetex" -> targets.noise();
-			case "shadowtex0" -> orWhite(targets, shadow == null ? null : shadow.depth());
-			case "shadowtex1" ->
+			// The HW spelling reads the same image as its plain twin, which is the whole of what
+			// SEPARATE_HARDWARE_SAMPLERS asks for. A compute makes every comparison in arithmetic
+			// whatever the pack declared, so nothing but the name reaches this line.
+			case "shadowtex0", "shadowtex0HW" ->
+					orWhite(targets, shadow == null ? null : shadow.depth());
+			case "shadowtex1", "shadowtex1HW" ->
 					orWhite(targets, shadow == null ? null : shadow.depthWithoutTranslucents());
 			case "shadowcolor0" -> orWhite(targets, shadow == null ? null : shadow.colour(0));
 			case "shadowcolor1" -> orWhite(targets, shadow == null ? null : shadow.colour(1));

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -61,12 +61,12 @@ can declare the features it cannot be drawn without, and Reverie declares severa
 before any of its programs is translated, so the refusal names what the pack asked for and did not
 get, the log listing them, rather than the symptom that would have come later.
 
-**Any name this engine has not built refuses the declaration.** Two names are built and served
-today, `BLOCK_EMISSION_ATTRIBUTE` and `CUSTOM_IMAGES`, so a pack that requires those alone
-loads; every other name still refuses the pack, with the list in the log. The served flags are
-also the only `IRIS_FEATURE_` defines a pack finds: a capability define is a promise, so each
-appears the day its feature is served and not before, and the optional declarations keep
-reading the truth.
+**Any name this engine has not built refuses the declaration.** Three names are built and served
+today, `BLOCK_EMISSION_ATTRIBUTE`, `CUSTOM_IMAGES` and `SEPARATE_HARDWARE_SAMPLERS`, so a pack
+that requires those alone loads; every other name still refuses the pack, with the list in the
+log. The served flags are also the only `IRIS_FEATURE_` defines a pack finds: a capability define
+is a promise, so each appears the day its feature is served and not before, and the optional
+declarations keep reading the truth.
 
 Iris draws Reverie. It refuses a required flag only when the name is unknown to it or the hardware
 cannot serve it, and it has built every one of the ones Reverie asks for: some outright, some
@@ -101,10 +101,12 @@ message is one of its passes, and it is drawn because a capability test in its c
 
 The test reads capability defines. This engine announces itself the way Iris does, but a
 capability define is a promise, so it defines only what the backend actually serves, which today
-is `IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE` and `IRIS_FEATURE_CUSTOM_IMAGES` and nothing else; the
-section above says why the features behind the other names are closed. A pack that finds the announcement without the capability it wants
-concludes it is running on OptiFine, the only renderer in that position when the pack was
-written, and words its message for it. Read "OptiFine" as "not Iris" and the message is accurate.
+is `IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE`, `IRIS_FEATURE_CUSTOM_IMAGES` and
+`IRIS_FEATURE_SEPARATE_HARDWARE_SAMPLERS` and nothing else; the section above says why the
+features behind the other names are closed. A pack that finds the announcement without the
+capability it wants concludes it is running on OptiFine, the only renderer in that position when
+the pack was written, and words its message for it. Read "OptiFine" as "not Iris" and the message
+is accurate.
 
 Complementary was the pack of the test set that did this, and it is why the define exists. Its
 colored lighting, which its two top profiles Very High and Ultra turn on, is voxel lighting:

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -117,10 +117,12 @@ A pack can read the shadow map with translucent geometry included or excluded. T
 a *copy* taken between the opaque and translucent halves of the shadow stage, not a second render.
 The translucent shadow pass is served through the fallback tree, unblended and without alpha test.
 
-Two of the three names are fixed: one always reads the map without translucents, the other never
-does. Only the bare `shadow` moves, and it moves when a program also declares the water-shadow name:
-then that name reads the map with the translucents in it and `shadow` falls back to the one
-without. No pack of the corpus writes it at all.
+Each of the two images carries a second name as well, `shadowtex0HW` and `shadowtex1HW`, so that
+one program can read the one map both hardware-compared and plain. Those four names are fixed:
+`shadowtex1` and `shadowtex1HW` always read the map without translucents, `shadowtex0` and
+`shadowtex0HW` never do. Only the bare `shadow` moves, and it moves when a program also declares
+the water-shadow name: then that name reads the map with the translucents in it and `shadow` falls
+back to the one without. No pack of the corpus writes it at all.
 
 Coloured light through stained glass does not rest on that swap. It rests on the pair plus the
 shadow colour buffer: a point occluded in one image and clear in the other has something translucent


### PR DESCRIPTION
## What changes

`shadowtex0HW` and `shadowtex1HW` are served: the same shadow depth images as `shadowtex0` and `shadowtex1`, read through the hardware comparison sampler, which is what a pack declaring `SEPARATE_HARDWARE_SAMPLERS` expects. Both names read back black before, and the flag refused a pack by itself; the flag is posed and no longer refuses. A pack that also requires a name this engine does not serve is still refused for that name.

## How it differs from the reference, and for what obstacle

One divergence, written in the javadoc and in `NOTICE`: Iris binds the two names only where the pack poses the flag and asks hardware filtering on that index (`samplers/IrisSamplers.java:179-183`); here anything spelling the names gets them, because the sampler classification is a static the translator and every harness tool call, with no pack flag list to consult. Inert on the corpus: only Reverie writes the names, and it poses the flag. The comparison rides the pack's own declaration, so the plain names stay uncompared exactly as Iris leaves them when the flag is on.

## What proves it

- `gradlew build` green.
- Off-game harness on the corpus, base against branch: `Cibles` on Reverie moves the two names from unserved to shadow depth, the other eight packs are byte-identical on `Harness`, `Chaine` and `Cibles`; the emitted GLSL shows `sampler2DShadow shadowtex0HW` beside `sampler2D shadowtex0`.
- Not seen in game: Reverie still needs two other flags, served by a sibling branch.

## What it leaves owing

The softness of Reverie's shadow edge is for the eye, once the pack loads.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
