### PR TITLE
fix(pack): read a loosely written conditional as the reference does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,18 @@ what the next one holds.
   no light whatever, and every night away from a torch was as dark as a new moon. The moon now
   dims through the cycle with the option on, and is a plain full moon every night with it off.
 
+- **A pack whose conditionals are written loosely draws, as it draws under Iris.** Reverie Beta
+  writes one `#ifdef` with no name after it and one with two names joined by `&&`, and Photon
+  writes an `#endif` with nothing open for it to close: none of the three is a directive GLSL will
+  take. Iris hands the compiler what its own preprocessor produced, so nothing of the sort reaches
+  a compiler there and both packs draw; here the lines went on to the compiler as the pack wrote
+  them, six of Reverie's programs and three of Photon's would not build, and one program that will
+  not build stops the whole pack with nothing of it drawn. The three shapes are now read the way
+  Iris reads them, a nameless one taking the branch it opens, a name followed by anything else
+  deciding on that name alone, and one with nothing to close being left out of the text, with the
+  file and the line said once in the log. A pack that writes its conditionals properly is
+  untouched.
+
 - **A pack that says it cannot bear anisotropic filtering is believed.** BSL and both
   Complementary variants write `breaksAnisotropy` in their `shaders.properties`, and the line was
   read nowhere: with Texture Filtering set to Anisotropic in Video Settings, their terrain showed

--- a/NOTICE
+++ b/NOTICE
@@ -877,6 +877,20 @@ GNU Lesser General Public License version 3
   against glsl-transformer (AGPL-3.0), only the values named above are reproduced: none of that
   code is here, and the translator in dev.vitrail.glsl is this project's own.
 
+Anarres C Preprocessor (jcpp), https://github.com/shevek/jcpp
+Copyright (c) 2007-2015, Shevek
+Apache License, Version 2.0
+
+  common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java reproduces what jcpp does with
+  a conditional directive a pack wrote loosely: a keyword with nothing that names a setting after
+  it leaves the group taken, tokens after a name are dropped and the name alone decides, an empty
+  expression is false, and a directive with no group open is passed over. Iris shades jcpp in as
+  org.anarres:jcpp:1.4.14 and runs it over every pack source, so a pack is written against these
+  answers rather than against Iris's own code. The same reading is given to the properties files a
+  pack ships, in common/src/main/java/dev/vitrail/pack/source/PropertiesFile.java: they carry the
+  same conditionals, and Iris runs the same preprocessor over them too. None of jcpp's code is
+  here.
+
 AMD FidelityFX Super Resolution 1.0, https://github.com/GPUOpen-Effects/FidelityFX-FSR
 Copyright (c) 2021 Advanced Micro Devices, Inc.
 MIT License

