### PR TITLE
fix(pack): read the conditionals before joining continued lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,18 @@ what the next one holds.
   in, which drags them out over several more. Every such buffer is now emptied whole the moment it
   is allocated, which is before the pack has drawn anything into it.
 
+- **A value a pack spreads over several lines stops at the end of its own branch.** A
+  `shaders.properties` value continued with a backslash was joined before the conditionals around
+  it were read, so a value whose last line carried a backslash too swallowed the `#else` or
+  `#endif` that closed its branch, and the conditional around it went dark with them. Photon
+  writes its moon brightness that way, one line per phase, and both sides of Moon Phase Affects
+  Brightness were wrong. Switched on, the table never parsed and the constant from the branch
+  meant to replace it was read instead, so the moon lit the ground the same on every night of the
+  cycle. Switched off, that constant sat inside the branch the swallowed `#else` had left open,
+  no brightness was declared at all, and the shaders read the missing one as zero: the moon gave
+  no light whatever, and every night away from a torch was as dark as a new moon. The moon now
+  dims through the cycle with the option on, and is a plain full moon every night with it off.
+
 - **A pack that says it cannot bear anisotropic filtering is believed.** BSL and both
   Complementary variants write `breaksAnisotropy` in their `shaders.properties`, and the line was
   read nowhere: with Texture Filtering set to Anisotropic in Video Settings, their terrain showed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,14 @@ what the next one holds.
   in, which drags them out over several more. Every such buffer is now emptied whole the moment it
   is allocated, which is before the pack has drawn anything into it.
 
+- **A modded dimension is drawn from the folder its pack sends it to.** Both Complementary
+  variants with Euphoria Patches list the worlds that belong to the Nether and to the End one
+  continued line per mod in `dimension.properties`, and only the first of those lines was read.
+  Everything the rest name, which is Ad Astra's planets and orbits, Prominent's dimensions, The
+  Bumblezone and half a dozen more, fell through to the pack's catch-all: those worlds were drawn
+  with the overworld sky, the overworld fog and the overworld full-screen passes instead of the
+  ones the pack wrote for them. They now get the folder the pack names, as they do under Iris.
+
 - **A value a pack spreads over several lines stops at the end of its own branch.** A
   `shaders.properties` value continued with a backslash was joined before the conditionals around
   it were read, so a value whose last line carried a backslash too swallowed the `#else` or

