### PR TITLE
perf(sodium): work out a block once for all its quads

### DIFF
--- a/common/src/main/java/dev/vitrail/mixin/sodium/BlockRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/sodium/BlockRendererMixin.java
@@ -6,6 +6,7 @@ import dev.vitrail.render.BlockStateIds;
 import net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
 import net.caffeinemc.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder;
 import net.caffeinemc.mods.sodium.client.render.model.AbstractBlockRenderContext;
+import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -73,6 +74,19 @@ public abstract class BlockRendererMixin extends AbstractBlockRenderContext {
 		return vitrail$stamp(vertices);
 	}
 
+	/** The block the two words below were worked out for, so that its quads share them. */
+	@Unique
+	private BlockState vitrail$stampedState;
+
+	@Unique
+	private long vitrail$stampedAt = Long.MIN_VALUE;
+
+	@Unique
+	private int vitrail$stampedId = BlockStateIds.NONE;
+
+	@Unique
+	private int vitrail$stampedOrigin;
+
 	/**
 	 * Everything this quad carries about the block it came from: the number the pack gave it, where
 	 * it stands in its section, and what it emits.
@@ -87,12 +101,25 @@ public abstract class BlockRendererMixin extends AbstractBlockRenderContext {
 		// Sodium's own, one instance reused for every face of every block, so a field left alone
 		// keeps what the block before wrote: an offset measured against another block, which wraps
 		// into its byte without a word. A quad that knows one of the two still gets that one.
-		TerrainVertex.stampOrigin(vertices, this.pos == null
-				? 0
-				: TerrainVertex.pack(this.pos.getX(), this.pos.getY(), this.pos.getZ(),
-						this.state == null ? 0 : this.state.getLightEmission()));
+		//
+		// Worked out once per block and not once per quad: the id is a table lookup and the origin
+		// a light emission and a pack, and a block hands the same two to every one of its faces.
+		// The position is compared by value, the context reusing one mutable position for every
+		// block of a section.
+		BlockState state = this.state;
+		long at = this.pos == null ? Long.MIN_VALUE : this.pos.asLong();
+		if (state != this.vitrail$stampedState || at != this.vitrail$stampedAt) {
+			this.vitrail$stampedState = state;
+			this.vitrail$stampedAt = at;
+			this.vitrail$stampedId = state == null ? BlockStateIds.NONE : BlockStateIds.packed(state);
+			this.vitrail$stampedOrigin = this.pos == null
+					? 0
+					: TerrainVertex.pack(this.pos.getX(), this.pos.getY(), this.pos.getZ(),
+							state == null ? 0 : state.getLightEmission());
+		}
 
-		return TerrainVertex.stamp(vertices,
-				this.state == null ? BlockStateIds.NONE : BlockStateIds.packed(this.state));
+		TerrainVertex.stampOrigin(vertices, this.vitrail$stampedOrigin);
+
+		return TerrainVertex.stamp(vertices, this.vitrail$stampedId);
 	}
 }

--- a/common/src/main/java/dev/vitrail/mixin/sodium/DefaultFluidRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/sodium/DefaultFluidRendererMixin.java
@@ -96,8 +96,11 @@ public abstract class DefaultFluidRendererMixin {
 		// exists to tell apart: the id below is computed and then goes nowhere, and printing it
 		// beside a startup line saying the mesh carries no block id would be the engine
 		// contradicting itself inside one log.
+		// A plain read first: the exchange is a locked instruction on one word every builder
+		// thread shares, and it only has anything to do once per table.
 		int table = BlockStateIds.generation();
-		if (TerrainDraw.asked() && vitrail$said.getAndSet(table) != table) {
+		if (TerrainDraw.asked() && vitrail$said.get() != table
+				&& vitrail$said.getAndSet(table) != table) {
 			// The table is named, because this line is not the only one of the run: two loads
 			// of the same pack print it twice, word for word, and nothing else would say which
 			// reading belongs to which table.

--- a/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
+++ b/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
@@ -532,7 +532,9 @@ public final class TerrainMesh implements ChunkVertexType {
 		for (int at = vertices.length - 1; at >= 0; at--) {
 			long from = pointer + (long) at * this.innerStride;
 			long to = pointer + (long) at * this.stride;
-			for (int word = this.innerStride - Integer.BYTES; word >= 0; word -= Integer.BYTES) {
+			// The first vertex does not move, both strides placing it at the pointer.
+			for (int word = at == 0 ? -1 : this.innerStride - Integer.BYTES; word >= 0;
+					word -= Integer.BYTES) {
 				MemoryUtil.memPutInt(to + word, MemoryUtil.memGetInt(from + word));
 			}
 


### PR DESCRIPTION
## What changes

Three costs on the chunk build path go away, and the mesh that comes out is the same bytes. A block's id and its packed origin were looked up and packed again for every quad of the block; they are worked out once per block and handed to each of its faces, the block being compared by identity and its position by value since the builder reuses one position object. Every fluid block paid a locked exchange on a word shared by all builder threads, only to decide whether to write a log line that is written once per block table; a plain read now settles the common case first and the exchange keeps the once-only for the rare one. And the widened mesh copied its first vertex onto itself, both strides placing that vertex at the same address.

## How it differs from the reference, and for what obstacle

It does not: Iris works its per-block words out per block as well.

## What proves it

- `gradlew build` green.
- The first vertex's copy is a no-op by construction: source and destination coincide at index nought whatever the two strides.
- In the game: not yet. The Fabric bench is held by another run. What to look at when it frees: a world under a pack that reads block ids and tangents (Complementary), terrain textured and lit as before, no garbage faces, the "first fluid meshed" line printed once per table.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
