### PR TITLE
feat(shadow): open the shadow colour buffers a pack asks for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ what the next one holds.
   view reads it again as before. The picture is the same, and none of this has been measured, so
   it says work removed rather than frames gained.
 
+### Added
+
+- **Eight shadow colour buffers for a pack that asks for them.** A pack declaring
+  `HIGHER_SHADOWCOLOR` may now draw the light into `shadowcolor0` through `shadowcolor7` and read
+  them back, which is what Iris gives it. Before, a shadow program naming anything above
+  `shadowcolor1` had its whole target list thrown away and drew into the first two instead, which
+  is still what a pack that does not declare the flag gets, exactly as under Iris. And only the
+  buffers some program of the pack names are allocated now, so a pack writing `shadowcolor0` alone
+  pays for that one image where it used to pay for two.
+
 ### Fixed
 
 - **Importing settings no longer acts on a screen you have already left.** The window that asks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ what the next one holds.
   buffers some program of the pack names are allocated now, so a pack writing `shadowcolor0` alone
   pays for that one image where it used to pay for two.
 
+- **Two more capability flags are announced and no longer refuse a pack**, `HIGHER_SHADOWCOLOR`
+  and `SSBO`. The storage buffers behind the second were already built and filled from a pack's
+  own `bufferObject` lines, and the name was simply never claimed, so a pack that declared it could
+  not be drawn at all. A pack requiring either, or both, now loads.
+
 ### Fixed
 
 - **Importing settings no longer acts on a screen you have already left.** The window that asks

--- a/NOTICE
+++ b/NOTICE
@@ -29,7 +29,13 @@ GNU Lesser General Public License version 3
   net.irisshaders.iris.shaderpack.parsing.ConstDirectiveParser and of
   net.irisshaders.iris.shaderpack.parsing.CommentDirectiveParser together with
   net.irisshaders.iris.shaderpack.properties.ProgramDirectives. Both rules are odd enough that
-  reasoning them out would get them wrong, so they are reproduced rather than reinvented.
+  reasoning them out would get them wrong, so they are reproduced rather than reinvented. The
+  second carries one more of Iris's rules, for the geometry drawn from the light: a declaration
+  naming a shadow colour buffer past the ceiling its pack may reach is thrown away whole and
+  answered with buffers nought and one, which is also what a program declaring nothing is given.
+  net.irisshaders.iris.shadows.ShadowRenderTargets.createColorFramebuffer writes that pair out
+  literally, as do net.irisshaders.iris.pipeline.programs.SodiumPrograms and
+  net.irisshaders.iris.pipeline.programs.ShaderCreator, so it stays the pair whatever the ceiling.
 
   common/src/main/java/dev/vitrail/pack/target/TargetDirectives.java and
   common/src/main/java/dev/vitrail/pack/target/TargetSchedule.java carry the semantics of
@@ -149,13 +155,19 @@ GNU Lesser General Public License version 3
   fall, and packs are written against that. SHADOWHPL, which is a comment directive rather than a
   const one, is not implemented.
 
