### PR TITLE
perf(pack): flatten each unit once per opening of a pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ what the next one holds.
   view reads it again as before. The picture is the same, and none of this has been measured, so
   it says work removed rather than frames gained.
 
+- **Picking a pack freezes the game for less time.** Reading a pack walked the same shader files
+  over and over, once to find its directives, once for its chain, once for its chunk programs and
+  once more for each of its compute programs, and every one of those walks read the archive again
+  and pasted the same shared headers together again. A pack is now read once per file and each of
+  its programs assembled once for as long as it stays open, which is the wait before the picture
+  appears when you choose a pack, apply a setting, or step through a portal. Nothing about the
+  picture changes.
+
 ### Added
 
 - **Eight shadow colour buffers for a pack that asks for them.** A pack declaring

--- a/common/src/main/java/dev/vitrail/glsl/LoadClock.java
+++ b/common/src/main/java/dev/vitrail/glsl/LoadClock.java
@@ -19,6 +19,12 @@ import java.util.concurrent.atomic.AtomicLong;
  * of it, so counting it in would leave the figure several times larger on one load than on the
  * next with nothing on the line saying which of the two had just been read.
  * <p>
+ * It carries a second number, which is the units an opening handed back instead of building: a
+ * load walks one place of the pack over and over, for its directives, its chain, its chunk
+ * programs and each of its computes. That number says how much of the flattening was taken off
+ * rather than how fast what remained of it ran, and the two move apart, so a report that carried
+ * only the milliseconds could not tell a pack that got quicker from a machine that was busier.
+ * <p>
  * <strong>It exists because the split decided what got built next.</strong> With shaderc alone
  * served from disk this figure only halved, which said the reflection was the other half of the
  * WORK and that a cache of the bytes on their own could not reach it. What answers that is the
