### PR TITLE
fix(render): ask SPIRV-Cross for storage buffers under their own type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ what the next one holds.
 
 ### Fixed
 
+- **A compute pass that reads the depth runs.** A compute a pack hangs off a full screen pass
+  could read every name that pass reads except `depthtex0`, `depthtex1`, `depthtex2`, the far
+  terrain's depth and `centerDepthSmooth`: those threw on every frame, so the compute never ran,
+  with one line in the log. Reverie's cloud compute reads `depthtex1`, and without it the images
+  its sky and clouds are built from stayed empty. The compute now reads the same depth as the pass
+  after it, which is what Iris gives it.
+
 - **Importing settings no longer acts on a screen you have already left.** The window that asks
   which file to read is the system's own and does not hold the game, so the settings screen can be
   closed while it is still up. Picking a file at that point queued its values anyway, into a page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack's storage buffers are read and written where the pack put them.** A pack that keeps
+  its own data in a shader storage buffer, declared with `bufferObject` lines, had that buffer
+  allocated and filled but never handed to the programs that name it: every such program kept the
+  slot number the pack wrote and read whatever the game had there, which is a buffer of its own.
+  Reverie keeps the frame's average brightness in one such buffer to set its exposure, read
+  nothing, and scaled the whole picture to black. Complementary's world-space reflections read
+  their block data out of another. Both now reach the pack's own bytes. The store of compiled
+  shader modules is rebuilt once on the first launch, as every module compiled before this
+  carried the old slot.
+
 - **A compute pass that reads the depth runs.** A compute a pack hangs off a full screen pass
   could read every name that pass reads except `depthtex0`, `depthtex1`, `depthtex2`, the far
   terrain's depth and `centerDepthSmooth`: those threw on every frame, so the compute never ran,

--- a/common/src/main/java/dev/vitrail/mixin/IntermediaryShaderModuleMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/IntermediaryShaderModuleMixin.java
@@ -16,8 +16,8 @@ import java.nio.ByteBuffer;
  * Lists SPIR-V storage images and storage buffers beside the resources the game asks SPIRV-Cross
  * for, and lets a 3D image through {@code rebind}.
  * <p>
- * Type 6 is a storage image. Type 5 is a storage buffer. Type 7 is a sampled image.
- * {@code createFromSpirv} walks 1 and 7 and leaves 5 and 6 on the bindings shaderc assigned.
+ * Type 6 is a storage image. Type 2 is a storage buffer. Type 7 is a sampled image.
+ * {@code createFromSpirv} walks 1 and 7 and leaves 2 and 6 on the bindings shaderc assigned.
  * Complementary's {@code uimage3D voxel_img} and {@code blockDataBuffer} are those resources.
  * Construction of the package-private records is {@link ComputeShader}, by reflection.
  */

