### PR TITLE
fix(render): give a pack's uninitialised variables the zero Iris reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,18 @@ what the next one holds.
   branch in. The right side is now skipped where the left one has already decided, as the
   preprocessor does, so such a branch is left out exactly as the pack meant it to be.
 
+- **A variable a pack reads before writing it reads zero, as it does under Iris.** A shader that
+  declares a variable without a value and adds to it before ever setting it is wrong, but under
+  Iris such a variable reads zero in practice, so the picture is right there and nobody notices.
+  Here it read something else, and what it read changed with the face being drawn: on
+  Complementary Unbound at its High and Ultra profiles, one face of the held hand was black at
+  every angle while the others were lit, and the water along far shores carried black lines that
+  came and went. Every variable a pack can read before writing it now starts at zero, in the
+  programs of every pack, and both defects are gone. A file `raw-locals` in the `vitrail` folder
+  of the game directory turns the zeroing off, for measuring what it costs. The store of compiled
+  shader modules is rebuilt once on the first launch, as every module compiled before this carried
+  the bare variables.
+
 - **A pack's storage buffers are read and written where the pack put them.** A pack that keeps
   its own data in a shader storage buffer, declared with `bufferObject` lines, had that buffer
   allocated and filled but never handed to the programs that name it: every such program kept the

