### PR TITLE
perf(render): settle at load what the frame worked out again

### DIFF
--- a/common/src/main/java/dev/vitrail/dh/DhDepth.java
+++ b/common/src/main/java/dev/vitrail/dh/DhDepth.java
@@ -146,17 +146,12 @@ public final class DhDepth {
 	 * unclamped one the class comment carries, and since the clamp only ever pulls that plane in, it
 	 * is always the further out of the two. Its far is out by the ratio of the two formulas.
 	 *
-	 * @param dest filled with the near plane and then the far one. Left alone where {@link #zRow}
-	 *             answered nothing, but carrying that row where this refused it for its shape, so a
-	 *             caller reads the pair only on true
+	 * @param scale  the z term of the row {@link #zRow} read
+	 * @param offset its w term
+	 * @param dest   filled with the near plane and then the far one, and left alone where the
+	 *               row has no perspective in it, so a caller reads the pair only on true
 	 */
-	public static boolean planes(Vector2f dest) {
-		if (!zRow(dest)) {
-			return false;
-		}
-
-		float scale = dest.x;
-		float offset = dest.y;
+	public static boolean planes(float scale, float offset, Vector2f dest) {
 		if (scale <= 0.0F) {
 			return false;
 		}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
@@ -2,6 +2,7 @@ package dev.vitrail.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
 import com.mojang.blaze3d.vulkan.VulkanRenderPass;
 import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
@@ -14,9 +15,11 @@ import org.lwjgl.vulkan.VkDescriptorImageInfo;
 import org.lwjgl.vulkan.VkWriteDescriptorSet;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Pushes a storage-image descriptor, a 3D sampled view, and a storage-buffer descriptor for
@@ -35,6 +38,13 @@ public abstract class VulkanRenderPassMixin {
 
 	@Shadow
 	protected VulkanRenderPipeline pipeline;
+
+	/** The pipeline the set below answers for, so that the set is asked once per pipeline. */
+	@Unique
+	private RenderPipeline vitrail$comparedFor;
+
+	@Unique
+	private Set<String> vitrail$compared = Set.of();
 
 	@WrapOperation(method = "pushDescriptors", require = 1,
 			at = @At(value = "INVOKE", target = "Ljava/util/List;get(I)Ljava/lang/Object;", ordinal = 0))
@@ -76,8 +86,7 @@ public abstract class VulkanRenderPassMixin {
 			// game's own pays a volatile read here and nothing else. Once one has been, the flag
 			// stays up for the session and the per-name lookup is the price of having the road.
 			VulkanBindGroupLayout.Entry entry = pushed.entry();
-			if (entry != null && this.pipeline != null
-					&& ShadowCompare.compared(this.pipeline.info(), entry.name())) {
+			if (entry != null && this.pipeline != null && vitrail$compared().contains(entry.name())) {
 				sampler = ShadowCompare.sampler(this.pipeline.device());
 			}
 		}
@@ -130,5 +139,16 @@ public abstract class VulkanRenderPassMixin {
 		}
 
 		return original.call(set, type);
+	}
+
+	@Unique
+	private Set<String> vitrail$compared() {
+		RenderPipeline info = this.pipeline.info();
+		if (info != this.vitrail$comparedFor) {
+			this.vitrail$comparedFor = info;
+			this.vitrail$compared = ShadowCompare.compared(info);
+		}
+
+		return this.vitrail$compared;
 	}
 }

--- a/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
@@ -5,6 +5,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
 import com.mojang.blaze3d.vulkan.VulkanRenderPass;
 import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
+import dev.vitrail.render.PushedDescriptor;
 import dev.vitrail.render.ShadowCompare;
 import dev.vitrail.render.StorageBuffers;
 import dev.vitrail.render.StorageImages;
@@ -13,7 +14,6 @@ import org.lwjgl.vulkan.VkDescriptorImageInfo;
 import org.lwjgl.vulkan.VkWriteDescriptorSet;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 import java.util.List;
@@ -33,9 +33,6 @@ import java.util.List;
 @Mixin(VulkanRenderPass.class)
 public abstract class VulkanRenderPassMixin {
 
-	@Unique
-	private static final ThreadLocal<VulkanBindGroupLayout.Entry> CURRENT = new ThreadLocal<>();
-
 	@Shadow
 	protected VulkanRenderPipeline pipeline;
 
@@ -44,7 +41,7 @@ public abstract class VulkanRenderPassMixin {
 	private Object vitrail$entry(List<?> entries, int index, Operation<Object> original) {
 		Object entry = original.call(entries, index);
 		if (entry instanceof VulkanBindGroupLayout.Entry named) {
-			CURRENT.set(named);
+			PushedDescriptor.begin(named);
 		}
 
 		return entry;
@@ -56,7 +53,7 @@ public abstract class VulkanRenderPassMixin {
 							+ "Lorg/lwjgl/vulkan/VkDescriptorImageInfo$Buffer;"))
 	private VkDescriptorImageInfo.Buffer vitrail$view(VkDescriptorImageInfo.Buffer info, long view,
 			Operation<VkDescriptorImageInfo.Buffer> original) {
-		StorageImages.Bound bound = currentBound();
+		StorageImages.Bound bound = PushedDescriptor.current().image();
 		if (bound != null) {
 			view = bound.view();
 		}
@@ -70,14 +67,15 @@ public abstract class VulkanRenderPassMixin {
 							+ "Lorg/lwjgl/vulkan/VkDescriptorImageInfo$Buffer;"))
 	private VkDescriptorImageInfo.Buffer vitrail$sampler(VkDescriptorImageInfo.Buffer info,
 			long sampler, Operation<VkDescriptorImageInfo.Buffer> original) {
-		StorageImages.Bound bound = currentBound();
+		PushedDescriptor pushed = PushedDescriptor.current();
+		StorageImages.Bound bound = pushed.image();
 		if (bound != null && bound.storage()) {
 			sampler = 0L;
 		} else if (ShadowCompare.noted()) {
 			// Behind the one flag: until the first pack that compares is loaded, every pass of the
 			// game's own pays a volatile read here and nothing else. Once one has been, the flag
 			// stays up for the session and the per-name lookup is the price of having the road.
-			VulkanBindGroupLayout.Entry entry = CURRENT.get();
+			VulkanBindGroupLayout.Entry entry = pushed.entry();
 			if (entry != null && this.pipeline != null
 					&& ShadowCompare.compared(this.pipeline.info(), entry.name())) {
 				sampler = ShadowCompare.sampler(this.pipeline.device());
@@ -93,7 +91,7 @@ public abstract class VulkanRenderPassMixin {
 							+ "Lorg/lwjgl/vulkan/VkDescriptorBufferInfo$Buffer;"))
 	private VkDescriptorBufferInfo.Buffer vitrail$buffer(VkDescriptorBufferInfo.Buffer info,
 			long buffer, Operation<VkDescriptorBufferInfo.Buffer> original) {
-		StorageBuffers.Bound bound = currentBuffer();
+		StorageBuffers.Bound bound = PushedDescriptor.current().buffer();
 		if (bound != null) {
 			buffer = bound.buffer();
 		}
@@ -107,7 +105,7 @@ public abstract class VulkanRenderPassMixin {
 							+ "Lorg/lwjgl/vulkan/VkDescriptorBufferInfo$Buffer;"))
 	private VkDescriptorBufferInfo.Buffer vitrail$range(VkDescriptorBufferInfo.Buffer info,
 			long range, Operation<VkDescriptorBufferInfo.Buffer> original) {
-		StorageBuffers.Bound bound = currentBuffer();
+		StorageBuffers.Bound bound = PushedDescriptor.current().buffer();
 		if (bound != null) {
 			range = bound.range();
 		}
@@ -121,27 +119,16 @@ public abstract class VulkanRenderPassMixin {
 							+ "Lorg/lwjgl/vulkan/VkWriteDescriptorSet;"))
 	private VkWriteDescriptorSet vitrail$type(VkWriteDescriptorSet set, int type,
 			Operation<VkWriteDescriptorSet> original) {
-		StorageImages.Bound image = currentBound();
+		PushedDescriptor pushed = PushedDescriptor.current();
+		StorageImages.Bound image = pushed.image();
 		if (type == 1 && image != null && image.storage()) {
 			type = 3;
 		}
 
-		if (type == 6 && currentBuffer() != null) {
+		if (type == 6 && pushed.buffer() != null) {
 			type = 7;
 		}
 
 		return original.call(set, type);
-	}
-
-	@Unique
-	private static StorageImages.Bound currentBound() {
-		VulkanBindGroupLayout.Entry entry = CURRENT.get();
-		return entry == null ? null : StorageImages.bound(entry.name());
-	}
-
-	@Unique
-	private static StorageBuffers.Bound currentBuffer() {
-		VulkanBindGroupLayout.Entry entry = CURRENT.get();
-		return entry == null ? null : StorageBuffers.bound(entry.name());
 	}
 }

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -255,6 +255,7 @@ public final class ChainPlan {
 	}
 
 	private final List<Pass> passes;
+	private final int deferredEnd;
 	private final Pass last;
 	private final Seed seed;
 
@@ -317,6 +318,7 @@ public final class ChainPlan {
 			List<String> history) {
 		this.place = place;
 		this.passes = List.copyOf(passes);
+		this.deferredEnd = pastDeferred(this.passes);
 		this.last = last;
 		this.seed = seed;
 		this.attachments = Map.copyOf(attachments);
@@ -1127,10 +1129,11 @@ public final class ChainPlan {
 	 * Answered here and not counted again by the renderer, for the reason this whole class exists:
 	 * the same number already decides where {@link #notes()} puts the translucent chunk pass, and
 	 * two walks of one list in two files are two chances of cutting the frame at different points
-	 * without a word.
+	 * without a word. Counted once, the plan never changing after it is built: the renderer asks
+	 * twice a frame.
 	 */
 	public int deferredEnd() {
-		return pastDeferred(this.passes);
+		return this.deferredEnd;
 	}
 
 	/** The final. Its attachments are always empty: it writes the game's own target. */

--- a/common/src/main/java/dev/vitrail/pack/target/TargetSize.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetSize.java
@@ -35,8 +35,11 @@ public record TargetSize(boolean relative, float width, float height) {
 	 */
 	public static final int MAX_DIMENSION = 16384;
 
+	/** The one answer for every target the pack sizes on the screen, asked per target per frame. */
+	private static final TargetSize SCREEN = new TargetSize(true, 1.0F, 1.0F);
+
 	public static TargetSize ofScreen() {
-		return new TargetSize(true, 1.0F, 1.0F);
+		return SCREEN;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -150,6 +150,11 @@ final class ColorTargets {
 	record PackBinding(GpuTextureView view, FilterMode filter, boolean repeat) {
 	}
 
+	/** The schedule the plan gave these targets, for a pass to settle its own step off. */
+	TargetSchedule schedule() {
+		return this.plan.schedule();
+	}
+
 	/**
 	 * What the pack supplies for a name, settled once: the image, and the filter and addressing
 	 * its directive and its .mcmeta asked for. Only the view behind the image moves after that,
@@ -198,6 +203,9 @@ final class ColorTargets {
 	private final CenterDepth centerDepth = new CenterDepth();
 
 	private final Map<Integer, GpuFormat> formats = new LinkedHashMap<>();
+
+	/** The filter each carried target is sampled with, settled with its format. */
+	private final Map<Integer, FilterMode> filters = new LinkedHashMap<>();
 	private final Map<Integer, Vector4fc> clearColours = new LinkedHashMap<>();
 
 	/**
@@ -349,7 +357,9 @@ final class ColorTargets {
 		TargetDirectives directives = plan.directives();
 		for (int index : plan.ordered()) {
 			TargetDirectives.Colour colour = directives.clearColour(index);
-			this.formats.put(index, GpuFormats.of(directives.format(index).used()));
+			TargetFormat format = directives.format(index).used();
+			this.formats.put(index, GpuFormats.of(format));
+			this.filters.put(index, GpuFormats.filterFor(format));
 			this.clearColours.put(index, new Vector4f(colour.r(), colour.g(), colour.b(), colour.a()));
 		}
 
@@ -793,11 +803,13 @@ final class ColorTargets {
 		return this.screenHeight;
 	}
 
-	/** LINEAR wherever Iris allows it, which is everywhere but an integer format. */
+	/**
+	 * LINEAR wherever Iris allows it, which is everywhere but an integer format, and NEAREST for
+	 * a target the plan does not carry. Read off the table rather than resolved through the
+	 * directives again: asked per colour sampler of every pass of every frame.
+	 */
 	FilterMode filter(int index) {
-		TargetFormat format = this.plan.directives().format(index).used();
-
-		return has(index) ? GpuFormats.filterFor(format) : FilterMode.NEAREST;
+		return this.filters.getOrDefault(index, FilterMode.NEAREST);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -150,6 +150,14 @@ final class ColorTargets {
 	record PackBinding(GpuTextureView view, FilterMode filter, boolean repeat) {
 	}
 
+	/**
+	 * What the pack supplies for a name, settled once: the image, and the filter and addressing
+	 * its directive and its .mcmeta asked for. Only the view behind the image moves after that,
+	 * and {@link #packView} answers it per frame.
+	 */
+	record PackSource(PackImages.Image image, FilterMode filter, boolean repeat) {
+	}
+
 	private final TargetPlan plan;
 	private final Set<Integer> doubled;
 	private final int noiseResolution;
@@ -1032,17 +1040,34 @@ final class ColorTargets {
 	 * different image, and the gutter would stop being read at all.
 	 */
 	PackBinding packTexture(TextureStage stage, String sampler) {
+		PackSource source = packSource(stage, sampler);
+		GpuTextureView view = source == null ? null : packView(source.image());
+
+		return view == null ? null : new PackBinding(view, source.filter(), source.repeat());
+	}
+
+	/**
+	 * The half of {@link #packTexture} that never moves once the pack is read, for a caller that
+	 * binds the same name every frame: null where the pack supplies nothing for it.
+	 */
+	PackSource packSource(TextureStage stage, String sampler) {
 		PackImages.Image image = this.packImages.find(stage, sampler);
-		TargetSurface surface = image == null ? null : this.packSurfaces.get(image);
-		if (surface == null || surface.view() == null) {
+		if (image == null) {
 			return null;
 		}
 
 		boolean flat = !sampler.equals(SamplerPlan.behind(sampler));
 
-		return new PackBinding(surface.view(),
+		return new PackSource(image,
 				image.texture().blur() ? FilterMode.LINEAR : FilterMode.NEAREST,
 				!flat && !image.texture().clamp());
+	}
+
+	/** The view behind a supplied image, or null while nothing could be put behind it. */
+	GpuTextureView packView(PackImages.Image image) {
+		TargetSurface surface = this.packSurfaces.get(image);
+
+		return surface == null ? null : surface.view();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -231,6 +231,9 @@ final class ColorTargets {
 	 */
 	private final Set<Integer> mipmapped;
 
+	/** For each program, the targets it reads at a lod and that carry a chain, in target order. */
+	private final Map<String, Set<Integer>> lodReads;
+
 	private TargetSurface black;
 	private TargetSurface white;
 	private TargetSurface grey;
@@ -372,6 +375,11 @@ final class ColorTargets {
 		this.mipmapped = directives.mipmapped().stream()
 				.filter(this.formats::containsKey)
 				.collect(Collectors.toCollection(TreeSet::new));
+		Map<String, Set<Integer>> lodReads = new LinkedHashMap<>();
+		directives.mipmapRequests().forEach((program, asked) -> lodReads.put(program,
+				asked.stream().filter(this.mipmapped::contains)
+						.collect(Collectors.toCollection(TreeSet::new))));
+		this.lodReads = Map.copyOf(lodReads);
 
 		// A flip directive may turn over a target no program of this place writes or samples, and
 		// nothing is allocated for one of those. Said here because the count of doubled targets is
@@ -775,11 +783,12 @@ final class ColorTargets {
 	 * program that reads one after such a write; taking the union here would rebuild every chain
 	 * before every program that happens to sample the target, which is ten render passes apiece
 	 * for a result nothing reads.
+	 * <p>
+	 * Settled with the plan rather than filtered on each ask: a compute asks per colour descriptor
+	 * of every dispatch.
 	 */
 	Set<Integer> lodReads(String program) {
-		return this.plan.directives().mipmapRequests().getOrDefault(program, Set.of()).stream()
-				.filter(this.mipmapped::contains)
-				.collect(Collectors.toCollection(TreeSet::new));
+		return this.lodReads.getOrDefault(program, Set.of());
 	}
 
 	GpuFormat format(int index) {

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -1285,6 +1285,14 @@ public final class EntityDraw {
 	 * for a pack this place can serve no entity with at all. */
 	private final Map<String, EntityProgram> programs = new LinkedHashMap<>();
 
+	/**
+	 * The element the last draw was recorded for and the program the map answered, because a
+	 * frame records hundreds of draws and runs of them share one element: the map is asked by
+	 * name once per run rather than once per draw. Dropped with the map.
+	 */
+	private Element recordedElement;
+	private EntityProgram recordedProgram;
+
 	/** Whether the pack has been read for its entities. A reading that served nothing is still one.
 	 * Volatile so the render thread sees it only after {@link #read} has filled the map. */
 	private volatile boolean read;
@@ -1667,7 +1675,15 @@ public final class EntityDraw {
 			return false;
 		}
 
-		EntityProgram program = this.programs.get(element.element());
+		EntityProgram program;
+		if (element == this.recordedElement) {
+			program = this.recordedProgram;
+		} else {
+			program = this.programs.get(element.element());
+			this.recordedElement = element;
+			this.recordedProgram = program;
+		}
+
 		if (program == null) {
 			end();
 
@@ -2090,6 +2106,8 @@ public final class EntityDraw {
 				return;
 			}
 
+			this.recordedElement = null;
+			this.recordedProgram = null;
 			groups.forEach(group -> keep(group, loaded));
 		} catch (IOException | RuntimeException e) {
 			Vitrail.logger().error("Could not prepare the entity programs of "
@@ -2385,6 +2403,8 @@ public final class EntityDraw {
 		end();
 		this.programs.values().forEach(EntityProgram::release);
 		this.programs.clear();
+		this.recordedElement = null;
+		this.recordedProgram = null;
 		// With the programs, or "once per load" would mean once per session: what is read again after
 		// this can refuse again, for the same reason or for another, and a reader watching a portal
 		// would see the first reading's lines and nothing after them.

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -141,6 +141,8 @@ public final class FrameState implements WorldState {
 	private float ambientLight;
 	private int dimensionOrdinal;
 	private int seaLevel;
+	/** The biome the two values below were classified for, so that they are not classified again. */
+	private Holder<Biome> biomeHolder;
 	private int biomeId;
 	private int biomeCategory;
 	private int biomePrecipitation;
@@ -379,6 +381,7 @@ public final class FrameState implements WorldState {
 		// the session before would be served as this one's.
 		this.lightningTick = Long.MIN_VALUE;
 		this.lightningBoltPosition.zero();
+		this.biomeHolder = null;
 	}
 
 	/**
@@ -472,13 +475,15 @@ public final class FrameState implements WorldState {
 		// this. They are named one by one in ViewMatrices.advanceDistant.
 		int distance = DhDepth.renderDistanceBlocks();
 
-		boolean planes = DhDepth.planes(this.distantPlanes);
-		float near = planes ? this.distantPlanes.x : ViewMatrices.FALLBACK_PLANE;
-		float far = planes ? this.distantPlanes.y : ViewMatrices.FALLBACK_PLANE;
-
+		// One reflective read of the row, and the planes worked out of it, rather than the row
+		// read twice through four field gets a frame.
 		boolean row = DhDepth.zRow(this.distantPlanes);
 		float scale = row ? this.distantPlanes.x : 0.0F;
 		float offset = row ? this.distantPlanes.y : 0.0F;
+
+		boolean planes = row && DhDepth.planes(scale, offset, this.distantPlanes);
+		float near = planes ? this.distantPlanes.x : ViewMatrices.FALLBACK_PLANE;
+		float far = planes ? this.distantPlanes.y : ViewMatrices.FALLBACK_PLANE;
 
 		if (!DhDepth.usable()) {
 			distance = -1;
@@ -921,8 +926,18 @@ public final class FrameState implements WorldState {
 		// different when the camera has backed through a wall.
 		BlockPos position = player.blockPosition();
 		Holder<Biome> holder = level.getBiome(position);
-		this.biomeId = BiomeClassifier.identify(holder);
-		this.biomeCategory = BiomeClassifier.categoryOf(holder);
+		// The number and the category are properties of the biome, and the registry hands the
+		// same holder back for it frame after frame: the sixteen tag tests of the category and
+		// the key lookup of the number run when the player crosses into another biome, which is
+		// how Iris reads them too, off a value it keeps on the biome itself. What neither
+		// follows is a data pack reload rebinding the tags of a biome the player is standing in:
+		// the category catches up when they leave it, where Iris keeps its first answer for the
+		// session.
+		if (holder != this.biomeHolder) {
+			this.biomeHolder = holder;
+			this.biomeId = BiomeClassifier.identify(holder);
+			this.biomeCategory = BiomeClassifier.categoryOf(holder);
+		}
 		this.biomePrecipitation =
 				switch (holder.value().getPrecipitationAt(position, level.getSeaLevel())) {
 					case NONE -> 0;

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -58,6 +58,7 @@ import org.joml.Vector4fc;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -287,6 +288,17 @@ final class GeometryProgram {
 		/** Whether this name is the albedo of whatever this pass is drawing. */
 		private final boolean albedo;
 
+		/** The plan's answer for the name, which never moves once the pack is read. */
+		private final SamplerPlan.Binding binding;
+
+		/**
+		 * What the pack supplies under the name, or null for every kind but a pack texture and
+		 * for a name the pack took over with nothing behind it. Settled here for the reason the
+		 * class carries: resolving it walked the pack's texture directives by name at every pass
+		 * open, three times over for one name.
+		 */
+		private final ColorTargets.PackSource source;
+
 		/**
 		 * Whether this map is read through the albedo's own sampler, which is every one of them but
 		 * the specular under labPBR. Settled at the pass open: the format is the resource pack's, and
@@ -300,10 +312,13 @@ final class GeometryProgram {
 		/** The sampler state that goes with it, on the same rule. */
 		private GpuSampler state;
 
-		Sampled(String name, PbrMap material, boolean albedo) {
+		Sampled(String name, PbrMap material, boolean albedo, SamplerPlan.Binding binding,
+				ColorTargets.PackSource source) {
 			this.name = name;
 			this.material = material;
 			this.albedo = albedo;
+			this.binding = binding;
+			this.source = source;
 		}
 
 		/** Whether the answer follows the DRAW's own image rather than the pass's. */
@@ -396,6 +411,14 @@ final class GeometryProgram {
 	 * pass open resolved for it. Read by the bind and by nothing else.
 	 */
 	private final Sampled[] bound;
+
+	/**
+	 * The two halves of {@link #bound}, split once: the names whose answer follows the draw's own
+	 * image, bound at every draw, and every other name, bound once per pass open. A bind used to
+	 * walk all of them at every draw to find the two to four that could move.
+	 */
+	private final Sampled[] following;
+	private final Sampled[] settledOnce;
 	private final RenderPipeline pipeline;
 	private final ShaderSource source;
 
@@ -652,7 +675,17 @@ final class GeometryProgram {
 		// Which map a name asks for, and whether it is the albedo, are questions about the NAME and
 		// about the plan the load built, so they are asked here once for the life of the program.
 		this.bound = this.samplers.stream()
-				.map(name -> new Sampled(name, material(name), ATLAS.contains(name)))
+				.map(name -> {
+					SamplerPlan.Binding binding = loaded.samplers().binding(name);
+					return new Sampled(name, material(name), ATLAS.contains(name), binding,
+							binding.kind() == SamplerPlan.Kind.PACK_TEXTURE
+									? targets.packSource(TextureStage.GBUFFERS, name)
+									: null);
+				})
+				.toArray(Sampled[]::new);
+		this.following = Arrays.stream(this.bound).filter(Sampled::followsTheImage)
+				.toArray(Sampled[]::new);
+		this.settledOnce = Arrays.stream(this.bound).filter(one -> !one.followsTheImage())
 				.toArray(Sampled[]::new);
 
 		String vertex = loaded.program().stages().get(ProgramStage.VERTEX).text();
@@ -1253,10 +1286,12 @@ final class GeometryProgram {
 		settledIn = pass;
 		settled = this;
 
-		for (Sampled one : this.bound) {
-			if (one.followsTheImage()) {
-				pass.bindTexture(one.name, imageView(one), imageSampler(one));
-			} else if (settle) {
+		for (Sampled one : this.following) {
+			pass.bindTexture(one.name, imageView(one), imageSampler(one));
+		}
+
+		if (settle) {
+			for (Sampled one : this.settledOnce) {
 				pass.bindTexture(one.name, one.view, one.state);
 			}
 		}
@@ -1413,14 +1448,11 @@ final class GeometryProgram {
 		// Bliss on gaux1 the loudest, and none of those programs ever reads the target at a lod. So
 		// the directive is theirs to declare and dead on their side, and the cost of honouring it
 		// here would be a risk taken for nobody.
-		SamplerPlan.Kind kind = this.loaded.samplers().binding(name).kind();
-		if (kind == SamplerPlan.Kind.PACK_TEXTURE) {
+		SamplerPlan.Kind kind = one.binding.kind();
+		if (one.source != null && this.targets.packView(one.source.image()) != null) {
 			// A file of the pack's own is filtered and addressed as the pack asked, in the .mcmeta
 			// beside it, and the name it took over has nothing to say about either.
-			ColorTargets.PackBinding supplied = this.targets.packTexture(TextureStage.GBUFFERS, name);
-			if (supplied != null) {
-				return PackPass.sampler(supplied.repeat(), supplied.filter(), false);
-			}
+			return PackPass.sampler(one.source.repeat(), one.source.filter(), false);
 		}
 
 		return PackPass.sampler(kind, filter(name), false);
@@ -1893,7 +1925,7 @@ final class GeometryProgram {
 			return lightmap == null ? this.constants.white() : lightmap;
 		}
 
-		SamplerPlan.Binding binding = this.loaded.samplers().binding(sampler);
+		SamplerPlan.Binding binding = one.binding;
 
 		// White and not black for a depth that stays a constant, and the reason is the image rather
 		// than a taste: what a depth lookup reads is already in the pack's own window, where one is
@@ -1908,17 +1940,17 @@ final class GeometryProgram {
 			// Every geometry program is drawn in the gbuffers stage, the shadow passes included,
 			// which is the one thing a texture.STAGE.NAME override needs to know. Mellow moves
 			// noisetex there and nowhere else, so this is not a case the chain also covers.
-			case PACK_TEXTURE -> packTexture(sampler);
+			case PACK_TEXTURE -> packTexture(one);
 			case DISTANT_DEPTH -> distantDepth();
 			default -> this.constants.black();
 		};
 	}
 
 	/** The pack's own file behind a name, or black when it took the name over and nothing was read. */
-	private GpuTextureView packTexture(String sampler) {
-		ColorTargets.PackBinding supplied = this.targets.packTexture(TextureStage.GBUFFERS, sampler);
+	private GpuTextureView packTexture(Sampled one) {
+		GpuTextureView supplied = one.source == null ? null : this.targets.packView(one.source.image());
 
-		return supplied == null ? this.constants.black() : supplied.view();
+		return supplied == null ? this.constants.black() : supplied;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -312,6 +312,16 @@ final class GeometryProgram {
 		/** The sampler state that goes with it, on the same rule. */
 		private GpuSampler state;
 
+		/**
+		 * The image the last draw brought and what its map answered, held for one pass. A pass
+		 * records hundreds of draws and most of them bring the image the draw before did, so the
+		 * two doors are asked once per image rather than once per draw. Dropped at
+		 * {@link #resolve}, which is the one place a stale answer cannot cross.
+		 */
+		private GpuTextureView servedFor;
+		private GpuTextureView served;
+		private boolean servedKnown;
+
 		Sampled(String name, PbrMap material, boolean albedo, SamplerPlan.Binding binding,
 				ColorTargets.PackSource source) {
 			this.name = name;
@@ -1328,6 +1338,9 @@ final class GeometryProgram {
 			one.interpolates = one.material != null && one.material.interpolates(labPbr);
 			one.view = passView(one);
 			one.state = passSampler(one);
+			one.servedKnown = false;
+			one.servedFor = null;
+			one.served = null;
 		}
 	}
 
@@ -1347,12 +1360,18 @@ final class GeometryProgram {
 			// under its own name. Iris keeps the same pair and picks between them by the class of the
 			// bound texture (pbr/loader/PBRTextureLoaderRegistry.java:15-16); here the atlas door
 			// answers only for an image it was built against, so asking it first picks the same one.
-			GpuTextureView served = PbrAtlases.view(this.atlas, one.material);
-			if (served == null) {
-				served = PbrTextures.view(this.atlas, one.material);
+			if (!one.servedKnown || one.servedFor != this.atlas) {
+				GpuTextureView served = PbrAtlases.view(this.atlas, one.material);
+				if (served == null) {
+					served = PbrTextures.view(this.atlas, one.material);
+				}
+
+				one.servedFor = this.atlas;
+				one.served = served;
+				one.servedKnown = true;
 			}
 
-			return served == null ? one.view : served;
+			return one.served == null ? one.view : one.served;
 		}
 
 		// One pixel where the pass has no atlas of its own, which is every cloud and the sky's own
@@ -1766,6 +1785,9 @@ final class GeometryProgram {
 		for (Sampled one : this.bound) {
 			one.view = null;
 			one.state = null;
+			one.servedFor = null;
+			one.served = null;
+			one.servedKnown = false;
 		}
 
 		// Let go of the pass and the program the same way, and for the same reason as the views

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2380,8 +2380,7 @@ public final class PackChain {
 				// render pass: a dispatch is a command of its own, and the barriers around it are
 				// what let the pass sample what the compute stored.
 				this.compute.dispatchBefore(pass.program(), encoder, device, this.values,
-						this.targets, this.chain.targets().schedule().step(pass.program())
-								.orElse(null), depth, distant, ready.main().width,
+						this.targets, pass.step(), depth, distant, ready.main().width,
 						ready.main().height);
 				this.currentChains.clear();
 			}

--- a/common/src/main/java/dev/vitrail/render/PackNameIds.java
+++ b/common/src/main/java/dev/vitrail/render/PackNameIds.java
@@ -52,6 +52,9 @@ public final class PackNameIds {
 
 	private static volatile NameIds items = NameIds.empty();
 
+	/** What a cache answers for a key nobody asked about yet, and never a pack's own number. */
+	private static final int UNASKED = Integer.MIN_VALUE;
+
 	/**
 	 * The answer for an entity type, worked out once each. Kept beside the table rather than inside
 	 * it because the key is the game's object and {@link NameIds} names no game class; replaced whole
@@ -113,7 +116,7 @@ public final class PackNameIds {
 	public static int entity(EntityType<?> type) {
 		Object2IntMap<EntityType<?>> cache = byType;
 		int known = cache.getInt(type);
-		if (known != NameIds.NONE || cache.containsKey(type)) {
+		if (known != UNASKED) {
 			return known;
 		}
 
@@ -128,13 +131,13 @@ public final class PackNameIds {
 	 * The pack's number for an item, named by its model identifier or by its registry key, and
 	 * worked out once each.
 	 * <p>
-	 * A name the pack named nowhere is remembered as {@link NameIds#NONE} as well, which is what
-	 * the lookup tells apart from a real one by asking whether the key is there at all.
+	 * A name the pack named nowhere is remembered as {@link NameIds#NONE} as well, which the
+	 * lookup tells apart from a name never asked about by the value the cache answers for those.
 	 */
 	public static int item(Identifier name) {
 		Object2IntMap<Identifier> cache = byName;
 		int known = cache.getInt(name);
-		if (known != NameIds.NONE || cache.containsKey(name)) {
+		if (known != UNASKED) {
 			return known;
 		}
 
@@ -145,13 +148,14 @@ public final class PackNameIds {
 	}
 
 	/**
-	 * A cache with nothing in it, answering {@link NameIds#NONE} for a key it has not been asked
-	 * about, which is what the lookups above tell apart from a real {@code NONE} by asking whether
-	 * the key is there at all.
+	 * A cache with nothing in it, answering {@link #UNASKED} for a key it has not been asked
+	 * about. A real {@code NONE} is stored like any other answer, so the lookups above tell the
+	 * two apart in the one probe: a second one asking whether the key was there paid a hash per
+	 * submission for every kind of entity the pack does not name, which is most of them.
 	 */
 	private static <K> Object2IntMap<K> emptyCache() {
 		Object2IntMap<K> cache = new Object2IntOpenHashMap<>();
-		cache.defaultReturnValue(NameIds.NONE);
+		cache.defaultReturnValue(UNASKED);
 
 		return cache;
 	}

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -38,6 +38,7 @@ import net.minecraft.client.renderer.BindGroupLayouts;
 import net.minecraft.resources.Identifier;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -124,6 +125,15 @@ final class PackPass {
 	 */
 	private final List<SamplerPlan.Binding> samplerBindings;
 
+	/**
+	 * For each of {@link #samplers}, what the pack supplies under that name, or null for every
+	 * other kind of binding and for a name the pack took over with nothing behind it. Settled
+	 * with the plan for the same reason as {@link #samplerBindings}: the resolution walked the
+	 * pack's texture directives by name per sampler, per pass and per frame, and only the view
+	 * behind the image can move.
+	 */
+	private final List<ColorTargets.PackSource> packSources;
+
 	private final List<String> storage;
 	private final List<LodRead> lodReads;
 
@@ -179,6 +189,13 @@ final class PackPass {
 		this.uniforms = new PackUniforms(loaded.program().uniforms(), values.catalog());
 		this.samplers = loaded.program().samplers().stream().map(TranslatedUnit.Uniform::name).toList();
 		this.samplerBindings = this.samplers.stream().map(loaded.samplers()::binding).toList();
+		List<ColorTargets.PackSource> sources = new ArrayList<>();
+		for (int at = 0; at < this.samplers.size(); at++) {
+			sources.add(this.samplerBindings.get(at).kind() == SamplerPlan.Kind.PACK_TEXTURE
+					? targets.packSource(this.textureStage, this.samplers.get(at))
+					: null);
+		}
+		this.packSources = Collections.unmodifiableList(sources);
 		this.storage = loaded.storageBlocks().stream()
 				.distinct()
 				.filter(StorageBuffers::named)
@@ -560,11 +577,10 @@ final class PackPass {
 			// A texture the pack ships answers all three questions at once, and they are one
 			// answer: which image, how it is filtered, and how it is addressed outside zero to one
 			// are all the pack's to say, in the same directive and the same .mcmeta beside it.
-			ColorTargets.PackBinding supplied = binding.kind() == SamplerPlan.Kind.PACK_TEXTURE
-					? targets.packTexture(this.textureStage, sampler)
-					: null;
+			ColorTargets.PackSource source = this.packSources.get(at);
+			GpuTextureView supplied = source == null ? null : targets.packView(source.image());
 
-			GpuTextureView bound = supplied != null ? supplied.view() : switch (binding.kind()) {
+			GpuTextureView bound = supplied != null ? supplied : switch (binding.kind()) {
 				case COLORTEX -> targets.view(binding.index(), binding.side());
 				// White where no image is there, and white is the far plane rather than a
 				// placeholder: what a depth lookup reads is now an image already in the pack's own
@@ -635,7 +651,7 @@ final class PackPass {
 			//
 			// A custom image is the image's own answer and not this pass's, which is why it is
 			// asked of one place rather than decided here: see customImageFilter.
-			FilterMode filter = supplied != null ? supplied.filter() : switch (binding.kind()) {
+			FilterMode filter = supplied != null ? source.filter() : switch (binding.kind()) {
 				case COLORTEX -> targets.filter(binding.index());
 				case NOISE, SHADOW_COLOUR, SHADOW_DEPTH -> FilterMode.LINEAR;
 				case CUSTOM_IMAGE -> customImageFilter(sampler);
@@ -671,7 +687,7 @@ final class PackPass {
 			// itself, in the .mcmeta beside the file.
 			pass.bindTexture(sampler, bound == null ? targets.black() : bound,
 					supplied != null
-							? sampler(supplied.repeat(), filter, false)
+							? sampler(source.repeat(), filter, false)
 							: sampler(binding.kind(), filter, mipmaps));
 		}
 	}

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -140,6 +140,13 @@ final class PackPass {
 	/** The targets of {@link #lodReads}, for the binding to answer one name at a time. */
 	private final Set<Integer> lodTargets;
 
+	/**
+	 * The schedule's step for this pass, or null where the schedule names none, for the computes
+	 * hanging off it. Settled here because the schedule answers by walking its steps and
+	 * comparing names, and the answer cannot change once the pack is read.
+	 */
+	private final TargetSchedule.Bound step;
+
 	private final RenderPipeline pipeline;
 	private final ShaderSource source;
 	private final Supplier<String> label;
@@ -184,7 +191,10 @@ final class PackPass {
 		this.attachments = List.copyOf(pass.attachments());
 		this.offset = offset;
 		this.last = this.attachments.isEmpty();
-		this.label = () -> "Vitrail " + this.path;
+		// Finished once: the encoder asks every pass of the game for its label to tell ours
+		// apart, so a supplier that concatenated on every ask paid a string per pass per frame.
+		String label = "Vitrail " + this.path;
+		this.label = () -> label;
 		this.values = values;
 		this.uniforms = new PackUniforms(loaded.program().uniforms(), values.catalog());
 		this.samplers = loaded.program().samplers().stream().map(TranslatedUnit.Uniform::name).toList();
@@ -202,6 +212,7 @@ final class PackPass {
 				.toList();
 		this.lodReads = lodReadsOf(program, loaded, targets);
 		this.lodTargets = this.lodReads.stream().map(LodRead::target).collect(Collectors.toSet());
+		this.step = targets.schedule().step(program).orElse(null);
 
 		if (this.attachments.size() > MAX_ATTACHMENTS) {
 			throw new IllegalStateException(this.path + " writes " + this.attachments.size()
@@ -303,6 +314,10 @@ final class PackPass {
 	}
 
 	/** The program name alone, {@code composite3}, which is what the schedule and the computes key on. */
+	TargetSchedule.Bound step() {
+		return this.step;
+	}
+
 	String program() {
 		return this.pass.program();
 	}
@@ -580,8 +595,14 @@ final class PackPass {
 			ColorTargets.PackSource source = this.packSources.get(at);
 			GpuTextureView supplied = source == null ? null : targets.packView(source.image());
 
+			// Resolved once for the view and the chain below, which used to be two walks of the
+			// same map for one name.
+			TargetSurface surface = binding.kind() == SamplerPlan.Kind.COLORTEX
+					? targets.surface(binding.index(), binding.side())
+					: null;
+
 			GpuTextureView bound = supplied != null ? supplied : switch (binding.kind()) {
-				case COLORTEX -> targets.view(binding.index(), binding.side());
+				case COLORTEX -> surface == null ? null : surface.view();
 				// White where no image is there, and white is the far plane rather than a
 				// placeholder: what a depth lookup reads is now an image already in the pack's own
 				// window, where one is the far plane, and the whole world would otherwise be drawn
@@ -673,9 +694,6 @@ final class PackPass {
 			// driver left there. Deciding this at the binding rather than when the pass was built
 			// is what makes the fall back real instead of announced: a chain nothing has written
 			// is read at level nought, which is the image the pack had before there were chains.
-			TargetSurface surface = binding.kind() == SamplerPlan.Kind.COLORTEX
-					? targets.surface(binding.index(), binding.side())
-					: null;
 			boolean mipmaps = surface != null && surface.chainWritten()
 					&& this.lodTargets.contains(binding.index());
 

--- a/common/src/main/java/dev/vitrail/render/PushedDescriptor.java
+++ b/common/src/main/java/dev/vitrail/render/PushedDescriptor.java
@@ -1,0 +1,56 @@
+package dev.vitrail.render;
+
+import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
+
+/**
+ * The bind group entry a descriptor push is writing, with what the pack's storage answers for
+ * its name, resolved once per entry and read by every field of the descriptor.
+ * <p>
+ * A push writes the view, the sampler, the buffer, its range and the descriptor type through as
+ * many wrapped calls, and each of them used to ask {@link StorageImages} and
+ * {@link StorageBuffers} for the entry's name again: five lookups per descriptor of every pass of
+ * the game and of Sodium, with or without a pack loaded. The entry is resolved where it is read
+ * off the layout, and the fields read the answer.
+ * <p>
+ * Held per thread rather than in a static, as the entry was before it: a push recorded off the
+ * render thread cannot read another push's entry, whatever the backend does later.
+ */
+public final class PushedDescriptor {
+
+	private static final ThreadLocal<PushedDescriptor> CURRENT =
+			ThreadLocal.withInitial(PushedDescriptor::new);
+
+	private VulkanBindGroupLayout.Entry entry;
+	private StorageImages.Bound image;
+	private StorageBuffers.Bound buffer;
+
+	private PushedDescriptor() {
+	}
+
+	/** The entry the push is about to write, and the pack's answers for its name. */
+	public static void begin(VulkanBindGroupLayout.Entry entry) {
+		PushedDescriptor current = CURRENT.get();
+		current.entry = entry;
+		current.image = StorageImages.bound(entry.name());
+		current.buffer = StorageBuffers.bound(entry.name());
+	}
+
+	public static PushedDescriptor current() {
+		return CURRENT.get();
+	}
+
+	/** The entry being written, or null before the first entry of the thread. */
+	public VulkanBindGroupLayout.Entry entry() {
+		return this.entry;
+	}
+
+	/** The pack image under the entry's name, or null where the pack declares none. */
+	public StorageImages.Bound image() {
+		return this.image;
+	}
+
+	/** The pack buffer under the entry's name, or null where the pack declares none. */
+	public StorageBuffers.Bound buffer() {
+		return this.buffer;
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/ShadowCompare.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowCompare.java
@@ -164,11 +164,15 @@ public final class ShadowCompare {
 		return noted;
 	}
 
-	/** Whether this pipeline reads this name through a comparison, asked while pushing descriptors. */
-	public static boolean compared(RenderPipeline pipeline, String name) {
+	/**
+	 * The names this pipeline reads through a comparison, empty for one that filed none. Asked
+	 * once per pipeline a pass draws with, the map behind it being a weak one under a monitor,
+	 * and the set answers for every descriptor of every draw after that.
+	 */
+	public static Set<String> compared(RenderPipeline pipeline) {
 		Set<String> names = COMPARED.get(pipeline);
 
-		return names != null && names.contains(name);
+		return names == null ? Set.of() : names;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/StorageBuffers.java
+++ b/common/src/main/java/dev/vitrail/render/StorageBuffers.java
@@ -27,7 +27,9 @@ import org.lwjgl.vulkan.VkCommandBuffer;
 
 import java.nio.LongBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The shader storage buffers a pack declared with {@code bufferObject.N}, allocated on the Vulkan
@@ -45,6 +47,9 @@ public final class StorageBuffers implements AutoCloseable {
 
 	private final BufferObject.Reading declared;
 	private final List<Allocated> allocated = new ArrayList<>();
+
+	/** Each allocation under the index the pack declared it at, rebuilt with {@link #allocated}. */
+	private Map<Integer, Bound> bindings = Map.of();
 	private GpuBuffer dummy;
 	private int lastWidth;
 	private int lastHeight;
@@ -71,18 +76,21 @@ public final class StorageBuffers implements AutoCloseable {
 	}
 
 	private Bound lookup(String name) {
-		int index = CustomStorage.indexOf(name);
-		if (index < 0) {
+		if (this.bindings.isEmpty()) {
 			return null;
 		}
 
+		int index = CustomStorage.indexOf(name);
+		return index < 0 ? null : this.bindings.get(index);
+	}
+
+	private void rebind() {
+		Map<Integer, Bound> bound = new HashMap<>();
 		for (Allocated buffer : this.allocated) {
-			if (buffer.declared.index() == index) {
-				return new Bound(buffer.buffer, buffer.bytes);
-			}
+			bound.putIfAbsent(buffer.declared.index(), new Bound(buffer.buffer, buffer.bytes));
 		}
 
-		return null;
+		this.bindings = Map.copyOf(bound);
 	}
 
 	/**
@@ -120,6 +128,22 @@ public final class StorageBuffers implements AutoCloseable {
 		}
 
 		ensurePlaceholder(device);
+		// The map follows the list whatever happens below: an allocation that throws halfway
+		// through a resize has already destroyed the relative buffers and dropped them from the
+		// list, and a map left standing would hand a destroyed handle to the next descriptor push.
+		try {
+			allocate(vulkan, first, resized, screenWidth, screenHeight);
+		} finally {
+			rebind();
+		}
+
+		this.lastWidth = screenWidth;
+		this.lastHeight = screenHeight;
+		zero(device);
+	}
+
+	private void allocate(VulkanDevice vulkan, boolean first, boolean resized, int screenWidth,
+			int screenHeight) {
 		if (first) {
 			for (BufferObject buffer : this.declared.buffers()) {
 				if (buffer.relative()) {
@@ -155,10 +179,6 @@ public final class StorageBuffers implements AutoCloseable {
 				Vitrail.logger().info("storage buffer {} at {} bytes", buffer.describe(), bytes);
 			}
 		}
-
-		this.lastWidth = screenWidth;
-		this.lastHeight = screenHeight;
-		zero(device);
 	}
 
 	private void ensurePlaceholder(GpuDevice device) {
@@ -173,6 +193,10 @@ public final class StorageBuffers implements AutoCloseable {
 	 * Mixins replace the {@code VkBuffer} and the range while the descriptors are pushed.
 	 */
 	public static void bind(RenderPass pass, List<String> names) {
+		if (names.isEmpty()) {
+			return;
+		}
+
 		GpuBufferSlice slice = current.placeholder();
 		if (slice == null) {
 			return;
@@ -266,6 +290,7 @@ public final class StorageBuffers implements AutoCloseable {
 		}
 
 		this.allocated.clear();
+		this.bindings = Map.of();
 		if (this.dummy != null) {
 			this.dummy.close();
 			this.dummy = null;

--- a/common/src/main/java/dev/vitrail/render/StorageImages.java
+++ b/common/src/main/java/dev/vitrail/render/StorageImages.java
@@ -31,7 +31,9 @@ import org.lwjgl.vulkan.VkImageViewCreateInfo;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The storage images a pack declared with {@code image.NAME}, allocated on the Vulkan device.
@@ -49,6 +51,13 @@ public final class StorageImages implements AutoCloseable {
 
 	private final ImageInformation.Reading declared;
 	private final List<Allocated> allocated = new ArrayList<>();
+
+	/**
+	 * Every name a descriptor push may ask for, resolved to the view it gets, rebuilt whenever
+	 * {@link #allocated} changes. The push asks once per descriptor of every pass of the game,
+	 * Sodium's included, so the answer is a map read and never a walk.
+	 */
+	private Map<String, Bound> bindings = Map.of();
 	private int lastWidth;
 	private int lastHeight;
 	private boolean laidOut;
@@ -80,17 +89,23 @@ public final class StorageImages implements AutoCloseable {
 	}
 
 	private Bound lookup(String name) {
-		for (Allocated image : this.allocated) {
-			if (image.declared.name().equals(name)) {
-				return new Bound(image.view, true, image.declared.internalFormat().used().integer());
-			}
+		return this.bindings.get(name);
+	}
 
-			if (image.declared.sampler().filter(name::equals).isPresent()) {
-				return new Bound(image.view, false, image.declared.internalFormat().used().integer());
-			}
+	/**
+	 * The first image declaring a name answers for it, the image uniform before the sampler on
+	 * the same line, which is the order the walk this replaces read them in.
+	 */
+	private void rebind() {
+		Map<String, Bound> bound = new HashMap<>();
+		for (Allocated image : this.allocated) {
+			boolean integer = image.declared.internalFormat().used().integer();
+			bound.putIfAbsent(image.declared.name(), new Bound(image.view, true, integer));
+			image.declared.sampler().ifPresent(sampler ->
+					bound.putIfAbsent(sampler, new Bound(image.view, false, integer)));
 		}
 
-		return null;
+		this.bindings = Map.copyOf(bound);
 	}
 
 	/**
@@ -183,6 +198,7 @@ public final class StorageImages implements AutoCloseable {
 
 		this.lastWidth = screenWidth;
 		this.lastHeight = screenHeight;
+		rebind();
 		layoutIfNeeded();
 	}
 
@@ -489,6 +505,7 @@ public final class StorageImages implements AutoCloseable {
 		}
 
 		this.allocated.clear();
+		this.bindings = Map.of();
 		this.lastWidth = 0;
 		this.lastHeight = 0;
 		this.laidOut = false;

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -124,6 +124,7 @@ public final class TerrainDraw {
 	 * where the pack serves none, and where the reading threw.
 	 */
 	private Map<TerrainPass, PackProgram.Loaded> loaded = Map.of();
+	private boolean shadowVoxelises;
 
 	/** The elements those programs declare, which is what this pack published through {@link #carries}. */
 	private List<String> declares = List.of();
@@ -241,6 +242,10 @@ public final class TerrainDraw {
 			PackProgram.Terrain read = TerrainProgram.read(pack, this.place, this.values);
 			this.loaded = read.programs();
 			this.declares = read.carried();
+			this.shadowVoxelises = this.loaded.entrySet().stream()
+					.filter(entry -> entry.getKey().shadow())
+					.map(Map.Entry::getValue)
+					.anyMatch(PackProgram.Loaded::voxelises);
 		} catch (IOException | RuntimeException e) {
 			wanted = false;
 			Vitrail.logger().error("Could not read the terrain programs of "
@@ -695,13 +700,11 @@ public final class TerrainDraw {
 	 * Whether any shadow terrain program of this pack voxelises, a geometry stage present or an
 	 * image load / store still standing on it. Iris asks the same of
 	 * {@code SHADOW_TERRAIN_CUTOUT}; the three shadow halves share one file on every pack that
-	 * ships one, and any of them answering is enough.
+	 * ships one, and any of them answering is enough. Settled when the programs are read: the
+	 * shadow walk asks once a frame, and the answer is a property of the pack.
 	 */
 	private boolean voxelisesShadow() {
-		return this.loaded.entrySet().stream()
-				.filter(entry -> entry.getKey().shadow())
-				.map(Map.Entry::getValue)
-				.anyMatch(PackProgram.Loaded::voxelises);
+		return this.shadowVoxelises;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java
+++ b/common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java
@@ -2,6 +2,7 @@ package dev.vitrail.screen;
 
 import dev.vitrail.Vitrail;
 import dev.vitrail.render.PackChain;
+import dev.vitrail.settings.PackSession;
 import dev.vitrail.sodium.ShadowTerrain;
 
 import net.minecraft.client.Minecraft;
@@ -41,6 +42,14 @@ public final class VitrailDebugEntry implements DebugScreenEntry {
 
 	private static final String PREFIX = "[" + Vitrail.MOD_NAME + "] ";
 
+	/**
+	 * The session the profile line below was built for, and the line. The sentence is a scan of
+	 * the pack's profiles against the applied settings, and both are fixed for the life of a
+	 * session, so it is built when the session changes rather than on every frame F3 is open.
+	 */
+	private static PackSession profiledSession;
+	private static String profileLine = "";
+
 	@Override
 	public void display(DebugScreenDisplayer displayer, @Nullable Level level,
 			@Nullable LevelChunk clientChunk, @Nullable LevelChunk serverChunk) {
@@ -50,11 +59,20 @@ public final class VitrailDebugEntry implements DebugScreenEntry {
 
 		PackChain.session().ifPresentOrElse(session -> {
 			displayer.addToGroup(GROUP, PREFIX + "Shaderpack: " + session.packFileName());
-			displayer.addToGroup(GROUP, PREFIX + session.profileInfo());
+			displayer.addToGroup(GROUP, profileLine(session));
 			if (level != null) {
 				shadowLines(displayer);
 			}
 		}, () -> displayer.addToGroup(GROUP, PREFIX + undrawnLine()));
+	}
+
+	private static String profileLine(PackSession session) {
+		if (session != profiledSession) {
+			profiledSession = session;
+			profileLine = PREFIX + session.profileInfo();
+		}
+
+		return profileLine;
 	}
 
 	/**


### PR DESCRIPTION
## What changes

Work that every frame, every pass or every draw used to repeat for an answer that never moves is done once, and the frame reads the answer. A descriptor push asked the pack's storage tables five times per descriptor of every pass in the game, walking the allocations each time; the tables now answer out of a map and the push asks once per entry. A fullscreen pass resolved the pack's own textures by name at every bind, and a geometry program asked the plan for the same sampler three times at every pass open; both are settled when the pass or the program is built, and only the view behind the image is asked per frame. The cut between the two halves of the chain, the schedule step a compute is handed, the filter of a colour target, the label the encoder reads off every pass, the lod set of a compute and the shadow voxelisation are read off fields instead of recomputed. A run of entity draws remembers its program and which material map served the image it brought, instead of resolving both per draw. The F3 profile sentence, the biome category and Distant Horizons' z row are read when their input changes rather than every frame, and a kind of entity the pack does not name costs one hash probe instead of two.

## How it differs from the reference, and for what obstacle

It does not. Iris keeps the biome category on the biome itself and settles its samplers per program; what this branch memoises, Iris never computed per frame either.

## What proves it

- `gradlew build` green.
- The off-game harness built from `dev` and from this branch runs `Harness`, `Chaine`, `Cibles` and `Semis` over the eight-pack corpus with byte-identical output, timing lines aside: the plan, the schedule and the target sizes this branch touches decide the same thing.
- Every claim of the branch was put to a counter-case before it was kept, and the one that survived is fixed here: a storage buffer whose reallocation fails halfway through a resize could have left a destroyed handle in the new map, so the map now follows the list whatever the allocation does.
- In the game: not yet. The Fabric bench is held by another run. What to look at when it frees: a pack with storage images and a compute (Complementary Unbound), the picture unchanged, entities and hand lit by the pack, the F3 profile line and the shadow overlay as before.

## What it leaves owing

A data pack reload that rebinds the tags of the biome the player stands in is followed when they leave it, where it was followed the next frame; Iris never follows it at all.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