@@ -60,6 +66,8 @@ public final class LoadClock {
 
 	private static final AtomicInteger EXPANDED = new AtomicInteger();
 
+	private static final AtomicInteger EXPANSIONS_SERVED = new AtomicInteger();
+
 	private static final AtomicLong TRANSLATION_NANOS = new AtomicLong();
 
 	private static final AtomicInteger TRANSLATED = new AtomicInteger();
@@ -75,6 +83,7 @@ public final class LoadClock {
 	public static void reset() {
 		EXPANSION_NANOS.set(0);
 		EXPANDED.set(0);
+		EXPANSIONS_SERVED.set(0);
 		TRANSLATION_NANOS.set(0);
 		TRANSLATED.set(0);
 		MODULE_NANOS.set(0);
@@ -85,6 +94,11 @@ public final class LoadClock {
 	public static void expansion(long nanos) {
 		EXPANSION_NANOS.addAndGet(nanos);
 		EXPANDED.incrementAndGet();
+	}
+
+	/** One unit asked for again inside the opening that had already built it, and not rebuilt. */
+	public static void expansionServed() {
+		EXPANSIONS_SERVED.incrementAndGet();
 	}
 
 	/** One translator call's worth of {@link System#nanoTime} span, workers included. */
@@ -109,6 +123,10 @@ public final class LoadClock {
 
 	public static int expanded() {
 		return EXPANDED.get();
+	}
+
+	public static int expansionsServed() {
+		return EXPANSIONS_SERVED.get();
 	}
 
 	public static long translationMillis() {

--- a/common/src/main/java/dev/vitrail/glsl/LoadClock.java
+++ b/common/src/main/java/dev/vitrail/glsl/LoadClock.java
@@ -4,9 +4,20 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Where the time of a pack load goes, split into the two posts nothing else can separate: the
- * translation of the pack's GLSL, and turning the translated text into modules, which is shaderc
- * and the SPIRV-Cross reflection together.
+ * Where the time of a pack load goes, split into the three posts nothing else can separate:
+ * flattening the pack's entry files into units, translating the GLSL those units hold, and turning
+ * the translated text into modules, which is shaderc and the SPIRV-Cross reflection together.
+ * <p>
+ * <strong>The flattening post is the one a load with both stores warm still pays.</strong> The key
+ * that finds a translation on disk is the flattened text, so nothing can be asked of either cache
+ * before it exists, and what is left of such a load is very nearly this figure alone. It is taken
+ * inside the expander rather than at its callers, there being five of those across three packages
+ * and a post missed at one of them reading as a unit that cost nothing to build.
+ * <p>
+ * One of those five is deliberately outside it, and it is the pack report's walk of every entry
+ * point a pack ships. That walk runs on the first load of a given pack and on none of the reloads
+ * of it, so counting it in would leave the figure several times larger on one load than on the
+ * next with nothing on the line saying which of the two had just been read.
  * <p>
  * <strong>It exists because the split decided what got built next.</strong> With shaderc alone
  * served from disk this figure only halved, which said the reflection was the other half of the
@@ -29,7 +40,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * small, and the driver's own pipeline build behind {@code vkCreateGraphicsPipelines}, which on
  * a cold driver cache is not.
  * <p>
- * Both counts are tallies in the sense the trig counter is: they are emptied at the head of a
+ * The counts are tallies in the sense the trig counter is: they are emptied at the head of a
  * load, a first report prints beside the pack-opened line for every installed chain, and a
  * second prints when the background warmup hands back its own figure, the families then in.
  * Two loads can smear into each other in both directions and neither reaches a live program:
@@ -45,6 +56,10 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class LoadClock {
 
+	private static final AtomicLong EXPANSION_NANOS = new AtomicLong();
+
+	private static final AtomicInteger EXPANDED = new AtomicInteger();
+
 	private static final AtomicLong TRANSLATION_NANOS = new AtomicLong();
 
 	private static final AtomicInteger TRANSLATED = new AtomicInteger();
@@ -58,10 +73,18 @@ public final class LoadClock {
 
 	/** Emptied at the head of a pack load: a tally belongs to the load it was taken under. */
 	public static void reset() {
+		EXPANSION_NANOS.set(0);
+		EXPANDED.set(0);
 		TRANSLATION_NANOS.set(0);
 		TRANSLATED.set(0);
 		MODULE_NANOS.set(0);
 		MODULES.set(0);
+	}
+
+	/** One entry file's worth of flattening, includes followed and settings applied. */
+	public static void expansion(long nanos) {
+		EXPANSION_NANOS.addAndGet(nanos);
+		EXPANDED.incrementAndGet();
 	}
 
 	/** One translator call's worth of {@link System#nanoTime} span, workers included. */
@@ -78,6 +101,14 @@ public final class LoadClock {
 	public static void module(long nanos) {
 		MODULE_NANOS.addAndGet(nanos);
 		MODULES.incrementAndGet();
+	}
+
+	public static long expansionMillis() {
+		return EXPANSION_NANOS.get() / 1_000_000L;
+	}
+
+	public static int expanded() {
+		return EXPANDED.get();
 	}
 
 	public static long translationMillis() {

--- a/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
+++ b/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
@@ -1,5 +1,6 @@
 package dev.vitrail.pack.source;
 
+import dev.vitrail.glsl.LoadClock;
 import dev.vitrail.pack.option.OptionRewriter;
 import dev.vitrail.pack.option.SettingSet;
 
@@ -75,6 +76,7 @@ public final class IncludeExpander {
 
 	private final ShaderPackSource source;
 	private final SettingSet settings;
+	private final boolean partOfALoad;
 
 	/**
 	 * The conditionals this pack writes loosely, each said once, in the order they were met. Held
@@ -84,17 +86,45 @@ public final class IncludeExpander {
 	private final Set<String> loose = new LinkedHashSet<>();
 
 	public IncludeExpander(ShaderPackSource source, SettingSet settings) {
-		this.source = source;
-		this.settings = settings;
+		this(source, settings, true);
 	}
 
+	private IncludeExpander(ShaderPackSource source, SettingSet settings, boolean partOfALoad) {
+		this.source = source;
+		this.settings = settings;
+		this.partOfALoad = partOfALoad;
+	}
+
+	/**
+	 * For the pack report's walk, whose flattening is left out of the load's clock.
+	 * <p>
+	 * That walk expands every entry point the pack ships, once each, and it is made on the first
+	 * load of a given pack and on none of the reloads of it. Counted in, it would leave the figure
+	 * several times larger on one load than on the next with nothing on the line saying which of
+	 * the two had just been read, where what the line is for is what a load pays every time.
+	 */
+	public static IncludeExpander forTheReport(ShaderPackSource source, SettingSet settings) {
+		return new IncludeExpander(source, settings, false);
+	}
+
+	/**
+	 * One entry file flattened, and the span it took posted to the load's clock. A load reads a
+	 * place of the pack several times over and this is paid before either compiled store can be
+	 * asked, so it is where a warm load's wait really goes.
+	 */
 	public ExpandedUnit expand(Path entry) throws IOException {
+		long began = System.nanoTime();
 		State state = new State(this.settings.unitDefines(), this.loose);
 
 		expandFile(entry, 0, state);
 
-		return new ExpandedUnit(this.source.rel(entry), List.copyOf(state.output), state.version,
-				state.toStats(), state.live);
+		ExpandedUnit unit = new ExpandedUnit(this.source.rel(entry), List.copyOf(state.output),
+				state.version, state.toStats(), state.live);
+		if (this.partOfALoad) {
+			LoadClock.expansion(System.nanoTime() - began);
+		}
+
+		return unit;
 	}
 
 	/** What this reader read for the pack across every unit expanded so far, ready for the log. */

--- a/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
+++ b/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
@@ -96,32 +96,60 @@ public final class IncludeExpander {
 	}
 
 	/**
-	 * For the pack report's walk, whose flattening is left out of the load's clock.
+	 * For the pack report's walk, whose flattening is neither clocked as a load's nor kept by the
+	 * opening.
 	 * <p>
 	 * That walk expands every entry point the pack ships, once each, and it is made on the first
-	 * load of a given pack and on none of the reloads of it. Counted in, it would leave the figure
-	 * several times larger on one load than on the next with nothing on the line saying which of
-	 * the two had just been read, where what the line is for is what a load pays every time.
+	 * load of a given pack and on none of the reloads of it. Counted into the clock, it would leave
+	 * the figure several times larger on one load than on the next with nothing on the line saying
+	 * which of the two had just been read, where what the line is for is what a load pays every
+	 * time.
+	 * <p>
+	 * Kept by the opening, it would find nothing there ever, no entry point being asked for twice,
+	 * and would hold every unit it built alive to the end of a reading whose whole point is to
+	 * throw them away, three hundred and thirty-nine of them for the widest pack of the corpus.
 	 */
 	public static IncludeExpander forTheReport(ShaderPackSource source, SettingSet settings) {
 		return new IncludeExpander(source, settings, false);
 	}
 
 	/**
-	 * One entry file flattened, and the span it took posted to the load's clock. A load reads a
-	 * place of the pack several times over and this is paid before either compiled store can be
-	 * asked, so it is where a warm load's wait really goes.
+	 * One entry file flattened, and flattened once per opening of the pack and per settings it is
+	 * read under.
+	 * <p>
+	 * <strong>The memo is what makes a load pay for a unit once.</strong> A load walks one place of
+	 * the pack over and over: once for its directives, once for the chain, once for the chunk
+	 * programs, and once more for every compute program it ships. Each of those walks every fragment
+	 * entry of the place, and expanding one of Photon's costs tens of milliseconds, so the same unit
+	 * built a dozen times was the bulk of what a load with both compiled stores warm still waited on.
+	 * <p>
+	 * The pack report's walk neither reads the memo nor fills it, and {@link #forTheReport} says
+	 * why.
+	 * <p>
+	 * A unit that throws is not remembered, so whoever asks next reads the file again and meets the
+	 * same failure rather than a silence.
 	 */
 	public ExpandedUnit expand(Path entry) throws IOException {
+		String relative = this.source.rel(entry);
+		if (this.partOfALoad) {
+			Optional<ExpandedUnit> known = this.source.expandedUnit(this.settings, relative);
+			if (known.isPresent()) {
+				LoadClock.expansionServed();
+
+				return known.get();
+			}
+		}
+
 		long began = System.nanoTime();
 		State state = new State(this.settings.unitDefines(), this.loose);
 
 		expandFile(entry, 0, state);
 
-		ExpandedUnit unit = new ExpandedUnit(this.source.rel(entry), List.copyOf(state.output),
-				state.version, state.toStats(), state.live);
+		ExpandedUnit unit = new ExpandedUnit(relative, List.copyOf(state.output), state.version,
+				state.toStats(), state.live);
 		if (this.partOfALoad) {
 			LoadClock.expansion(System.nanoTime() - began);
+			this.source.rememberUnit(this.settings, relative, unit);
 		}
 
 		return unit;
@@ -532,8 +560,20 @@ public final class IncludeExpander {
 	public record ExpandedUnit(String entry, List<String> lines, String version,
 			ExpansionStats stats, BitSet live) {
 
+		/**
+		 * Copied in and copied out, a {@link BitSet} being mutable. In on its own was enough while
+		 * a unit was built for one reader and dropped; now that an opening hands the same unit back
+		 * to every walk of a load that asks for it, a reader that set a bit would set it for all
+		 * the others too, and the key a translation is found on disk by is taken over this set,
+		 * so a stray bit moves which cached program a unit lands on.
+		 */
 		public ExpandedUnit {
 			live = (BitSet) live.clone();
+		}
+
+		@Override
+		public BitSet live() {
+			return (BitSet) this.live.clone();
 		}
 
 		public String text() {

--- a/common/src/main/java/dev/vitrail/pack/source/PackLoader.java
+++ b/common/src/main/java/dev/vitrail/pack/source/PackLoader.java
@@ -74,7 +74,9 @@ public final class PackLoader {
 			// This walk is a diagnosis of a pack and not a step of a load: it is made the first
 			// time a pack is read and never again for the same one, so what it costs is left out
 			// of the load's clock rather than doubling a figure the log invites the two to be
-			// compared on.
+			// compared on. It leaves nothing in the opening's memo either, which is what keeps
+			// the note above true: a key here is a file of the pack and each of them comes up
+			// once, so there would be nothing to find there and every unit to hold.
 			IncludeExpander expander = IncludeExpander.forTheReport(source, settings);
 			ExpansionStats expansion = ExpansionStats.NONE;
 			int expanded = 0;

--- a/common/src/main/java/dev/vitrail/pack/source/PackLoader.java
+++ b/common/src/main/java/dev/vitrail/pack/source/PackLoader.java
@@ -71,7 +71,11 @@ public final class PackLoader {
 				}
 			});
 
-			IncludeExpander expander = new IncludeExpander(source, settings);
+			// This walk is a diagnosis of a pack and not a step of a load: it is made the first
+			// time a pack is read and never again for the same one, so what it costs is left out
+			// of the load's clock rather than doubling a figure the log invites the two to be
+			// compared on.
+			IncludeExpander expander = IncludeExpander.forTheReport(source, settings);
 			ExpansionStats expansion = ExpansionStats.NONE;
 			int expanded = 0;
 			for (ProgramSet.ProgramKey key : programs.keys()) {

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
@@ -1,5 +1,7 @@
 package dev.vitrail.pack.source;
 
+import dev.vitrail.pack.option.SettingSet;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -72,6 +74,36 @@ public final class ShaderPackSource implements AutoCloseable {
 	// Directory listings, lower-cased, kept for the case-insensitive fallback below. Built on
 	// demand because most packs never need it.
 	private final Map<String, Map<String, Path>> listingsByDirectory = new HashMap<>();
+
+	/**
+	 * Every file this opening has already decoded, by its path under {@code shaders/}.
+	 * <p>
+	 * Held because a pack's includes are read far more often than they are opened: one entry file
+	 * pulls in the same handful of shared headers as the thirty odd others of its place, and the
+	 * place is walked once for the directives, once for the chain, once for the chunk programs and
+	 * once per compute program. Reading, decoding and splitting a header again for each of those was
+	 * the largest single cost of a warm load.
+	 * <p>
+	 * It is bounded by the pack: the widest of the corpus ships a megabyte and a half of source
+	 * across five hundred files, and everything in here dies with {@link #close()}.
+	 */
+	private final Map<String, List<String>> linesByFile = new HashMap<>();
+
+	/**
+	 * Units this opening has already flattened, by the entry file and the settings it was read
+	 * under.
+	 * <p>
+	 * The settings are compared by IDENTITY, which a {@link SettingSet} being immutable is what
+	 * makes safe: one reading of a pack resolves exactly one of them and hands it to every expander
+	 * it builds, so two readings that happened to resolve equal tables would miss this memo and
+	 * expand again, which costs time and cannot cost an answer.
+	 * <p>
+	 * Nearly free to hold beside the map above: most of a unit's lines are the very strings that map
+	 * already keeps, so what is added here is a list of references, the liveness bits, and the few
+	 * lines the expansion wrote itself, which are the settings it rewrote and the markers it leaves
+	 * where an include was not taken or could not be read.
+	 */
+	private final Map<Expansion, IncludeExpander.ExpandedUnit> expandedUnits = new HashMap<>();
 
 	private int caseInsensitiveHits;
 
@@ -271,14 +303,24 @@ public final class ShaderPackSource implements AutoCloseable {
 	 * Decoding never throws. A pack that ships one file in the wrong encoding should lose that
 	 * file's accented comments, not fail to load; the compiler will complain later if the loss
 	 * touched something that mattered.
+	 * <p>
+	 * Read once per opening and kept, which is what {@link #linesByFile} exists for. The list handed
+	 * back is immutable and always was, so callers cannot tell a second reader from the first; a
+	 * file too big to read is not kept, and every caller of it goes on getting the refusal.
 	 */
 	public List<String> readLines(Path file) throws IOException {
+		String relative = rel(file);
+		List<String> known = this.linesByFile.get(relative);
+		if (known != null) {
+			return known;
+		}
+
 		// The largest source file in the corpus is a hundred and sixty kilobytes. Reading without
 		// a ceiling means a zip that unpacks to half a gigabyte is read whole into memory before
 		// anything downstream gets the chance to refuse it.
 		long size = Files.size(file);
 		if (size > MAX_FILE_BYTES) {
-			throw new IOException(rel(file) + " is " + size + " bytes, past the " + MAX_FILE_BYTES
+			throw new IOException(relative + " is " + size + " bytes, past the " + MAX_FILE_BYTES
 					+ " a shader source is allowed");
 		}
 
@@ -294,7 +336,23 @@ public final class ShaderPackSource implements AutoCloseable {
 
 		// Splitting on a lone carriage return as well: some pack files still carry classic Mac
 		// line endings, and treating such a file as one long line loses every directive in it.
-		return List.of(text.split("\r\n|\n|\r", -1));
+		List<String> lines = List.of(text.split("\r\n|\n|\r", -1));
+		this.linesByFile.put(relative, lines);
+
+		return lines;
+	}
+
+	/** A unit this opening has already flattened under those settings, or nothing. */
+	Optional<IncludeExpander.ExpandedUnit> expandedUnit(SettingSet settings, String entry) {
+		return Optional.ofNullable(this.expandedUnits.get(new Expansion(settings, entry)));
+	}
+
+	/** Kept for the next reading of this opening. A unit that threw never reaches here. */
+	void rememberUnit(SettingSet settings, String entry, IncludeExpander.ExpandedUnit unit) {
+		this.expandedUnits.put(new Expansion(settings, entry), unit);
+	}
+
+	private record Expansion(SettingSet settings, String entry) {
 	}
 
 	/** Resolves a path written with a leading slash, which means relative to {@code shaders/}. */
@@ -452,8 +510,16 @@ public final class ShaderPackSource implements AutoCloseable {
 		return Files.readAllBytes(file);
 	}
 
+	/**
+	 * Lets the two memos go as well as the archive, which is what makes an opening the bound on
+	 * what they hold: a directory pack owns no filesystem at all, so without these two lines
+	 * closing one would free nothing, and an opening a caller keeps in a field past its own use
+	 * would carry a pack's worth of text for as long as it lived.
+	 */
 	@Override
 	public void close() throws IOException {
+		this.linesByFile.clear();
+		this.expandedUnits.clear();
 		if (this.ownedFileSystem != null) {
 			this.ownedFileSystem.close();
 		}

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -422,9 +422,12 @@ public final class TargetPlan {
 		TargetDirectives.Builder builder = TargetDirectives.builder();
 		long began = System.nanoTime();
 
-		// Iris's order, from ProgramSet.locateDirectives, and the last live declaration wins. One
-		// unit is held at a time: the worst of the corpus expands to four hundred kilobytes and
-		// one dimension has up to forty six of them.
+		// Iris's order, from ProgramSet.locateDirectives, and the last live declaration wins. The
+		// units are kept by the opening rather than dropped as this loop goes, which is what lets
+		// the walks a load repeats read them back instead of building them again: one dimension has
+		// up to forty six of them and the worst expands to four hundred kilobytes, but most of what
+		// a unit holds is the very strings the opening already keeps, so what keeping one adds is a
+		// list of references, the liveness bits, and the few lines the expansion wrote itself.
 		for (ProgramSet.ProgramKey key : ProgramSet.sorted(entries, ProgramNames::directiveRank)) {
 			Optional<Path> file = source.file(key.file());
 			if (file.isEmpty()) {

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -973,12 +973,14 @@ public final class PackChain {
 				// the chain's units and not the pack's, which is what parts it from the pack
 				// report's own expansion line: that walk counts every entry point the pack ships
 				// and is made once ever, this one counts what this load built and is made at each.
-				Vitrail.logger().info("Flattening the chain's units cost {} ms over {} of them, "
-						+ "the pack report's own walk not counted; translating cost {} ms over {} "
+				Vitrail.logger().info("Flattening the chain's units cost {} ms over {} of them "
+						+ "with {} more handed back by an opening that had already built them, the "
+						+ "pack report's own walk not counted; translating cost {} ms over {} "
 						+ "translator calls before the chain went live; the modules follow on the "
 						+ "draws and the workers, counted into the report that closes the warmup",
 						LoadClock.expansionMillis(), LoadClock.expanded(),
-						LoadClock.translationMillis(), LoadClock.translated());
+						LoadClock.expansionsServed(), LoadClock.translationMillis(),
+						LoadClock.translated());
 				// Both ways, whichever way it went. A cache that only speaks when it helps leaves
 				// every later reading of a log ambiguous, since a silence would then mean either
 				// that nothing was served or that nothing was asked. It rides the line above rather
@@ -3174,9 +3176,10 @@ public final class PackChain {
 				// so together they can pass the wall clock of the load; they compare with each
 				// other, not with it.
 				Vitrail.logger().info("With the families in, flattening the chain's units cost {} "
-						+ "ms over {} of them, translating cost {} ms over {} translator calls and "
-						+ "making modules cost {} ms over {} modules, shaderc and SPIRV-Cross "
-						+ "together", LoadClock.expansionMillis(), LoadClock.expanded(),
+						+ "ms over {} of them with {} more handed back, translating cost {} ms over "
+						+ "{} translator calls and making modules cost {} ms over {} modules, "
+						+ "shaderc and SPIRV-Cross together", LoadClock.expansionMillis(),
+						LoadClock.expanded(), LoadClock.expansionsServed(),
 						LoadClock.translationMillis(), LoadClock.translated(),
 						LoadClock.moduleMillis(), LoadClock.modules());
 			}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -966,11 +966,18 @@ public final class PackChain {
 						ShaderPackSource.openings() - openings);
 				// Once per installed chain, whatever else this load does or fails to do later:
 				// the second report, with the families in, only exists when a warmup fans out.
-				// Translation only, because this method does no device work by design: the
-				// modules follow on the first draws and the workers, and land in the next report.
-				Vitrail.logger().info("Translating cost {} ms over {} translator calls before "
-						+ "the chain went live; the modules follow on the draws and the workers, "
-						+ "counted into the report that closes the warmup",
+				// Flattening and translating only, because this method does no device work by
+				// design: the modules follow on the first draws and the workers, and land in the
+				// next report. The flattening is said first because it is paid first, and because
+				// it is what a load whose translations all come off disk is left with. It names
+				// the chain's units and not the pack's, which is what parts it from the pack
+				// report's own expansion line: that walk counts every entry point the pack ships
+				// and is made once ever, this one counts what this load built and is made at each.
+				Vitrail.logger().info("Flattening the chain's units cost {} ms over {} of them, "
+						+ "the pack report's own walk not counted; translating cost {} ms over {} "
+						+ "translator calls before the chain went live; the modules follow on the "
+						+ "draws and the workers, counted into the report that closes the warmup",
+						LoadClock.expansionMillis(), LoadClock.expanded(),
 						LoadClock.translationMillis(), LoadClock.translated());
 				// Both ways, whichever way it went. A cache that only speaks when it helps leaves
 				// every later reading of a log ambiguous, since a silence would then mean either
@@ -3166,10 +3173,12 @@ public final class PackChain {
 				// Beside the total it explains. The spans are summed per program across workers,
 				// so together they can pass the wall clock of the load; they compare with each
 				// other, not with it.
-				Vitrail.logger().info("With the families in, translating cost {} ms over {} "
-						+ "translator calls and making modules cost {} ms over {} modules, "
-						+ "shaderc and SPIRV-Cross together", LoadClock.translationMillis(),
-						LoadClock.translated(), LoadClock.moduleMillis(), LoadClock.modules());
+				Vitrail.logger().info("With the families in, flattening the chain's units cost {} "
+						+ "ms over {} of them, translating cost {} ms over {} translator calls and "
+						+ "making modules cost {} ms over {} modules, shaderc and SPIRV-Cross "
+						+ "together", LoadClock.expansionMillis(), LoadClock.expanded(),
+						LoadClock.translationMillis(), LoadClock.translated(),
+						LoadClock.moduleMillis(), LoadClock.modules());
 			}
 
 			return (Void) null;


### PR DESCRIPTION
## What changes

Picking a pack freezes the game for less time. Within one opening of a pack, the same unit was flattened several times over: once for the directives, once for the target plan of the chain, once for the terrain's, once per compute program, and again by each of the six geometry families opening the pack for themselves. Each opening now keeps the lines of every file it read and every unit it flattened under a given set of settings, and hands them back to the next reader; both die with the opening. The report walk that counts a pack's programs at its first load stays outside the memo, since its keys are all distinct and it would only pay. A third load clock post says what flattening cost the chain's units.

## How it differs from the reference, and for what obstacle

It does not: the flattened text is byte for byte what it was, only read once.

## What proves it

- `gradlew build` green.
- Off-game harness `Traduction` on the eleven pack entries, base against branch: 5324 output files, translated GLSL and SPIR-V, byte-identical; the verdict table identical once the work path is normalised.
- A probe on the engine's own load road: the report walk posts nothing to the clock and leaves the memo empty, a chain load fills it and is served from it, and `close()` empties it. Off-game replay of the load path: Complementary Unbound about 3.3 to 1.7 s, Photon about 6.5 to 3.3 s, on a machine under load and best of seven, so the shape of the gain rather than its figure.
- Not measured in game.

## What it leaves owing

The target plan is still built once per call, cheap now but not free; and the reload report's own expansion is untouched. Issue #285 stays open on those two.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