--- a/common/src/main/java/dev/vitrail/glsl/LocalZeroes.java
+++ b/common/src/main/java/dev/vitrail/glsl/LocalZeroes.java
@@ -1,0 +1,731 @@
+package dev.vitrail.glsl;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Gives every variable a compiled module can read before writing the zero it reads under Iris.
+ * <p>
+ * <strong>Why a pass on the SPIR-V and not a rule for packs.</strong> GLSL leaves a variable
+ * declared without an initialiser undefined until it is written, so a pack that reads one first
+ * has a defect, and one that shows nowhere on the platform it was written on: measured against
+ * Iris at the same spot, on the same machine, the pack reads zero there. Compiled through shaderc
+ * the {@code OpVariable} stays bare, and what the Vulkan driver hands back changed with the face
+ * being drawn and with every edit to the shader's text, which is what a register left over from
+ * the previous work looks like. Complementary Unbound's {@code GetComplexLightVolume} accumulates
+ * into a {@code vec4} it never zeroes when its corner leak fix is on, and that was a hand black on
+ * one face and black lines along every far shore, both gone with that one variable started at
+ * zero, and the face then reading the byte Iris reads. The pack is wrong and the picture Iris
+ * shows is the one packs were tuned against, so this engine reproduces the zero.
+ * <p>
+ * <strong>Why here and not in the translated text.</strong> An initialiser written into the GLSL
+ * has to know the type of each variable, arrays and structs included, and has to find every
+ * declaration in every scope of every unit the pack ships. The SPIR-V already carries both: a
+ * variable is one instruction naming its pointer type, and {@code OpConstantNull} zeroes every
+ * type a bare variable of a pack has, the opaque handles being the ones it refuses and the ones
+ * no GLSL declares bare.
+ * <p>
+ * <strong>Only the variables that need it, and that was measured.</strong> Zeroing every bare
+ * variable of a module cost eight percent of the frame on Complementary Unbound at its Ultra
+ * profile, on a bench where the two states ran in one launch a pack reload apart: twelve hundred
+ * locals in one fragment stage, most of them the compiler's own temporaries, plus a hundred
+ * globals, and the driver did not fold those stores away. So the pass works out which variables
+ * some path can read before any store reaches them, by the ordinary definite-assignment walk over
+ * each function's blocks, and only those get the zero. Calls are summarised rather than feared:
+ * glslang hands every argument over as a pointer to a temporary, so a function is first asked
+ * which of its parameters and which globals it may read before writing, and which it writes on
+ * every path that returns, and a call site reads and defines accordingly. The summaries start at
+ * the most conservative answer and the module is walked again until none moves, which GLSL's ban
+ * on recursion makes finite: the call graph is a directed acyclic graph, the functions are walked
+ * in the order the module lists them, and each round settles at least one more level of callers
+ * above their callees. A global is judged from the entry point, since that is where an invocation
+ * starts.
+ * <p>
+ * <strong>Where the walk is conservative and where it is blind.</strong> A store through an access
+ * chain writes one component and so defines nothing, and a callee this module does not define
+ * reads everything and defines nothing: both err towards the zero. A pointer the walk cannot
+ * trace to a variable, which would take a pointer chosen by {@code OpPhi} or {@code OpSelect} or
+ * handed back by a call, is left alone; glslang emits none of those for GLSL, which has no pointer
+ * values.
+ * <p>
+ * <strong>The optimised road.</strong> A module shaderc optimised before this pass saw it has had
+ * its variables rewritten into values, and a read of one never written is then an {@code OpUndef}
+ * rather than a bare variable. Those become the null constant of their type as well, so a
+ * compute compiled at the performance level reads its zero like a fragment compiled at none.
+ */
+public final class LocalZeroes {
+
+	/**
+	 * What the module cache hashes into its key for this pass: any change to what the pass emits
+	 * for a given module bumps it, so that a blob zeroed by the old walk is never served under the
+	 * new one, with nothing in the log to say why.
+	 */
+	public static final String VERSION = "locals-2";
+
+	/**
+	 * What one pass did to one module.
+	 *
+	 * @param variables the bare variables given an initialiser
+	 * @param undefs    the undefined values given a constant instead
+	 */
+	public record Result(int[] words, int variables, int undefs) {
+
+		/** Whether the module came back changed at all. */
+		public boolean changed() {
+			return this.variables > 0 || this.undefs > 0;
+		}
+	}
+
+	private static final int MAGIC = 0x07230203;
+
+	private static final int HEADER_WORDS = 5;
+
+	private static final int OP_UNDEF = 1;
+	private static final int OP_ENTRY_POINT = 15;
+	private static final int OP_TYPE_FIRST = 19;
+	private static final int OP_TYPE_LAST = 39;
+	private static final int OP_TYPE_IMAGE = 25;
+	private static final int OP_TYPE_SAMPLER = 26;
+	private static final int OP_TYPE_SAMPLED_IMAGE = 27;
+	private static final int OP_TYPE_ARRAY = 28;
+	private static final int OP_TYPE_RUNTIME_ARRAY = 29;
+	private static final int OP_TYPE_STRUCT = 30;
+	private static final int OP_TYPE_OPAQUE = 31;
+	private static final int OP_TYPE_POINTER = 32;
+	private static final int OP_TYPE_FORWARD_POINTER = 39;
+	private static final int OP_CONSTANT_NULL = 46;
+	private static final int OP_FUNCTION = 54;
+	private static final int OP_FUNCTION_PARAMETER = 55;
+	private static final int OP_FUNCTION_END = 56;
+	private static final int OP_FUNCTION_CALL = 57;
+	private static final int OP_VARIABLE = 59;
+	private static final int OP_LOAD = 61;
+	private static final int OP_STORE = 62;
+	private static final int OP_COPY_MEMORY = 63;
+	private static final int OP_ACCESS_CHAIN = 65;
+	private static final int OP_IN_BOUNDS_ACCESS_CHAIN = 66;
+	private static final int OP_PTR_ACCESS_CHAIN = 67;
+	private static final int OP_COPY_OBJECT = 83;
+	private static final int OP_LABEL = 248;
+	private static final int OP_BRANCH = 249;
+	private static final int OP_BRANCH_CONDITIONAL = 250;
+	private static final int OP_SWITCH = 251;
+	private static final int OP_KILL = 252;
+	private static final int OP_RETURN = 253;
+	private static final int OP_RETURN_VALUE = 254;
+	private static final int OP_UNREACHABLE = 255;
+	private static final int OP_TERMINATE_INVOCATION = 4416;
+
+	private static final int STORAGE_PRIVATE = 6;
+	private static final int STORAGE_FUNCTION = 7;
+
+	/** The instruction header of an OpConstantNull, three words long. */
+	private static final int CONSTANT_NULL_HEAD = (3 << 16) | OP_CONSTANT_NULL;
+
+	/** The instruction header of an OpVariable that carries an initialiser, five words long. */
+	private static final int VARIABLE_WITH_INITIALISER_HEAD = (5 << 16) | OP_VARIABLE;
+
+	/**
+	 * How many rounds the summaries get before the pass stops refining them. Walked in the
+	 * module's order, a chain of callers each listed before its callee settles one level a round,
+	 * and no pack's call graph is anywhere near this deep; a module that has not settled by then
+	 * keeps its conservative summaries and zeroes more, never less.
+	 */
+	private static final int MOST_ROUNDS = 32;
+
+	private LocalZeroes() {
+	}
+
+	/**
+	 * The module with every variable some path reads before writing initialised to zero, and
+	 * every undefined value replaced by the zero of its type.
+	 *
+	 * @param words the module in the platform's word order, the magic number first
+	 * @return the same array when nothing needed changing or the module could not be read as
+	 *         SPIR-V, a new one otherwise
+	 */
+	public static Result apply(int[] words) {
+		if (words.length < HEADER_WORDS || words[0] != MAGIC || !wellFormed(words)) {
+			return new Result(words, 0, 0);
+		}
+
+		Types types = Types.read(words);
+
+		// The bare globals, in declaration order, which is the index every function knows them by
+		// behind its own parameters; the entry points; the undefined values, wherever they stand;
+		// then each function.
+		List<Integer> entryPoints = new ArrayList<>();
+		List<Integer> privateIds = new ArrayList<>();
+		List<Integer> privateAt = new ArrayList<>();
+		// An undefined value's instruction position, and the type whose null it becomes.
+		Map<Integer, Integer> undefAt = new LinkedHashMap<>();
+		int at = HEADER_WORDS;
+		while (at < words.length) {
+			int count = words[at] >>> 16;
+			int opcode = words[at] & 0xFFFF;
+			if (opcode == OP_ENTRY_POINT && count >= 3) {
+				entryPoints.add(words[at + 2]);
+			} else if (opcode == OP_VARIABLE && count == 4 && words[at + 3] == STORAGE_PRIVATE
+					&& types.zeroablePointee(words[at + 1]) != null) {
+				privateIds.add(words[at + 2]);
+				privateAt.add(at);
+			} else if (opcode == OP_UNDEF && count == 3 && types.zeroable(words[at + 1])) {
+				undefAt.put(at, words[at + 1]);
+			}
+
+			at += count;
+		}
+
+		List<Function> functions = new ArrayList<>();
+		at = HEADER_WORDS;
+		while (at < words.length) {
+			int count = words[at] >>> 16;
+			if ((words[at] & 0xFFFF) == OP_FUNCTION) {
+				Function function = Function.read(words, at, types, privateIds);
+				functions.add(function);
+				at = function.end();
+				continue;
+			}
+
+			at += count;
+		}
+
+		// The variables to zero, keyed by the position of their instruction.
+		Map<Integer, Integer> zeroAt = new LinkedHashMap<>();
+		readFirst(words, functions, entryPoints, privateAt, types, zeroAt);
+
+		if (zeroAt.isEmpty() && undefAt.isEmpty()) {
+			return new Result(words, 0, 0);
+		}
+
+		// One null constant per pointee type, in first-use order so the output is deterministic.
+		// An undefined value keeps its own id, and its constant is declared where a new one would
+		// be: behind the type, which stands before every use of the value wherever the value was.
+		Map<Integer, Integer> nulls = new LinkedHashMap<>();
+		Map<Integer, List<Integer>> undefsByType = new LinkedHashMap<>();
+		int bound = words[3];
+		for (int pointee : zeroAt.values()) {
+			if (!nulls.containsKey(pointee)) {
+				nulls.put(pointee, bound++);
+			}
+		}
+
+		for (Map.Entry<Integer, Integer> undef : undefAt.entrySet()) {
+			undefsByType.computeIfAbsent(undef.getValue(), _ -> new ArrayList<>())
+					.add(words[undef.getKey() + 2]);
+		}
+
+		int[] out = new int[words.length + 3 * nulls.size() + zeroAt.size()];
+		System.arraycopy(words, 0, out, 0, HEADER_WORDS);
+		out[3] = bound;
+		int to = HEADER_WORDS;
+		at = HEADER_WORDS;
+		while (at < words.length) {
+			int count = words[at] >>> 16;
+			int opcode = words[at] & 0xFFFF;
+			Integer pointee = zeroAt.get(at);
+			if (pointee != null) {
+				out[to] = VARIABLE_WITH_INITIALISER_HEAD;
+				out[to + 1] = words[at + 1];
+				out[to + 2] = words[at + 2];
+				out[to + 3] = words[at + 3];
+				out[to + 4] = nulls.get(pointee);
+				to += 5;
+				at += count;
+				continue;
+			}
+
+			if (undefAt.containsKey(at)) {
+				// Declared behind its type instead, under the same id.
+				at += count;
+				continue;
+			}
+
+			System.arraycopy(words, at, out, to, count);
+			to += count;
+			at += count;
+
+			// Right behind the type it zeroes: that is after the type and before any pointer to it,
+			// so before any variable of it, wherever the module declares those. A struct or an
+			// array is a type like any other here, which is what a textual initialiser could not
+			// have said in one line. A forward pointer declaration names no type of its own.
+			if (opcode >= OP_TYPE_FIRST && opcode <= OP_TYPE_LAST && opcode != OP_TYPE_FORWARD_POINTER
+					&& count >= 2) {
+				int type = words[at - count + 1];
+				Integer zero = nulls.get(type);
+				if (zero != null) {
+					out[to] = CONSTANT_NULL_HEAD;
+					out[to + 1] = type;
+					out[to + 2] = zero;
+					to += 3;
+				}
+
+				for (int id : undefsByType.getOrDefault(type, List.of())) {
+					out[to] = CONSTANT_NULL_HEAD;
+					out[to + 1] = type;
+					out[to + 2] = id;
+					to += 3;
+				}
+			}
+		}
+
+		return new Result(out, zeroAt.size(), undefAt.size());
+	}
+
+	/** Whether every instruction's word count keeps inside the module. */
+	private static boolean wellFormed(int[] words) {
+		int at = HEADER_WORDS;
+		while (at < words.length) {
+			int count = words[at] >>> 16;
+			if (count == 0 || at + count > words.length) {
+				return false;
+			}
+
+			at += count;
+		}
+
+		return true;
+	}
+
+	/**
+	 * The type declarations of a module, which all stand before its first function: each type's
+	 * opcode and the types it is made of.
+	 */
+	private record Types(Map<Integer, Integer> opcodes, Map<Integer, int[]> members,
+			Map<Integer, Integer> pointees) {
+
+		static Types read(int[] words) {
+			Map<Integer, Integer> opcodes = new HashMap<>();
+			Map<Integer, int[]> members = new HashMap<>();
+			Map<Integer, Integer> pointees = new HashMap<>();
+			int at = HEADER_WORDS;
+			while (at < words.length) {
+				int count = words[at] >>> 16;
+				int opcode = words[at] & 0xFFFF;
+				// A forward pointer declaration's first operand is the pointer type it announces,
+				// not a result id of its own.
+				if (opcode >= OP_TYPE_FIRST && opcode <= OP_TYPE_LAST
+						&& opcode != OP_TYPE_FORWARD_POINTER && count >= 2) {
+					int id = words[at + 1];
+					opcodes.put(id, opcode);
+					if (opcode == OP_TYPE_POINTER && count >= 4) {
+						pointees.put(id, words[at + 3]);
+					} else if (opcode == OP_TYPE_ARRAY && count >= 3) {
+						members.put(id, new int[] {words[at + 2]});
+					} else if (opcode == OP_TYPE_STRUCT) {
+						int[] made = new int[count - 2];
+						System.arraycopy(words, at + 2, made, 0, made.length);
+						members.put(id, made);
+					}
+				}
+
+				at += count;
+			}
+
+			return new Types(opcodes, members, pointees);
+		}
+
+		/**
+		 * The pointee a null constant would name for a variable of this pointer type, or null when
+		 * that pointee is not one {@code OpConstantNull} may name.
+		 */
+		Integer zeroablePointee(int pointerType) {
+			Integer pointee = this.pointees.get(pointerType);
+
+			return pointee != null && zeroable(pointee) ? pointee : null;
+		}
+
+		/**
+		 * Whether {@code OpConstantNull} may name this type: anything but an opaque handle, a
+		 * runtime array, a pointer, or a composite holding one of those at any depth, none of
+		 * which a bare variable of a translated pack ever has.
+		 */
+		boolean zeroable(int type) {
+			Integer opcode = this.opcodes.get(type);
+			if (opcode == null
+					|| opcode == OP_TYPE_IMAGE
+					|| opcode == OP_TYPE_SAMPLER
+					|| opcode == OP_TYPE_SAMPLED_IMAGE
+					|| opcode == OP_TYPE_RUNTIME_ARRAY
+					|| opcode == OP_TYPE_OPAQUE
+					|| opcode == OP_TYPE_POINTER) {
+				return false;
+			}
+
+			for (int member : this.members.getOrDefault(type, new int[0])) {
+				if (!zeroable(member)) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+	}
+
+	/** One basic block of a function: where its instructions start and end, and where it goes. */
+	private record Block(int start, int end, List<Integer> successors, boolean returns) {
+	}
+
+	/**
+	 * What a call site may assume of a function, over its parameters and then the module's bare
+	 * globals: which it can read before it writes them, and which it has written on every path
+	 * that returns.
+	 */
+	private record Summary(BitSet readsFirst, BitSet defines) {
+
+		/** The summary of a function nothing is known about: reads everything, defines nothing. */
+		static Summary unknown(int shared) {
+			BitSet reads = new BitSet(shared);
+			reads.set(0, shared);
+
+			return new Summary(reads, new BitSet(shared));
+		}
+	}
+
+	/**
+	 * One function, read once: its blocks, and the pointers the walk tracks under one index each,
+	 * which are its parameters first, then the module's bare globals, then its own bare locals.
+	 * Aliases are the access chains and copies made of a tracked pointer, which name the same
+	 * variable.
+	 *
+	 * @param shared  how many indices the parameters and the globals take, which is what a summary
+	 *                speaks about
+	 * @param localAt the instruction position of each tracked local, by its index less
+	 *                {@code shared}
+	 */
+	private record Function(int id, int end, int parameters, int shared, List<Block> blocks,
+			Map<Integer, Integer> labelToBlock, Map<Integer, Integer> index,
+			List<Integer> localAt, Map<Integer, Integer> aliases) {
+
+		static Function read(int[] words, int start, Types types, List<Integer> privateIds) {
+			int id = words[start + 2];
+			List<Block> blocks = new ArrayList<>();
+			Map<Integer, Integer> labelToBlock = new HashMap<>();
+			Map<Integer, Integer> index = new LinkedHashMap<>();
+			List<Integer> localAt = new ArrayList<>();
+			Map<Integer, Integer> aliases = new HashMap<>();
+			int parameters = 0;
+			int at = start + (words[start] >>> 16);
+			while (at < words.length && (words[at] & 0xFFFF) == OP_FUNCTION_PARAMETER) {
+				// Every parameter takes an index, opaque ones included, so that a call site's
+				// argument positions and the summary's bits line up.
+				if (types.zeroablePointee(words[at + 1]) != null) {
+					index.put(words[at + 2], parameters);
+				}
+
+				parameters++;
+				at += words[at] >>> 16;
+			}
+
+			for (int k = 0; k < privateIds.size(); k++) {
+				index.put(privateIds.get(k), parameters + k);
+			}
+
+			int shared = parameters + privateIds.size();
+			int blockStart = -1;
+			while (at < words.length) {
+				int count = words[at] >>> 16;
+				int opcode = words[at] & 0xFFFF;
+				if (opcode == OP_FUNCTION_END) {
+					at += count;
+					break;
+				}
+
+				if (opcode == OP_LABEL) {
+					blockStart = at;
+					labelToBlock.put(words[at + 1], blocks.size());
+				} else if (opcode == OP_VARIABLE && count == 4 && words[at + 3] == STORAGE_FUNCTION) {
+					if (types.zeroablePointee(words[at + 1]) != null) {
+						index.put(words[at + 2], shared + localAt.size());
+						localAt.add(at);
+					}
+				} else if (opcode == OP_ACCESS_CHAIN || opcode == OP_IN_BOUNDS_ACCESS_CHAIN
+						|| opcode == OP_PTR_ACCESS_CHAIN || opcode == OP_COPY_OBJECT) {
+					// In the module's order, which is the order a definition precedes its uses in
+					// the structured control flow glslang emits.
+					Integer base = base(words[at + 3], index, aliases);
+					if (base != null) {
+						aliases.put(words[at + 2], base);
+					}
+				} else if (terminator(opcode)) {
+					blocks.add(new Block(blockStart, at + count, successors(words, at),
+							opcode == OP_RETURN || opcode == OP_RETURN_VALUE));
+					blockStart = -1;
+				}
+
+				at += count;
+			}
+
+			return new Function(id, at, parameters, shared, blocks, labelToBlock, index, localAt,
+					aliases);
+		}
+
+		int tracked() {
+			return this.shared + this.localAt.size();
+		}
+	}
+
+	/**
+	 * Puts into {@code zeroAt} every bare variable of the module that some path reads before a
+	 * store reaches it: a local by the walk of its function, a global by the walk of each entry
+	 * point, the functions' summaries refined together until none moves.
+	 */
+	private static void readFirst(int[] words, List<Function> functions, List<Integer> entryPoints,
+			List<Integer> privateAt, Types types, Map<Integer, Integer> zeroAt) {
+		Map<Integer, Function> byId = new HashMap<>();
+		Map<Integer, Summary> summaries = new HashMap<>();
+		for (Function function : functions) {
+			byId.put(function.id(), function);
+			summaries.put(function.id(), Summary.unknown(function.shared()));
+		}
+
+		Map<Integer, BitSet> needs = new HashMap<>();
+		for (int round = 0; round < MOST_ROUNDS; round++) {
+			boolean moved = false;
+			for (Function function : functions) {
+				BitSet read = new BitSet(function.tracked());
+				Summary summary = walk(words, function, byId, summaries, read);
+				needs.put(function.id(), read);
+				if (!summary.equals(summaries.get(function.id()))) {
+					summaries.put(function.id(), summary);
+					moved = true;
+				}
+			}
+
+			if (!moved) {
+				break;
+			}
+		}
+
+		for (Function function : functions) {
+			BitSet read = needs.get(function.id());
+			boolean root = entryPoints.contains(function.id());
+			for (int index = read.nextSetBit(0); index >= 0; index = read.nextSetBit(index + 1)) {
+				int position;
+				if (index >= function.shared()) {
+					position = function.localAt().get(index - function.shared());
+				} else if (root && index >= function.parameters()) {
+					position = privateAt.get(index - function.parameters());
+				} else {
+					continue;
+				}
+
+				zeroAt.put(position, types.zeroablePointee(words[position + 1]));
+			}
+		}
+	}
+
+	/**
+	 * The must-analysis over one function: what is definitely stored on every path into each
+	 * block, the entry starting empty and every other block full, the sets only ever shrinking.
+	 * Marks in {@code read} every tracked pointer some block reads while it is not yet stored, and
+	 * returns what the function's parameters and the globals look like from a call site.
+	 */
+	private static Summary walk(int[] words, Function function, Map<Integer, Function> byId,
+			Map<Integer, Summary> summaries, BitSet read) {
+		int tracked = function.tracked();
+		List<Block> blocks = function.blocks();
+		if (blocks.isEmpty()) {
+			return Summary.unknown(function.shared());
+		}
+
+		List<List<Integer>> predecessors = new ArrayList<>();
+		for (int index = 0; index < blocks.size(); index++) {
+			predecessors.add(new ArrayList<>());
+		}
+
+		for (int index = 0; index < blocks.size(); index++) {
+			for (int label : blocks.get(index).successors()) {
+				Integer target = function.labelToBlock().get(label);
+				if (target != null) {
+					predecessors.get(target).add(index);
+				}
+			}
+		}
+
+		BitSet[] in = new BitSet[blocks.size()];
+		BitSet[] out = new BitSet[blocks.size()];
+		for (int index = 0; index < blocks.size(); index++) {
+			in[index] = new BitSet(tracked);
+			if (index > 0) {
+				in[index].set(0, tracked);
+			}
+
+			out[index] = transfer(words, function, blocks.get(index), in[index], byId, summaries,
+					null);
+		}
+
+		boolean moved = true;
+		while (moved) {
+			moved = false;
+			for (int index = 1; index < blocks.size(); index++) {
+				List<Integer> preds = predecessors.get(index);
+				if (preds.isEmpty()) {
+					continue;
+				}
+
+				BitSet meet = new BitSet(tracked);
+				meet.set(0, tracked);
+				for (int pred : preds) {
+					meet.and(out[pred]);
+				}
+
+				if (!meet.equals(in[index])) {
+					in[index] = meet;
+					out[index] = transfer(words, function, blocks.get(index), meet, byId, summaries,
+							null);
+					moved = true;
+				}
+			}
+		}
+
+		// What is defined on every path that returns: a path that kills never hands anything back,
+		// so it does not weaken the meet. A function with no returning block defines everything.
+		BitSet defined = new BitSet(tracked);
+		defined.set(0, tracked);
+		for (int index = 0; index < blocks.size(); index++) {
+			transfer(words, function, blocks.get(index), in[index], byId, summaries, read);
+			if (blocks.get(index).returns()) {
+				defined.and(out[index]);
+			}
+		}
+
+		return new Summary(read.get(0, function.shared()), defined.get(0, function.shared()));
+	}
+
+	/**
+	 * Runs one block from a set of definitely stored pointers and returns what is definitely
+	 * stored at its end. With {@code read} given, also marks every pointer the block reads while
+	 * it is not yet stored.
+	 */
+	private static BitSet transfer(int[] words, Function function, Block block, BitSet in,
+			Map<Integer, Function> byId, Map<Integer, Summary> summaries, BitSet read) {
+		BitSet defined = (BitSet) in.clone();
+		Map<Integer, Integer> index = function.index();
+		Map<Integer, Integer> aliases = function.aliases();
+		int at = block.start();
+		while (at < block.end()) {
+			int count = words[at] >>> 16;
+			int opcode = words[at] & 0xFFFF;
+			switch (opcode) {
+				case OP_STORE -> define(words[at + 1], defined, index);
+				case OP_LOAD -> use(words[at + 3], defined, index, aliases, read);
+				case OP_COPY_MEMORY -> {
+					use(words[at + 2], defined, index, aliases, read);
+					define(words[at + 1], defined, index);
+				}
+				case OP_FUNCTION_CALL -> call(words, at, function, byId, summaries, defined, read);
+				default -> {
+					// Nothing else in what glslang emits for GLSL reads or writes a variable
+					// through its pointer.
+				}
+			}
+
+			at += count;
+		}
+
+		return defined;
+	}
+
+	/**
+	 * A call: each argument the callee may read first is read here, each one it writes on every
+	 * path is defined here, and the globals go the same way under the callee's own indices.
+	 */
+	private static void call(int[] words, int at, Function caller, Map<Integer, Function> byId,
+			Map<Integer, Summary> summaries, BitSet defined, BitSet read) {
+		int count = words[at] >>> 16;
+		Function callee = byId.get(words[at + 3]);
+		Summary summary = summaries.get(words[at + 3]);
+		Map<Integer, Integer> index = caller.index();
+		Map<Integer, Integer> aliases = caller.aliases();
+		for (int argument = 0; argument + 4 < count; argument++) {
+			int pointer = words[at + 4 + argument];
+			if (summary == null || summary.readsFirst().get(argument)) {
+				use(pointer, defined, index, aliases, read);
+			}
+
+			if (summary != null && summary.defines().get(argument)) {
+				define(pointer, defined, index);
+			}
+		}
+
+		if (callee == null || summary == null) {
+			// A callee this module does not define reads every global and defines none.
+			for (int k = caller.parameters(); k < caller.shared(); k++) {
+				if (!defined.get(k) && read != null) {
+					read.set(k);
+				}
+			}
+
+			return;
+		}
+
+		int globals = caller.shared() - caller.parameters();
+		for (int k = 0; k < globals; k++) {
+			int here = caller.parameters() + k;
+			int there = callee.parameters() + k;
+			if (summary.readsFirst().get(there) && !defined.get(here) && read != null) {
+				read.set(here);
+			}
+
+			if (summary.defines().get(there)) {
+				defined.set(here);
+			}
+		}
+	}
+
+	/** A store through the variable's own pointer defines it whole; one through a chain does not. */
+	private static void define(int pointer, BitSet defined, Map<Integer, Integer> index) {
+		Integer whole = index.get(pointer);
+		if (whole != null) {
+			defined.set(whole);
+		}
+	}
+
+	/** A read of a pointer: the tracked variable behind it, if not yet stored, needs its zero. */
+	private static void use(int pointer, BitSet defined, Map<Integer, Integer> index,
+			Map<Integer, Integer> aliases, BitSet read) {
+		Integer base = base(pointer, index, aliases);
+		if (base != null && !defined.get(base) && read != null) {
+			read.set(base);
+		}
+	}
+
+	/** The index of the tracked pointer an id names, directly or through an alias. */
+	private static Integer base(int pointer, Map<Integer, Integer> index,
+			Map<Integer, Integer> aliases) {
+		Integer direct = index.get(pointer);
+
+		return direct != null ? direct : aliases.get(pointer);
+	}
+
+	private static boolean terminator(int opcode) {
+		return opcode == OP_BRANCH || opcode == OP_BRANCH_CONDITIONAL || opcode == OP_SWITCH
+				|| opcode == OP_KILL || opcode == OP_RETURN || opcode == OP_RETURN_VALUE
+				|| opcode == OP_UNREACHABLE || opcode == OP_TERMINATE_INVOCATION;
+	}
+
+	/** The labels a terminator can go to. A switch's literals are read as single words. */
+	private static List<Integer> successors(int[] words, int at) {
+		int count = words[at] >>> 16;
+		int opcode = words[at] & 0xFFFF;
+		List<Integer> targets = new ArrayList<>();
+		if (opcode == OP_BRANCH) {
+			targets.add(words[at + 1]);
+		} else if (opcode == OP_BRANCH_CONDITIONAL) {
+			targets.add(words[at + 2]);
+			targets.add(words[at + 3]);
+		} else if (opcode == OP_SWITCH) {
+			targets.add(words[at + 2]);
+			for (int label = at + 4; label < at + count; label += 2) {
+				targets.add(words[label]);
+			}
+		}
+
+		return targets;
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
@@ -8,14 +8,17 @@ import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
 import dev.vitrail.glsl.LoadClock;
 import dev.vitrail.render.ModuleCache;
+import dev.vitrail.render.RawLocals;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Coerce;
 
+import java.nio.ByteBuffer;
+
 /**
- * Lets a sampled or stored 3D image through the bind-group walk, and puts {@link ModuleCache}
- * around the one call that turns a pack's GLSL into a module, which is also where
- * {@link LoadClock} counts what that costs.
+ * Lets a sampled or stored 3D image through the bind-group walk, gives the compiler's output its
+ * zeroes before the reflection reads it, and puts {@link ModuleCache} around the one call that
+ * turns a pack's GLSL into a module, which is also where {@link LoadClock} counts what that costs.
  * <p>
  * {@code addToBindGroup} refuses anything whose SPIR-V dimension is not 2D or Cube. SpvDim3D is 2.
  * Pretending it is 2D is enough for the check; the view that is actually bound is the 3D one
@@ -50,6 +53,23 @@ public abstract class GlslCompilerMixin {
 	}
 
 	/**
+	 * Between shaderc and SPIRV-Cross, on the copy the game made of the compiler's output: every
+	 * variable the pack can read before writing gets the zero it reads under Iris.
+	 * {@link RawLocals} carries the switch and the why. Inside the wrapped method below, so a
+	 * module served from the cache was zeroed the day it was built and is not walked again, and
+	 * under the state that method took at its head, so the key and the bytes agree.
+	 */
+	@WrapOperation(method = "createIntermediary", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lcom/mojang/blaze3d/vulkan/glsl/IntermediaryShaderModule;createFromSpirv("
+							+ "Ljava/lang/String;Ljava/nio/ByteBuffer;)"
+							+ "Lcom/mojang/blaze3d/vulkan/glsl/IntermediaryShaderModule;"))
+	private IntermediaryShaderModule vitrail$zeroLocals(String filename, ByteBuffer spirv,
+			Operation<IntermediaryShaderModule> original) {
+		return original.call(filename, RawLocals.patch(filename, spirv));
+	}
+
+	/**
 	 * The text keyed on is the one this method is handed, which is two lines short of the one
 	 * shaderc sees: the method splices the compiler's own two global defines in behind the
 	 * version directive. They are built once in its constructor out of literals and nothing can
@@ -62,6 +82,10 @@ public abstract class GlslCompilerMixin {
 	private IntermediaryShaderModule vitrail$module(String filename, String source, ShaderType type,
 			Operation<IntermediaryShaderModule> original) {
 		long began = System.nanoTime();
+		// The state the key is hashed under is the state the bytes are patched under, taken once
+		// here: a load flipping the switch while this thread is between the two would otherwise
+		// store one state's module under the other's key.
+		RawLocals.begin();
 		try {
 			String key = ModuleCache.keyOf(source, type.name());
 			IntermediaryShaderModule served = ModuleCache.lookup(key, filename);
@@ -78,6 +102,7 @@ public abstract class GlslCompilerMixin {
 
 			return built;
 		} finally {
+			RawLocals.end();
 			LoadClock.module(System.nanoTime() - began);
 		}
 	}

--- a/common/src/main/java/dev/vitrail/render/ModuleCache.java
+++ b/common/src/main/java/dev/vitrail/render/ModuleCache.java
@@ -2,6 +2,7 @@ package dev.vitrail.render;
 
 import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
 import dev.vitrail.Vitrail;
+import dev.vitrail.glsl.LocalZeroes;
 import dev.vitrail.mixin.access.IntermediaryShaderModuleAccessor;
 
 import org.jspecify.annotations.Nullable;
@@ -160,9 +161,13 @@ public final class ModuleCache {
 	 * sweep is what eventually collects it. Two is where the uniform buffer table first carries the
 	 * storage blocks: every blob before it lists none, a hit skips the reflection that would add
 	 * them, and a pipeline built off such a blob leaves every storage block on the binding its pack
-	 * wrote.
+	 * wrote. Three is where the SPIR-V itself first carries the zeroes of {@link RawLocals}: a
+	 * blob before it holds the compiler's bare variables, and a hit on one would draw the black
+	 * faces the pass exists to take away, with nothing in the log to say why. What the pass emits
+	 * for a module can move without this layout moving, so the pass carries a version of its own
+	 * that {@link #keyOf} hashes beside this.
 	 */
-	private static final String FORMAT = "vitrail-module-2";
+	private static final String FORMAT = "vitrail-module-3";
 
 	private static final String FOLDER = "modules";
 	private static final String SUFFIX = ".mod";
@@ -316,6 +321,10 @@ public final class ModuleCache {
 		feed(digest, Vitrail.platform().loaderName());
 		feed(digest, Vitrail.platform().loaderVersion());
 		feed(digest, Version.getVersion());
+		// The one switch that changes the bytes a compile produces without changing its text: the
+		// two states keep two sets of blobs, and a reading taken under one never draws the other's.
+		feed(digest, RawLocals.cacheWord());
+		feed(digest, LocalZeroes.VERSION);
 		feed(digest, stage);
 		feed(digest, source);
 
@@ -600,6 +609,7 @@ public final class ModuleCache {
 		if (!ENABLED) {
 			Vitrail.logger().info("Module cache off, so all {} units of this load were compiled and "
 					+ "reflected ({} since this launch)", misses, COMPILED_SINCE_LAUNCH.get());
+			RawLocals.say(misses);
 
 			return;
 		}
@@ -609,6 +619,9 @@ public final class ModuleCache {
 						+ "since this launch, {} MB in {}",
 				hits, misses, SERVED_SINCE_LAUNCH.get(), COMPILED_SINCE_LAUNCH.get(),
 				megabytes(BYTES.get()), root == null ? "nowhere" : root);
+		// At the same quiet moment and about the same compiles: what the pass did to the modules
+		// this line counts as built.
+		RawLocals.say(misses);
 	}
 
 	/** The directory, made and measured at the first unit of the run, or null when there is none. */

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -636,6 +636,9 @@ public final class PackChain {
 		// Here and not lower down: it decides what the translation emits, and every road
 		// below this point that reads a pack translates one.
 		DriverTrig.read(gameDirectory);
+		// Beside it, for the compiles rather than the translations: it decides the bytes every
+		// module of this load is made of, and the key it is stored under.
+		RawLocals.read(gameDirectory);
 		// Beside the trig switch and for the same reason: what follows is what these tallies
 		// are a tally of. The cache empties its own on the same line, so that its counts and the
 		// clock's milliseconds are read off one load.

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -682,6 +682,8 @@ final class PackCompute implements AutoCloseable {
 			// cannot serve this blob.
 			long began = System.nanoTime();
 			IntermediaryShaderModule module = null;
+			// One state for the key and the patch, as the game's compiler road takes it.
+			RawLocals.begin();
 			try {
 				String source = unit.text();
 				String key = ModuleCache.keyOf(source, MODULE_CACHE_STAGE);
@@ -699,7 +701,14 @@ final class PackCompute implements AutoCloseable {
 
 				try {
 					if (module == null) {
-						module = IntermediaryShaderModule.createFromSpirv(this.label, spirv);
+						// The same zeroes the game's compiler road gets in GlslCompilerMixin: this
+						// road has its own shaderc call, so it has to ask for them itself, and
+						// before the reflection and the store, so a served blob carries them too.
+						// Compiled at the performance level, this module has mostly values where
+						// that road has variables, and its undefined reads are what the pass turns
+						// into zeroes here.
+						module = IntermediaryShaderModule.createFromSpirv(this.label,
+								RawLocals.patch(this.label, spirv));
 						ModuleCache.store(key, module);
 					}
 
@@ -721,6 +730,7 @@ final class PackCompute implements AutoCloseable {
 					return;
 				}
 			} finally {
+				RawLocals.end();
 				if (module != null) {
 					module.close();
 				}

--- a/common/src/main/java/dev/vitrail/render/RawLocals.java
+++ b/common/src/main/java/dev/vitrail/render/RawLocals.java
@@ -1,0 +1,163 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+import dev.vitrail.glsl.LocalZeroes;
+import org.lwjgl.system.MemoryUtil;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Whether the variables a pack leaves uninitialised are left raw, as shaderc emits them, instead
+ * of being given the zero they read under Iris.
+ * <p>
+ * The default is the zero, and {@link LocalZeroes} says why. This is the switch that turns it
+ * off, and it exists for the same reason {@link DriverTrig} does: a cost is measured rather than
+ * assumed, and it is measured in one jar, a pack load apart, so that the one variable under test
+ * is the only thing between two readings. It is also what tells a picture apart: a face or a
+ * shore that goes black with the file in place and lights up without it is a pack reading a
+ * variable it never wrote, and the variable is then found in the module rather than guessed at.
+ * <p>
+ * A file {@code vitrail/raw-locals} in the game directory, read again at every pack load, or
+ * {@code -Dvitrail.rawLocals=true}, read once at start. It changes the bytes every compiled
+ * module is made of, so it is part of the module cache's key: the two states keep two sets of
+ * blobs and neither is ever served for the other. The state a compile runs under is taken once,
+ * at the head of the compile, and both the key and the patch read that one snapshot: a worker
+ * still compiling for the outgoing chain when a load flips the switch would otherwise store a
+ * module of one state under the key of the other, and serve it for as long as the key lives.
+ * <p>
+ * The pass runs between shaderc and the reflection, on the buffer the game copied the compiler's
+ * output into, and hands the reflection a buffer of its own allocation when anything was changed:
+ * the module frees whichever buffer it was built on, so the copy the game made is freed here in
+ * that case and nothing is freed twice.
+ */
+public final class RawLocals {
+
+	private static final boolean PROPERTY = Boolean.getBoolean("vitrail.rawLocals");
+
+	private static final String ARM_FILE = "raw-locals";
+
+	private static volatile boolean armed;
+
+	/** The state the compile on this thread runs under, taken at its head; null between compiles. */
+	private static final ThreadLocal<Boolean> SNAPSHOT = new ThreadLocal<>();
+
+	/** What the compiles since the last report did, for the line the module cache prints. */
+	private static final AtomicLong WALKED = new AtomicLong();
+	private static final AtomicLong ZEROED = new AtomicLong();
+	private static final AtomicLong VALUES = new AtomicLong();
+
+	private RawLocals() {
+	}
+
+	/**
+	 * Read at the head of a pack load, before one module of it has been compiled, since what it
+	 * decides is what every compile of the load emits.
+	 */
+	public static void read(Path gameDirectory) {
+		armed = PROPERTY
+				|| Files.isRegularFile(gameDirectory.resolve(Vitrail.MOD_ID).resolve(ARM_FILE));
+	}
+
+	/**
+	 * Takes the state one compile runs under, for the key and the patch alike. Paired with
+	 * {@link #end} in a finally, so a compile that throws leaves nothing behind on its thread.
+	 */
+	public static void begin() {
+		SNAPSHOT.set(armed);
+	}
+
+	public static void end() {
+		SNAPSHOT.remove();
+	}
+
+	private static boolean raw() {
+		Boolean snapshot = SNAPSHOT.get();
+
+		return snapshot != null ? snapshot : armed;
+	}
+
+	/** The word the module cache's key carries for the state, since the state decides the bytes. */
+	public static String cacheWord() {
+		return raw() ? "raw-locals" : "zeroed-locals";
+	}
+
+	/**
+	 * The module the reflection should read: the one handed in, or one with its bare variables
+	 * zeroed, in which case the one handed in has been freed.
+	 * <p>
+	 * Only what this engine hands the compiler, which is a pack's programs and its own few
+	 * shaders. The game's own shaders and Sodium's go through the same compiler and are left as
+	 * they are: the zero reproduces what packs were written against, and neither of those was
+	 * written against anything but itself. This engine's own shaders come through too, because
+	 * their names share the prefix, and lose nothing by it: a shader that writes before it reads
+	 * comes out unchanged.
+	 *
+	 * @param filename the debug name the compile was given, which says whose module it is
+	 * @param spirv    the compiler's output as the game copied it, native order, position at nought
+	 */
+	public static ByteBuffer patch(String filename, ByteBuffer spirv) {
+		if (raw() || !ours(filename)) {
+			return spirv;
+		}
+
+		WALKED.incrementAndGet();
+		int[] words = new int[spirv.remaining() / 4];
+		spirv.duplicate().order(ByteOrder.nativeOrder()).asIntBuffer().get(words);
+		LocalZeroes.Result result = LocalZeroes.apply(words);
+		if (!result.changed()) {
+			return spirv;
+		}
+
+		// The same allocator and the same zeroing as the game's own copy, since the module closes
+		// this buffer exactly as it would have closed that one.
+		ByteBuffer zeroed = MemoryUtil.memCalloc(result.words().length * 4);
+		zeroed.order(ByteOrder.nativeOrder()).asIntBuffer().put(result.words());
+		MemoryUtil.memFree(spirv);
+		ZEROED.incrementAndGet();
+		VALUES.addAndGet(result.variables() + result.undefs());
+
+		return zeroed;
+	}
+
+	/**
+	 * Whether a debug name is one this engine hands the compiler: a geometry or fullscreen
+	 * program's identifier flattened by the game ({@code vitrail_pack_...},
+	 * {@code vitrail_sodium_pack_...}, and this engine's own {@code vitrail_...}), or the label
+	 * {@link PackCompute} gives a compute ({@code pack/<load>/...}).
+	 */
+	private static boolean ours(String filename) {
+		return filename.startsWith(Vitrail.MOD_ID + "_") || filename.startsWith("pack/");
+	}
+
+	/**
+	 * One line beside the module cache's, at the same quiet moment, said in BOTH states and
+	 * whether or not this load compiled anything: a load served whole from the store ran under the
+	 * state its blobs were built under, which the key guarantees, and a reading taken under it has
+	 * to be able to name that state. {@link DriverTrig#announce} follows the same rule.
+	 *
+	 * @param compiled how many modules the compiler built this load, this engine's and the rest
+	 */
+	public static void say(long compiled) {
+		long walked = WALKED.getAndSet(0L);
+		long zeroed = ZEROED.getAndSet(0L);
+		long values = VALUES.getAndSet(0L);
+		if (armed) {
+			Vitrail.logger().warn("Uninitialised variables left RAW, asked for by vitrail/{} or by "
+					+ "-Dvitrail.rawLocals ({} modules built this load, none walked): a pack reading "
+					+ "one before writing it gets whatever the register held here and zero under "
+					+ "Iris; remove the file to go back", ARM_FILE, compiled);
+
+			return;
+		}
+
+		Vitrail.logger().info("Uninitialised variables given their zero: {} values in {} of the {} "
+				+ "pack modules walked ({} modules built this load in all, the rest served already "
+				+ "zeroed), which is the default. vitrail/{} would leave them raw, and this line is "
+				+ "said either way so that a reading can name the state it was taken under",
+				values, zeroed, walked, compiled, ARM_FILE);
+	}
+}

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -380,6 +380,29 @@ does; [the game's graphics API](internals/game-graphics-api.md) says where the s
 **Defects in the pack itself.** A conditional directive with no name is a pack bug and stays a
 failure.
 
+One class of pack defect is handed a value instead, because under the reference it has one. GLSL
+leaves a variable declared without an initialiser undefined until it is written, and a pack that
+reads one first has a defect that shows nowhere on the platform it was written on: measured against
+Iris at the same spot on the same machine, the pack reads zero there, so the picture is right and
+nobody notices. Compiled through shaderc the variable stays bare, and what came back here changed
+with the face being drawn and with every edit to the shader's text, which is what a register left
+over from the previous work looks like. A hand black on one face and lit on the next, or black
+lines along every far shore, is what that looks like. So after shaderc has compiled a unit and
+before the game's reflection reads it, every `Function` or `Private` variable of the module that
+some path can read before a store reaches it is given a null constant as its initialiser, and an
+undefined value the optimiser left in a module gets the null of its type. Which variables need it
+is worked out rather than assumed: giving every bare variable a zero cost eight percent of the
+frame on one pack, twelve hundred of them in one fragment stage and most of them the compiler's own
+temporaries, since the driver does not fold every such store away. The pass works on the SPIR-V
+rather than on the translated text because the module already knows the type of every variable,
+arrays and structs included, where a textual initialiser would have to find every declaration in
+every scope and spell each type out. The game's own shaders and Sodium's go through the same
+compiler and are left as they are: the zero reproduces what packs were written against, and
+neither of those was written against anything but itself. A file `vitrail/raw-locals` in the game
+directory leaves the variables raw, which is how the cost of the pass is measured in one jar and
+how a black face is told apart from every other cause in one pack reload; the log says at every
+load which state it ran under.
+
 **Missing values rather than missing translation.** A vanilla-style uniform a pack expects is closed
 by supplying the value, not by changing the translator. It shows up in the unanswered list, not in
 a compile error.


### PR DESCRIPTION
## What changes

A variable a pack declares without a value and reads before writing it now reads zero, as it does under Iris. GLSL leaves it undefined, but the OpenGL compiler most packs are written on starts it at zero, so the defect never shows there; through shaderc the variable stays bare and the Vulkan driver hands back whatever the previous work left in the register, which changes with the face being drawn and with every edit to the shader's text. Complementary Unbound's `GetComplexLightVolume` accumulates into a `vec4` it never zeroes at the High profile and above: one face of the held hand was black at every angle, and the water along far shores carried black lines. After shaderc has compiled a unit and before the game's reflection reads it, every `Function` or `Private` variable of a pack module that some path can read before a store reaches it gets an `OpConstantNull` initialiser. Which ones is decided by a definite-assignment walk over each function's blocks, calls summarised and globals judged from the entry point, so a fragment stage carrying twelve hundred bare locals ends up with the one it really reads first. The game's own shaders and Sodium's are left alone. The module cache moves to format 3 and carries the switch in its key; a file `vitrail/raw-locals` leaves the variables raw, and the log says which state a load ran under.

## How it differs from the reference, and for what obstacle

It does not, in the picture: the pack reads here the value it reads under Iris on the driver it was written against. Iris rewrites nothing about declarations (`CommonTransformer.java`) because its driver does the work; shaderc emits the bare `OpVariable` and the Vulkan driver leaves it bare, so this engine does it on the copy `GlslCompiler.createIntermediary` makes of the compiler's output.

## What proves it

- `gradlew build` green, after the rebase.
- The out-of-game harness over the fifteen entries of the bench's `shaderpacks/`: every one of the 3063 modules shaderc compiles is still accepted by `spirv-val` and by the SPIRV-Cross reflection after the pass, zero refusals; the negative control breaks one initialiser per touched module and refuses exactly that many.
- In the game, Complementary Unbound r5.8.1 at Ultra, `frozen real vitrail` at the pinned water station, twenty-four chunks: the hand's left face reads the same value as under Iris at the same spot, and the far water counts no black pixel where the raw modules count around two hundred, the two states switched in one launch through `vitrail/raw-locals`.
- Frame rate at the same station, both states a pack reload apart in one launch: the pass sits inside the drift five reloads of one state show on their own. Zeroing every bare variable had cost eight percent, which is why the walk exists.

## What it leaves owing

Which other packs read a bare variable first is not audited pack by pack; the pass answers for all of them, and the log line counts what it zeroed at each load.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