--- a/common/src/main/java/dev/vitrail/pack/source/DimensionSet.java
+++ b/common/src/main/java/dev/vitrail/pack/source/DimensionSet.java
@@ -4,11 +4,11 @@ import dev.vitrail.pack.option.EngineDefines;
 import dev.vitrail.pack.target.TargetPlan;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -67,14 +67,13 @@ public final class DimensionSet {
 		Map<String, String> places = new LinkedHashMap<>();
 		boolean declared = false;
 
-		Optional<java.nio.file.Path> properties = source.file(PROPERTIES);
-		if (properties.isPresent()) {
+		PropertiesFile properties = PropertiesFile.read(source, PROPERTIES);
+		if (properties.present()) {
 			// The engine's table and never the pack's settings: the reference preprocesses this
 			// file before the include graph exists, so a conditional here can only see the
 			// environment defines (ShaderPack.java:125-126). A declaration in a dead branch is
 			// no declaration.
 			Map<String, String> defines = EngineDefines.table(EngineDefines.machine());
-			ConditionStack conditions = new ConditionStack();
 
 			// A folder to the LAST worlds it was assigned, in first-assignment order. The
 			// reference reads this file as ordered properties, so re-assigning dimension.<folder>
@@ -83,17 +82,15 @@ public final class DimensionSet {
 			// claiming one world are settled by whichever entry sits later.
 			Map<String, String> assignments = new LinkedHashMap<>();
 
-			for (String line : source.readLines(properties.get())) {
-				Matcher directive = ShaderProperties.DIRECTIVE.matcher(line);
-				if (directive.matches()) {
-					ShaderProperties.applyDirective(directive.group(1), line, conditions, defines);
-					continue;
-				}
+			// The shared walk, for the continuations as much as for the conditionals: both
+			// Complementary variants list the modded worlds of a dimension one continued line per
+			// mod, and the reference joins them because it loads the preprocessed file as
+			// properties (ShaderPack.java:376-385). Read line by line, every mod but the first is
+			// lost and the backslash is left behind as a world of its own.
+			List<String> live = new ArrayList<>();
+			properties.walk(defines, live::add);
 
-				if (!conditions.active()) {
-					continue;
-				}
-
+			for (String line : live) {
 				Matcher declaration = DECLARATION.matcher(line);
 				if (declaration.matches()) {
 					assignments.put(declaration.group(1), declaration.group(2));

--- a/common/src/main/java/dev/vitrail/pack/source/PropertiesFile.java
+++ b/common/src/main/java/dev/vitrail/pack/source/PropertiesFile.java
@@ -65,10 +65,15 @@ public final class PropertiesFile {
 	 * never a blank line.
 	 */
 	public void walk(Map<String, String> defines, Consumer<String> line) {
+		walk(this.lines, defines, line);
+	}
+
+	/** The same walk over lines held elsewhere, so that {@link ShaderProperties} reads its own. */
+	static void walk(List<String> lines, Map<String, String> defines, Consumer<String> line) {
 		ConditionStack conditions = new ConditionStack();
 		StringBuilder joined = null;
 
-		for (String text : this.lines) {
+		for (String text : lines) {
 			Matcher directive = DIRECTIVE.matcher(text);
 			if (directive.matches()) {
 				apply(directive.group(1), text, conditions, defines);

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -68,8 +68,7 @@ public final class ShaderProperties {
 	// three of its continuations on a blank line, and its main screen swallowed the commented
 	// block underneath.
 	private static final Pattern CONTINUATION = Pattern.compile("\\\\\\r?\\n[ \\t]*");
-	// Package visible rather than private: DimensionSet walks its own file with the same stack.
-	static final Pattern DIRECTIVE = Pattern.compile("^\\s*#\\s*(if|ifdef|ifndef|else|elif|endif)\\b.*$");
+	private static final Pattern DIRECTIVE = Pattern.compile("^\\s*#\\s*(if|ifdef|ifndef|else|elif|endif)\\b.*$");
 
 	private static final Pattern PROFILE = Pattern.compile("^\\s*profile\\.(\\w+)\\s*=\\s*(.*)$");
 	private static final Pattern PROGRAM_ENABLED = Pattern.compile("^\\s*program\\.(.+?)\\.enabled\\s*=\\s*(.*)$");
@@ -815,26 +814,6 @@ public final class ShaderProperties {
 				this.position++;
 			}
 		}
-	}
-
-	static void applyDirective(String keyword, String line, ConditionStack conditions,
-			Map<String, String> defines) {
-		switch (keyword) {
-			case "ifdef", "ifndef" -> {
-				String name = line.replaceAll("^\\s*#\\s*\\w+\\s+", "").trim().split("\\s+", -1)[0];
-				conditions.ifDirective(keyword.equals("ifdef") == defines.containsKey(name));
-			}
-			case "if" -> conditions.ifDirective(
-					PreprocessorExpression.evaluate(after(line), defines).orElse(true));
-			case "elif" -> conditions.elifDirective(
-					() -> PreprocessorExpression.evaluate(after(line), defines).orElse(true));
-			case "else" -> conditions.elseDirective();
-			default -> conditions.endifDirective();
-		}
-	}
-
-	private static String after(String line) {
-		return line.replaceAll("^\\s*#\\s*\\w+\\s*", "");
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -41,6 +41,23 @@ import java.util.regex.Pattern;
  * <p>
  * It also carries conditionals, and they matter: packs switch whole programs off with an
  * {@code #if} on a setting. Reading the file flat would report those programs as present.
+ * <p>
+ * <strong>Two roads run through this file, and which one a key takes is settled by whether a
+ * setting can decide it.</strong> Every reader handed a define table walks the lines as written,
+ * applying the conditionals first and joining the continuations after. That is the order the
+ * reference has by construction: it runs its preprocessor over the whole file and only then hands
+ * the result to {@code Properties.load}. Joining first lets a value that ends on a backslash
+ * swallow the {@code #else} or {@code #endif} that closes its own branch, and the branch then runs
+ * on into the one meant to replace it. Photon writes exactly that, its moon brightness spread over
+ * eleven continued lines of which the last one continues too.
+ * <p>
+ * The one pass in {@link #parse} takes the other road, a flat fold of the file read straight
+ * through with the directives stepped over, and it has to: it runs before any setting exists, and
+ * the profiles it reads are themselves what decide the settings a conditional would be evaluated
+ * against. What it keeps is what the reference reads off its own non-preprocessed copy for that
+ * same reason, the profiles, the screens with their pages and column counts, the sliders and the
+ * two feature lines, {@code properties/ShaderProperties.java:600} there. Everything else it
+ * recognises it only counts, the readers above answering for the value.
  */
 public final class ShaderProperties {
 
@@ -210,15 +227,27 @@ public final class ShaderProperties {
 
 		builder.present = true;
 
-		String text = String.join("\n", source.readLines(file.get()));
+		builder.lines = List.copyOf(source.readLines(file.get()));
+
+		String text = String.join("\n", builder.lines);
 		Matcher continuation = CONTINUATION.matcher(text);
 		while (continuation.find()) {
 			builder.continuationCount++;
 		}
 
-		builder.lines = List.of(CONTINUATION.matcher(text).replaceAll(" ").split("\n", -1));
-
+		// Counted on the lines as written and not on the fold below, since those are the lines the
+		// conditional readers apply: a directive a continued value swallows is one the file carries
+		// and one that decides a branch, so a census taken after the fold reports fewer directives
+		// than the pack has. Photon's #else at shaders.properties:495 is the one in the corpus.
 		for (String line : builder.lines) {
+			if (DIRECTIVE.matcher(line).matches()) {
+				builder.directiveCount++;
+			}
+		}
+
+		// The flat road of the two the class comment describes: no setting exists yet to decide a
+		// conditional with, so this reads the file folded and straight through.
+		for (String line : CONTINUATION.matcher(text).replaceAll(" ").split("\n", -1)) {
 			read(line, builder);
 		}
 
@@ -227,7 +256,6 @@ public final class ShaderProperties {
 
 	private static void read(String line, Builder builder) {
 		if (DIRECTIVE.matcher(line).matches()) {
-			builder.directiveCount++;
 			return;
 		}
 
@@ -592,24 +620,13 @@ public final class ShaderProperties {
 	 */
 	public Map<String, String> programConditions(Map<String, String> defines) {
 		Map<String, String> expressions = new LinkedHashMap<>();
-		ConditionStack conditions = new ConditionStack();
 
-		for (String line : this.lines) {
-			Matcher directive = DIRECTIVE.matcher(line);
-			if (directive.matches()) {
-				applyDirective(directive.group(1), line, conditions, defines);
-				continue;
-			}
-
-			if (!conditions.active()) {
-				continue;
-			}
-
+		PropertiesFile.walk(this.lines, defines, line -> {
 			Matcher program = PROGRAM_ENABLED.matcher(line);
 			if (program.matches()) {
 				expressions.put(program.group(1), program.group(2).trim());
 			}
-		}
+		});
 
 		return expressions;
 	}
@@ -834,25 +851,14 @@ public final class ShaderProperties {
 	 */
 	public List<CustomUniform> customUniforms(Map<String, String> defines) {
 		List<CustomUniform> uniforms = new ArrayList<>();
-		ConditionStack conditions = new ConditionStack();
 
-		for (String line : this.lines) {
-			Matcher directive = DIRECTIVE.matcher(line);
-			if (directive.matches()) {
-				applyDirective(directive.group(1), line, conditions, defines);
-				continue;
-			}
-
-			if (!conditions.active()) {
-				continue;
-			}
-
+		PropertiesFile.walk(this.lines, defines, line -> {
 			Matcher uniform = CUSTOM_UNIFORM.matcher(line);
 			if (uniform.matches()) {
 				uniforms.add(new CustomUniform(uniform.group(1).equals("uniform"), uniform.group(2),
 						uniform.group(3), Macros.expand(uniform.group(4).trim(), defines)));
 			}
-		}
+		});
 
 		return uniforms;
 	}
@@ -872,24 +878,17 @@ public final class ShaderProperties {
 	 */
 	public Map<String, String> customTextures(Map<String, String> defines) {
 		Map<String, String> declared = new LinkedHashMap<>();
-		ConditionStack conditions = new ConditionStack();
 
-		for (String line : this.lines) {
-			Matcher directive = DIRECTIVE.matcher(line);
-			if (directive.matches()) {
-				applyDirective(directive.group(1), line, conditions, defines);
-				continue;
-			}
-
-			if (!conditions.active() || TEXTURE_NOISE.matcher(line).matches()) {
-				continue;
+		PropertiesFile.walk(this.lines, defines, line -> {
+			if (TEXTURE_NOISE.matcher(line).matches()) {
+				return;
 			}
 
 			Matcher texture = CUSTOM_TEXTURE.matcher(line);
 			if (texture.matches()) {
 				declared.put(texture.group(1), texture.group(2).trim());
 			}
-		}
+		});
 
 		return declared;
 	}
@@ -1023,20 +1022,13 @@ public final class ShaderProperties {
 	 */
 	private List<Matcher> live(Pattern pattern, Map<String, String> defines) {
 		List<Matcher> matched = new ArrayList<>();
-		ConditionStack conditions = new ConditionStack();
 
-		for (String line : this.lines) {
-			Matcher directive = DIRECTIVE.matcher(line);
-			if (directive.matches()) {
-				applyDirective(directive.group(1), line, conditions, defines);
-				continue;
-			}
-
+		PropertiesFile.walk(this.lines, defines, line -> {
 			Matcher match = pattern.matcher(line);
-			if (conditions.active() && match.matches()) {
+			if (match.matches()) {
 				matched.add(match);
 			}
-		}
+		});
 
 		return matched;
 	}
@@ -1099,18 +1091,11 @@ public final class ShaderProperties {
 	public ImageInformation.Reading imageDirectives(Map<String, String> defines) {
 		List<ImageInformation> images = new ArrayList<>();
 		List<String> dropped = new ArrayList<>();
-		ConditionStack conditions = new ConditionStack();
 
-		for (String line : this.lines) {
-			Matcher directive = DIRECTIVE.matcher(line);
-			if (directive.matches()) {
-				applyDirective(directive.group(1), line, conditions, defines);
-				continue;
-			}
-
+		PropertiesFile.walk(this.lines, defines, line -> {
 			Matcher image = IMAGE.matcher(line);
-			if (!conditions.active() || !image.matches()) {
-				continue;
+			if (!image.matches()) {
+				return;
 			}
 
 			String name = image.group(1);
@@ -1118,14 +1103,14 @@ public final class ShaderProperties {
 			if (images.size() >= ImageInformation.LIMIT) {
 				dropped.add("image." + name + ": only " + ImageInformation.LIMIT
 						+ " storage images are allowed");
-				continue;
+				return;
 			}
 
 			String reason = readImage(name, value, defines, images);
 			if (reason != null) {
 				dropped.add("image." + name + " = " + value + ": " + reason);
 			}
-		}
+		});
 
 		return new ImageInformation.Reading(images, dropped);
 	}
@@ -1142,18 +1127,11 @@ public final class ShaderProperties {
 	public BufferObject.Reading bufferObjects(Map<String, String> defines) {
 		Map<Integer, BufferObject> buffers = new LinkedHashMap<>();
 		List<String> dropped = new ArrayList<>();
-		ConditionStack conditions = new ConditionStack();
 
-		for (String line : this.lines) {
-			Matcher directive = DIRECTIVE.matcher(line);
-			if (directive.matches()) {
-				applyDirective(directive.group(1), line, conditions, defines);
-				continue;
-			}
-
+		PropertiesFile.walk(this.lines, defines, line -> {
 			Matcher buffer = BUFFER_OBJECT.matcher(line);
-			if (!conditions.active() || !buffer.matches()) {
-				continue;
+			if (!buffer.matches()) {
+				return;
 			}
 
 			String reason = readBufferObject(buffer.group(1), buffer.group(2).trim(), buffers);
@@ -1161,7 +1139,7 @@ public final class ShaderProperties {
 				dropped.add("bufferObject." + buffer.group(1) + " = " + buffer.group(2).trim()
 						+ ": " + reason);
 			}
-		}
+		});
 
 		return new BufferObject.Reading(List.copyOf(buffers.values()), dropped);
 	}

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -96,11 +96,24 @@ had no parent.
 Only `=` separates a key from its value, and **there is no end-of-line comment**: everything after
 the first `=` is the value.
 
-Backslash continuations are joined before the file is split into lines, and the joining rule
-swallows the following line's indentation, but never a blank line. That boundary is the whole of
-the rule and it is not a detail: widening it to "any whitespace" makes a continued key absorb
-whatever block follows it, and packs do end continuations on a blank line. One pack's main screen
-swallowed the commented-out block underneath when the rule was written the other way.
+**The conditionals are resolved first and the backslash continuations joined after**, which is the
+order the reference has by construction: its preprocessor runs over the whole file, and only the
+result of that is handed to a properties reader that knows how to join. Fold the file first and a
+value whose last continued line also ends on a backslash swallows the `#else` or `#endif` that
+closes its own branch, so the branch runs on into the one written to replace it and neither value
+comes out as the pack wrote it. Every key read against the pack's settings takes that road here,
+which is everything in this file bar the handful named next.
+
+Profiles, the settings screen with its pages and column counts, the sliders and the two feature
+lines are read the other way, off one flat fold of the file with the directives passed over. They
+have to be, since a profile decides the settings a conditional would be evaluated against, and the
+reference reads those same keys off its own non-preprocessed copy for the same reason.
+
+Either way the joining rule swallows the following line's indentation, but never a blank line. That
+boundary is the whole of the rule and it is not a detail: widening it to "any whitespace" makes a
+continued key absorb whatever block follows it, and packs do end continuations on a blank line. One
+pack's main screen swallowed the commented-out block underneath when the rule was written the other
+way.
 
 The recognised families include profiles, per-program enable flags, custom uniform and variable
 declarations, the settings screen and its pages, blending, alpha test and sliders, and also the


### PR DESCRIPTION
## What changes

A `shaders.properties` value continued across lines with a backslash no longer swallows the conditional directive that follows it. The file was folded before its conditionals were read, so a continued value whose last line also ended with a backslash ate the `#else` under it: Photon's moon brightness table was lost, the moon read as full at every phase with the setting on and gave no moonlight with it off. The conditionals are now resolved first and the lines joined after, in the order Iris takes. The same walk now joins the continued lines of `dimension.properties`, which were never joined: both Complementary builds declare modded dimensions across lines there, and those ids now reach the pack's nether and end folders as declared.

## How it differs from the reference, and for what obstacle

It does not. Iris hides every backslash from its preprocessor and lets `Properties.load` join afterwards (`PropertiesPreprocessor.java`, `properties/ShaderProperties.java:131-147`); the readers Iris takes from the non-preprocessed copy (profiles, screens, sliders, feature lines) keep folding flat here too.

## What proves it

- `gradlew build` green.
- Iris's own bytecode run as the oracle on Photon's file: it keeps the table with the setting on and gives `1.0` with it off, which is what this engine now reads.
- Off-game harness on the corpus, base against branch: `Expressions` on Photon goes from 71 declared and 9 dropped to 70 and 8, `moon_phase_brightness` no longer among the failures; the two algorithms replayed over all nine packs differ on that one value only; `Harness` TSV byte-identical; a probe over `DimensionSet` shows Complementary's six modded dimension ids landing in the declared folders where they fell to the overworld before.
- Not seen in game: the moon's brightness through a lunar cycle under Photon is for a dated capture.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