-  common/src/main/java/dev/vitrail/render/ShadowTargets.java sizes the light's colour targets at
-  two, which is the count net.irisshaders.iris.shadows.ShadowRenderTargets gives a pack that does
-  not ask for HIGHER_SHADOWCOLOR, line 46, and keeps the rule that a clear turned off still leaves
-  a buffer starting life at its clear colour. The eight of HIGHER_SHADOWCOLOR are not implemented,
-  the one pack of the corpus asking being refused at load for a reason of its own; and all the
-  targets are made with the map where Iris builds each one the first time a framebuffer names it,
-  lines 127 and 136, which changes when memory is taken and nothing a pack can read.
+  common/src/main/java/dev/vitrail/render/ShadowTargets.java ceilings the light's colour targets
+  the way net.irisshaders.iris.shadows.ShadowRenderTargets sizes its array, line 46: two for a pack
+  that does not declare HIGHER_SHADOWCOLOR and eight for one that does, both numbers from
+  net.irisshaders.iris.shaderpack.properties.PackShadowDirectives lines 19 and 20, and the
+  declaration read off the pack's own iris.features lines as
+  net.irisshaders.iris.shaderpack.ShaderPack does, lines 208 to 213. It keeps the rule that a clear
+  turned off still leaves a buffer starting life at its clear colour, and the rule that a buffer no
+  program of the place names is never allocated, which Iris gets from building each one where a
+  framebuffer or a sampler first asks for it, lines 127 and 136 and
+  net.irisshaders.iris.samplers.IrisSamplers.addShadowSamplers, and buffer nought at construction
+  whatever any program says, lines 73 and 75. What is not reused is when: the named ones are all
+  built with the map rather than each at its first use, because the shadow programs of this engine
+  are not all built before the first frame is drawn.
 
   common/src/main/java/dev/vitrail/render/StorageBuffers.java keeps the rule that a bufferObject
   starts life at zero, which net.irisshaders.iris.gl.buffer.ShaderStorageBuffer applies at line 79

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -182,7 +182,7 @@ public final class EngineDefines {
 
 		// The block emission attribute is served: the chunk element carries the block's own light
 		// in the fourth component of at_midBlock, on the terrain and in the shadow map alike
-		// (SodiumVertex.MID_BLOCK). Iris poses the flag whatever the hardware
+		// (SodiumVertex.MID_BLOCK). Iris holds the flag usable whatever the hardware
 		// (features/FeatureFlags.java:20), and packs decide more than a vertex read on it:
 		// Complementary sizes its two reflection targets under it, Bliss writes its voxel
 		// emission under it.
@@ -193,9 +193,31 @@ public final class EngineDefines {
 		// whatever the hardware, features/FeatureFlags.java:12.
 		defines.put("IRIS_FEATURE_SEPARATE_HARDWARE_SAMPLERS", "");
 
-		// The rest of IRIS_FEATURE_ stays unposted until each capability is served. See
-		// ShaderProperties.optionalFeatures for the other half of the answer, and PackChain for
-		// what a pack requiring one is told.
+		// The eight shadow colour buffers are served: a pack that declares HIGHER_SHADOWCOLOR may
+		// name shadowcolor0 to shadowcolor7, and render/ShadowTargets allocates the ones some
+		// program of the place writes or samples. Iris holds the flag usable whatever the hardware
+		// (features/FeatureFlags.java:13) and reads it in one place only, the size of its shadow
+		// colour array (shadows/ShadowRenderTargets.java:46). This define does not raise that
+		// ceiling and must not be read as though it did: what sizes it is the pack's own
+		// iris.features line, TargetPlan.shadowCeiling here.
+		defines.put("IRIS_FEATURE_HIGHER_SHADOWCOLOR", "");
+
+		// Storage blocks are served: a bufferObject directive is read and its buffer allocated
+		// (render/StorageBuffers), and a block a program declares is bound as a storage descriptor
+		// rather than a uniform one (mixin/VulkanBindGroupLayoutMixin). Iris holds the flag usable
+		// only where the driver has them (features/FeatureFlags.java:22,
+		// IrisRenderSystem.supportsSSBO). Vulkan has them everywhere, so the condition has nothing
+		// left to test.
+		defines.put("IRIS_FEATURE_SSBO", "");
+
+		// The rest of IRIS_FEATURE_ stays unposted until each capability is served, and each of the
+		// five above is posed for every pack. That is a divergence: Iris poses IRIS_FEATURE_X only
+		// where the pack itself listed X under iris.features.optional
+		// (shaderpack/ShaderPack.java:247-251), its all-usable list serving the evaluation of
+		// shaders.properties and nothing in the GLSL (lines 171-175). The two differ only for a
+		// pack that reads a symbol it never declared, and closing it is a lot of its own. See
+		// ShaderProperties.declares for the declaration itself, and PackChain for what a pack
+		// requiring one of these names is told.
 
 		// Straight off the enum the engine sets, so that the number a pack compares against and the
 		// number the block carries cannot part company. The value IS the ordinal.

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -1615,19 +1615,32 @@ public final class ShaderProperties {
 
 	/**
 	 * What the pack would use if it were there, and takes another path without. It is the list Iris
-	 * turns into {@code IRIS_FEATURE_} defines for the GLSL. A flag is posed the day the capability
+	 * turns into the {@code IRIS_FEATURE_} defines a pack's GLSL finds
+	 * ({@code shaderpack/ShaderPack.java:247-251}). A flag is posed here the day the capability
 	 * behind it is served and not before, a define being a promise, and every other name stays
-	 * unposed, which is what tells a pack to take the other path for it. Which names those are
-	 * today is written where they are posed, {@code EngineDefines.table}.
+	 * unposed, which is what tells a pack to take the other path for it. Iris poses a define only
+	 * where the pack lists the flag here; this engine poses the ones it serves for every pack, and
+	 * {@code EngineDefines.table} owns that difference and the list of names.
 	 * <p>
-	 * Nothing in the engine reads this list, and that is deliberate rather than an oversight: there
-	 * is nothing here to decide from it. What taking the line out of the ignored keys buys is
-	 * already bought by reading it at all, since that is what stops it being counted; what the list
-	 * itself is for is the measurement made out of the game, which is where the corpus is counted,
-	 * exactly as {@link #malformedAlphaTests} is.
+	 * Kept whole and unfiltered, because it is also what the measurement made out of the game
+	 * counts, exactly as {@link #malformedAlphaTests} is.
 	 */
 	public List<String> optionalFeatures() {
 		return this.optionalFeatures;
+	}
+
+	/**
+	 * Whether the pack names a capability at all, required or optional, which is the question that
+	 * decides what a name buys it. Iris folds the two lists into one set and asks it exactly this
+	 * ({@code shaderpack/ShaderPack.java:208-213}, read at line 620 by {@code hasFeature}), and its
+	 * own lookup is case-insensitive ({@code features/FeatureFlags.java:65-73}), so this one is too.
+	 */
+	public boolean declares(String feature) {
+		return names(this.requiredFeatures, feature) || names(this.optionalFeatures, feature);
+	}
+
+	private static boolean names(List<String> declared, String feature) {
+		return declared.stream().anyMatch(name -> name.equalsIgnoreCase(feature));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -1606,8 +1606,10 @@ public final class ShaderProperties {
 	 * What the pack says it cannot be drawn without, in the pack's own spelling and unfiltered.
 	 * <p>
 	 * Whoever compares this list decides what the names mean; this class only reads them. Iris
-	 * refuses a pack naming one it cannot serve, and the same answer is the honest one here: this
-	 * engine serves none of them, so any name at all is a name it cannot answer.
+	 * refuses a pack naming one it cannot serve and the rule here is the same: {@code PackChain}
+	 * strikes off the names this engine has built, which are the ones {@code EngineDefines} poses
+	 * an {@code IRIS_FEATURE_} define for, and refuses the pack on whatever is left over. The two
+	 * move together, a define being the promise the refusal is the other half of.
 	 */
 	public List<String> requiredFeatures() {
 		return this.requiredFeatures;

--- a/common/src/main/java/dev/vitrail/pack/target/DrawBuffers.java
+++ b/common/src/main/java/dev/vitrail/pack/target/DrawBuffers.java
@@ -4,7 +4,6 @@ import dev.vitrail.pack.source.IncludeExpander;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
 
 /**
  * Which colour attachments a program says it writes.
@@ -35,6 +34,9 @@ import java.util.stream.IntStream;
  * declare sixteen outputs.
  */
 public final class DrawBuffers {
+
+	/** What the light is drawn into when its program's declaration says nothing usable. */
+	private static final List<Integer> PAIR = List.of(0, 1);
 
 	private DrawBuffers() {
 	}
@@ -93,23 +95,31 @@ public final class DrawBuffers {
 	 * pair answers a program that declares nothing, from the other end of the same call
 	 * ({@code pipeline/programs/SodiumPrograms.java:137-139}).
 	 * <p>
-	 * Reverie is the one pack of the corpus this changes anything for, with
-	 * {@code RENDERTARGETS:0,2,1}, and it is refused at load here for a reason of its own. Keeping
-	 * its rank as an empty slot instead was the shape this had first, and it is wrong twice over:
-	 * Iris never produces that mapping, and an empty slot at rank nought is a shadow stage that
-	 * throws in the middle of a frame rather than drawing.
+	 * <strong>The pair is the pair, whatever the ceiling.</strong> Iris writes it out as
+	 * {@code new int[]{0, 1}} at all three of those places and never as "every buffer there is", so
+	 * raising the ceiling to the eight of {@code HIGHER_SHADOWCOLOR} must not widen what a program
+	 * declaring nothing draws into. Reading the pair off the count was the shape this had first,
+	 * and it answered the same list only while the count was two.
+	 * <p>
+	 * Reverie is the one pack of the corpus the ceiling changes anything for, with
+	 * {@code RENDERTARGETS:0,2,1}, and it is also the one pack of it that declares the flag. Keeping
+	 * its rank as an empty slot instead was another shape this had, and it is wrong twice over: Iris
+	 * never produces that mapping, and an empty slot at rank nought is a shadow stage that throws in
+	 * the middle of a frame rather than drawing.
 	 *
-	 * @param existing how many shadow colour targets this engine has at all, which is the ceiling
-	 *                 Iris compares a declared index against ({@code targets.length}, returned by
-	 *                 {@code shadows/ShadowRenderTargets.java:112}) and not how many are in use
+	 * @param existing how many shadow colour targets THIS PACK may reach, which is the ceiling Iris
+	 *                 compares a declared index against ({@code targets.length}, returned by
+	 *                 {@code shadows/ShadowRenderTargets.java:112}) and not how many are in use. It
+	 *                 is the pack's own {@code HIGHER_SHADOWCOLOR} declaration that sizes it, line
+	 *                 46 there and {@link TargetPlan#shadowCeiling} here, so the same declaration
+	 *                 that reaches {@code shadowcolor2} is what stops every other pack reaching it
 	 */
 	public static List<Integer> shadowColours(List<Integer> declared, int existing) {
-		List<Integer> pair = IntStream.range(0, existing).boxed().toList();
 		if (declared.isEmpty()) {
-			return pair;
+			return PAIR;
 		}
 
-		return declared.stream().anyMatch(index -> index >= existing) ? pair : List.copyOf(declared);
+		return declared.stream().anyMatch(index -> index >= existing) ? PAIR : List.copyOf(declared);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
+++ b/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
@@ -41,6 +41,37 @@ import java.util.TreeMap;
  */
 public final class PackDirectives {
 
+	/** The name a pack declares to be given the eight, in Iris's own spelling. */
+	public static final String HIGHER_SHADOWCOLOR = "HIGHER_SHADOWCOLOR";
+
+	/**
+	 * How many {@code shadowcolor} buffers a pack that declares {@link #HIGHER_SHADOWCOLOR} may
+	 * name ({@code shaderpack/properties/PackShadowDirectives.java:19}).
+	 * <p>
+	 * It is what a name is admitted against and not what is allocated: {@code render/ShadowTargets}
+	 * takes the memory for a buffer some program of the place writes or samples, and for no other.
+	 */
+	public static final int MAX_SHADOW_COLOURS = 8;
+
+	/**
+	 * How many a pack that does not declare it may name, the two of ShadersMod and OptiFine
+	 * ({@code shaderpack/properties/PackShadowDirectives.java:20}).
+	 * <p>
+	 * <strong>The lower number is the one most packs get, and posing the define does not raise
+	 * it.</strong> Iris sizes the array off the pack's own declaration and off nothing else
+	 * ({@code shadows/ShadowRenderTargets.java:46} asking {@code hasFeature}, which is the two
+	 * {@code iris.features} lines and no more, {@code shaderpack/ShaderPack.java:208-213}), so a
+	 * pack that never asked for the eight has to keep reaching the same two: its
+	 * {@code RENDERTARGETS:0,2} is a list past the ceiling, thrown away whole, and what it draws
+	 * into is the pair.
+	 */
+	public static final int SHADOW_COLOURS = 2;
+
+	/** The ceiling one pack is read against, which is one of the two above and nothing between. */
+	public static int shadowColours(boolean declared) {
+		return declared ? MAX_SHADOW_COLOURS : SHADOW_COLOURS;
+	}
+
 	private final float sunPathRotation;
 	private final float ambientOcclusionLevel;
 	private final float wetnessHalflife;

--- a/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
@@ -99,8 +99,13 @@ public final class SamplerPlan {
 	 */
 	private static final String CENTER_DEPTH = "ofCenterDepthSmooth";
 
-	/** Iris allows eight, and the corpus stops at three. */
-	private static final int MAX_SHADOW_COLOURS = 8;
+	/**
+	 * The highest a {@code shadowcolor} name goes, and deliberately not the ceiling the pack it
+	 * belongs to may reach: that one is {@link TargetPlan#shadowCeiling} and it decides what is
+	 * ALLOCATED. A name above the pack's own ceiling is still a shadow colour here, and what it
+	 * reads is the white stand-in, which is the answer every buffer nothing filled already gets.
+	 */
+	private static final int MAX_SHADOW_COLOURS = PackDirectives.MAX_SHADOW_COLOURS;
 
 	private final List<Binding> bindings;
 	private final Map<String, Binding> byName;
@@ -506,7 +511,8 @@ public final class SamplerPlan {
 				: name.charAt(SHADOW_COLOUR_PREFIX.length()) - '0';
 	}
 
-	private static boolean isShadowColour(String name) {
+	/** Whether a name reads one of the light's colour targets, the bare {@code shadowcolor} included. */
+	public static boolean isShadowColour(String name) {
 		if (name.equals(SHADOW_COLOUR_PREFIX)) {
 			return true;
 		}

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -90,6 +90,8 @@ public final class TargetPlan {
 	private final Set<Integer> written;
 	private final Set<Integer> sampled;
 	private final Set<Integer> allocated;
+	private final int shadowCeiling;
+	private final Set<Integer> shadowAllocated;
 	private final List<Integer> ordered;
 	private final Set<Integer> persistent;
 	private final List<String> running;
@@ -133,6 +135,8 @@ public final class TargetPlan {
 		allocated.addAll(draft.sampled);
 		this.allocated = Collections.unmodifiableSet(allocated);
 		this.ordered = List.copyOf(allocated);
+		this.shadowCeiling = draft.shadowCeiling;
+		this.shadowAllocated = Collections.unmodifiableSet(new TreeSet<>(draft.shadowNamed));
 
 		TreeSet<Integer> persistent = new TreeSet<>();
 		allocated.stream().filter(index -> !draft.directives.clears(index)).forEach(persistent::add);
@@ -180,6 +184,8 @@ public final class TargetPlan {
 		draft.dimension = dimension;
 		draft.place = present ? dimension : ProgramSet.ROOT;
 		draft.properties = properties;
+		draft.shadowCeiling =
+				PackDirectives.shadowColours(properties.declares(PackDirectives.HIGHER_SHADOWCOLOR));
 
 		List<ProgramSet.ProgramKey> entries = programs.fragmentsOf(draft.place);
 
@@ -473,12 +479,26 @@ public final class TargetPlan {
 			draft.writes.put(key.name().baseName(), writes);
 			if (fromTheLight) {
 				draft.fromTheLight.add(key.name().baseName());
+				// Through the same rule the light's own pass will be attached by, so that what is
+				// allocated cannot come out short of what a shadow program draws into: a declaration
+				// naming a buffer past the ceiling is the pair, and so is no declaration at all.
+				draft.shadowNamed.addAll(DrawBuffers.shadowColours(writes, draft.shadowCeiling));
 			} else {
 				draft.written.addAll(writes);
 			}
 
 			Set<Integer> indices = new TreeSet<>();
 			for (String sampler : samplers(unit)) {
+				// Under the same ceiling, which is what stops a name from allocating an image Iris
+				// would not have. Iris binds a shadow colour sampler by walking the array it sized
+				// off the declaration and building each one it finds a name for
+				// (samplers/IrisSamplers.java:159-163), so shadowcolor2 in a pack that never asked
+				// for the eight is a name nothing answers rather than an image.
+				if (SamplerPlan.isShadowColour(sampler)
+						&& SamplerPlan.shadowColour(sampler) < draft.shadowCeiling) {
+					draft.shadowNamed.add(SamplerPlan.shadowColour(sampler));
+				}
+
 				TargetName.index(sampler).ifPresent(index -> {
 					draft.sampled.add(index);
 					indices.add(index);
@@ -548,6 +568,36 @@ public final class TargetPlan {
 	/** Written or sampled by some program of the place. Nothing else is allocated. */
 	public Set<Integer> allocated() {
 		return this.allocated;
+	}
+
+	/**
+	 * How many {@code shadowcolor} buffers this pack may reach, which is the pack's own answer and
+	 * not the engine's: the eight where it declares {@link PackDirectives#HIGHER_SHADOWCOLOR} and
+	 * the two of OptiFine where it does not, exactly as Iris sizes its array
+	 * ({@code shadows/ShadowRenderTargets.java:46}). Every reading of a declared index goes through
+	 * it, here and in {@code render/GeometryProgram}, so a list naming a buffer above it is thrown
+	 * away whole and answered with the pair.
+	 */
+	public int shadowCeiling() {
+		return this.shadowCeiling;
+	}
+
+	/**
+	 * The same question for the light's own colour buffers: which {@code shadowcolor} a program of
+	 * the place draws into or samples, and therefore which of them are worth the memory.
+	 * <p>
+	 * Read off the fragment stages, which is where the writes live: {@code RENDERTARGETS} is a
+	 * fragment directive, and the sampler scan runs over the same units. A name declared in a
+	 * vertex stage alone is not in here, and neither is one only a COMPUTE of the place reads,
+	 * which is a divergence {@code render/PackCompute.engineView} sets out whole. What either
+	 * reads is the white stand-in, the same answer it gets for a buffer the light never draws into.
+	 * <p>
+	 * A place with no shadow geometry at all leaves it empty, and then nothing but the map's own
+	 * first colour is taken: the pair is what a shadow PROGRAM declaring nothing is answered with,
+	 * not what a pack with no such program is charged for.
+	 */
+	public Set<Integer> shadowAllocated() {
+		return this.shadowAllocated;
 	}
 
 	/** Sorted, holes and all: a pack declaring 0 to 9 and 16 has eleven entries. */
@@ -892,6 +942,13 @@ public final class TargetPlan {
 		private final Set<String> shadowComposites = new TreeSet<>();
 		private final Set<Integer> written = new TreeSet<>();
 		private final Set<Integer> sampled = new TreeSet<>();
+
+		/** Shadow colour buffers a program of the place draws into or reads. */
+		private final Set<Integer> shadowNamed = new TreeSet<>();
+
+		/** How many of them the pack's own declaration lets it reach. */
+		private int shadowCeiling = PackDirectives.SHADOW_COLOURS;
+
 		private final List<String> unreadable = new ArrayList<>();
 
 		private int geometryAt = -1;

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -326,7 +326,12 @@ final class ColorTargets {
 		// The image wins over the directive when the pack ships both: the directive sizes the
 		// generated field, and the image is uploaded as it stands, which is Iris's rule.
 		this.noiseImage = noiseImage;
-		this.shadowMap = new ShadowTargets(shadowResolution, shadowColours);
+		// Which of the light's colour buffers are worth the memory is the plan's answer and not a
+		// count, on the rule the colour targets themselves follow: a pack naming shadowcolor2 gets
+		// the image, a pack writing nought alone pays for nought alone. The ceiling those names were
+		// read against comes from the same place, being the pack's own declaration and not ours.
+		this.shadowMap = new ShadowTargets(shadowResolution, shadowColours, plan.shadowAllocated(),
+				plan.shadowCeiling());
 		this.doubled = Set.copyOf(plan.schedule().doubled());
 
 		// The format and the starting colour are read once and kept. Neither moves while a pack

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -604,7 +604,7 @@ final class GeometryProgram {
 		this.shadowColours = pass.shadow()
 				? DrawBuffers.shadowColours(
 						loaded.program().stages().get(ProgramStage.FRAGMENT).drawBuffers(),
-						ShadowTargets.COLOURS).stream()
+						targets.shadow().colourCeiling()).stream()
 						.limit(Math.clamp(outputs, 1, ColorTargetState.MAX_COLOR_TARGETS))
 						.toList()
 				: List.of();
@@ -1630,11 +1630,13 @@ final class GeometryProgram {
 
 		this.shadowViews.clear();
 		for (int index : this.shadowColours) {
-			// One attachment per state the pipeline carries, and in the same order. The images are
-			// allocated together with the depth, so this is null only where the depth above is, and
-			// the test is kept all the same because the two failures are not equal: a pass short of
-			// an attachment the pipeline names is setPipeline refusing in the middle of the world,
-			// where a null descriptor out of this method is the shadow stage not opening at all.
+			// One attachment per state the pipeline carries, and in the same order. Every index in
+			// the list is one the plan read for this same program through this same rule, so an
+			// image for it was allocated with the depth and this is null only where the depth above
+			// is. The test is kept all the same because the two failures are not equal: a pass short
+			// of an attachment the pipeline names is setPipeline refusing in the middle of the
+			// world, where a null descriptor out of this method is the shadow stage not opening at
+			// all.
 			GpuTextureView colour = this.shadow.colour(index);
 			if (colour == null) {
 				return null;
@@ -2284,14 +2286,16 @@ final class GeometryProgram {
 			}
 
 			// Said apart, because it is a different thing and the count above cannot show it: a
-			// directive naming a target this engine does not allocate is thrown away WHOLE, so the
-			// program draws into the pair instead of into what it asked for.
+			// directive naming a target past the ceiling is thrown away WHOLE, so the program draws
+			// into the pair instead of into what it asked for.
 			List<Integer> declared = fragment.drawBuffers();
-			if (declared.stream().anyMatch(index -> index >= ShadowTargets.COLOURS)) {
-				Vitrail.logger().warn("{} asks for {}, and this engine draws the light into {} colour "
-						+ "targets, so the whole list is set aside and the first {} are drawn into "
-						+ "instead, as the reference does with it", this.path, declared,
-						ShadowTargets.COLOURS, this.shadowColours.size());
+			int ceiling = this.shadow.colourCeiling();
+			if (declared.stream().anyMatch(index -> index >= ceiling)) {
+				Vitrail.logger().warn("{} asks for {}, and this pack may draw the light into {} "
+						+ "colour targets, so the whole list is set aside and the first {} are drawn "
+						+ "into instead, as the reference does with it. A pack reaches the eight by "
+						+ "declaring HIGHER_SHADOWCOLOR", this.path, declared, ceiling,
+						this.shadowColours.size());
 			}
 		} else if (this.ownsFirst) {
 			// Nought included, and the log says the sides because they are the whole fix: a write on

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -14,6 +14,7 @@ import dev.vitrail.pack.source.PackLoader;
 import dev.vitrail.pack.source.PackReport;
 import dev.vitrail.pack.source.ShaderPackSource;
 import dev.vitrail.pack.target.ChainPlan;
+import dev.vitrail.pack.target.PackDirectives;
 import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.TargetDirectives;
 import dev.vitrail.pack.target.TargetName;
@@ -838,14 +839,28 @@ public final class PackChain {
 			// hold at every load and the report is taken once.
 			List<String> required = new ArrayList<>(PackLoader.properties(pack).requiredFeatures());
 			// Only the names this engine has not built refuse the pack: the block emission
-			// attribute rides in the chunk element, and custom images are served now, so a pack
-			// that cannot draw without either is simply right about what it needs.
-			required.remove("BLOCK_EMISSION_ATTRIBUTE");
-			// The second shadow depth name of each map is bound too, SamplerPlan.SHADOW_DEPTH.
-			required.remove("SEPARATE_HARDWARE_SAMPLERS");
+			// attribute rides in the chunk element, a pack declaring HIGHER_SHADOWCOLOR draws the
+			// light into the eight it asked for, a storage block is bound off the pack's own
+			// bufferObject, and custom images are served now, so a pack that cannot draw without one
+			// of those is simply right about what it needs. The list is the one EngineDefines poses
+			// IRIS_FEATURE_ for, and the two have to move together: a define is a promise, and a
+			// refusal is the same promise refused.
+			//
+			// Matched without regard to case, and that is not politeness: the list above is kept in
+			// the pack's own spelling, and Iris never reads it that way. It upper-cases a declared
+			// name before it looks the flag up (features/FeatureFlags.java:70), and the message it
+			// prints to pack authors spells the name in lower case,
+			// "iris.features.required/optional = ssbo" (shaderpack/ShaderPack.java:216). A pack
+			// that wrote what that message told it to would be refused here on a name this engine
+			// serves. ShaderProperties.declares already reads the same lists that way.
+			Set<String> served = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+			served.addAll(List.of("BLOCK_EMISSION_ATTRIBUTE", PackDirectives.HIGHER_SHADOWCOLOR,
+					"SSBO", "SEPARATE_HARDWARE_SAMPLERS"));
 			if (CustomImages.served()) {
-				required.remove("CUSTOM_IMAGES");
+				served.add("CUSTOM_IMAGES");
 			}
+
+			required.removeIf(served::contains);
 
 			if (!required.isEmpty()) {
 				disabled = true;

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -10,6 +10,7 @@ import dev.vitrail.pack.program.ProgramNames;
 import dev.vitrail.pack.program.ProgramStage;
 import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.source.OpenedPack;
+import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.TargetName;
 import dev.vitrail.pack.target.TargetSchedule;
 import dev.vitrail.pack.texture.CustomImages;
@@ -412,9 +413,26 @@ final class PackCompute implements AutoCloseable {
 					orWhite(targets, shadow == null ? null : shadow.depth());
 			case "shadowtex1", "shadowtex1HW" ->
 					orWhite(targets, shadow == null ? null : shadow.depthWithoutTranslucents());
-			case "shadowcolor0" -> orWhite(targets, shadow == null ? null : shadow.colour(0));
-			case "shadowcolor1" -> orWhite(targets, shadow == null ? null : shadow.colour(1));
-			default -> null;
+			// Every name SamplerPlan reads as a shadow colour, the bare shadowcolor with them, and
+			// the white stand-in for one no program of the place named. That is the rule a full
+			// screen pass follows for the same names (PackPass.java:585), and the ceiling is not
+			// consulted here because it does not have to be: a buffer the pack may not reach was
+			// never allocated, so colour() answers null for it and white is what the compute reads,
+			// exactly as it does for a buffer nothing has written.
+			//
+			// White covers one more case than it should, and that is a divergence rather than a
+			// rule: what gets allocated is read off the FRAGMENT stages of the place alone
+			// (TargetPlan.build walks fragmentsOf), so a shadowcolor that only a COMPUTE of the
+			// place names is never opened, and this hands the compute white for a buffer the pack
+			// does mean to read. Iris opens it from the compute itself, addShadowSamplers calling
+			// createIfEmpty for each shadowcolor the program declares, on the compute path as on
+			// the composite one (CompositeRenderer.java:461, samplers/IrisSamplers.java:156-163).
+			// Closing it means expanding every compute of the pack while the plan is built, which
+			// is a second reading of the archive, and nothing of the corpus asks for it: every
+			// shadowcolor a compute of it names is named by a fragment stage of the same place too.
+			default -> SamplerPlan.isShadowColour(name)
+					? orWhite(targets, shadow == null ? null : shadow.colour(SamplerPlan.shadowColour(name)))
+					: null;
 		};
 	}
 

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -513,9 +513,14 @@ public final class PackValues {
 	 * What the pack asks of each {@code shadowcolor} the light may draw into: its format, and what
 	 * emptying it means. One entry a buffer, in order, and a buffer the pack said nothing about
 	 * carries Iris's own defaults rather than being left out.
+	 * <p>
+	 * As many entries as a name can go high, and not as many as this pack may reach nor as many as
+	 * are allocated. It is a table of directives and costs no memory. Cutting it at the ceiling
+	 * would make its length a second answer to a question {@code TargetPlan} already answers, and
+	 * two answers to one question is the shape of divergence that shows as a plausible picture.
 	 */
 	public List<PackDirectives.ShadowColour> shadowColours() {
-		return IntStream.range(0, ShadowTargets.COLOURS)
+		return IntStream.range(0, ShadowTargets.MAX_COLOURS)
 				.mapToObj(index -> this.state.directives().shadowColour(index))
 				.toList();
 	}

--- a/common/src/main/java/dev/vitrail/render/ShadowTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowTargets.java
@@ -19,16 +19,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * The shadow map: one depth image the world is drawn into from the light, and the colour targets
  * beside it.
  * <p>
- * <strong>More than one colour target, which is Iris's own count.</strong> It sizes the shadow
- * colour targets at two, eight where a pack asks for {@code HIGHER_SHADOWCOLOR}
- * ({@code shadows/ShadowRenderTargets.java:46}, from
- * {@code shaderpack/properties/PackShadowDirectives.java:19-20}), and opens {@code {0, 1}} for a
- * shadow program whose draw buffers it cannot read
+ * <strong>Two colour targets, or eight where the pack asked for them.</strong> The ceiling is
+ * Iris's and it is read off the PACK: two where {@code HIGHER_SHADOWCOLOR} is not declared, eight
+ * where it is ({@code shadows/ShadowRenderTargets.java:46}, from
+ * {@code shaderpack/properties/PackShadowDirectives.java:19-20}). Posing the define for every pack
+ * does not raise it, a define being what a pack READS and a declaration what it ASKS FOR, so the
+ * number here is {@code TargetPlan.shadowCeiling} and every index is admitted against that. Iris
+ * opens {@code {0, 1}} for a shadow program whose draw buffers it cannot read
  * ({@code pipeline/programs/SodiumPrograms.java:137-139}). When each of them is built differs here,
  * and the field they live in says why.
  * <p>
@@ -71,12 +76,11 @@ final class ShadowTargets {
 	private static final int MAX_RESOLUTION = 16384;
 
 	/**
-	 * How many colour targets the light may draw into. Iris's number for a pack that does not ask
-	 * for {@code HIGHER_SHADOWCOLOR}, and the only pack of the corpus that does ask
-	 * ({@code Reverie Beta v0.9}, {@code shaders/shaders.properties:10}) is refused at load here for
-	 * a reason of its own, so eight would be memory no program of this place could name.
+	 * The highest a {@code shadowcolor} name can go, which is what the arrays below are sized at and
+	 * NOT what any one pack may reach: that is {@link #ceiling}, and a pack which never declared the
+	 * flag stops at two of these eight slots.
 	 */
-	static final int COLOURS = 2;
+	static final int MAX_COLOURS = PackDirectives.MAX_SHADOW_COLOURS;
 
 	/**
 	 * Its own, and not the one {@link ColorTargets} empties under: the census groups a frame's passes
@@ -92,12 +96,32 @@ final class ShadowTargets {
 	private final List<Vector4fc> clearColours;
 
 	/**
+	 * How many of them this pack may reach, its own declaration deciding. Clamped to what the arrays
+	 * below hold, because the number is worked out in another class and an index past their length
+	 * would be an out of bounds in the middle of an allocation rather than a buffer left out.
+	 */
+	private final int ceiling;
+
+	/**
+	 * Which of them are allocated, sorted, holes and all. Every loop of this class runs over this
+	 * and never over the ceiling: a pack naming {@code shadowcolor2} alone gets three images and not
+	 * eight, which is the same rule {@link ColorTargets} follows for the colour targets.
+	 * <p>
+	 * Nought is in it whatever the pack names, and that is Iris rather than a floor of our own: it
+	 * builds the buffer at construction, for the framebuffer its depth copy is taken through
+	 * ({@code shadows/ShadowRenderTargets.java:73,75}), so the image exists before a program has
+	 * asked for anything. Here it is the colour attachment the depth shares a {@link TextureTarget}
+	 * with, so it exists for the same reason and cannot be left out of the clear.
+	 */
+	private final List<Integer> live;
+
+	/**
 	 * Whether each colour has yet to be emptied once. A pack that turns its own clear off is asking
 	 * to keep what the shadow stage wrote from one frame to the next, not to read whatever the
 	 * allocation left in the image, and Iris says the same on the directive: the clear colour is
 	 * still what the buffer starts life holding.
 	 */
-	private final boolean[] unstarted = new boolean[COLOURS];
+	private final boolean[] unstarted = new boolean[MAX_COLOURS];
 
 	private TextureTarget target;
 
@@ -106,20 +130,20 @@ final class ShadowTargets {
 	 * carries one colour attachment and one depth, so the rest are images of their own, attached
 	 * beside it by whoever opens the pass.
 	 * <p>
-	 * <strong>All of them are made with the map, where Iris builds each one the first time a
-	 * framebuffer names it</strong> ({@code shadows/ShadowRenderTargets.java:127,136}). That is a
-	 * difference in when memory is taken and in nothing a pack can read: a buffer no program writes
-	 * holds its clear colour either way, and a sampler for one reads exactly that.
+	 * <strong>The live ones are all made with the map, where Iris builds each one the first time a
+	 * framebuffer or a sampler names it</strong> ({@code shadows/ShadowRenderTargets.java:127,136}).
+	 * That is a difference in when memory is taken and in nothing a pack can read: a buffer no
+	 * program writes holds its clear colour either way, and a sampler for one reads exactly that.
 	 * <p>
-	 * What it costs is one image at the map's own resolution for a pack that writes only nought,
-	 * which on this corpus is Mellow, and Mellow asks for 512 texels: one mebibyte. What it buys is
-	 * that nothing has to keep an order between an image and the program that names it, and the
-	 * shadow programs are NOT all built before the first frame is drawn - the terrain's are read
-	 * inside a frame ({@code TerrainDraw:625-634}) and the entities' from inside the light's own
-	 * walk ({@code EntityDraw:1069-1070}), so a set filled from the programs would have to be
-	 * answered by a pass already recording, where nothing may allocate.
+	 * What it costs is nothing, and what it buys is that no order has to be kept between an image
+	 * and the program that names it. The shadow programs are NOT all built before the first frame
+	 * is drawn: the terrain's are read inside a frame ({@code TerrainDraw:625-634}) and the
+	 * entities' from inside the light's own walk ({@code EntityDraw:1069-1070}), so a set filled
+	 * from the programs would have to be answered by a pass already recording, where nothing may
+	 * allocate. The plan is read instead, and it read every fragment stage of the place before the
+	 * chain was built, which is why a pack that writes only nought pays for only nought.
 	 */
-	private final TargetSurface[] rest = new TargetSurface[COLOURS - 1];
+	private final TargetSurface[] rest = new TargetSurface[MAX_COLOURS - 1];
 
 	/**
 	 * The map as it stood before anything translucent was drawn into it, which the OptiFine model
@@ -145,10 +169,18 @@ final class ShadowTargets {
 	private boolean broken;
 
 	/** Load-ops waiting for the first shadow pass of the frame, or a standalone encode if none opens. */
-	private final Vector4fc[] pendingColour = new Vector4fc[COLOURS];
+	private final Vector4fc[] pendingColour = new Vector4fc[MAX_COLOURS];
 	private boolean pendingDepth;
 
-	ShadowTargets(int resolution, List<PackDirectives.ShadowColour> asked) {
+	/**
+	 * @param named   which buffers a program of the place draws into or samples, from
+	 *                {@code TargetPlan.shadowAllocated}, already read against the ceiling. A shadow
+	 *                program declaring nothing is {@code {0, 1}} in there, which is the one way the
+	 *                pair reaches this class
+	 * @param ceiling how many the pack may reach, from {@code TargetPlan.shadowCeiling}
+	 */
+	ShadowTargets(int resolution, List<PackDirectives.ShadowColour> asked, Set<Integer> named,
+			int ceiling) {
 		// Clamped rather than refused: a directive that survived a setting nobody expanded can be
 		// any number at all, and a shadow map is not worth taking the pack down for.
 		this.resolution = Math.clamp(resolution, 1, MAX_RESOLUTION);
@@ -171,6 +203,11 @@ final class ShadowTargets {
 			return (Vector4fc) new Vector4f(colour.r(), colour.g(), colour.b(),
 					one.format().alphaAdded() && !one.declaresClearColour() ? 1.0F : colour.a());
 		}).toList();
+
+		this.ceiling = Math.clamp(ceiling, 1, MAX_COLOURS);
+		SortedSet<Integer> live = new TreeSet<>(Set.of(0));
+		named.stream().filter(index -> index > 0 && index < this.ceiling).forEach(live::add);
+		this.live = List.copyOf(live);
 	}
 
 	/**
@@ -202,7 +239,11 @@ final class ShadowTargets {
 			this.target = new TextureTarget("Vitrail shadow", this.resolution, this.resolution, true,
 					this.formats.get(0));
 			this.unstarted[0] = true;
-			for (int index = 1; index < COLOURS; index++) {
+			for (int index : this.live) {
+				if (index == 0) {
+					continue;
+				}
+
 				this.rest[index - 1] = new TargetSurface("Vitrail shadowcolor" + index,
 						this.formats.get(index), false, this.resolution, this.resolution);
 				this.unstarted[index] = true;
@@ -283,9 +324,9 @@ final class ShadowTargets {
 			return;
 		}
 
-		List<GpuTextureView> colours = new ArrayList<>(COLOURS);
-		List<Vector4fc> colourValues = new ArrayList<>(COLOURS);
-		for (int index = 0; index < COLOURS; index++) {
+		List<GpuTextureView> colours = new ArrayList<>(this.live.size());
+		List<Vector4fc> colourValues = new ArrayList<>(this.live.size());
+		for (int index : this.live) {
 			if (this.pendingColour[index] == null) {
 				continue;
 			}
@@ -327,7 +368,7 @@ final class ShadowTargets {
 	private void stash() {
 		this.copied = false;
 		this.pendingDepth = false;
-		for (int index = 0; index < COLOURS; index++) {
+		for (int index : this.live) {
 			this.pendingColour[index] = null;
 		}
 
@@ -340,7 +381,11 @@ final class ShadowTargets {
 			this.pendingColour[0] = this.clearColours.get(0);
 		}
 
-		for (int index = 1; index < COLOURS; index++) {
+		for (int index : this.live) {
+			if (index == 0) {
+				continue;
+			}
+
 			TargetSurface surface = this.rest[index - 1];
 			if (surface != null && wanted(index)) {
 				this.pendingColour[index] = this.clearColours.get(index);
@@ -366,8 +411,8 @@ final class ShadowTargets {
 	/** Each colour target's format and whether the pack keeps it, for the allocation's own line. */
 	private String describe() {
 		StringBuilder text = new StringBuilder();
-		for (int index = 0; index < COLOURS; index++) {
-			text.append(index == 0 ? "" : " and ")
+		for (int index : this.live) {
+			text.append(text.isEmpty() ? "" : " and ")
 					.append("shadowcolor").append(index)
 					.append(" as ").append(this.formats.get(index))
 					.append(this.asked.get(index).clear() ? "" : ", which the pack keeps between frames");
@@ -420,13 +465,13 @@ final class ShadowTargets {
 	}
 
 	/**
-	 * A shadow colour target, or null past the pair this engine allocates. Never nought's image under
+	 * A shadow colour target, or null for one nothing of this place named. Never nought's image under
 	 * another name: a pack reading a buffer nothing filled has to read the clear colour, which is
 	 * white and which it multiplies by, where nought's image would be a picture that is plausible and
 	 * wrong.
 	 */
 	GpuTextureView colour(int index) {
-		if (index < 0 || index >= COLOURS) {
+		if (index < 0 || index >= MAX_COLOURS) {
 			return null;
 		}
 
@@ -441,6 +486,14 @@ final class ShadowTargets {
 
 	int resolution() {
 		return this.resolution;
+	}
+
+	/**
+	 * How many colour buffers this pack may name, which is what a declared list is admitted against
+	 * and never how many exist. See the class comment for where the number comes from.
+	 */
+	int colourCeiling() {
+		return this.ceiling;
 	}
 
 	/**
@@ -461,7 +514,7 @@ final class ShadowTargets {
 			this.target = null;
 		}
 
-		for (int index = 1; index < COLOURS; index++) {
+		for (int index = 1; index < MAX_COLOURS; index++) {
 			if (this.rest[index - 1] != null) {
 				this.rest[index - 1].close();
 				this.rest[index - 1] = null;

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -528,8 +528,9 @@ public final class TerrainDraw {
 			//
 			// What the pack reads then is the DEPTH emptied to the far plane, both names of it,
 			// because the clear below empties the depth whichever way the pack's own keep directive
-			// reads (ShadowTargets.java:236-241). A shadowcolor the pack asked to KEEP is a
-			// different matter and is NOT emptied (:243-248 through :256-264): it holds the last
+			// reads (ShadowTargets.stash raises it for every frame the map exists). A shadowcolor
+			// the pack asked to KEEP is a different matter and is NOT emptied (the same method,
+			// through ShadowTargets.wanted, which is what reads the directive): it holds the last
 			// frame the stage drew, for as long as the setting stays at nought. Iris returns before
 			// touching any of its targets, so there both halves keep the last frame.
 			//

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -21,7 +21,7 @@ quietly stale.
 | Mellow v3.3 | Drawn, and it exercises two more of them: it ships a three-dimensional volume as a raw blob, and it asks for a single-channel shadow buffer. |
 | Photon v1.3b | Drawn, at default settings. It exercises a clamped volume of half floats as its atmosphere table, reads its volumes through macros standing for the sampler's name, and lays a volume over the name of a colour target that the same stage also reads as a plain `sampler2D`. Not yet compared against the reference shot for shot. |
 | Body Camera v1.6.1 | Drawn. It is one of the packs that branches on the star flag in the sky, so it is worth reading [the sky goes flat](#the-sky-goes-flat) alongside. |
-| Reverie Beta v0.9 | **Refused at load, and the log names what it asked for.** It declares four features it cannot be drawn without, and this engine has built one of them, so it refuses the pack on the other three rather than half drawing it. That is a gap here and not a fault of the pack: Iris draws it. See [the pack was refused](#the-pack-was-refused). |
+| Reverie Beta v0.9 | **Loads, and nothing of it is drawn yet.** The four features it declares it cannot be drawn without are all served now, so the load no longer refuses it; its `prepare` program then fails to compile on a conditional written loosely, which the game's compiler refuses where Iris's preprocessor reads past it, and a full-screen program that does not compile takes the whole pack with it. That is a gap here and not a fault of the pack: Iris draws it. See [the pack was refused](#the-pack-was-refused). |
 
 Start from what you are seeing. Each symptom below names its cause, and says how to confirm it
 rather than guess.
@@ -53,24 +53,26 @@ The engine refuses a pack rather than drawing something wrong with it, and it na
 compiler closes several of them by name, not by missing effort here, and
 [translation](translation.md) carries which. Storage images, storage buffers and a pack's shadow
 compute are no longer on that list: they are served beside that compiler rather than through it,
-which is what `IRIS_FEATURE_CUSTOM_IMAGES` announces and why voxel lighting draws. The full-screen
-shadow composites are a different family and are still skipped, the log naming them at load.
+which is what `IRIS_FEATURE_CUSTOM_IMAGES` and `IRIS_FEATURE_SSBO` announce and why voxel lighting
+draws. The full-screen shadow composites are a different family and are still skipped, the log
+naming them at load.
 
-Of the packs used for testing, Reverie is the one in that position, and it says so itself. A pack
-can declare the features it cannot be drawn without, and Reverie declares several. That line is read
-before any of its programs is translated, so the refusal names what the pack asked for and did not
-get, the log listing them, rather than the symptom that would have come later.
+A pack can declare the features it cannot be drawn without, and Reverie declares several. That
+line is read before any of its programs is translated, so a refusal names what the pack asked for
+and did not get, the log listing them, rather than the symptom that would have come later. Every
+name Reverie declares is served now, so it is no longer refused there; what stops it today is
+written in its row of the table above.
 
-**Any name this engine has not built refuses the declaration.** Three names are built and served
-today, `BLOCK_EMISSION_ATTRIBUTE`, `CUSTOM_IMAGES` and `SEPARATE_HARDWARE_SAMPLERS`, so a pack
-that requires those alone loads; every other name still refuses the pack, with the list in the
-log. The served flags are also the only `IRIS_FEATURE_` defines a pack finds: a capability define
-is a promise, so each appears the day its feature is served and not before, and the optional
-declarations keep reading the truth.
+**Any name this engine has not built refuses the declaration.** Five names are built and served
+today, `BLOCK_EMISSION_ATTRIBUTE`, `CUSTOM_IMAGES`, `HIGHER_SHADOWCOLOR`,
+`SEPARATE_HARDWARE_SAMPLERS` and `SSBO`, so a pack that requires those alone loads, and every
+other name still refuses the pack, with the list in the log. The served flags are also the only
+`IRIS_FEATURE_` defines a pack finds: a capability define is a promise, so each appears the day
+its feature is served and not before, and the optional declarations keep reading the truth.
 
-Iris draws Reverie. It refuses a required flag only when the name is unknown to it or the hardware
-cannot serve it, and it has built every one of the ones Reverie asks for: some outright, some
-wherever the driver supports them.
+Iris refuses a required flag only when the name is unknown to it or the hardware cannot serve
+it, and it has built every one of the ones Reverie asks for: some outright, some wherever the
+driver supports them.
 
 **A full-screen pass that fails to compile takes the whole pack with it**, and the log names the
 program. One shape of that was a `const` whose initialiser Vulkan will not take as a constant,
@@ -99,14 +101,14 @@ The image dims and a red message of the pack's own says the feature you turned o
 and asks you to switch to Iris. This is not the engine refusing anything: the pack is running, the
 message is one of its passes, and it is drawn because a capability test in its code came out false.
 
-The test reads capability defines. This engine announces itself the way Iris does, but a
-capability define is a promise, so it defines only what the backend actually serves, which today
-is `IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE`, `IRIS_FEATURE_CUSTOM_IMAGES` and
-`IRIS_FEATURE_SEPARATE_HARDWARE_SAMPLERS` and nothing else; the section above says why the
-features behind the other names are closed. A pack that finds the announcement without the
-capability it wants concludes it is running on OptiFine, the only renderer in that position when
-the pack was written, and words its message for it. Read "OptiFine" as "not Iris" and the message
-is accurate.
+The test reads capability defines. This engine announces itself the way Iris does, but a capability
+define is a promise, so it defines only what the backend actually serves, which today is
+`IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE`, `IRIS_FEATURE_CUSTOM_IMAGES`,
+`IRIS_FEATURE_HIGHER_SHADOWCOLOR`, `IRIS_FEATURE_SEPARATE_HARDWARE_SAMPLERS` and
+`IRIS_FEATURE_SSBO` and nothing else. The section above says why the features behind the other
+names are closed. A pack that finds the announcement without the capability it wants concludes it
+is running on OptiFine, the only renderer in that position when the pack was written, and words
+its message for it. Read "OptiFine" as "not Iris" and the message is accurate.
 
 Complementary was the pack of the test set that did this, and it is why the define exists. Its
 colored lighting, which its two top profiles Very High and Ultra turn on, is voxel lighting:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -438,17 +438,24 @@ A short reference, if you are writing a pack or wondering why yours is treated d
 - **A pack can ask for an unusual shadow buffer format.** Mellow asks for a single-channel one,
   which is why the shadow pipeline's colour state is built from the attachment rather than
   hardcoded.
-- **The light draws into two colour buffers, `shadowcolor0` and `shadowcolor1`**, which is what the
-  reference serves a pack that does not ask for more. A shadow program is given the buffers its own
-  draw buffers name, and a directive naming a buffer past those two is thrown away whole and
-  answered with the pair, which is again what the reference does. **Where a program names none, or
-  names more buffers than it writes outputs, it is given only as many as it writes**: a buffer
-  short of the reference. That is deliberate: Vulkan leaves an attachment no fragment writes
-  undefined for the whole draw, where the GL these packs were written against leaves it standing,
-  and what a pack reads out of an untouched shadow buffer is the white a coloured shadow multiplies
-  by. The second buffer is not decoration: one pack of the corpus writes the tint of its light
-  shafts there and reads it back for every ray that reaches through something translucent, so a
-  buffer it could not write filled every body of water with white.
+- **How far a pack may count its shadow colour buffers is the pack's own answer.** Two,
+  `shadowcolor0` and `shadowcolor1`, unless it declares `HIGHER_SHADOWCOLOR` on an `iris.features`
+  line, which takes it to eight: that is where the reference reads it from as well, and it is that
+  declaration which decides, never an `IRIS_FEATURE_HIGHER_SHADOWCOLOR` the GLSL may find defined.
+  A shadow program is given the buffers its own draw buffers name, and a directive naming a buffer
+  past the ceiling is thrown away whole and answered with the pair, which is again what the
+  reference does, the log naming the program it happened to. **Of those, only the ones some program
+  of the place writes or samples are allocated**, so a pack whose light never names `shadowcolor1`
+  is not charged an image at the shadow map's own resolution for it.
+  `shadowcolor0` stands whatever the pack writes, being the attachment the map's depth shares an
+  object with. **Where a program names none, or names more buffers than it writes outputs, it is
+  given only as many as it writes**: a buffer short of the reference. That is deliberate: Vulkan
+  leaves an attachment no fragment writes undefined for the whole draw, where the GL these packs
+  were written against leaves it standing, and what a pack reads out of an untouched shadow buffer
+  is the white a coloured shadow multiplies by. The second buffer is not decoration: one pack of the
+  corpus writes the tint of its light shafts there and reads it back for every ray that reaches
+  through something translucent, so a buffer it could not write filled every body of water with
+  white.
 - **A pack can ask the engine not to draw a piece of the sky** because it draws that piece itself,
   inside one of its own programs. Four such requests are read, and two of them take a piece away:
   the sun and the moon, which is where both references stand. `stars=false` takes nothing, the


### PR DESCRIPTION
## What changes

The light draws into the shadow colour buffers a pack asks for, as Iris allocates them: eight are reachable when the pack declares `HIGHER_SHADOWCOLOR` among its features, two otherwise, and only the buffers some program of the place writes or samples are allocated, `shadowcolor0` always. A pack that writes only `shadowcolor0` no longer pays for a second buffer nobody reads; a shadow program that declares nothing keeps the pair Iris hands it. The `SSBO` and `HIGHER_SHADOWCOLOR` flags are posed, since storage buffers are served and the buffers are now reachable, and neither name refuses a pack any more; the four served names are matched whatever their case, as Iris matches them. A pack requiring a name this engine does not serve is still refused for that name.

## How it differs from the reference, and for what obstacle

One divergence, written in the javadoc: a shadow colour buffer named only by a compute program is not allocated here, where Iris allocates it on the compute's sampler list (`pipeline/CompositeRenderer.java:461`, `samplers/IrisSamplers.java:156-163`). The target plan reads fragment stages and never expands a compute, so the scan would cost a second reading of the archive at plan time. No pack of the corpus names a shadow colour in a compute that its fragments do not also name. Everything else follows Iris: the ceiling off the pack's declared features (`ShaderPack.java:208-213,620`, `shadows/ShadowRenderTargets.java:46`), nought at construction and the rest on first use (`:73,75`), a shadow program declaring nothing writing the pair (`:306`, `SodiumPrograms:138`, `ShaderCreator:331`), a draw buffer list naming an index past the ceiling thrown away whole (`:298-305`).

## What proves it

- `gradlew build` green.
- Off-game harness on the corpus, base against branch: `Cibles`, `Chaine` and `Harness` byte-identical apart from timing lines; the define table grows by exactly the two new `IRIS_FEATURE_` names. A probe over the corpus gives ceiling two for every pack and eight for Reverie alone, and the allocated set goes from two buffers to one for Mellow, Photon and Body Camera's nether and end, three for Reverie.
- In game, Fabric bench: Mellow draws as before with one shadow colour buffer, and Reverie passes the load it was refused at, stopping on a conditional its `prepare` program writes loosely, which a sibling branch reads as Iris reads it.

## What it leaves owing

Reverie's image, once its conditionals are read, is for the eye. The rule that poses every served `IRIS_FEATURE_` define into every pack's GLSL is the engine's existing rule for its two older flags, where Iris poses a define only when the pack lists the flag as optional; unchanged here, named in the code.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