--- a/common/src/main/java/dev/vitrail/render/ComputeShader.java
+++ b/common/src/main/java/dev/vitrail/render/ComputeShader.java
@@ -28,10 +28,15 @@ import java.util.List;
 public final class ComputeShader {
 
 	/** {@code SPVC_RESOURCE_TYPE_STORAGE_IMAGE}. */
-	private static final int STORAGE_IMAGE = 6;
+	private static final int STORAGE_IMAGE = Spvc.SPVC_RESOURCE_TYPE_STORAGE_IMAGE;
 
-	/** {@code SPVC_RESOURCE_TYPE_STORAGE_BUFFER}. */
-	private static final int STORAGE_BUFFER = 5;
+	/**
+	 * {@code SPVC_RESOURCE_TYPE_STORAGE_BUFFER}, taken from the binding rather than typed: SPIRV-Cross
+	 * numbers it 2, and the 5 this held was {@code SUBPASS_INPUT}. Asked for that, the listing was
+	 * always empty, so no storage block of any pack was ever remapped: each kept the
+	 * {@code binding = N} its pack wrote and read whatever the layout held at that slot.
+	 */
+	private static final int STORAGE_BUFFER = Spvc.SPVC_RESOURCE_TYPE_STORAGE_BUFFER;
 
 	private static final Constructor<?> SAMPLER;
 	private static final Constructor<?> UNIFORM;
@@ -79,8 +84,9 @@ public final class ComputeShader {
 	}
 
 	/**
-	 * SPIRV-Cross type 5, which the game never asks for. Complementary's {@code blockDataBuffer}
-	 * is that resource; without it the binding shaderc assigned is never remapped.
+	 * SPIRV-Cross type 2, which the game never asks for. Complementary's {@code blockDataBuffer}
+	 * and Reverie's two blocks are that resource; without it the binding the pack wrote is never
+	 * remapped.
 	 */
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	public static void appendStorageBuffers(IntermediaryShaderModule module) {

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -2143,6 +2143,15 @@ final class GeometryProgram {
 		SamplerPlan.Binding binding = this.loaded.samplers().binding(sampler);
 		SamplerPlan.Kind kind = binding.kind();
 
+		// A file of the pack's own counts when the file is there, on the same call the bind makes:
+		// what packTexture answers is what the draw reads. Left out of this list, Reverie's eight
+		// lookup tables and Complementary's cloud-water were all reported as one pixel on every
+		// geometry program while the draw was reading them, and the line sent a whole session
+		// after a black picture whose cause was elsewhere.
+		if (kind == SamplerPlan.Kind.PACK_TEXTURE) {
+			return this.targets.packTexture(TextureStage.GBUFFERS, sampler) != null;
+		}
+
 		return ATLAS.contains(sampler) || LIGHTMAP.equals(sampler) || OVERLAY.equals(sampler)
 				|| kind == SamplerPlan.Kind.COLORTEX
 				|| kind == SamplerPlan.Kind.CUSTOM_IMAGE

--- a/common/src/main/java/dev/vitrail/render/ModuleCache.java
+++ b/common/src/main/java/dev/vitrail/render/ModuleCache.java
@@ -155,10 +155,14 @@ public final class ModuleCache {
 	private static final long SWEEP_BACKOFF_NANOS = 60_000_000_000L;
 
 	/**
-	 * Bumped by hand when the layout of a file changes rather than its content. Every blob written
-	 * under an older one is then unreachable, and the sweep is what eventually collects it.
+	 * Bumped by hand when the layout of a file changes rather than its content, or when what the
+	 * tables in it hold does. Every blob written under an older one is then unreachable, and the
+	 * sweep is what eventually collects it. Two is where the uniform buffer table first carries the
+	 * storage blocks: every blob before it lists none, a hit skips the reflection that would add
+	 * them, and a pipeline built off such a blob leaves every storage block on the binding its pack
+	 * wrote.
 	 */
-	private static final String FORMAT = "vitrail-module-1";
+	private static final String FORMAT = "vitrail-module-2";
 
 	private static final String FOLDER = "modules";
 	private static final String SUFFIX = ".mod";

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2381,7 +2381,8 @@ public final class PackChain {
 				// what let the pass sample what the compute stored.
 				this.compute.dispatchBefore(pass.program(), encoder, device, this.values,
 						this.targets, this.chain.targets().schedule().step(pass.program())
-								.orElse(null), ready.main().width, ready.main().height);
+								.orElse(null), depth, distant, ready.main().width,
+						ready.main().height);
 				this.currentChains.clear();
 			}
 

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -255,12 +255,23 @@ final class PackCompute implements AutoCloseable {
 	 * Dispatches the computes hanging off that full screen pass, right before it, as Iris does.
 	 * Nothing happens for a pass with none, which is every pass of most packs.
 	 *
-	 * @param step the halves that pass reads and writes, which is where its computes read a colour
-	 *             target from and write one to: Iris binds both the sampler and the image on the
-	 *             flipped state of that moment ({@code IrisImages.addRenderTargetImages})
+	 * @param step    the halves that pass reads and writes, which is where its computes read a
+	 *                colour target from and write one to: Iris binds both the sampler and the
+	 *                image on the flipped state of that moment
+	 *                ({@code IrisImages.addRenderTargetImages})
+	 * @param depth   what that pass reads as {@code depthtex0}, already in the pack's own window,
+	 *                and so what its computes read under the same name: Iris hands a compute the
+	 *                three depth names of the pass it hangs off through the same
+	 *                {@code IrisSamplers.addCompositeSamplers} call
+	 *                ({@code pipeline/CompositeRenderer.java:458} against {@code :402}), and the
+	 *                far terrain's through the same {@code addRenderTargetSamplers}
+	 *                ({@code :450} against {@code :394})
+	 * @param distant what that pass reads as {@code dhDepthTex0}, on the same split, or null for
+	 *                the far plane on the frames the pack drew no far terrain
 	 */
 	void dispatchBefore(String program, CommandEncoder encoder, GpuDevice device, PackValues values,
-			ColorTargets targets, TargetSchedule.Bound step, int width, int height) {
+			ColorTargets targets, TargetSchedule.Bound step, GpuTextureView depth,
+			GpuTextureView distant, int width, int height) {
 		List<Pass> attached = this.chained.get(program);
 		if (attached == null || attached.isEmpty()) {
 			return;
@@ -283,7 +294,7 @@ final class PackCompute implements AutoCloseable {
 
 		for (Pass pass : attached) {
 			try {
-				pass.dispatch(vulkan, commands, values, targets, width, height, step);
+				pass.dispatch(vulkan, commands, values, targets, width, height, step, depth, distant);
 			} catch (RuntimeException e) {
 				if (pass.failed.add(e.toString())) {
 					Vitrail.logger().warn("compute {} failed: {}", pass.path, e.toString());
@@ -344,7 +355,7 @@ final class PackCompute implements AutoCloseable {
 		int height = main == null ? 0 : main.height;
 		for (Pass pass : this.passes) {
 			try {
-				pass.dispatch(vulkan, commands, values, targets, width, height, null);
+				pass.dispatch(vulkan, commands, values, targets, width, height, null, null, null);
 			} catch (RuntimeException e) {
 				if (pass.failed.add(e.toString())) {
 					Vitrail.logger().warn("shadow compute {} failed: {}", pass.path, e.toString());
@@ -575,11 +586,17 @@ final class PackCompute implements AutoCloseable {
 		}
 
 		/**
-		 * @param step the halves of the pass this compute hangs off, or null for a shadow compute,
-		 *             which reads no colour target
+		 * @param step    the halves of the pass this compute hangs off, or null for a shadow
+		 *                compute, which reads no colour target
+		 * @param depth   the depth the pass this compute hangs off reads, or null for a shadow
+		 *                compute, which is dispatched before the frame has one: {@code depthtex0}
+		 *                then reads the far plane, and the two copies read what they last held,
+		 *                as they do for a pass drawn before the copy is taken
+		 * @param distant the far terrain's depth on the same terms
 		 */
 		private void dispatch(VulkanDevice vulkan, VkCommandBuffer commands, PackValues values,
-				ColorTargets targets, int width, int height, TargetSchedule.Bound step) {
+				ColorTargets targets, int width, int height, TargetSchedule.Bound step,
+				GpuTextureView depth, GpuTextureView distant) {
 			if (!this.compiled) {
 				compile(vulkan);
 			}
@@ -592,7 +609,7 @@ final class PackCompute implements AutoCloseable {
 			try (MemoryStack stack = MemoryStack.stackPush()) {
 				VulkanCommandEncoder.memoryBarrier(commands, stack);
 				VK12.vkCmdBindPipeline(commands, VK12.VK_PIPELINE_BIND_POINT_COMPUTE, this.pipeline);
-				pushDescriptors(commands, stack, targets, step);
+				pushDescriptors(commands, stack, targets, step, depth, distant);
 				// The screen and not the shadow map: Iris sizes a shadow composite's compute off
 				// the main render target, ShadowCompositeRenderer.java:212, and the resolution of
 				// the shadow map is what it sizes the shadow GEOMETRY computes off instead,
@@ -812,7 +829,8 @@ final class PackCompute implements AutoCloseable {
 		}
 
 		private void pushDescriptors(VkCommandBuffer commands, MemoryStack stack,
-				ColorTargets targets, TargetSchedule.Bound step) {
+				ColorTargets targets, TargetSchedule.Bound step, GpuTextureView depth,
+				GpuTextureView distant) {
 			if (this.entries.isEmpty()) {
 				return;
 			}
@@ -879,6 +897,28 @@ final class PackCompute implements AutoCloseable {
 				}
 
 				if (bound == null) {
+					// The depth of the pass this compute hangs off, under the three names, the far
+					// terrain's and the smoothed centre depth, answered by the methods that answer
+					// the pass itself: Iris gives a compute the depth samplers of its pass
+					// (CompositeRenderer.java:458 and :461), and Reverie's cloud compute reads
+					// depthtex1 to know where the sky ends. Ahead of the engine set below because
+					// that set carries no depth, and a name it did not carry threw on every
+					// dispatch, so the compute never ran and said so once.
+					GpuTextureView read = switch (SamplerPlan.classify(entry.name())) {
+						case DEPTH -> PackPass.depth(entry.name(), targets, depth);
+						case DISTANT_DEPTH -> PackPass.distant(entry.name(), targets, distant);
+						case CENTER_DEPTH -> PackPass.centerDepth(targets);
+						default -> null;
+					};
+					if (read instanceof VulkanGpuTextureView served) {
+						imageInfo.sampler(samplerFor(entry.name()));
+						imageInfo.imageView(served.vkImageView());
+						imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+						write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+						write.pImageInfo(imageInfo);
+						continue;
+					}
+
 					// The samplers the engine serves every pack program, noisetex and the shadow
 					// set among them: shadowcomp reads them the way a composite does, and only a
 					// name neither the pack's images nor this set carries is a real miss.

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -587,15 +587,13 @@ final class PackPass {
 				// White until the pass behind it has drawn once, which is the far plane in the pack's
 				// own window and so a focus point at the horizon. Black would be a focus point at the
 				// camera, which is the defect this whole path exists to close.
-				case CENTER_DEPTH -> or(targets.centerDepth().view(), targets.white());
+				case CENTER_DEPTH -> centerDepth(targets);
 				// The far terrain's own depth, kept beside the world's as Iris keeps it, and white
 				// for the far plane on the frames the pack drew no far terrain: the pack's Distant
 				// Horizons branches then stay shut, exactly as without the mod. dhDepthTex1 is the
 				// image without the water whichever half asks, which is Iris's copy before the
 				// translucent LODs; the other two names follow the half, like depthtex0.
-				case DISTANT_DEPTH -> SamplerPlan.distantWithoutWater(binding.sampler())
-						? or(targets.depth().distantOpaque(), targets.white())
-						: or(distantView, targets.white());
+				case DISTANT_DEPTH -> distant(binding.sampler(), targets, distantView);
 				// A name this backend cannot bind should have taken its program out of the chain
 				// before a frame was drawn. It is still answered rather than left out, because the
 				// layout carries it either way and the draw throws on the first name it misses.
@@ -694,8 +692,7 @@ final class PackPass {
 	 * also reached when an image was wanted and could not be had, which is not the same thing:
 	 * {@link PackDepth#preHand} carries the cases apart and says which of them reach the log.
 	 */
-	private static GpuTextureView depth(String sampler, ColorTargets targets,
-			GpuTextureView depthView) {
+	static GpuTextureView depth(String sampler, ColorTargets targets, GpuTextureView depthView) {
 		if (SamplerPlan.depthCopy(sampler)) {
 			if (SamplerPlan.preHandCopy(sampler)) {
 				GpuTextureView preHand = targets.depth().preHand();
@@ -711,6 +708,30 @@ final class PackPass {
 		}
 
 		return depthView == null ? targets.white() : depthView;
+	}
+
+	/**
+	 * Which far terrain depth a name reads, and white for the far plane on the frames the pack
+	 * drew no far terrain, so that the pack's Distant Horizons branches stay shut exactly as
+	 * without the mod. {@code dhDepthTex1} is the image without the water whichever half asks,
+	 * which is Iris's copy before the translucent LODs; the other two names follow the half, like
+	 * {@code depthtex0}. Package private for the compute road, so that a compute reads the far
+	 * terrain exactly as the pass it hangs off does.
+	 */
+	static GpuTextureView distant(String sampler, ColorTargets targets, GpuTextureView distantView) {
+		return SamplerPlan.distantWithoutWater(sampler)
+				? or(targets.depth().distantOpaque(), targets.white())
+				: or(distantView, targets.white());
+	}
+
+	/**
+	 * The one texel {@code centerDepthSmooth} is read out of, and white until the pass behind it
+	 * has drawn once: the far plane in the pack's own window, so a focus point at the horizon,
+	 * where black would be one at the camera. Package private for the compute road, which Iris
+	 * hands the same texel ({@code pipeline/CompositeRenderer.java:461}).
+	 */
+	static GpuTextureView centerDepth(ColorTargets targets) {
+		return or(targets.centerDepth().view(), targets.white());
 	}
 
 	/** The first of the two that exists, for a name whose image may not be allocated yet. */

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -21,7 +21,7 @@ quietly stale.
 | Mellow v3.3 | Drawn, and it exercises two more of them: it ships a three-dimensional volume as a raw blob, and it asks for a single-channel shadow buffer. |
 | Photon v1.3b | Drawn, at default settings. It exercises a clamped volume of half floats as its atmosphere table, reads its volumes through macros standing for the sampler's name, and lays a volume over the name of a colour target that the same stage also reads as a plain `sampler2D`. Not yet compared against the reference shot for shot. |
 | Body Camera v1.6.1 | Drawn. It is one of the packs that branches on the star flag in the sky, so it is worth reading [the sky goes flat](#the-sky-goes-flat) alongside. |
-| Reverie Beta v0.9 | **Loads and compiles whole, and its picture is black.** The four features it declares it cannot be drawn without are all served, its loosely written conditionals are read as the reference reads them, and every one of its full-screen passes and computes runs. What it draws is black: the textures it ships reach its geometry programs as a single pixel, and eight of its own uniforms are handed as zeros, matrices among them. That is a gap here and not a fault of the pack: Iris draws it. |
+| Reverie Beta v0.9 | Drawn, at its shipped profile. It is the pack that exercises the storage buffers hardest: its exposure is an average brightness that a compute writes into one and every later pass reads back, and a compute of its cloud pass reads the depth. It declares the uniforms of the Voxy mod beside those of Distant Horizons and reads them only under a `VOXY` define that mod sets and nothing here does, so the seven `vx` names the log reports as zeros are handed as zeros by Iris too without that mod, and the misspelt `previouscameraPositionFract` beside them is read by no program of the pack. Not yet compared against the reference shot for shot. |
 
 Start from what you are seeing. Each symptom below names its cause, and says how to confirm it
 rather than guess.
@@ -60,8 +60,7 @@ naming them at load.
 A pack can declare the features it cannot be drawn without, and Reverie declares several. That
 line is read before any of its programs is translated, so a refusal names what the pack asked for
 and did not get, the log listing them, rather than the symptom that would have come later. Every
-name Reverie declares is served now, so it is no longer refused there; what it still lacks is
-written in its row of the table above.
+name Reverie declares is served now, so it is no longer refused there.
 
 **Any name this engine has not built refuses the declaration.** Five names are built and served
 today, `BLOCK_EMISSION_ATTRIBUTE`, `CUSTOM_IMAGES`, `HIGHER_SHADOWCOLOR`,


### PR DESCRIPTION
## What changes

A pack's shader storage buffers reach the programs that name them. The reflection that lists a
module's storage blocks asked SPIRV-Cross for the wrong resource type, so the listing was always
empty: every storage block kept the `binding = N` its pack wrote, in the game's own descriptor set,
and read whatever sat there. Reverie keeps its average luminance in one such block and scaled
every frame to black; Complementary's world-space reflections read their block data out of
another. The store of compiled modules keeps the reflection tables beside the bytes, so its format
goes up and the store is rebuilt once. Beside that, a compute hanging off a full screen pass now
reads the depth names, the far terrain's depth and `centerDepthSmooth` exactly as the pass after it
does, where before any of those names threw on every dispatch and the compute never ran; and the
load line of a geometry program counts a texture the pack ships as read, where it listed every one
of them among the samplers reading one pixel while the draw was reading them.

## How it differs from the reference, and for what obstacle

It does not. Iris binds a compute's samplers with the same `addCompositeSamplers` and
`addRenderTargetSamplers` calls as the pass it hangs off (`pipeline/CompositeRenderer.java:450-461`
against `:394-402`), and a storage block is bound by the index of its layout qualifier there; here
the block is remapped by name onto the bind group entry the engine declares for it, which is the
same buffer under the same name.

## What proves it

- `gradlew build` green.
- In the game, Fabric bench, `frozen real vitrail`: Reverie Beta v0.9 at its shipped profile draws
  sky, clouds, terrain, water and hand where the same scene was black before, and its log no
  longer reports `compute world0/composite4 failed` nor lists the pack's own textures among the
  samplers reading one pixel. With the chain cut to its first seventeen passes the scene was
  already lit, and it went black at the eighteenth, the exposure pass that reads the block.
  Complementary Unbound at its ULTRA profile loads and draws on the same jar, its world-space
  reflection composite included.

## What it leaves owing

Complementary Ultra's far-water flashes and the black left face of the hand are not settled by
this branch: both need a capture at the vantage they were seen from, and only the reflection
half could be touched by the storage fix. Whether the picture of Reverie matches Iris shot for
shot has not been compared.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
