### PR TITLE
perf(pack): load a pack through one reading and off the render thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ what the next one holds.
   appears when you choose a pack, apply a setting, or step through a portal. Nothing about the
   picture changes.
 
+- **A pack loads its entities, sky, clouds, weather, particles and far terrain in one reading.**
+  Each of those six families opened the pack again on the loading thread and worked out the same
+  plan and the same program tree for itself before reading its own files, which was most of the
+  archive walking a load did. They now share one reading, and the report of a pack that used to
+  hold the title screen and every Apply for a second or two is written from a background thread
+  instead. On Complementary Unbound the families take under a second of background work where
+  they took four. Nothing about the picture changes.
+
 ### Added
 
 - **Eight shadow colour buffers for a pack that asks for them.** A pack declaring
@@ -59,6 +67,12 @@ what the next one holds.
   not be drawn at all. A pack requiring either, or both, now loads.
 
 ### Fixed
+
+- **A `#if` decides like the compiler where one side of an `&&` or `||` cannot be worked out.**
+  A condition such as `X != 0 && 100 / X > 5` with `X` at zero was left undecided, because the
+  right side was worked out whatever the left one said, and an undecided condition kept its
+  branch in. The right side is now skipped where the left one has already decided, as the
+  preprocessor does, so such a branch is left out exactly as the pack meant it to be.
 
 - **A pack's storage buffers are read and written where the pack put them.** A pack that keeps
   its own data in a shader storage buffer, declared with `bufferObject` lines, had that buffer