--- a/common/src/main/java/dev/vitrail/pack/source/ConditionStack.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ConditionStack.java
@@ -21,8 +21,22 @@ public final class ConditionStack {
 	private final Deque<Level> levels = new ArrayDeque<>();
 
 	public void ifDirective(boolean condition) {
+		push(condition, false);
+	}
+
+	/**
+	 * A conditional whose directive is written out rewritten, because what the pack wrote is not
+	 * one the compiler will read. Marked apart from the rest so that one the file never closes can
+	 * be closed where the file ends: the text carries its directives to the compiler, and what this
+	 * reader put in the text has to balance in the text.
+	 */
+	public void rewrittenIfDirective(boolean condition) {
+		push(condition, true);
+	}
+
+	private void push(boolean condition, boolean rewritten) {
 		boolean parent = active();
-		this.levels.push(new Level(parent && condition, condition, parent));
+		this.levels.push(new Level(parent && condition, condition, parent, rewritten));
 	}
 
 	/**
@@ -70,16 +84,23 @@ public final class ConditionStack {
 		return this.levels.size();
 	}
 
+	/** How many of the levels still open were opened by {@link #rewrittenIfDirective}. */
+	public int unclosedRewritten() {
+		return (int) this.levels.stream().filter(level -> level.rewritten).count();
+	}
+
 	private static final class Level {
 
 		private boolean active;
 		private boolean taken;
 		private final boolean parentActive;
+		private final boolean rewritten;
 
-		private Level(boolean active, boolean taken, boolean parentActive) {
+		private Level(boolean active, boolean taken, boolean parentActive, boolean rewritten) {
 			this.active = active;
 			this.taken = taken;
 			this.parentActive = parentActive;
+			this.rewritten = rewritten;
 		}
 	}
 }

--- a/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
+++ b/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,6 +29,11 @@ import java.util.regex.Pattern;
  * An include in a branch that is off becomes a comment rather than staying as it was. Keeping
  * it would leave a directive GLSL has no notion of sitting in the text, which is a gamble on
  * how the compiler treats directives inside a block it is discarding.
+ * <p>
+ * The other lines that do not survive as written are the conditionals a pack wrote loosely, which
+ * the compiler would refuse where the reference never shows it a conditional at all. They are
+ * rewritten into a directive GLSL will take, or commented out where there is nothing for them to
+ * close: see {@link #defined} and {@link #unopened}.
  */
 public final class IncludeExpander {
 
@@ -54,9 +60,13 @@ public final class IncludeExpander {
 	private static final int MAX_CHARACTERS = 4_000_000;
 
 	private static final Pattern INCLUDE = Pattern.compile("^\\s*#\\s*include\\s+[<\"](.+?)[>\"].*$");
-	private static final Pattern IF_DEFINED = Pattern.compile("^\\s*#\\s*(ifdef|ifndef)\\s+([A-Za-z_]\\w*).*$");
-	private static final Pattern IF = Pattern.compile("^\\s*#\\s*if\\s+(.*)$");
-	private static final Pattern ELIF = Pattern.compile("^\\s*#\\s*elif\\s+(.*)$");
+	private static final Pattern IF_DEFINED = Pattern.compile("^(\\s*)#\\s*(ifdef|ifndef)\\b(.*)$");
+
+	/** What has to follow {@code #ifdef} for the directive to be one the compiler will read. */
+	static final Pattern DEFINED_NAME = Pattern.compile("^\\s+([A-Za-z_]\\w*)(.*)$");
+
+	private static final Pattern IF = Pattern.compile("^(\\s*)#\\s*if\\b(.*)$");
+	private static final Pattern ELIF = Pattern.compile("^(\\s*)#\\s*elif\\b(.*)$");
 	private static final Pattern ELSE = Pattern.compile("^\\s*#\\s*else\\b.*$");
 	private static final Pattern ENDIF = Pattern.compile("^\\s*#\\s*endif\\b.*$");
 	private static final Pattern DEFINE = Pattern.compile("^\\s*#\\s*define\\s+([A-Za-z_]\\w*)\\s*(.*)$");
@@ -66,18 +76,30 @@ public final class IncludeExpander {
 	private final ShaderPackSource source;
 	private final SettingSet settings;
 
+	/**
+	 * The conditionals this pack writes loosely, each said once, in the order they were met. Held
+	 * on the expander and not on a unit: a loose directive lives in a shared body, so it is met
+	 * again in every program that includes it, and one line per program would bury it.
+	 */
+	private final Set<String> loose = new LinkedHashSet<>();
+
 	public IncludeExpander(ShaderPackSource source, SettingSet settings) {
 		this.source = source;
 		this.settings = settings;
 	}
 
 	public ExpandedUnit expand(Path entry) throws IOException {
-		State state = new State(this.settings.unitDefines());
+		State state = new State(this.settings.unitDefines(), this.loose);
 
 		expandFile(entry, 0, state);
 
 		return new ExpandedUnit(this.source.rel(entry), List.copyOf(state.output), state.version,
 				state.toStats(), state.live);
+	}
+
+	/** What this reader read for the pack across every unit expanded so far, ready for the log. */
+	public List<String> looseConditionals() {
+		return List.copyOf(this.loose);
 	}
 
 	private void expandFile(Path file, int depth, State state) throws IOException {
@@ -120,8 +142,14 @@ public final class IncludeExpander {
 			}
 
 			String line = logical.text();
-			if (handleCondition(line, conditions, state)) {
-				state.emit(logical.physical(), true);
+			String directive = handleCondition(logical, relative, conditions, state);
+			if (directive != null) {
+				if (directive.equals(line)) {
+					state.emit(logical.physical(), true);
+				} else {
+					state.emit(directive, true);
+				}
+
 				continue;
 			}
 
@@ -164,11 +192,25 @@ public final class IncludeExpander {
 			}
 		}
 
+		// A rewritten conditional the file never closes would leave a directive this reader put in
+		// the text with nothing to close it, so it is closed where the file ends.
+		//
+		// Only those are closed. A group the PACK left open is one the compiler may never have
+		// opened: this reader matches directives line by line and a compiler strips comments
+		// first, so a conditional written inside a block comment is open here and absent there.
+		// Sildur's writes four such files, and an #endif added at the end of them is refused as
+		// a mismatched statement where the file compiles untouched.
+		for (int open = conditions.unclosedRewritten(); open > 0; open--) {
+			state.emit("#endif", true);
+			state.openInOutput--;
+		}
+
 		state.onPath.remove(relative);
 	}
 
 	/**
-	 * One line as the compiler reads it, and the lines of the file it was written over.
+	 * One line as the compiler reads it, where in the file it starts, and the lines it was written
+	 * over.
 	 * <p>
 	 * A backslash before a line break joins the next line onto this one before the compiler reads
 	 * a single directive, so the directives are matched and the conditions decided on the joined
@@ -182,16 +224,18 @@ public final class IncludeExpander {
 	 * once: Bliss ends a comment with three backslashes and a blank line under it, the compiler
 	 * takes the last backslash with the blank line and the comment ends there, and a joined line
 	 * written out would end with the two backslashes left, which the compiler would then take
-	 * with the line of code below. Sixteen units lost a declaration that way. The one line written
-	 * out joined is a {@code #define} a setting rewrote, which no pack of the corpus continues.
+	 * with the line of code below. Sixteen units lost a declaration that way. The lines written out
+	 * joined are the ones this reader had to rewrite, a {@code #define} a setting changed and a
+	 * conditional the pack wrote loosely, and no pack of the corpus continues either of those.
 	 */
-	private record Logical(String text, List<String> physical) {
+	private record Logical(String text, int number, List<String> physical) {
 	}
 
 	private static List<Logical> logicalLines(List<String> lines) {
 		List<Logical> logical = new ArrayList<>(lines.size());
 		StringBuilder joined = new StringBuilder();
 		List<String> physical = new ArrayList<>();
+		int number = 1;
 		for (String line : lines) {
 			physical.add(line);
 			if (line.endsWith("\\")) {
@@ -200,53 +244,192 @@ public final class IncludeExpander {
 			}
 
 			joined.append(line);
-			logical.add(new Logical(joined.toString(), List.copyOf(physical)));
+			logical.add(new Logical(joined.toString(), number, List.copyOf(physical)));
+			number += physical.size();
 			joined.setLength(0);
 			physical.clear();
 		}
 
 		if (!physical.isEmpty()) {
-			logical.add(new Logical(joined.toString(), List.copyOf(physical)));
+			logical.add(new Logical(joined.toString(), number, List.copyOf(physical)));
 		}
 
 		return logical;
 	}
 
-	/** Returns true when the line was a conditional directive and has been accounted for. */
-	private boolean handleCondition(String line, ConditionStack conditions, State state) {
+	/**
+	 * Accounts for a conditional directive and says what to write in its place.
+	 *
+	 * @return null when the line is not a conditional directive, and otherwise the text to write,
+	 *         which is the line itself unless the pack wrote the directive loosely
+	 */
+	private String handleCondition(Logical logical, String relative, ConditionStack conditions,
+			State state) {
+		String line = logical.text();
+
 		Matcher ifDefined = IF_DEFINED.matcher(line);
 		if (ifDefined.matches()) {
 			state.conditionals++;
-			boolean defined = state.defines.containsKey(ifDefined.group(2));
-			conditions.ifDirective(ifDefined.group(1).equals("ifdef") == defined);
-			return true;
+			state.openInOutput++;
+
+			return defined(logical, relative, ifDefined, conditions, state);
 		}
 
 		Matcher iff = IF.matcher(line);
 		if (iff.matches()) {
 			state.conditionals++;
-			conditions.ifDirective(decide(iff.group(1), state));
-			return true;
+			state.openInOutput++;
+			if (!beyondComments(iff.group(2)).isEmpty()) {
+				conditions.ifDirective(decide(iff.group(2), state));
+				return line;
+			}
+
+			report(conditions, state, relative, logical,
+					"no expression follows it, so the group it opens is not taken");
+			conditions.rewrittenIfDirective(false);
+
+			return iff.group(1) + "#if 0";
 		}
 
 		Matcher elif = ELIF.matcher(line);
 		if (elif.matches()) {
 			state.conditionals++;
-			conditions.elifDirective(() -> decide(elif.group(1), state));
-			return true;
+			if (state.openInOutput == 0) {
+				return unopened(conditions, state, relative, logical);
+			}
+
+			if (!beyondComments(elif.group(2)).isEmpty()) {
+				conditions.elifDirective(() -> decide(elif.group(2), state));
+				return line;
+			}
+
+			report(conditions, state, relative, logical,
+					"no expression follows it, so the branch it opens is not taken");
+			conditions.elifDirective(() -> false);
+
+			return elif.group(1) + "#elif 0";
 		}
 
 		if (ELSE.matcher(line).matches()) {
+			if (state.openInOutput == 0) {
+				return unopened(conditions, state, relative, logical);
+			}
+
 			conditions.elseDirective();
-			return true;
+
+			return line;
 		}
 
 		if (ENDIF.matcher(line).matches()) {
+			if (state.openInOutput == 0) {
+				return unopened(conditions, state, relative, logical);
+			}
+
+			state.openInOutput--;
 			conditions.endifDirective();
-			return true;
+
+			return line;
 		}
 
-		return false;
+		return null;
+	}
+
+	/**
+	 * A directive that continues or closes a group where the text written out has none open. jcpp
+	 * reports it and carries on with the text it had; the compiler here would be handed the
+	 * directive and refuse the program for it, so it becomes a comment. Photon writes one, and it
+	 * is what costs its three {@code composite3} programs.
+	 * <p>
+	 * The count that decides this is of what has been WRITTEN, never the depth of the file being
+	 * read, and it errs the one way it can afford to. A conditional inside a block comment is a
+	 * directive to this reader and not to the compiler, so the count can only be too high, and too
+	 * high leaves the directive alone. Too low would delete the one {@code #endif} a group needed.
+	 */
+	private static String unopened(ConditionStack conditions, State state, String relative,
+			Logical logical) {
+		report(conditions, state, relative, logical,
+				"nothing is open for it to close, so it is not written out");
+
+		return "// no conditional is open here: " + logical.text().trim();
+	}
+
+	/**
+	 * Says what was read of a directive the pack wrote loosely.
+	 * <p>
+	 * Not said from a branch that is off: the reference's preprocessor does not read the inside of
+	 * one, so there is nothing it decided differently there to report.
+	 */
+	private static void report(ConditionStack conditions, State state, String relative,
+			Logical logical, String decided) {
+		if (conditions.active()) {
+			state.loose(relative, logical, decided);
+		}
+	}
+
+	/**
+	 * Reads one {@code #ifdef} or {@code #ifndef}, and rewrites it when what the pack wrote is not
+	 * a directive the compiler will take.
+	 * <p>
+	 * Two shapes are written loosely and the reference lets both through, because it hands the
+	 * compiler the text its preprocessor produced rather than the text the pack wrote, so no
+	 * conditional directive survives as far as a compiler at all: {@code JcppProcessor.java:55-64}
+	 * of the reference walks the tokens jcpp yields and {@code ShaderPack.java:317} makes that the
+	 * program source. Here the directives are left in the text for the compiler to read, which is
+	 * what turns a shape jcpp merely complains about into a program that will not build.
+	 * <p>
+	 * A name followed by anything else: jcpp reads the first token, decides on it, and reports each
+	 * further token as an unexpected one, so the extra tokens are dropped and the decision is
+	 * unchanged. Anything else than a name after the keyword, a number, a bracket, or the end of
+	 * the line: jcpp reports what it read instead of a name and leaves the group it opened taken,
+	 * so it becomes a group that is always taken. Both are reported to the listener rather than
+	 * thrown, and the reference's listener only prints, so neither refuses the pack there.
+	 * <p>
+	 * One thing jcpp does that is not reproduced: when the keyword is followed by nothing at all,
+	 * recovering eats the line under it, the newline having already been read as the name that was
+	 * missing. That is a slip of its recovery rather than a decision, it does not happen when a
+	 * token other than a name is there to be read, and reproducing it would silently drop a line of
+	 * a pack's code.
+	 */
+	private String defined(Logical logical, String relative, Matcher ifDefined,
+			ConditionStack conditions, State state) {
+		String indent = ifDefined.group(1);
+		String keyword = ifDefined.group(2);
+		Matcher name = DEFINED_NAME.matcher(ifDefined.group(3));
+
+		if (!name.matches()) {
+			report(conditions, state, relative, logical,
+					"nothing that can name a setting follows it, so the group it opens is taken");
+			conditions.rewrittenIfDirective(true);
+
+			return indent + "#if 1";
+		}
+
+		boolean defined = state.defines.containsKey(name.group(1));
+		conditions.ifDirective(keyword.equals("ifdef") == defined);
+
+		if (beyondComments(name.group(2)).isEmpty()) {
+			return logical.text();
+		}
+
+		report(conditions, state, relative, logical, "only " + name.group(1) + " is read");
+
+		return indent + "#" + keyword + " " + name.group(1);
+	}
+
+	/** What the compiler still has to read once the comments are taken out of a directive's tail. */
+	private static String beyondComments(String tail) {
+		String code = tail.replaceAll("/\\*.*?\\*/", " ");
+		int line = code.indexOf("//");
+		int unterminated = code.indexOf("/*");
+		if (line >= 0) {
+			code = code.substring(0, line);
+		}
+
+		if (unterminated >= 0 && (line < 0 || unterminated < line)) {
+			code = code.substring(0, unterminated);
+		}
+
+		return code.trim();
 	}
 
 	/**
@@ -335,6 +518,7 @@ public final class IncludeExpander {
 	private static final class State {
 
 		private final Map<String, String> defines;
+		private final Set<String> loose;
 		private final List<String> output = new ArrayList<>();
 		private final BitSet live = new BitSet();
 		private final Set<String> onPath = new HashSet<>();
@@ -355,8 +539,21 @@ public final class IncludeExpander {
 		private int conditionals;
 		private int undecidable;
 
-		private State(Map<String, String> defines) {
+		/**
+		 * How many conditional groups the text written out so far leaves open, which is not the
+		 * depth of any one file: a group opened in an include is closed by whatever file writes the
+		 * {@code #endif}, and the compiler reads the unit as one text.
+		 */
+		private int openInOutput;
+
+		private State(Map<String, String> defines, Set<String> loose) {
 			this.defines = new LinkedHashMap<>(defines);
+			this.loose = loose;
+		}
+
+		private void loose(String relative, Logical logical, String decided) {
+			this.loose.add(relative + ":" + logical.number() + " writes " + logical.text().trim()
+					+ ", and " + decided);
 		}
 
 		private void emit(String line, boolean taken) {

--- a/common/src/main/java/dev/vitrail/pack/source/LoadedPack.java
+++ b/common/src/main/java/dev/vitrail/pack/source/LoadedPack.java
@@ -4,6 +4,7 @@ import dev.vitrail.pack.option.OptionIndex;
 import dev.vitrail.pack.program.ProgramResolver;
 import dev.vitrail.pack.program.ProgramSet;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -16,5 +17,6 @@ import java.util.Set;
 public record LoadedPack(String packName, boolean fromZip, DimensionSet dimensions,
 		ShaderProperties properties, OptionIndex options, ProgramSet programs,
 		ProgramResolver resolved, PackStats stats, ExpansionStats expansion, int expandedUnits,
-		Set<String> disabledPrograms, int caseInsensitiveHits, long loadMillis) {
+		List<String> looseConditionals, Set<String> disabledPrograms, int caseInsensitiveHits,
+		long loadMillis) {
 }

--- a/common/src/main/java/dev/vitrail/pack/source/PackLoader.java
+++ b/common/src/main/java/dev/vitrail/pack/source/PackLoader.java
@@ -83,8 +83,9 @@ public final class PackLoader {
 			}
 
 			return new LoadedPack(source.packName(), source.isZip(), dimensions, properties, options,
-					programs, resolved, stats, expansion, expanded, Set.copyOf(disabled),
-					source.caseInsensitiveHits(), (System.nanoTime() - start) / 1_000_000L);
+					programs, resolved, stats, expansion, expanded, expander.looseConditionals(),
+					Set.copyOf(disabled), source.caseInsensitiveHits(),
+					(System.nanoTime() - start) / 1_000_000L);
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/pack/source/PackReport.java
+++ b/common/src/main/java/dev/vitrail/pack/source/PackReport.java
@@ -119,6 +119,11 @@ public final class PackReport {
 			Vitrail.logger().warn("{}  expansion did not come out clean, see the counters above", PREFIX);
 		}
 
+		// One line per shape and not per program, because the file it is written in is shared: the
+		// pack builds either way, and what is said is which of its own lines this engine read for it.
+		pack.looseConditionals().forEach(loose -> Vitrail.logger().warn(
+				"{}  loosely written conditional, read as the reference reads it: {}", PREFIX, loose));
+
 		logIfAny("  ignored directories", programs.skippedDirectories());
 		logIfAny("  unrecognised program names", programs.skippedNames());
 

--- a/common/src/main/java/dev/vitrail/pack/source/PropertiesFile.java
+++ b/common/src/main/java/dev/vitrail/pack/source/PropertiesFile.java
@@ -110,16 +110,29 @@ public final class PropertiesFile {
 			Map<String, String> defines) {
 		switch (keyword) {
 			case "ifdef", "ifndef" -> {
-				String name = line.replaceAll("^\\s*#\\s*\\w+\\s+", "").trim().split("\\s+", -1)[0];
-				conditions.ifDirective(keyword.equals("ifdef") == defines.containsKey(name));
+				Matcher name = IncludeExpander.DEFINED_NAME
+						.matcher(line.replaceFirst("^\\s*#\\s*\\w+", ""));
+				// Nothing that can name a setting after the keyword leaves the group taken, and
+				// anything written after the name is dropped. These files carry the conditionals
+				// a pack's shaders carry, so they get the same reading: one stack, one decision.
+				conditions.ifDirective(!name.matches()
+						|| keyword.equals("ifdef") == defines.containsKey(name.group(1)));
 			}
-			case "if" -> conditions.ifDirective(
-					PreprocessorExpression.evaluate(after(line), defines).orElse(true));
-			case "elif" -> conditions.elifDirective(
-					() -> PreprocessorExpression.evaluate(after(line), defines).orElse(true));
+			case "if" -> conditions.ifDirective(decide(after(line), defines));
+			case "elif" -> conditions.elifDirective(() -> decide(after(line), defines));
 			case "else" -> conditions.elseDirective();
 			default -> conditions.endifDirective();
 		}
+	}
+
+	/**
+	 * Nothing to evaluate is not the same as an expression that could not be worked out. The
+	 * reference reads the end of the line where it wanted a token and leaves the group off, where
+	 * one it cannot decide is taken so that no code goes missing.
+	 */
+	private static boolean decide(String expression, Map<String, String> defines) {
+		return !expression.isBlank()
+				&& PreprocessorExpression.evaluate(expression, defines).orElse(true);
 	}
 
 	private static String after(String line) {

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -21,7 +21,7 @@ quietly stale.
 | Mellow v3.3 | Drawn, and it exercises two more of them: it ships a three-dimensional volume as a raw blob, and it asks for a single-channel shadow buffer. |
 | Photon v1.3b | Drawn, at default settings. It exercises a clamped volume of half floats as its atmosphere table, reads its volumes through macros standing for the sampler's name, and lays a volume over the name of a colour target that the same stage also reads as a plain `sampler2D`. Not yet compared against the reference shot for shot. |
 | Body Camera v1.6.1 | Drawn. It is one of the packs that branches on the star flag in the sky, so it is worth reading [the sky goes flat](#the-sky-goes-flat) alongside. |
-| Reverie Beta v0.9 | **Loads, and nothing of it is drawn yet.** The four features it declares it cannot be drawn without are all served now, so the load no longer refuses it; its `prepare` program then fails to compile on a conditional written loosely, which the game's compiler refuses where Iris's preprocessor reads past it, and a full-screen program that does not compile takes the whole pack with it. That is a gap here and not a fault of the pack: Iris draws it. See [the pack was refused](#the-pack-was-refused). |
+| Reverie Beta v0.9 | **Loads and compiles whole, and its picture is black.** The four features it declares it cannot be drawn without are all served, its loosely written conditionals are read as the reference reads them, and every one of its full-screen passes and computes runs. What it draws is black: the textures it ships reach its geometry programs as a single pixel, and eight of its own uniforms are handed as zeros, matrices among them. That is a gap here and not a fault of the pack: Iris draws it. |
 
 Start from what you are seeing. Each symptom below names its cause, and says how to confirm it
 rather than guess.
@@ -60,7 +60,7 @@ naming them at load.
 A pack can declare the features it cannot be drawn without, and Reverie declares several. That
 line is read before any of its programs is translated, so a refusal names what the pack asked for
 and did not get, the log listing them, rather than the symptom that would have come later. Every
-name Reverie declares is served now, so it is no longer refused there; what stops it today is
+name Reverie declares is served now, so it is no longer refused there; what it still lacks is
 written in its row of the table above.
 
 **Any name this engine has not built refuses the declaration.** Five names are built and served


### PR DESCRIPTION
## What changes

A conditional written loosely in a pack's GLSL is read the way the reference reads it, instead of being handed to the compiler as written. Iris never shows a compiler a directive: it compiles what its preprocessor produced, so an `#ifdef` with no name takes the group it opens, tokens after the name are dropped, an empty `#if` expression is false, and an `#endif` with nothing to close is left out. Each of those shapes was refused by the game's compiler here, and a full-screen program that does not compile takes the whole pack with it: Reverie's `prepare` was the case, and Photon's three `composite3` programs include a body with a stray `#endif`. The same decisions apply to the conditionals of the properties files a pack ships, which the reference runs through the same preprocessor. A group the pack itself left open is left alone: this reader matches directives line by line where a compiler strips comments first, and the four such files in the corpus compile untouched.

## How it differs from the reference, and for what obstacle

One divergence, written in the code: jcpp also eats the line under a nameless directive, its recovery reading the newline as the missing name, and that is not reproduced. In the one site of the corpus the eaten line is a comment. The rule reproduced is jcpp's, the C preprocessor Iris ships, and `NOTICE` names it.

## What proves it

- `gradlew build` green.
- jcpp 1.4.14 extracted from the Iris jar and run as an oracle on every shape, driven as Iris drives it: the engine's decisions match, group by group.
- Off-game harness `Traduction` on the corpus, base against branch: 12 units gained, none lost (Reverie 291 to 297 entry points, Photon 324 to 327); BSL and every other pack byte-identical, 355 translated files diffed.
- In game, Fabric bench: Reverie, which was stopped at `prepare`, now compiles whole and runs its 21 full-screen passes and nine computes. Its picture is still black, which is the next gap and is not this branch's: its own textures reach the geometry programs as one pixel and eight of its custom uniforms are handed as zeros.

## What it leaves owing

`#elif` followed by junk is still decided as taken where jcpp decides false; no pack of the corpus writes one, and the junk reaches the compiler either way.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