--- a/common/src/main/java/dev/vitrail/glsl/GlslLexer.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslLexer.java
@@ -14,6 +14,18 @@ import java.util.List;
  */
 public final class GlslLexer {
 
+	/**
+	 * The spelling of every operator character below the first non-ASCII one, made once: about a
+	 * third of the tokens of a unit are operators, and each was a fresh one-character string.
+	 */
+	private static final String[] OPERATORS = new String[128];
+
+	static {
+		for (char c = 0; c < OPERATORS.length; c++) {
+			OPERATORS[c] = String.valueOf(c);
+		}
+	}
+
 	private GlslLexer() {
 	}
 
@@ -158,7 +170,8 @@ public final class GlslLexer {
 
 			// One character per operator token. The translator only ever asks about brackets,
 			// commas and semicolons, and single characters make joining the stream back exact.
-			tokens.add(new Token(Kind.OPERATOR, String.valueOf(c), null));
+			tokens.add(new Token(Kind.OPERATOR, c < OPERATORS.length ? OPERATORS[c] : String.valueOf(c),
+					null));
 			index++;
 		}
 

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -404,6 +404,10 @@ public final class GlslTranslator {
 	private final boolean coverage;
 	private final List<Token> tokens;
 
+	/** The parameter list {@link #functionEnd} last answered for, and its answer. */
+	private int functionEndFor = -1;
+	private int functionEndAt;
+
 	/** Names the pack defines as macros. Their uses belong to the preprocessor, not to us. */
 	private final Set<String> packMacros = new HashSet<>();
 
@@ -2672,6 +2676,8 @@ public final class GlslTranslator {
 		if (closings.isEmpty()) {
 			return;
 		}
+
+		this.functionEndFor = -1;
 
 		// One walk that copies the list with the closings dropped in, rather than one shift of
 		// every later token per closing: a stage carries hundreds of thousands of tokens and a
@@ -5166,6 +5172,21 @@ public final class GlslTranslator {
 	 * body, or the parenthesis itself when the function is only declared.
 	 */
 	private int functionEnd(int parameters) {
+		// Asked once per parameter of a list and answered once per list: the walk to the
+		// function's closing brace is the same for every parameter, and every helper that
+		// touches a token forgets this first.
+		if (parameters == this.functionEndFor) {
+			return this.functionEndAt;
+		}
+
+		int end = walkFunctionEnd(parameters);
+		this.functionEndFor = parameters;
+		this.functionEndAt = end;
+
+		return end;
+	}
+
+	private int walkFunctionEnd(int parameters) {
 		int close = matchingBracket(parameters);
 		int brace = close < 0 ? -1 : significantAfter(close);
 		if (brace < 0 || !this.tokens.get(brace).operator("{")) {
@@ -5999,15 +6020,18 @@ public final class GlslTranslator {
 
 
 	private void replace(int index, String text) {
+		this.functionEndFor = -1;
 		this.tokens.set(index, this.tokens.get(index).as(text));
 	}
 
 	/** Replaces a token with text of our own, which no later pass will match again. */
 	private void inject(int index, String text) {
+		this.functionEndFor = -1;
 		this.tokens.set(index, new Token(Kind.RAW, text, this.tokens.get(index).directive()));
 	}
 
 	private void blank(int index) {
+		this.functionEndFor = -1;
 		if (index >= 0) {
 			this.tokens.set(index, Token.BLANK);
 		}
@@ -6015,6 +6039,7 @@ public final class GlslTranslator {
 
 	/** Empties a range but keeps its line breaks, so error messages still point at the right line. */
 	private void blankRange(int start, int end) {
+		this.functionEndFor = -1;
 		for (int index = start; index <= end; index++) {
 			Token token = this.tokens.get(index);
 			if (token.kind() == Kind.NEWLINE) {
@@ -6032,6 +6057,7 @@ public final class GlslTranslator {
 	}
 
 	private void blankDirective(int hash) {
+		this.functionEndFor = -1;
 		for (int index = hash; index < this.tokens.size(); index++) {
 			if (this.tokens.get(index).kind() == Kind.NEWLINE) {
 				return;

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -1591,10 +1591,12 @@ public final class GlslTranslator {
 		// move a token, so anything a later pass still has to know about a token is carried on the
 		// token, as Token#macroName is. A position kept across here would be read against somebody
 		// else's token, and the reading pass has no way to notice.
-		closings.sort(Comparator.reverseOrder());
+		List<Closing> parentheses = new ArrayList<>(closings.size());
 		for (int at : closings) {
-			this.tokens.add(at, new Token(Kind.RAW, ")", null));
+			parentheses.add(new Closing(at, ")", null));
 		}
+
+		insertClosings(parentheses);
 	}
 
 	/**
@@ -2667,10 +2669,36 @@ public final class GlslTranslator {
 	 * nothing downstream can tell.
 	 */
 	private void insertClosings(List<Closing> closings) {
-		closings.sort(Comparator.comparingInt(Closing::at).reversed());
-		for (Closing closing : closings) {
-			this.tokens.add(closing.at(), new Token(Kind.RAW, closing.text(), closing.directive()));
+		if (closings.isEmpty()) {
+			return;
 		}
+
+		// One walk that copies the list with the closings dropped in, rather than one shift of
+		// every later token per closing: a stage carries hundreds of thousands of tokens and a
+		// few hundred closings, and the shifts were the whole cost of the pass. The order is the
+		// one the shifts produced: closings sharing a position land latest first, because each
+		// shift pushed the one inserted before it along.
+		closings.sort(Comparator.comparingInt(Closing::at));
+		List<Token> rebuilt = new ArrayList<>(this.tokens.size() + closings.size());
+		int next = 0;
+		for (int at = 0; at <= this.tokens.size(); at++) {
+			int first = next;
+			while (next < closings.size() && closings.get(next).at() == at) {
+				next++;
+			}
+
+			for (int closing = next - 1; closing >= first; closing--) {
+				Closing one = closings.get(closing);
+				rebuilt.add(new Token(Kind.RAW, one.text(), one.directive()));
+			}
+
+			if (at < this.tokens.size()) {
+				rebuilt.add(this.tokens.get(at));
+			}
+		}
+
+		this.tokens.clear();
+		this.tokens.addAll(rebuilt);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -674,6 +674,28 @@ public final class PackProgram {
 	private record ReadingKey(SettingSet settings, String place) {
 	}
 
+	/**
+	 * What decides which elements a vertex stage reads: the unit, the mesh contract, the program
+	 * name and the volumes behind its samplers. The alpha test and the coverage mask are left out
+	 * because both act on the fragment stage alone, so two passes served by one file share the
+	 * answer whatever they discard at.
+	 */
+	private record ReadsKey(ExpandedUnit vertex, VertexInputs inputs, String program,
+			Map<String, VolumeAtlas> volumes) {
+	}
+
+	/**
+	 * {@link ProgramTranslator#reads}, once per opening for each vertex unit and contract. The
+	 * answer is a whole translation of the stage thrown away but for a set of names, and the
+	 * chunk passes asked it up to six times per place for three distinct answers.
+	 */
+	private static Set<String> reads(ShaderPackSource source, ExpandedUnit vertex,
+			VertexInputs inputs, AlphaTest alphaTest, boolean coverage, String program,
+			Map<String, VolumeAtlas> volumes) throws IOException {
+		return source.derived(new ReadsKey(vertex, inputs, program, volumes),
+				() -> ProgramTranslator.reads(vertex, inputs, alphaTest, coverage, program, volumes));
+	}
+
 	private static Reading reading(OpenedPack pack, String place) throws IOException {
 		ShaderPackSource source = pack.source();
 		return source.derived(new ReadingKey(pack.settings(), place), () -> {
@@ -792,8 +814,8 @@ public final class PackProgram {
 
 			AlphaTest alphaTest = pass.alphaTest(overrides, servedBy);
 			served.put(pass, new Served(path, units, alphaTest));
-			reads.addAll(ProgramTranslator.reads(units.get(ProgramStage.VERTEX), inputs,
-					alphaTest, pass.covers(), pass.program(), textures.volumes()));
+			reads.addAll(reads(source, units.get(ProgramStage.VERTEX), inputs, alphaTest,
+					pass.covers(), pass.program(), textures.volumes()));
 		}
 
 		// Nothing to draw and therefore nothing to carry, which is not the same answer as a mesh
@@ -917,8 +939,8 @@ public final class PackProgram {
 
 			AlphaTest alphaTest = overrides.getOrDefault(servedBy, element.alphaTest());
 			served.put(element.element(), new Served(path, units, alphaTest, element));
-			reads.addAll(ProgramTranslator.reads(units.get(ProgramStage.VERTEX), element.inputs(),
-					alphaTest, element.coverage(), element.program(), textures.volumes()));
+			reads.addAll(reads(source, units.get(ProgramStage.VERTEX), element.inputs(), alphaTest,
+					element.coverage(), element.program(), textures.volumes()));
 		}
 
 		if (served.isEmpty()) {

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -661,6 +661,37 @@ public final class PackProgram {
 	}
 
 	/**
+	 * What every family of programs works out of one opening before reading its own files: the
+	 * expander, the plan of the place, the pack's textures and the program tree. Kept on the
+	 * opening for its life, so that the six families a load reads through one opening pay for
+	 * it once rather than each walking the archive again for the same answers.
+	 */
+	private record Reading(IncludeExpander expander, TargetPlan targets, PackTextures textures,
+			ProgramResolver resolver) {
+	}
+
+	/** The settings and the place a reading was taken for; the settings compare by identity. */
+	private record ReadingKey(SettingSet settings, String place) {
+	}
+
+	private static Reading reading(OpenedPack pack, String place) throws IOException {
+		ShaderPackSource source = pack.source();
+		return source.derived(new ReadingKey(pack.settings(), place), () -> {
+			IncludeExpander expander = new IncludeExpander(source, pack.settings());
+			TargetPlan targets = TargetPlan.build(source, pack.options(), pack.settings(),
+					pack.properties(), place);
+			PackTextures textures = textures(source, pack.properties(), pack.options(), pack.settings());
+			DimensionSet dimensions = source.derived(DimensionSet.class,
+					() -> DimensionSet.discover(source));
+			ProgramResolver resolver = ProgramResolver.resolve(
+					source.derived(ProgramSet.class, () -> ProgramSet.enumerate(source, dimensions)),
+					dimensions);
+
+			return new Reading(expander, targets, textures, resolver);
+		});
+	}
+
+	/**
 	 * Reads the three programs the chunk renderer draws a section with, in one opening of the pack.
 	 * <p>
 	 * The three are read together and not one at a time for the reason {@link #loadChain} gives: the
@@ -717,13 +748,11 @@ public final class PackProgram {
 		OptionIndex options = pack.options();
 		ShaderProperties properties = pack.properties();
 		SettingSet settings = pack.settings();
-		IncludeExpander expander = new IncludeExpander(source, settings);
-		TargetPlan targets = TargetPlan.build(source, options, settings, properties, place);
-		PackTextures textures = textures(source, properties, options, settings);
-
-		DimensionSet dimensions = DimensionSet.discover(source);
-		ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
-				dimensions);
+		Reading reading = reading(pack, place);
+		IncludeExpander expander = reading.expander();
+		TargetPlan targets = reading.targets();
+		PackTextures textures = reading.textures();
+		ProgramResolver resolver = reading.resolver();
 
 		Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
 		// The pack's own switch comes before its programs: the reference nulls its whole
@@ -834,6 +863,14 @@ public final class PackProgram {
 	 */
 	public static Distant loadDistant(Path packPath, String place, List<GeometryElement> elements,
 			Map<String, OptionValue> chosen, String profile) throws IOException {
+		try (OpenedPack pack = OpenedPack.open(packPath, chosen, profile)) {
+			return loadDistant(pack, place, elements);
+		}
+	}
+
+	/** The same, reading an opening the caller already holds. */
+	public static Distant loadDistant(OpenedPack pack, String place, List<GeometryElement> elements)
+			throws IOException {
 		for (GeometryElement element : elements) {
 			if (element.inputs() != VertexInputs.DISTANT) {
 				throw new IllegalArgumentException("The far terrain is drawn from Distant Horizons' own "
@@ -842,68 +879,61 @@ public final class PackProgram {
 			}
 		}
 
-		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
-			OptionIndex options = OptionIndex.build(source);
-			ShaderProperties properties = ShaderProperties.parse(source);
-			Map<String, OptionValue> fromProfile = profile.isEmpty()
-					? Map.of()
-					: properties.expandProfile(profile);
-			SettingSet settings =
-					SettingSet.resolve(fromProfile, chosen, profile.isEmpty() ? "chosen" : profile);
-			IncludeExpander expander = new IncludeExpander(source, settings);
-			TargetPlan targets = TargetPlan.build(source, options, settings, properties, place);
-			PackTextures textures = textures(source, properties, options, settings);
+		ShaderPackSource source = pack.source();
+		OptionIndex options = pack.options();
+		ShaderProperties properties = pack.properties();
+		SettingSet settings = pack.settings();
+		Reading reading = reading(pack, place);
+		IncludeExpander expander = reading.expander();
+		TargetPlan targets = reading.targets();
+		PackTextures textures = reading.textures();
+		ProgramResolver resolver = reading.resolver();
 
-			DimensionSet dimensions = DimensionSet.discover(source);
-			ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
-					dimensions);
+		Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
 
-			Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
-
-			record Served(String path, Map<ProgramStage, ExpandedUnit> units, AlphaTest alphaTest,
-					GeometryElement element) {
-			}
-
-			Map<String, Served> served = new LinkedHashMap<>();
-			Set<String> reads = new LinkedHashSet<>();
-			for (GeometryElement element : elements) {
-				Optional<ProgramResolver.Resolution> resolution =
-						resolver.lookup(place, element.program());
-				if (resolution.isEmpty()) {
-					continue;
-				}
-
-				// The file that really serves the half and not the name asked for, which is how Iris
-				// looks it up and how the chunk passes read the same line: a pack shipping one
-				// dh_terrain and no dh_water draws its far water with the first.
-				String servedBy = resolution.get().servedBy();
-				String path = pathOf(place, servedBy);
-				Map<ProgramStage, ExpandedUnit> units = read(source, expander, path);
-				if (!units.containsKey(ProgramStage.VERTEX)
-						|| !units.containsKey(ProgramStage.FRAGMENT)) {
-					continue;
-				}
-
-				AlphaTest alphaTest = overrides.getOrDefault(servedBy, element.alphaTest());
-				served.put(element.element(), new Served(path, units, alphaTest, element));
-				reads.addAll(ProgramTranslator.reads(units.get(ProgramStage.VERTEX), element.inputs(),
-						alphaTest, element.coverage(), element.program(), textures.volumes()));
-			}
-
-			if (served.isEmpty()) {
-				return new Distant(Map.of(), List.of());
-			}
-
-			List<String> carried = DistantVertex.carried(reads);
-			Map<String, Loaded> loaded = new LinkedHashMap<>();
-			served.forEach((key, one) -> loaded.put(key, bind(source.packName(), one.path(),
-					ProgramTranslator.translate(one.units(), one.element().inputs(), carried,
-							one.alphaTest(), one.element().coverage(), one.element().program(),
-							textures.volumes()),
-					targets, one.alphaTest(), textures)));
-
-			return new Distant(loaded, carried);
+		record Served(String path, Map<ProgramStage, ExpandedUnit> units, AlphaTest alphaTest,
+				GeometryElement element) {
 		}
+
+		Map<String, Served> served = new LinkedHashMap<>();
+		Set<String> reads = new LinkedHashSet<>();
+		for (GeometryElement element : elements) {
+			Optional<ProgramResolver.Resolution> resolution =
+					resolver.lookup(place, element.program());
+			if (resolution.isEmpty()) {
+				continue;
+			}
+
+			// The file that really serves the half and not the name asked for, which is how Iris
+			// looks it up and how the chunk passes read the same line: a pack shipping one
+			// dh_terrain and no dh_water draws its far water with the first.
+			String servedBy = resolution.get().servedBy();
+			String path = pathOf(place, servedBy);
+			Map<ProgramStage, ExpandedUnit> units = read(source, expander, path);
+			if (!units.containsKey(ProgramStage.VERTEX)
+					|| !units.containsKey(ProgramStage.FRAGMENT)) {
+				continue;
+			}
+
+			AlphaTest alphaTest = overrides.getOrDefault(servedBy, element.alphaTest());
+			served.put(element.element(), new Served(path, units, alphaTest, element));
+			reads.addAll(ProgramTranslator.reads(units.get(ProgramStage.VERTEX), element.inputs(),
+					alphaTest, element.coverage(), element.program(), textures.volumes()));
+		}
+
+		if (served.isEmpty()) {
+			return new Distant(Map.of(), List.of());
+		}
+
+		List<String> carried = DistantVertex.carried(reads);
+		Map<String, Loaded> loaded = new LinkedHashMap<>();
+		served.forEach((key, one) -> loaded.put(key, bind(source.packName(), one.path(),
+				ProgramTranslator.translate(one.units(), one.element().inputs(), carried,
+						one.alphaTest(), one.element().coverage(), one.element().program(),
+						textures.volumes()),
+				targets, one.alphaTest(), textures)));
+
+		return new Distant(loaded, carried);
 	}
 
 	/**
@@ -978,54 +1008,56 @@ public final class PackProgram {
 	 */
 	public static Map<String, Loaded> loadSky(Path packPath, String place, List<SkyElement> elements,
 			Map<String, OptionValue> chosen, String profile) throws IOException {
-		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
-			OptionIndex options = OptionIndex.build(source);
-			ShaderProperties properties = ShaderProperties.parse(source);
-			Map<String, OptionValue> fromProfile = profile.isEmpty()
-					? Map.of()
-					: properties.expandProfile(profile);
-			SettingSet settings = SettingSet.resolve(fromProfile, chosen, profile.isEmpty() ? "chosen" : profile);
-			IncludeExpander expander = new IncludeExpander(source, settings);
-			TargetPlan targets = TargetPlan.build(source, options, settings, properties, place);
-			PackTextures textures = textures(source, properties, options, settings);
+		try (OpenedPack pack = OpenedPack.open(packPath, chosen, profile)) {
+			return loadSky(pack, place, elements);
+		}
+	}
 
-			DimensionSet dimensions = DimensionSet.discover(source);
-			ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
-					dimensions);
+	/** The same, reading an opening the caller already holds. */
+	public static Map<String, Loaded> loadSky(OpenedPack pack, String place,
+			List<SkyElement> elements) throws IOException {
+		ShaderPackSource source = pack.source();
+		OptionIndex options = pack.options();
+		ShaderProperties properties = pack.properties();
+		SettingSet settings = pack.settings();
+		Reading reading = reading(pack, place);
+		IncludeExpander expander = reading.expander();
+		TargetPlan targets = reading.targets();
+		PackTextures textures = reading.textures();
+		ProgramResolver resolver = reading.resolver();
 
-			Map<String, Map<ProgramStage, ExpandedUnit>> expanded = new LinkedHashMap<>();
-			Map<String, Loaded> translated = new LinkedHashMap<>();
-			Map<String, Loaded> loaded = new LinkedHashMap<>();
-			for (SkyElement element : elements) {
-				Optional<ProgramResolver.Resolution> resolution =
-						resolver.lookup(place, element.program());
-				if (resolution.isEmpty()) {
-					continue;
-				}
-
-				String path = pathOf(place, resolution.get().servedBy());
-				if (!expanded.containsKey(path)) {
-					expanded.put(path, read(source, expander, path));
-				}
-
-				Map<ProgramStage, ExpandedUnit> units = expanded.get(path);
-				if (!units.containsKey(ProgramStage.VERTEX) || !units.containsKey(ProgramStage.FRAGMENT)) {
-					continue;
-				}
-
-				// No alpha test anywhere in the sky: the format has no line for one, and nothing the
-				// game draws there is cut out. The program the engine supplies uniforms for is the one
-				// the piece wanted, not the file that ended up serving it, as everywhere else.
-				translated.computeIfAbsent(element.translation(), _ -> bind(source.packName(), path,
-						ProgramTranslator.translate(units, VertexInputs.SKY, element.bound(),
-								AlphaTest.OFF, element.coverage(), element.program(),
-								textures.volumes()),
-						targets, AlphaTest.OFF, textures));
-				loaded.put(element.element(), translated.get(element.translation()));
+		Map<String, Map<ProgramStage, ExpandedUnit>> expanded = new LinkedHashMap<>();
+		Map<String, Loaded> translated = new LinkedHashMap<>();
+		Map<String, Loaded> loaded = new LinkedHashMap<>();
+		for (SkyElement element : elements) {
+			Optional<ProgramResolver.Resolution> resolution =
+					resolver.lookup(place, element.program());
+			if (resolution.isEmpty()) {
+				continue;
 			}
 
-			return loaded;
+			String path = pathOf(place, resolution.get().servedBy());
+			if (!expanded.containsKey(path)) {
+				expanded.put(path, read(source, expander, path));
+			}
+
+			Map<ProgramStage, ExpandedUnit> units = expanded.get(path);
+			if (!units.containsKey(ProgramStage.VERTEX) || !units.containsKey(ProgramStage.FRAGMENT)) {
+				continue;
+			}
+
+			// No alpha test anywhere in the sky: the format has no line for one, and nothing the
+			// game draws there is cut out. The program the engine supplies uniforms for is the one
+			// the piece wanted, not the file that ended up serving it, as everywhere else.
+			translated.computeIfAbsent(element.translation(), _ -> bind(source.packName(), path,
+					ProgramTranslator.translate(units, VertexInputs.SKY, element.bound(),
+							AlphaTest.OFF, element.coverage(), element.program(),
+							textures.volumes()),
+					targets, AlphaTest.OFF, textures));
+			loaded.put(element.element(), translated.get(element.translation()));
 		}
+
+		return loaded;
 	}
 
 	/**
@@ -1047,43 +1079,44 @@ public final class PackProgram {
 	 */
 	public static Optional<Loaded> loadClouds(Path packPath, String place,
 			Map<String, OptionValue> chosen, String profile) throws IOException {
-		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
-			OptionIndex options = OptionIndex.build(source);
-			ShaderProperties properties = ShaderProperties.parse(source);
-			Map<String, OptionValue> fromProfile = profile.isEmpty()
-					? Map.of()
-					: properties.expandProfile(profile);
-			SettingSet settings = SettingSet.resolve(fromProfile, chosen, profile.isEmpty() ? "chosen" : profile);
-			IncludeExpander expander = new IncludeExpander(source, settings);
-			TargetPlan targets = TargetPlan.build(source, options, settings, properties, place);
-			PackTextures textures = textures(source, properties, options, settings);
-
-			DimensionSet dimensions = DimensionSet.discover(source);
-			ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
-					dimensions);
-
-			Optional<ProgramResolver.Resolution> resolution = resolver.lookup(place, CLOUD_PROGRAM);
-			if (resolution.isEmpty()) {
-				return Optional.empty();
-			}
-
-			String path = pathOf(place, resolution.get().servedBy());
-			Map<ProgramStage, ExpandedUnit> units = read(source, expander, path);
-			if (!units.containsKey(ProgramStage.VERTEX) || !units.containsKey(ProgramStage.FRAGMENT)) {
-				return Optional.empty();
-			}
-
-			// No alpha test, as in the sky: the format has no line for one over this name and nothing
-			// the game draws here is cut out. No coverage mask either, the clouds being drawn long
-			// after the scene seed has run.
-			//
-			// No bound elements, and that is the whole difference from the sky: this pass binds no
-			// vertex format at all, so exactly nothing is declared as an input.
-			return Optional.of(bind(source.packName(), path,
-					ProgramTranslator.translate(units, VertexInputs.CLOUDS, List.of(), AlphaTest.OFF,
-							false, CLOUD_PROGRAM, textures.volumes()),
-					targets, AlphaTest.OFF, textures));
+		try (OpenedPack pack = OpenedPack.open(packPath, chosen, profile)) {
+			return loadClouds(pack, place);
 		}
+	}
+
+	/** The same, reading an opening the caller already holds. */
+	public static Optional<Loaded> loadClouds(OpenedPack pack, String place) throws IOException {
+		ShaderPackSource source = pack.source();
+		OptionIndex options = pack.options();
+		ShaderProperties properties = pack.properties();
+		SettingSet settings = pack.settings();
+		Reading reading = reading(pack, place);
+		IncludeExpander expander = reading.expander();
+		TargetPlan targets = reading.targets();
+		PackTextures textures = reading.textures();
+		ProgramResolver resolver = reading.resolver();
+
+		Optional<ProgramResolver.Resolution> resolution = resolver.lookup(place, CLOUD_PROGRAM);
+		if (resolution.isEmpty()) {
+			return Optional.empty();
+		}
+
+		String path = pathOf(place, resolution.get().servedBy());
+		Map<ProgramStage, ExpandedUnit> units = read(source, expander, path);
+		if (!units.containsKey(ProgramStage.VERTEX) || !units.containsKey(ProgramStage.FRAGMENT)) {
+			return Optional.empty();
+		}
+
+		// No alpha test, as in the sky: the format has no line for one over this name and nothing
+		// the game draws here is cut out. No coverage mask either, the clouds being drawn long
+		// after the scene seed has run.
+		//
+		// No bound elements, and that is the whole difference from the sky: this pass binds no
+		// vertex format at all, so exactly nothing is declared as an input.
+		return Optional.of(bind(source.packName(), path,
+				ProgramTranslator.translate(units, VertexInputs.CLOUDS, List.of(), AlphaTest.OFF,
+						false, CLOUD_PROGRAM, textures.volumes()),
+				targets, AlphaTest.OFF, textures));
 	}
 
 	/**
@@ -1150,99 +1183,101 @@ public final class PackProgram {
 	public static Map<String, Loaded> loadGeometry(Path packPath, String place,
 			List<GeometryElement> elements, Map<String, OptionValue> chosen, String profile)
 			throws IOException {
-		try (ShaderPackSource source = ShaderPackSource.open(packPath)) {
-			OptionIndex options = OptionIndex.build(source);
-			ShaderProperties properties = ShaderProperties.parse(source);
-			Map<String, OptionValue> fromProfile = profile.isEmpty()
-					? Map.of()
-					: properties.expandProfile(profile);
-			SettingSet settings = SettingSet.resolve(fromProfile, chosen, profile.isEmpty() ? "chosen" : profile);
-			IncludeExpander expander = new IncludeExpander(source, settings);
-			TargetPlan targets = TargetPlan.build(source, options, settings, properties, place);
-			PackTextures textures = textures(source, properties, options, settings);
+		try (OpenedPack pack = OpenedPack.open(packPath, chosen, profile)) {
+			return loadGeometry(pack, place, elements);
+		}
+	}
 
-			DimensionSet dimensions = DimensionSet.discover(source);
-			ProgramResolver resolver = ProgramResolver.resolve(ProgramSet.enumerate(source, dimensions),
-					dimensions);
+	/** The same, reading an opening the caller already holds. */
+	public static Map<String, Loaded> loadGeometry(OpenedPack pack, String place,
+			List<GeometryElement> elements) throws IOException {
+		ShaderPackSource source = pack.source();
+		OptionIndex options = pack.options();
+		ShaderProperties properties = pack.properties();
+		SettingSet settings = pack.settings();
+		Reading reading = reading(pack, place);
+		IncludeExpander expander = reading.expander();
+		TargetPlan targets = reading.targets();
+		PackTextures textures = reading.textures();
+		ProgramResolver resolver = reading.resolver();
 
-			Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
+		Map<String, AlphaTest> overrides = properties.alphaTests(settings.globalDefines(options));
 
-			Map<String, Map<ProgramStage, ExpandedUnit>> expanded = new LinkedHashMap<>();
-			Map<String, Loaded> translated = new LinkedHashMap<>();
-			Map<String, Loaded> loaded = new LinkedHashMap<>();
-			for (GeometryElement element : elements) {
-				Optional<ProgramResolver.Resolution> resolution =
-						resolver.lookup(place, element.program());
-				if (resolution.isEmpty()) {
-					continue;
-				}
-
-				// The name the override is written under is the file that really serves the piece and
-				// not the one that was asked for, which is how Iris looks it up and how the chunk
-				// passes read the same line.
-				String servedBy = resolution.get().servedBy();
-				String path = pathOf(place, servedBy);
-				if (!expanded.containsKey(path)) {
-					expanded.put(path, read(source, expander, path));
-				}
-
-				Map<ProgramStage, ExpandedUnit> units = expanded.get(path);
-				if (!units.containsKey(ProgramStage.VERTEX) || !units.containsKey(ProgramStage.FRAGMENT)) {
-					continue;
-				}
-
-				AlphaTest alphaTest = overrides.getOrDefault(servedBy, element.alphaTest());
-				// What two pieces have to agree on to be one translation, and the element is not part
-				// of it. The threshold is, because it is written into the fragment stage: two pieces of
-				// one program discarding at different alphas are two texts, and sharing one would draw
-				// a mob with the silhouette of whichever piece was translated first.
-				//
-				// The FILE and not the name asked for, which is the whole point of sharing: the two
-				// names of this family walk to one file wherever the fallback tree lands them on the
-				// same program, and keying by name would expand, translate and compile that file
-				// twice there, which is the one thing reading them all at once exists to avoid.
-				//
-				// A program NAME reaches the translation through two answers, and both are in the key
-				// while the name itself is not: LegacyGlsl.drawsEntities decides whether the entity
-				// uniforms are declared, and LegacyGlsl.bindsGameTransforms whether a read of
-				// gl_TextureMatrix[0] goes to the game's own block.
-				//
-				// A third answer, LegacyGlsl.readsDrawModelView, is NOT here and does not need to be:
-				// it differs from the second on the two shadow roots alone, and the shadow chain of
-				// ProgramFallbacks shares no name with the gbuffers one, so no file is ever asked for
-				// both ways and a key on the second already tells those two files apart.
-				//
-				// THE GLINT IS WHAT MAKES THEM TWO ANSWERS RATHER THAN ONE: its mesh carries no entity
-				// and its draw is still one the game prepared, so it is the first name asked for here
-				// that answers the two differently. The shape that would cost something is a pack
-				// shipping no gbuffers_armor_glint: it and gbuffers_entities then walk to one
-				// gbuffers_textured, one file serving both, and a key without this answer would hand
-				// whichever was translated second the other one's uniforms without a word. Both are
-				// written out all the same rather than left to the two lines below to imply, because
-				// what saves that case today is that the glint is also the only element carrying its
-				// format and its threshold, and neither of those is a fact about the uniforms.
-				//
-				// The format is in the key for the same reason and a harder one: it decides which
-				// names the vertex head declares as inputs, and two stages built from one text against
-				// two formats are two different modules.
-				//
-				// The mask is in the key as well, and it is the one answer here that is not a fact
-				// about the text: two pieces of one file are two texts as soon as one of them writes
-				// the mask, because the mask is an output the other one's pipeline carries no state
-				// for, and one module cannot be right for both.
-				VertexInputs inputs = element.inputs();
-				String key = path + "|" + alphaTest + "|" + LegacyGlsl.drawsEntities(element.program())
-						+ "|" + LegacyGlsl.bindsGameTransforms(element.program()) + "|" + inputs
-						+ "|" + element.coverage();
-				translated.computeIfAbsent(key, _ -> bind(source.packName(), path,
-						ProgramTranslator.translate(units, inputs, inputs.elements(), alphaTest,
-								element.coverage(), element.program(), textures.volumes()),
-						targets, alphaTest, textures));
-				loaded.put(element.element(), translated.get(key));
+		Map<String, Map<ProgramStage, ExpandedUnit>> expanded = new LinkedHashMap<>();
+		Map<String, Loaded> translated = new LinkedHashMap<>();
+		Map<String, Loaded> loaded = new LinkedHashMap<>();
+		for (GeometryElement element : elements) {
+			Optional<ProgramResolver.Resolution> resolution =
+					resolver.lookup(place, element.program());
+			if (resolution.isEmpty()) {
+				continue;
 			}
 
-			return loaded;
+			// The name the override is written under is the file that really serves the piece and
+			// not the one that was asked for, which is how Iris looks it up and how the chunk
+			// passes read the same line.
+			String servedBy = resolution.get().servedBy();
+			String path = pathOf(place, servedBy);
+			if (!expanded.containsKey(path)) {
+				expanded.put(path, read(source, expander, path));
+			}
+
+			Map<ProgramStage, ExpandedUnit> units = expanded.get(path);
+			if (!units.containsKey(ProgramStage.VERTEX) || !units.containsKey(ProgramStage.FRAGMENT)) {
+				continue;
+			}
+
+			AlphaTest alphaTest = overrides.getOrDefault(servedBy, element.alphaTest());
+			// What two pieces have to agree on to be one translation, and the element is not part
+			// of it. The threshold is, because it is written into the fragment stage: two pieces of
+			// one program discarding at different alphas are two texts, and sharing one would draw
+			// a mob with the silhouette of whichever piece was translated first.
+			//
+			// The FILE and not the name asked for, which is the whole point of sharing: the two
+			// names of this family walk to one file wherever the fallback tree lands them on the
+			// same program, and keying by name would expand, translate and compile that file
+			// twice there, which is the one thing reading them all at once exists to avoid.
+			//
+			// A program NAME reaches the translation through two answers, and both are in the key
+			// while the name itself is not: LegacyGlsl.drawsEntities decides whether the entity
+			// uniforms are declared, and LegacyGlsl.bindsGameTransforms whether a read of
+			// gl_TextureMatrix[0] goes to the game's own block.
+			//
+			// A third answer, LegacyGlsl.readsDrawModelView, is NOT here and does not need to be:
+			// it differs from the second on the two shadow roots alone, and the shadow chain of
+			// ProgramFallbacks shares no name with the gbuffers one, so no file is ever asked for
+			// both ways and a key on the second already tells those two files apart.
+			//
+			// THE GLINT IS WHAT MAKES THEM TWO ANSWERS RATHER THAN ONE: its mesh carries no entity
+			// and its draw is still one the game prepared, so it is the first name asked for here
+			// that answers the two differently. The shape that would cost something is a pack
+			// shipping no gbuffers_armor_glint: it and gbuffers_entities then walk to one
+			// gbuffers_textured, one file serving both, and a key without this answer would hand
+			// whichever was translated second the other one's uniforms without a word. Both are
+			// written out all the same rather than left to the two lines below to imply, because
+			// what saves that case today is that the glint is also the only element carrying its
+			// format and its threshold, and neither of those is a fact about the uniforms.
+			//
+			// The format is in the key for the same reason and a harder one: it decides which
+			// names the vertex head declares as inputs, and two stages built from one text against
+			// two formats are two different modules.
+			//
+			// The mask is in the key as well, and it is the one answer here that is not a fact
+			// about the text: two pieces of one file are two texts as soon as one of them writes
+			// the mask, because the mask is an output the other one's pipeline carries no state
+			// for, and one module cannot be right for both.
+			VertexInputs inputs = element.inputs();
+			String key = path + "|" + alphaTest + "|" + LegacyGlsl.drawsEntities(element.program())
+					+ "|" + LegacyGlsl.bindsGameTransforms(element.program()) + "|" + inputs
+					+ "|" + element.coverage();
+			translated.computeIfAbsent(key, _ -> bind(source.packName(), path,
+					ProgramTranslator.translate(units, inputs, inputs.elements(), alphaTest,
+							element.coverage(), element.program(), textures.volumes()),
+					targets, alphaTest, textures));
+			loaded.put(element.element(), translated.get(key));
 		}
+
+		return loaded;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -151,6 +151,7 @@ public final class ProgramTranslator {
 			boolean coverage, String program, Map<String, VolumeAtlas> volumes) {
 		// Clocked like the whole translations: this half-translation is real translator work a
 		// chunk program pays before its full one, and leaving it out would undercount terrain.
+		// The caller keeps the answer per opening, so the passes a file serves clock it once.
 		long began = System.nanoTime();
 		try {
 			return GlslTranslator.prepare(vertex, ProgramStage.VERTEX, inputs, inputs.elements(),

--- a/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
@@ -402,7 +402,7 @@ public final class TranslationCache {
 			feed(digest, stage.name());
 			feed(digest, unit.entry());
 			feed(digest, unit.version());
-			feed(digest, unit.text());
+			feedLines(digest, unit.lines());
 			// The lines the preprocessor left live, which the translator reads on nearly every walk
 			// it makes: two texts that differ only in which of their lines are dead translate
 			// differently and would otherwise share a key.
@@ -458,6 +458,51 @@ public final class TranslationCache {
 		byte[] raw = text.getBytes(StandardCharsets.UTF_8);
 		digest.update(intBytes(raw.length));
 		digest.update(raw);
+	}
+
+	/**
+	 * The same bytes {@link #feed} would take for the lines joined by newlines, fed a line at a
+	 * time: the joined text of a unit runs to megabytes and was built, and copied again into
+	 * bytes, for every stage of every program of a load, cache hits included. The length prefix
+	 * is counted first, so the key does not move.
+	 */
+	private static void feedLines(MessageDigest digest, List<String> lines) {
+		int length = Math.max(0, lines.size() - 1);
+		for (String line : lines) {
+			length += utf8Length(line);
+		}
+
+		digest.update(intBytes(length));
+		for (int at = 0; at < lines.size(); at++) {
+			if (at > 0) {
+				digest.update((byte) '\n');
+			}
+
+			digest.update(lines.get(at).getBytes(StandardCharsets.UTF_8));
+		}
+	}
+
+	/** How many bytes {@code getBytes(UTF_8)} yields, a lone surrogate counting as its replacement. */
+	private static int utf8Length(String text) {
+		int length = 0;
+		for (int at = 0; at < text.length(); at++) {
+			char c = text.charAt(at);
+			if (c < 0x80) {
+				length += 1;
+			} else if (c < 0x800) {
+				length += 2;
+			} else if (Character.isHighSurrogate(c) && at + 1 < text.length()
+					&& Character.isLowSurrogate(text.charAt(at + 1))) {
+				length += 4;
+				at++;
+			} else if (Character.isSurrogate(c)) {
+				length += 1;
+			} else {
+				length += 3;
+			}
+		}
+
+		return length;
 	}
 
 	private static byte[] intBytes(int value) {

--- a/common/src/main/java/dev/vitrail/pack/source/ConditionStack.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ConditionStack.java
@@ -25,6 +25,17 @@ public final class ConditionStack {
 	}
 
 	/**
+	 * The same, with the condition evaluated only under a live parent: inside a group that is
+	 * not taken, nothing about a nested condition can matter, and the preprocessor does not
+	 * read it either. An expression that fails there would otherwise count as undecidable.
+	 * The group counts as taken then, so that its {@code #elif} and {@code #else} are not read
+	 * either, which is what a true condition would have bought.
+	 */
+	public void ifDirective(BooleanSupplier condition) {
+		push(!active() || condition.getAsBoolean(), false);
+	}
+
+	/**
 	 * A conditional whose directive is written out rewritten, because what the pack wrote is not
 	 * one the compiler will read. Marked apart from the rest so that one the file never closes can
 	 * be closed where the file ends: the text carries its directives to the compiler, and what this

--- a/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
+++ b/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
@@ -74,6 +74,10 @@ public final class IncludeExpander {
 	private static final Pattern UNDEF = Pattern.compile("^\\s*#\\s*undef\\s+([A-Za-z_]\\w*).*$");
 	private static final Pattern VERSION = Pattern.compile("^\\s*#\\s*version\\s+(.*)$");
 
+	/** The two comment shapes a directive's tail is stripped of, compiled once for every line. */
+	private static final Pattern LINE_COMMENT = Pattern.compile("//.*");
+	private static final Pattern BLOCK_COMMENT = Pattern.compile("/\\*.*?\\*/");
+
 	private final ShaderPackSource source;
 	private final SettingSet settings;
 	private final boolean partOfALoad;
@@ -190,7 +194,7 @@ public final class IncludeExpander {
 
 		ConditionStack conditions = new ConditionStack();
 
-		for (Logical logical : logicalLines(this.source.readLines(file))) {
+		for (Logical logical : logicalLines(file)) {
 			// Checked here and not only on the way in. One file is enough on its own: a pack that
 			// ships a single shader of a million lines never expands anything, so a budget read
 			// once per file would never be read at all.
@@ -235,7 +239,7 @@ public final class IncludeExpander {
 				// A unit has exactly one version directive and it is the entry file's. Later
 				// ones come from includes and would be an error where they land.
 				if (state.version == null) {
-					state.version = version.group(1).replaceAll("//.*", "").trim();
+					state.version = LINE_COMMENT.matcher(version.group(1)).replaceAll("").trim();
 					state.emit(logical.physical(), true);
 				}
 
@@ -289,6 +293,24 @@ public final class IncludeExpander {
 	private record Logical(String text, int number, List<String> physical) {
 	}
 
+	/** The file's lines as the compiler joins them, kept on the opening with the raw lines. */
+	private record LogicalLinesOf(Path file) {
+	}
+
+	/**
+	 * Once per file of an opening rather than once per inclusion of it: a header a unit pulls in
+	 * twenty times was wrapped twenty times over lines the opening already kept. The report's
+	 * walk keeps nothing on its opening, as its other memo does not either.
+	 */
+	private List<Logical> logicalLines(Path file) throws IOException {
+		if (!this.partOfALoad) {
+			return logicalLines(this.source.readLines(file));
+		}
+
+		return this.source.derived(new LogicalLinesOf(file),
+				() -> logicalLines(this.source.readLines(file)));
+	}
+
 	private static List<Logical> logicalLines(List<String> lines) {
 		List<Logical> logical = new ArrayList<>(lines.size());
 		StringBuilder joined = new StringBuilder();
@@ -338,7 +360,7 @@ public final class IncludeExpander {
 			state.conditionals++;
 			state.openInOutput++;
 			if (!beyondComments(iff.group(2)).isEmpty()) {
-				conditions.ifDirective(decide(iff.group(2), state));
+				conditions.ifDirective(() -> decide(iff.group(2), state));
 				return line;
 			}
 
@@ -476,7 +498,7 @@ public final class IncludeExpander {
 
 	/** What the compiler still has to read once the comments are taken out of a directive's tail. */
 	private static String beyondComments(String tail) {
-		String code = tail.replaceAll("/\\*.*?\\*/", " ");
+		String code = BLOCK_COMMENT.matcher(tail).replaceAll(" ");
 		int line = code.indexOf("//");
 		int unterminated = code.indexOf("/*");
 		if (line >= 0) {
@@ -538,7 +560,8 @@ public final class IncludeExpander {
 		Matcher applied = DEFINE.matcher(rewritten);
 
 		if (applied.matches()) {
-			state.defines.put(applied.group(1), applied.group(2).replaceAll("//.*", "").trim());
+			state.defines.put(applied.group(1),
+					LINE_COMMENT.matcher(applied.group(2)).replaceAll("").trim());
 		} else if (original.matches()) {
 			// The line declared something and no longer does: a switch that was turned off.
 			state.defines.remove(original.group(1));

--- a/common/src/main/java/dev/vitrail/pack/source/PreprocessorExpression.java
+++ b/common/src/main/java/dev/vitrail/pack/source/PreprocessorExpression.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.regex.Pattern;
 
 /**
  * Evaluates the expression of an {@code #if} or {@code #elif} well enough to decide which
@@ -38,13 +39,24 @@ public final class PreprocessorExpression {
 	 */
 	private static final int MAX_NESTING_DEPTH = 64;
 
+	/** Compiled once: an expression is evaluated for every conditional of every unit of a load. */
+	private static final Pattern BLOCK_COMMENT = Pattern.compile("/\\*.*?\\*/");
+	private static final Pattern LINE_COMMENT = Pattern.compile("//.*");
+
 	private final List<String> tokens;
 	private final Map<String, String> defines;
 	private final int depth;
 
 	private int position;
 	private int nesting;
+	/**
+	 * Whether a value could not be worked out: a division by nought, a shift by an absurd amount.
+	 * Forgiven where it happened in an operand the preprocessor never evaluates.
+	 */
 	private boolean failed;
+
+	/** Whether the text is not an expression at all, which no operator forgives. */
+	private boolean malformed;
 
 	private PreprocessorExpression(List<String> tokens, Map<String, String> defines, int depth) {
 		this.tokens = tokens;
@@ -71,7 +83,7 @@ public final class PreprocessorExpression {
 
 		PreprocessorExpression parser = new PreprocessorExpression(tokens, defines, depth);
 		long result = parser.logicalOr();
-		if (parser.failed || parser.position < tokens.size()) {
+		if (parser.failed || parser.malformed || parser.position < tokens.size()) {
 			return OptionalLong.empty();
 		}
 
@@ -79,7 +91,7 @@ public final class PreprocessorExpression {
 	}
 
 	private static String stripComments(String expression) {
-		return expression.replaceAll("/\\*.*?\\*/", " ").replaceAll("//.*", "");
+		return LINE_COMMENT.matcher(BLOCK_COMMENT.matcher(expression).replaceAll(" ")).replaceAll("");
 	}
 
 	private static List<String> tokenise(String text) {
@@ -143,10 +155,22 @@ public final class PreprocessorExpression {
 		return false;
 	}
 
+	/**
+	 * The two short-circuit operators. The right operand is always walked, so that its tokens are
+	 * consumed and its syntax still has to hold, but where the left side already decides, what
+	 * the right side failed to work out is forgotten: the preprocessor never evaluates that
+	 * operand, so {@code X != 0 && 100 / X > 5} is false at zero rather than undecidable, and an
+	 * undecidable answer would have put the whole branch back in.
+	 */
 	private long logicalOr() {
 		long left = logicalAnd();
 		while (accept("||")) {
+			boolean decided = this.failed;
 			long right = logicalAnd();
+			if (left != 0) {
+				this.failed = decided;
+			}
+
 			left = left != 0 || right != 0 ? 1 : 0;
 		}
 
@@ -156,7 +180,12 @@ public final class PreprocessorExpression {
 	private long logicalAnd() {
 		long left = bitwiseOr();
 		while (accept("&&")) {
+			boolean decided = this.failed;
 			long right = bitwiseOr();
+			if (left == 0) {
+				this.failed = decided;
+			}
+
 			left = left != 0 && right != 0 ? 1 : 0;
 		}
 
@@ -294,7 +323,7 @@ public final class PreprocessorExpression {
 
 		this.position++;
 		if (++this.nesting > MAX_NESTING_DEPTH) {
-			this.failed = true;
+			this.malformed = true;
 			return 0;
 		}
 
@@ -319,20 +348,20 @@ public final class PreprocessorExpression {
 	private long primary() {
 		String token = peek();
 		if (token == null) {
-			this.failed = true;
+			this.malformed = true;
 			return 0;
 		}
 
 		if (accept("(")) {
 			if (++this.nesting > MAX_NESTING_DEPTH) {
-				this.failed = true;
+				this.malformed = true;
 				return 0;
 			}
 
 			long value = logicalOr();
 			this.nesting--;
 			if (!accept(")")) {
-				this.failed = true;
+				this.malformed = true;
 			}
 
 			return value;
@@ -350,7 +379,7 @@ public final class PreprocessorExpression {
 
 		OptionalLong number = parseNumber(token);
 		if (number.isEmpty()) {
-			this.failed = true;
+			this.malformed = true;
 			return 0;
 		}
 
@@ -361,13 +390,13 @@ public final class PreprocessorExpression {
 		boolean parenthesised = accept("(");
 		String name = peek();
 		if (name == null || !isIdentifier(name)) {
-			this.failed = true;
+			this.malformed = true;
 			return 0;
 		}
 
 		this.position++;
 		if (parenthesised && !accept(")")) {
-			this.failed = true;
+			this.malformed = true;
 			return 0;
 		}
 

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
@@ -105,6 +105,15 @@ public final class ShaderPackSource implements AutoCloseable {
 	 */
 	private final Map<Expansion, IncludeExpander.ExpandedUnit> expandedUnits = new HashMap<>();
 
+	/**
+	 * Whatever else a reader works out of this opening alone and would work out again on the
+	 * next read: the plan of a place, its textures, the program tree. Each family of programs
+	 * used to open the pack for itself and rebuild all of it, so a load walked the archive once
+	 * per family. Keyed by whatever the reader chooses, and like the two memos above it belongs
+	 * to the one thread that reads through this opening.
+	 */
+	private final Map<Object, Object> derived = new HashMap<>();
+
 	private int caseInsensitiveHits;
 
 	private ShaderPackSource(String packName, Path shadersRoot, FileSystem ownedFileSystem) {
@@ -138,6 +147,27 @@ public final class ShaderPackSource implements AutoCloseable {
 	/** How many packs have been opened so far, which a load takes a before and an after of. */
 	public static int openings() {
 		return OPENINGS.get();
+	}
+
+	/** A computation that reads the archive, for {@link #derived}. */
+	public interface Derivation<T> {
+		T read() throws IOException;
+	}
+
+	/**
+	 * The value {@code compute} yields for this opening, worked out on the first ask under that
+	 * key and handed back as it is after. The key says what was asked and with what: two asks
+	 * with equal keys are one question.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T derived(Object key, Derivation<T> compute) throws IOException {
+		Object known = this.derived.get(key);
+		if (known == null) {
+			known = compute.read();
+			this.derived.put(key, known);
+		}
+
+		return (T) known;
 	}
 
 	public static ShaderPackSource open(Path packPath) throws IOException {
@@ -520,6 +550,7 @@ public final class ShaderPackSource implements AutoCloseable {
 	public void close() throws IOException {
 		this.linesByFile.clear();
 		this.expandedUnits.clear();
+		this.derived.clear();
 		if (this.ownedFileSystem != null) {
 			this.ownedFileSystem.close();
 		}

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -167,8 +167,12 @@ public final class TargetPlan {
 	 */
 	public static TargetPlan build(ShaderPackSource source, OptionIndex options, SettingSet settings,
 			ShaderProperties properties, String dimension, ChainFilter filter) throws IOException {
-		DimensionSet dimensions = DimensionSet.discover(source);
-		ProgramSet programs = ProgramSet.enumerate(source, dimensions);
+		// Both walk the archive, and both are the same answer for every place and every family of
+		// one reading of it.
+		DimensionSet dimensions = source.derived(DimensionSet.class,
+				() -> DimensionSet.discover(source));
+		ProgramSet programs = source.derived(ProgramSet.class,
+				() -> ProgramSet.enumerate(source, dimensions));
 
 		// A dimension directory replaces the root rather than being layered over it, and what
 		// decides is that the directory EXISTS, never what it holds. Iris builds a program set for

--- a/common/src/main/java/dev/vitrail/render/CloudDraw.java
+++ b/common/src/main/java/dev/vitrail/render/CloudDraw.java
@@ -2,6 +2,7 @@ package dev.vitrail.render;
 
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.option.OptionValue;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.source.ShaderProperties;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
@@ -125,8 +126,17 @@ public final class CloudDraw {
 	 * draw.
 	 */
 	void prefetch() {
+		prefetch(null);
+	}
+
+	/**
+	 * The same through an opening the caller holds, which is how the load worker reads the six
+	 * families: one opening, one plan of the place and one program tree shared between them,
+	 * where each used to open the archive and rebuild all three for itself.
+	 */
+	void prefetch(OpenedPack shared) {
 		if (!this.read && wanted()) {
-			read();
+			read(shared);
 		}
 	}
 
@@ -263,10 +273,11 @@ public final class CloudDraw {
 	 * until it is about to draw one, and a place with the clouds switched off should not pay for a
 	 * program it never draws.
 	 */
-	private void read() {
+	private void read(OpenedPack shared) {
 		try {
-			Optional<PackProgram.Loaded> loaded =
-					PackProgram.loadClouds(this.packPath, this.place, this.chosen, this.profile);
+			Optional<PackProgram.Loaded> loaded = shared != null
+					? PackProgram.loadClouds(shared, this.place)
+					: PackProgram.loadClouds(this.packPath, this.place, this.chosen, this.profile);
 			if (loaded.isEmpty()) {
 				Vitrail.logger().info("{} serves nothing in {} for its clouds, so the game keeps its "
 						+ "own", this.packPath.getFileName(),

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -7,6 +7,7 @@ import dev.vitrail.glsl.VertexInputs;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.AlphaTest;
 import dev.vitrail.pack.program.RenderStage;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.target.TargetSize;
@@ -1053,8 +1054,17 @@ public final class DistantDraw {
 	 * the first draw.
 	 */
 	void prefetch() {
+		prefetch(null);
+	}
+
+	/**
+	 * The same through an opening the caller holds, which is how the load worker reads the six
+	 * families: one opening, one plan of the place and one program tree shared between them,
+	 * where each used to open the archive and rebuild all three for itself.
+	 */
+	void prefetch(OpenedPack shared) {
 		if (!this.read) {
-			read();
+			read(shared);
 		}
 	}
 
@@ -1066,11 +1076,13 @@ public final class DistantDraw {
 	 * the whole pack. It also settles the mesh, which is the union of what they all declare and
 	 * cannot be settled one half at a time.
 	 */
-	private void read() {
+	private void read(OpenedPack shared) {
 		try {
 			List<Element> asked = ELEMENTS.values().stream().filter(this::wanted).toList();
-			PackProgram.Distant distant = PackProgram.loadDistant(this.packPath, this.place,
-					asked.stream().map(Element::asked).toList(), this.chosen, this.profile);
+			List<PackProgram.GeometryElement> names = asked.stream().map(Element::asked).toList();
+			PackProgram.Distant distant = shared != null
+					? PackProgram.loadDistant(shared, this.place, names)
+					: PackProgram.loadDistant(this.packPath, this.place, names, this.chosen, this.profile);
 			if (distant.programs().isEmpty()) {
 				Vitrail.logger().info("{} serves nothing in {} for the far terrain, so Distant "
 						+ "Horizons keeps drawing it with its own shader", this.packPath.getFileName(),

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -9,6 +9,7 @@ import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.AlphaTest;
 import dev.vitrail.pack.program.ProgramStage;
 import dev.vitrail.pack.program.RenderStage;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetName;
 import dev.vitrail.pack.target.TargetPlan;
@@ -1365,8 +1366,17 @@ public final class EntityDraw {
 	 * asks during its warm-up so shaderc does not land on the first draw.
 	 */
 	void prefetch() {
+		prefetch(null);
+	}
+
+	/**
+	 * The same through an opening the caller holds, which is how the load worker reads the six
+	 * families: one opening, one plan of the place and one program tree shared between them,
+	 * where each used to open the archive and rebuild all three for itself.
+	 */
+	void prefetch(OpenedPack shared) {
 		if (!this.read && (wanted() || HandDraw.wanted())) {
-			read();
+			read(shared);
 		}
 	}
 
@@ -1999,15 +2009,15 @@ public final class EntityDraw {
 	 * a line saying a pack serves nothing for the hand, printed for somebody who never turned the
 	 * hand on, reads as a fault of the pack.
 	 */
-	private void read() {
+	private void read(OpenedPack shared) {
 		try {
-			readPrograms();
+			readPrograms(shared);
 		} finally {
 			this.read = true;
 		}
 	}
 
-	private void readPrograms() {
+	private void readPrograms(OpenedPack shared) {
 		List<Element> served = ELEMENTS.values().stream().filter(EntityDraw::decodable).toList();
 
 		// Asked once for the four pieces that share the glint's one pipeline, and only where a switch
@@ -2096,8 +2106,10 @@ public final class EntityDraw {
 		}
 
 		try {
-			Map<String, PackProgram.Loaded> loaded = PackProgram.loadGeometry(this.packPath, this.place,
-					asked.stream().map(Element::asked).toList(), this.chosen, this.profile);
+			List<PackProgram.GeometryElement> names = asked.stream().map(Element::asked).toList();
+			Map<String, PackProgram.Loaded> loaded = shared != null
+					? PackProgram.loadGeometry(shared, this.place, names)
+					: PackProgram.loadGeometry(this.packPath, this.place, names, this.chosen, this.profile);
 			if (loaded.isEmpty()) {
 				Vitrail.logger().info("{} serves nothing in {} for the entities, the hand or the "
 						+ "glint, so the game keeps its own shader for them",

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -763,28 +763,6 @@ public final class PackChain {
 				return;
 			}
 
-			// Where the pack is known, rather than over the whole folder before one was chosen, and
-			// once per pack rather than at every load. This reading walks the whole archive, and
-			// this method is the road every reload takes: a portal and an Apply both come back
-			// through here, on the render thread, and neither has anything new to report.
-			//
-			// Never fatal either, and that is the whole reason for the catch. It is a report and not
-			// the drawing, so its own failures stop here: letting one reach the catch below would
-			// turn a diagnosis that could not be taken into a pack that is not drawn.
-			if (!pack.equals(reported)) {
-				try {
-					PackReport.log(PackLoader.load(pack));
-					reported = pack;
-				} catch (IOException | RuntimeException e) {
-					// No promise about what happens next, deliberately: an archive that cannot be
-					// opened at all will not be opened by the lines below either, and the catch at
-					// the end of this method is what will have the last word. What this line buys is
-					// the failure that belongs to the report alone, in a measurement or a count, and
-					// it is said by the report so that it keeps the report's own prefix.
-					PackReport.couldNotRead(ShaderPackSource.nameOf(pack), e);
-				}
-			}
-
 			SettingsLayers.Resolved settings = open(gameDirectory, pack);
 
 			Map<String, OptionValue> chosen = new LinkedHashMap<>(settings.chosen());
@@ -911,6 +889,7 @@ public final class PackChain {
 			// uniform outside a block. Complementary's deferred1 died that way on a DH toggle.
 			// Iris has one table for both jobs, StandardMacros.java:64-65.
 			PackDefines.install();
+			report(pack);
 
 			try (OpenedPack opened = OpenedPack.open(pack, chosen, settings.profile())) {
 				// The world decides the directory, and the pack decides which world that is: a folder
@@ -970,9 +949,9 @@ public final class PackChain {
 				// moving.
 				DriverTrig.announce();
 				// The count, so that what a load costs is a figure in the log rather than a feeling.
-				// It covers the whole of this method, the report and the settings reading included,
-				// and the families are deliberately outside it: they translate on a worker, off the
-				// thread the player is waiting on, and each opens the pack for itself.
+				// It covers the whole of this method, the settings reading included, and the report
+				// and the families are deliberately outside it: both run on a worker, off the thread
+				// the player is waiting on, the families through one opening of their own.
 				Vitrail.logger().info("Opened {} {} times to load it", chain.packName(),
 						ShaderPackSource.openings() - openings);
 				// Once per installed chain, whatever else this load does or fails to do later:
@@ -1038,6 +1017,46 @@ public final class PackChain {
 			disabled = true;
 			lastError = "Could not prepare this pack: " + e;
 			Vitrail.logger().error("Vitrail could not prepare a pack's chain", e);
+		}
+	}
+
+	/**
+	 * The report of a pack, once per pack rather than at every load: this reading walks the
+	 * whole archive, and the load is the road every reload takes, a portal and an Apply both
+	 * coming back through it with nothing new to report.
+	 * <p>
+	 * Off the render thread, on an opening of its own: the walk takes a second and a half on
+	 * Complementary and its only product is the [pack] block of the log, which held the title
+	 * screen and every Apply for exactly that long. The lines land a little later than they
+	 * did and in the same order among themselves. Asked after the machine table is installed,
+	 * so the walk reads the same table as the load it describes, and outside the count of
+	 * openings the load prints, which no longer includes it.
+	 * <p>
+	 * Never fatal, and that is the whole reason for the catches: it is a report and not the
+	 * drawing, so its own failures stop here, and a failure gives the next load its chance to
+	 * report again. An executor refusing the task at shutdown is a report not taken, and not
+	 * a pack that is not drawn.
+	 */
+	private static void report(Path pack) {
+		if (pack.equals(reported)) {
+			return;
+		}
+
+		reported = pack;
+		try {
+			Util.backgroundExecutor().execute(() -> {
+				try {
+					PackReport.log(PackLoader.load(pack));
+				} catch (IOException | RuntimeException e) {
+					// Said by the report so that it keeps the report's own prefix: the failure
+					// belongs to a measurement or a count, and the load has the last word on
+					// whether the archive opens at all.
+					PackReport.couldNotRead(ShaderPackSource.nameOf(pack), e);
+					reported = null;
+				}
+			});
+		} catch (RejectedExecutionException e) {
+			reported = null;
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -283,6 +283,14 @@ public final class PackChain {
 
 	private final PackProgram.Chain chain;
 	private final PackValues values;
+
+	/**
+	 * What opens the pack again for the six families the load worker reads: the archive, the
+	 * settings chosen for it and the profile they came from. One opening serves all six there.
+	 */
+	private final Path packPath;
+	private final Map<String, OptionValue> chosen;
+	private final String profile;
 	private final String world;
 	private final ColorTargets targets;
 
@@ -408,6 +416,9 @@ public final class PackChain {
 			OpenedPack opened, Path packPath, Map<String, OptionValue> chosen, String profile) {
 		this.chain = chain;
 		this.values = values;
+		this.packPath = packPath;
+		this.chosen = Map.copyOf(chosen);
+		this.profile = profile;
 		this.world = world;
 		this.seedEnabled = seedEnabled;
 		this.load = LOADS.incrementAndGet();
@@ -3121,18 +3132,22 @@ public final class PackChain {
 				fanned.set(device != null);
 
 				List<CompletableFuture<Void>> compiles = new ArrayList<>(FAMILIES);
-				try {
-					prefetchFamily(this.sky::prefetch);
+				// One opening for the six, so the plan of the place, the program tree and every
+				// header they share are worked out once on this worker rather than once per family:
+				// the families used to be five of every six walks a warm load made of the archive.
+				// A family that reads later on its own, at a first draw, still opens for itself.
+				try (OpenedPack shared = OpenedPack.open(this.packPath, this.chosen, this.profile)) {
+					prefetchFamily(() -> this.sky.prefetch(shared));
 					spawnFamilyCompiles(compiles, 0, device);
-					prefetchFamily(this.entities::prefetch);
+					prefetchFamily(() -> this.entities.prefetch(shared));
 					spawnFamilyCompiles(compiles, 1, device);
-					prefetchFamily(this.clouds::prefetch);
+					prefetchFamily(() -> this.clouds.prefetch(shared));
 					spawnFamilyCompiles(compiles, 2, device);
-					prefetchFamily(this.weather::prefetch);
+					prefetchFamily(() -> this.weather.prefetch(shared));
 					spawnFamilyCompiles(compiles, 3, device);
-					prefetchFamily(this.particles::prefetch);
+					prefetchFamily(() -> this.particles.prefetch(shared));
 					spawnFamilyCompiles(compiles, 4, device);
-					prefetchFamily(this.distant::prefetch);
+					prefetchFamily(() -> this.distant.prefetch(shared));
 					spawnFamilyCompiles(compiles, 5, device);
 				} catch (Throwable e) {
 					// prefetchFamily catches the RuntimeException of one translation; anything

--- a/common/src/main/java/dev/vitrail/render/ParticleDraw.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleDraw.java
@@ -5,6 +5,7 @@ import dev.vitrail.glsl.VertexInputs;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.AlphaTest;
 import dev.vitrail.pack.program.RenderStage;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetName;
 import dev.vitrail.pack.target.TargetPlan;
@@ -228,8 +229,17 @@ public final class ParticleDraw {
 	 * draw.
 	 */
 	void prefetch() {
+		prefetch(null);
+	}
+
+	/**
+	 * The same through an opening the caller holds, which is how the load worker reads the six
+	 * families: one opening, one plan of the place and one program tree shared between them,
+	 * where each used to open the archive and rebuild all three for itself.
+	 */
+	void prefetch(OpenedPack shared) {
 		if (!this.read && wanted()) {
-			read();
+			read(shared);
 		}
 	}
 
@@ -541,10 +551,12 @@ public final class ParticleDraw {
 	 * frame apart at most, so nothing is saved by waiting, and a reading is an opening and an
 	 * expansion of the whole pack.
 	 */
-	private void read() {
+	private void read(OpenedPack shared) {
 		try {
-			Map<String, PackProgram.Loaded> loaded = PackProgram.loadGeometry(this.packPath, this.place,
-					ELEMENTS.values().stream().map(Element::asked).toList(), this.chosen, this.profile);
+			List<PackProgram.GeometryElement> asked = ELEMENTS.values().stream().map(Element::asked).toList();
+			Map<String, PackProgram.Loaded> loaded = shared != null
+					? PackProgram.loadGeometry(shared, this.place, asked)
+					: PackProgram.loadGeometry(this.packPath, this.place, asked, this.chosen, this.profile);
 			if (loaded.isEmpty()) {
 				Vitrail.logger().info("{} serves nothing in {} for the particles, so the game keeps its "
 						+ "own shader for them", this.packPath.getFileName(),

--- a/common/src/main/java/dev/vitrail/render/SkyDraw.java
+++ b/common/src/main/java/dev/vitrail/render/SkyDraw.java
@@ -3,6 +3,7 @@ package dev.vitrail.render;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.RenderStage;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.target.TargetSize;
@@ -242,8 +243,17 @@ public final class SkyDraw {
 	 * draw.
 	 */
 	void prefetch() {
+		prefetch(null);
+	}
+
+	/**
+	 * The same through an opening the caller holds, which is how the load worker reads the six
+	 * families: one opening, one plan of the place and one program tree shared between them,
+	 * where each used to open the archive and rebuild all three for itself.
+	 */
+	void prefetch(OpenedPack shared) {
 		if (!this.read && wanted()) {
-			read();
+			read(shared);
 		}
 	}
 
@@ -458,7 +468,7 @@ public final class SkyDraw {
 	 * pack of the August 2026 corpus reaches that - all eight answer both sky programs in
 	 * {@code world1}, Body Camera through the fallback tree rather than with a file of its own.
 	 */
-	private void read() {
+	private void read(OpenedPack shared) {
 		try {
 			List<String> off = ELEMENTS.values().stream()
 					.map(Element::directive)
@@ -472,8 +482,11 @@ public final class SkyDraw {
 			}
 
 			try {
-				Map<String, PackProgram.Loaded> loaded = PackProgram.loadSky(this.packPath, this.place,
-						ELEMENTS.values().stream().map(Element::asked).toList(), this.chosen, this.profile);
+				List<PackProgram.SkyElement> asked =
+						ELEMENTS.values().stream().map(Element::asked).toList();
+				Map<String, PackProgram.Loaded> loaded = shared != null
+						? PackProgram.loadSky(shared, this.place, asked)
+						: PackProgram.loadSky(this.packPath, this.place, asked, this.chosen, this.profile);
 
 				// Asked once per PROGRAM and not once per piece: four of the eight are drawn with
 				// gbuffers_skybasic and the other four with gbuffers_skytextured, and the plan would

--- a/common/src/main/java/dev/vitrail/render/WeatherDraw.java
+++ b/common/src/main/java/dev/vitrail/render/WeatherDraw.java
@@ -5,6 +5,7 @@ import dev.vitrail.glsl.VertexInputs;
 import dev.vitrail.pack.option.OptionValue;
 import dev.vitrail.pack.program.AlphaTest;
 import dev.vitrail.pack.program.RenderStage;
+import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.target.TargetSize;
@@ -186,8 +187,17 @@ public final class WeatherDraw {
 	 * draw.
 	 */
 	void prefetch() {
+		prefetch(null);
+	}
+
+	/**
+	 * The same through an opening the caller holds, which is how the load worker reads the six
+	 * families: one opening, one plan of the place and one program tree shared between them,
+	 * where each used to open the archive and rebuild all three for itself.
+	 */
+	void prefetch(OpenedPack shared) {
 		if (!this.read && wanted()) {
-			read();
+			read(shared);
 		}
 	}
 
@@ -432,10 +442,12 @@ public final class WeatherDraw {
 	 * pack would be opened, expanded and translated inside that frame, on the render thread and in
 	 * the middle of a storm.
 	 */
-	private void read() {
+	private void read(OpenedPack shared) {
 		try {
-			Map<String, PackProgram.Loaded> loaded = PackProgram.loadGeometry(this.packPath, this.place,
-					ELEMENTS.values().stream().map(Element::asked).toList(), this.chosen, this.profile);
+			List<PackProgram.GeometryElement> asked = ELEMENTS.values().stream().map(Element::asked).toList();
+			Map<String, PackProgram.Loaded> loaded = shared != null
+					? PackProgram.loadGeometry(shared, this.place, asked)
+					: PackProgram.loadGeometry(this.packPath, this.place, asked, this.chosen, this.profile);
 			if (loaded.isEmpty()) {
 				Vitrail.logger().info("{} serves nothing in {} for the weather, so the game keeps its "
 						+ "own shader for the rain and the snow", this.packPath.getFileName(),


### PR DESCRIPTION
## What changes

A pack loads with less work and the same result. The six geometry families the load worker reads used to open the archive each for itself and rebuild the option index, the properties, the plan of the place, the textures and the program tree before reading their own files: the worker holds one opening for the six now, and what a reader works out of an opening alone is kept on it for its life, beside the flattened units it already kept. The report of a pack, a walk of the whole archive whose only product is a block of the log, leaves the render thread, where it held the title screen and every Apply for a second and a half. The translator keys a stored translation without joining the unit's text, drops every closing into its token list in one walk instead of one shift per closing, spells operators out of a table and walks to a function's end once per parameter list; the expander keeps a file's logical lines per opening, compiles its comment patterns once and no longer evaluates a `#if` nested under a group that is not taken.

One behaviour changes, and it is a fix: the `#if` evaluator now short-circuits `&&` and `||` as the preprocessor does. A right operand that cannot be worked out on its own, a division by a setting standing at zero being the plain case, used to make the whole condition undecidable and keep its branch in; now `X != 0 && 100 / X > 5` is false at zero and the branch is skipped. The right side is still walked, so a malformed expression stays malformed.

## How it differs from the reference, and for what obstacle

It does not. Iris flattens each program once per load and keeps its pack open across portals; the preprocessor it hands GLSL to short-circuits.

## What proves it

- `gradlew build` green.
- The off-game harness translated the whole eight-pack corpus, 2771 units, from `dev` and from this branch: the translated GLSL and the SPIR-V are byte-identical. `Harness`, `Chaine`, `Semis` are identical; a new `Conditions` tool checks the evaluator against the preprocessor's answers, and its negative control is `dev`, which fails four short-circuit rows.
- Every claim of the branch was put to a counter-case by a reviewer, and what survived is fixed here: the report's task is submitted after the machine table is installed and outside the count of openings the load prints, a rejected task or a failed report leaves the next load its chance, a nested `#if` under a dead group counts as taken so its `#elif` is not read either, the report's walk keeps nothing on its opening, and a sixth token-writing helper forgets the function-end memo.
- In the game, Fabric bench, Complementary Unbound on the arena: the picture is the one `dev` draws, a mean of sixty frames against a mean taken with `dev`, the only moving pixels being the waving leaves, the clouds and a mob. The load log shows the six families flattening 87 units where they flattened 247, and the family stage taking 843 ms of background work where it took 4031 ms; the report block lands from a worker thread.

## What it leaves owing

The warm load still expands the chain's units on the render thread before every cache lookup, and a world join still compiles the title load's chain before finding the registries stale and loading again; both are the next branch.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
