### PR TITLE
refactor(render): one base for the seven family programs

### DIFF
--- a/common/src/main/java/dev/vitrail/render/CloudProgram.java
+++ b/common/src/main/java/dev/vitrail/render/CloudProgram.java
@@ -4,7 +4,6 @@ import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
-import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.PrimitiveTopology;
@@ -12,11 +11,6 @@ import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderPass;
-import com.mojang.blaze3d.systems.RenderPassDescriptor;
-import com.mojang.blaze3d.textures.GpuTextureView;
-import com.mojang.blaze3d.vulkan.VulkanDevice;
-import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 import net.minecraft.client.renderer.BindGroupLayouts;
 
 import java.util.List;
@@ -45,7 +39,7 @@ import java.util.Set;
  * {@link SkyProgram} gives: the word turns push constants on, and the cloud pass has no region to
  * fill them from.
  */
-final class CloudProgram implements DumpedProgram {
+final class CloudProgram extends FamilyProgram {
 
 	/** What the log calls this geometry, one word in the middle of a sentence. */
 	private static final String FAMILY = "cloud";
@@ -53,10 +47,8 @@ final class CloudProgram implements DumpedProgram {
 	/** Ours, and deliberately without the word that turns push constants on. */
 	private static final String NAMESPACE = Vitrail.MOD_ID;
 
-	private final GeometryProgram body;
-
 	private CloudProgram(GeometryProgram body) {
-		this.body = body;
+		super(body);
 	}
 
 	/**
@@ -124,24 +116,6 @@ final class CloudProgram implements DumpedProgram {
 	}
 
 	/**
-	 * The pass the clouds are drawn into, or null to leave the renderer the one it meant to open.
-	 *
-	 * @see GeometryProgram#descriptor
-	 */
-	RenderPassDescriptor descriptor(GpuTextureView colour, GpuTextureView depth) {
-		return this.body.descriptor(colour, depth);
-	}
-
-	/**
-	 * Binds this program's block and every sampler it declares, inside the pass just opened.
-	 *
-	 * @see GeometryProgram#bind
-	 */
-	void bind(RenderPass pass) {
-		this.body.bind(pass);
-	}
-
-	/**
 	 * Whether the pipeline a pass has bound is this program's.
 	 *
 	 * @see GeometryProgram#owns
@@ -150,67 +124,4 @@ final class CloudProgram implements DumpedProgram {
 		return this.body.owns(bound);
 	}
 
-	/** @see GeometryProgram#compile */
-	@Override
-	public boolean compile(GpuDevice device) {
-		return this.body.compile(device);
-	}
-
-	/** @see GeometryProgram#compiled */
-	@Override
-	public boolean compiled() {
-		return this.body.compiled();
-	}
-
-	/** @see GeometryProgram#forgetCompiled */
-	@Override
-	public void forgetCompiled() {
-		this.body.forgetCompiled();
-	}
-
-	@Override
-	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
-		return this.body.warmAhead(device, compiler);
-	}
-
-	@Override
-	public void discardAhead() {
-		this.body.discardAhead();
-	}
-
-	/** @see GeometryProgram#decoded */
-	@Override
-	public String decoded(WorldState world) {
-		return this.body.decoded(world);
-	}
-
-	/** @see GeometryProgram#path */
-	@Override
-	public String path() {
-		return this.body.path();
-	}
-
-	/** @see GeometryProgram#label */
-	@Override
-	public String label() {
-		return this.body.label();
-	}
-
-	/**
-	 * Rotates the ring buffer, once the frame's draw has been recorded.
-	 *
-	 * @see GeometryProgram#rotate
-	 */
-	void rotate() {
-		this.body.rotate();
-	}
-
-	/**
-	 * Closes this program's block and the placeholder textures it made.
-	 *
-	 * @see GeometryProgram#release
-	 */
-	void release() {
-		this.body.release();
-	}
 }

--- a/common/src/main/java/dev/vitrail/render/DistantProgram.java
+++ b/common/src/main/java/dev/vitrail/render/DistantProgram.java
@@ -5,7 +5,6 @@ import dev.vitrail.glsl.DistantVertex;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
-import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.PrimitiveTopology;
@@ -14,9 +13,6 @@ import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.platform.CompareOp;
 import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderPass;
-import com.mojang.blaze3d.systems.RenderPassDescriptor;
-import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vulkan.VulkanDevice;
 import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
@@ -70,7 +66,7 @@ import java.util.Optional;
  * into the layout, and DH's mesh has no region. It has a section instead, and that is what the
  * second uniform block is for.
  */
-final class DistantProgram implements DumpedProgram {
+final class DistantProgram extends FamilyProgram {
 
 	/** What the log calls this geometry, one word in the middle of a sentence. */
 	private static final String FAMILY = "far terrain";
@@ -102,10 +98,8 @@ final class DistantProgram implements DumpedProgram {
 	private static final DepthStencilState SHADOW_DEPTH =
 			new DepthStencilState(CompareOp.LESS_THAN_OR_EQUAL, true);
 
-	private final GeometryProgram body;
-
 	private DistantProgram(GeometryProgram body) {
-		this.body = body;
+		super(body);
 	}
 
 	/**
@@ -197,48 +191,12 @@ final class DistantProgram implements DumpedProgram {
 	}
 
 	/**
-	 * The pass this program is drawn into, or null to open the plain one.
-	 *
-	 * @see GeometryProgram#descriptor
-	 */
-	RenderPassDescriptor descriptor(GpuTextureView colour, GpuTextureView depth) {
-		return this.body.descriptor(colour, depth);
-	}
-
-	/**
 	 * Whether the pass to open is the plain one, with none of the pack's own targets named.
 	 *
 	 * @see GeometryProgram#plain
 	 */
 	boolean plain() {
 		return this.body.plain();
-	}
-
-	/**
-	 * Binds this program's block and every sampler it declares, inside the pass just opened.
-	 *
-	 * @see GeometryProgram#bind
-	 */
-	void bind(RenderPass pass) {
-		this.body.bind(pass);
-	}
-
-	/** @see GeometryProgram#compile */
-	@Override
-	public boolean compile(GpuDevice device) {
-		return this.body.compile(device);
-	}
-
-	/** @see GeometryProgram#compiled */
-	@Override
-	public boolean compiled() {
-		return this.body.compiled();
-	}
-
-	/** @see GeometryProgram#forgetCompiled */
-	@Override
-	public void forgetCompiled() {
-		this.body.forgetCompiled();
 	}
 
 	@Override
@@ -250,47 +208,7 @@ final class DistantProgram implements DumpedProgram {
 			return false;
 		}
 
-		return this.body.warmAhead(device, compiler);
+		return super.warmAhead(device, compiler);
 	}
 
-	@Override
-	public void discardAhead() {
-		this.body.discardAhead();
-	}
-
-	/** @see GeometryProgram#decoded */
-	@Override
-	public String decoded(WorldState world) {
-		return this.body.decoded(world);
-	}
-
-	/** @see GeometryProgram#path */
-	@Override
-	public String path() {
-		return this.body.path();
-	}
-
-	/** @see GeometryProgram#label */
-	@Override
-	public String label() {
-		return this.body.label();
-	}
-
-	/**
-	 * Rotates the ring buffer, once the frame's draws have been recorded.
-	 *
-	 * @see GeometryProgram#rotate
-	 */
-	void rotate() {
-		this.body.rotate();
-	}
-
-	/**
-	 * Closes this program's block and the placeholder textures it made.
-	 *
-	 * @see GeometryProgram#release
-	 */
-	void release() {
-		this.body.release();
-	}
 }

--- a/common/src/main/java/dev/vitrail/render/DumpedProgram.java
+++ b/common/src/main/java/dev/vitrail/render/DumpedProgram.java
@@ -47,8 +47,9 @@ interface DumpedProgram {
 
 	/**
 	 * Compiles this program's pipeline on the pack-load worker, so its first draw finds the work
-	 * already paid instead of paying shaderc on the render thread. The six on-demand families
-	 * override it; the terrain does not, compiling while the world is still held back.
+	 * already paid instead of paying shaderc on the render thread. {@link FamilyProgram} hands it
+	 * to the program for the six on-demand families; the terrain turns it off, compiling while
+	 * the world is still held back.
 	 *
 	 * @param compiler the worker's own compiler, never the device's: the device's belongs to the
 	 *                 render thread along with the caches around it

--- a/common/src/main/java/dev/vitrail/render/EntityProgram.java
+++ b/common/src/main/java/dev/vitrail/render/EntityProgram.java
@@ -4,10 +4,8 @@ import dev.vitrail.glsl.EntityVertex;
 import dev.vitrail.glsl.LinesVertex;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.program.ProgramFallbacks;
-import dev.vitrail.pack.program.RenderStage;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
-import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.platform.CompareOp;
@@ -15,13 +13,8 @@ import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderPass;
-import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vulkan.VulkanDevice;
-import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 import org.joml.Matrix4fc;
 
@@ -91,7 +84,7 @@ import java.util.Set;
  * {@code pipeline/IrisPipelines.java:150,160,193,205,217}), which is a narrower claim and the true
  * one.
  */
-final class EntityProgram implements DumpedProgram {
+final class EntityProgram extends FamilyProgram {
 
 	/** What the log calls this geometry, one word in the middle of a sentence. */
 	private static final String FAMILY = "entity";
@@ -121,10 +114,8 @@ final class EntityProgram implements DumpedProgram {
 		return element.lines() ? LinesVertex.ANSWERED : EntityVertex.ANSWERED;
 	}
 
-	private final GeometryProgram body;
-
 	private EntityProgram(GeometryProgram body) {
-		this.body = body;
+		super(body);
 	}
 
 	/**
@@ -320,59 +311,12 @@ final class EntityProgram implements DumpedProgram {
 	}
 
 	/**
-	 * The pass the run is recorded into, or null, which the caller answers with a plain pass of its
-	 * own or with a refusal.
-	 *
-	 * @see GeometryProgram#descriptor
-	 */
-	RenderPassDescriptor descriptor(GpuTextureView colour, GpuTextureView depth) {
-		return this.body.descriptor(colour, depth);
-	}
-
-	/**
 	 * Whether the pass to open is the plain one, with none of the pack's own targets named.
 	 *
 	 * @see GeometryProgram#plain
 	 */
 	boolean plain() {
 		return this.body.plain();
-	}
-
-	/**
-	 * Binds this program's block and every sampler it declares, inside the pass just opened.
-	 *
-	 * @see GeometryProgram#bind
-	 */
-	void bind(RenderPass pass) {
-		this.body.bind(pass);
-	}
-
-	/** @see GeometryProgram#compile */
-	@Override
-	public boolean compile(GpuDevice device) {
-		return this.body.compile(device);
-	}
-
-	/** @see GeometryProgram#compiled */
-	@Override
-	public boolean compiled() {
-		return this.body.compiled();
-	}
-
-	/** @see GeometryProgram#forgetCompiled */
-	@Override
-	public void forgetCompiled() {
-		this.body.forgetCompiled();
-	}
-
-	@Override
-	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
-		return this.body.warmAhead(device, compiler);
-	}
-
-	@Override
-	public void discardAhead() {
-		this.body.discardAhead();
 	}
 
 	/**
@@ -385,39 +329,4 @@ final class EntityProgram implements DumpedProgram {
 		return this.body.readsGameTransforms();
 	}
 
-	/** @see GeometryProgram#decoded */
-	@Override
-	public String decoded(WorldState world) {
-		return this.body.decoded(world);
-	}
-
-	/** @see GeometryProgram#path */
-	@Override
-	public String path() {
-		return this.body.path();
-	}
-
-	/** @see GeometryProgram#label */
-	@Override
-	public String label() {
-		return this.body.label();
-	}
-
-	/**
-	 * Rotates the ring buffer, once the frame's draw has been recorded.
-	 *
-	 * @see GeometryProgram#rotate
-	 */
-	void rotate() {
-		this.body.rotate();
-	}
-
-	/**
-	 * Closes this program's block and the placeholder textures it made.
-	 *
-	 * @see GeometryProgram#release
-	 */
-	void release() {
-		this.body.release();
-	}
 }

--- a/common/src/main/java/dev/vitrail/render/FamilyProgram.java
+++ b/common/src/main/java/dev/vitrail/render/FamilyProgram.java
@@ -1,0 +1,115 @@
+package dev.vitrail.render;
+
+import dev.vitrail.uniform.WorldState;
+
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.RenderPass;
+import com.mojang.blaze3d.systems.RenderPassDescriptor;
+import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
+
+/**
+ * What every family's program is over the {@link GeometryProgram} it holds: the part of the
+ * contract that is the same seven times, delegated once.
+ * <p>
+ * A family adapter exists for what differs, which is how its geometry is placed and what it is
+ * drawn with: the sky hands in a model view and a colour, the terrain an atlas, the far terrain a
+ * projection. Everything that is not that, compiling, dumping, rotating the ring, releasing, was
+ * written out seven times as {@code return this.body.x();}, and a family that forgot one of them
+ * silently took the interface's default: it compiled, it drew, and it paid shaderc on the render
+ * thread at its first draw with nothing to say so. Here the default is the delegation, and the
+ * one family that must not compile ahead says so where it stands.
+ */
+abstract class FamilyProgram implements DumpedProgram {
+
+	protected final GeometryProgram body;
+
+	FamilyProgram(GeometryProgram body) {
+		this.body = body;
+	}
+
+	/**
+	 * The pass this program is drawn into, or null to leave the renderer the one it meant to open.
+	 *
+	 * @see GeometryProgram#descriptor
+	 */
+	RenderPassDescriptor descriptor(GpuTextureView colour, GpuTextureView depth) {
+		return this.body.descriptor(colour, depth);
+	}
+
+	/**
+	 * Binds this program's block and every sampler it declares, inside the pass just opened.
+	 *
+	 * @see GeometryProgram#bind
+	 */
+	void bind(RenderPass pass) {
+		this.body.bind(pass);
+	}
+
+	/** @see GeometryProgram#compile */
+	@Override
+	public boolean compile(GpuDevice device) {
+		return this.body.compile(device);
+	}
+
+	/** @see GeometryProgram#compiled */
+	@Override
+	public boolean compiled() {
+		return this.body.compiled();
+	}
+
+	/** @see GeometryProgram#forgetCompiled */
+	@Override
+	public void forgetCompiled() {
+		this.body.forgetCompiled();
+	}
+
+	/** @see GeometryProgram#warmAhead */
+	@Override
+	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
+		return this.body.warmAhead(device, compiler);
+	}
+
+	/** @see GeometryProgram#discardAhead */
+	@Override
+	public void discardAhead() {
+		this.body.discardAhead();
+	}
+
+	/** @see GeometryProgram#decoded */
+	@Override
+	public String decoded(WorldState world) {
+		return this.body.decoded(world);
+	}
+
+	/** @see GeometryProgram#path */
+	@Override
+	public String path() {
+		return this.body.path();
+	}
+
+	/** @see GeometryProgram#label */
+	@Override
+	public String label() {
+		return this.body.label();
+	}
+
+	/**
+	 * Rotates the ring buffer, once the frame's draw has been recorded.
+	 *
+	 * @see GeometryProgram#rotate
+	 */
+	void rotate() {
+		this.body.rotate();
+	}
+
+	/**
+	 * Closes this program's block and the placeholder textures it made.
+	 *
+	 * @see GeometryProgram#release
+	 */
+	void release() {
+		this.body.release();
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/ParticleProgram.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleProgram.java
@@ -3,19 +3,14 @@ package dev.vitrail.render;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
-import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderPass;
-import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
-import com.mojang.blaze3d.vulkan.VulkanDevice;
-import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 import java.util.List;
 import java.util.Set;
@@ -43,7 +38,7 @@ import java.util.Set;
  * {@link SkyProgram} gives: the word is what makes Sodium's mixin push twenty bytes of region offset
  * into the layout, and a particle mesh has no region.
  */
-final class ParticleProgram implements DumpedProgram {
+final class ParticleProgram extends FamilyProgram {
 
 	/** What the log calls this geometry, one word in the middle of a sentence. */
 	private static final String FAMILY = "particles";
@@ -61,10 +56,8 @@ final class ParticleProgram implements DumpedProgram {
 	 */
 	private static final Set<String> ANSWERED = Set.of();
 
-	private final GeometryProgram body;
-
 	private ParticleProgram(GeometryProgram body) {
-		this.body = body;
+		super(body);
 	}
 
 	/**
@@ -140,30 +133,12 @@ final class ParticleProgram implements DumpedProgram {
 	}
 
 	/**
-	 * The pass this program is drawn into, or null to leave the renderer the one it meant to open.
-	 *
-	 * @see GeometryProgram#descriptor
-	 */
-	RenderPassDescriptor descriptor(GpuTextureView colour, GpuTextureView depth) {
-		return this.body.descriptor(colour, depth);
-	}
-
-	/**
 	 * Whether the pass to open is the plain one, with none of the pack's own targets named.
 	 *
 	 * @see GeometryProgram#plain
 	 */
 	boolean plain() {
 		return this.body.plain();
-	}
-
-	/**
-	 * Binds this program's block and every sampler it declares, inside the pass just opened.
-	 *
-	 * @see GeometryProgram#bind
-	 */
-	void bind(RenderPass pass) {
-		this.body.bind(pass);
 	}
 
 	/**
@@ -175,67 +150,4 @@ final class ParticleProgram implements DumpedProgram {
 		return this.body.reshape(device, layout);
 	}
 
-	/** @see GeometryProgram#compile */
-	@Override
-	public boolean compile(GpuDevice device) {
-		return this.body.compile(device);
-	}
-
-	/** @see GeometryProgram#compiled */
-	@Override
-	public boolean compiled() {
-		return this.body.compiled();
-	}
-
-	/** @see GeometryProgram#forgetCompiled */
-	@Override
-	public void forgetCompiled() {
-		this.body.forgetCompiled();
-	}
-
-	@Override
-	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
-		return this.body.warmAhead(device, compiler);
-	}
-
-	@Override
-	public void discardAhead() {
-		this.body.discardAhead();
-	}
-
-	/** @see GeometryProgram#decoded */
-	@Override
-	public String decoded(WorldState world) {
-		return this.body.decoded(world);
-	}
-
-	/** @see GeometryProgram#path */
-	@Override
-	public String path() {
-		return this.body.path();
-	}
-
-	/** @see GeometryProgram#label */
-	@Override
-	public String label() {
-		return this.body.label();
-	}
-
-	/**
-	 * Rotates the ring buffer, once the frame's draw has been recorded.
-	 *
-	 * @see GeometryProgram#rotate
-	 */
-	void rotate() {
-		this.body.rotate();
-	}
-
-	/**
-	 * Closes this program's block and the placeholder textures it made.
-	 *
-	 * @see GeometryProgram#release
-	 */
-	void release() {
-		this.body.release();
-	}
 }

--- a/common/src/main/java/dev/vitrail/render/SkyProgram.java
+++ b/common/src/main/java/dev/vitrail/render/SkyProgram.java
@@ -4,17 +4,12 @@ import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.glsl.SkyVertex;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
-import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderPass;
-import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
-import com.mojang.blaze3d.vulkan.VulkanDevice;
-import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 import org.joml.Matrix4fc;
 import org.joml.Vector4fc;
@@ -44,7 +39,7 @@ import java.util.Set;
  * Sodium's mixin push twenty bytes of region offset into the layout, and the sky is the game's
  * geometry: it has no region and no push constants, and borrowing the word would push them anyway.
  */
-final class SkyProgram implements DumpedProgram {
+final class SkyProgram extends FamilyProgram {
 
 	/** What the log calls this geometry, one word in the middle of a sentence. */
 	private static final String FAMILY = "sky";
@@ -52,10 +47,8 @@ final class SkyProgram implements DumpedProgram {
 	/** Ours, and deliberately without the word that turns push constants on. See the class comment. */
 	private static final String NAMESPACE = Vitrail.MOD_ID;
 
-	private final GeometryProgram body;
-
 	private SkyProgram(GeometryProgram body) {
-		this.body = body;
+		super(body);
 	}
 
 	/**
@@ -137,52 +130,6 @@ final class SkyProgram implements DumpedProgram {
 	}
 
 	/**
-	 * The pass this program is drawn into, or null to leave the renderer the one it meant to open.
-	 *
-	 * @see GeometryProgram#descriptor
-	 */
-	RenderPassDescriptor descriptor(GpuTextureView colour, GpuTextureView depth) {
-		return this.body.descriptor(colour, depth);
-	}
-
-	/**
-	 * Binds this program's block and every sampler it declares, inside the pass just opened.
-	 *
-	 * @see GeometryProgram#bind
-	 */
-	void bind(RenderPass pass) {
-		this.body.bind(pass);
-	}
-
-	/** @see GeometryProgram#compile */
-	@Override
-	public boolean compile(GpuDevice device) {
-		return this.body.compile(device);
-	}
-
-	/** @see GeometryProgram#compiled */
-	@Override
-	public boolean compiled() {
-		return this.body.compiled();
-	}
-
-	/** @see GeometryProgram#forgetCompiled */
-	@Override
-	public void forgetCompiled() {
-		this.body.forgetCompiled();
-	}
-
-	@Override
-	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
-		return this.body.warmAhead(device, compiler);
-	}
-
-	@Override
-	public void discardAhead() {
-		this.body.discardAhead();
-	}
-
-	/**
 	 * Whether the pipeline a pass has bound is this program's.
 	 *
 	 * @see GeometryProgram#owns
@@ -191,39 +138,4 @@ final class SkyProgram implements DumpedProgram {
 		return this.body.owns(bound);
 	}
 
-	/** @see GeometryProgram#decoded */
-	@Override
-	public String decoded(WorldState world) {
-		return this.body.decoded(world);
-	}
-
-	/** @see GeometryProgram#path */
-	@Override
-	public String path() {
-		return this.body.path();
-	}
-
-	/** @see GeometryProgram#label */
-	@Override
-	public String label() {
-		return this.body.label();
-	}
-
-	/**
-	 * Rotates the ring buffer, once the frame's draw has been recorded.
-	 *
-	 * @see GeometryProgram#rotate
-	 */
-	void rotate() {
-		this.body.rotate();
-	}
-
-	/**
-	 * Closes this program's block and the placeholder textures it made.
-	 *
-	 * @see GeometryProgram#release
-	 */
-	void release() {
-		this.body.release();
-	}
 }

--- a/common/src/main/java/dev/vitrail/render/TerrainProgram.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainProgram.java
@@ -8,7 +8,6 @@ import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.target.TargetSize;
-import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.PrimitiveTopology;
@@ -17,12 +16,12 @@ import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderPass;
-import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 import java.io.IOException;
 import java.util.EnumMap;
@@ -57,7 +56,7 @@ import java.util.Optional;
  * <strong>A family whose geometry is not Sodium's must not borrow it</strong>, or it takes the push
  * constants with it.
  */
-public final class TerrainProgram implements DumpedProgram {
+public final class TerrainProgram extends FamilyProgram {
 
 	/** The one name that decides everything. See the class comment before shortening it. */
 	private static final String NAMESPACE = Vitrail.MOD_ID + "_sodium";
@@ -65,12 +64,10 @@ public final class TerrainProgram implements DumpedProgram {
 	/** What the log calls this geometry, one word in the middle of a sentence. */
 	private static final String FAMILY = "chunk";
 
-	private final GeometryProgram body;
-
 	private TerrainProgram(TerrainPass pass, PackProgram.Loaded loaded, PackValues values, int load,
 			VertexFormat format, List<ChainPlan.Attachment> writes, ColorTargets targets,
 			boolean chainRuns) {
-		this.body = new GeometryProgram(new GeometryProgram.Pass(FAMILY,
+		super(new GeometryProgram(new GeometryProgram.Pass(FAMILY,
 				pass.name().toLowerCase(Locale.ROOT), NAMESPACE, SodiumVertex.ANSWERED,
 				pass.shadow(),
 				// The translucent half blends over the world, the two opaque ones write outright.
@@ -93,7 +90,21 @@ public final class TerrainProgram implements DumpedProgram {
 				null,
 				// Drawn in the game's own volume, so the dh matrices answer the game's.
 				false),
-				loaded, values, load, format, writes, targets, chainRuns);
+				loaded, values, load, format, writes, targets, chainRuns));
+	}
+
+	/**
+	 * Never ahead: the chunk programs compile while the world is still held back, on the render
+	 * thread where the renderer asks for its shader, and the load worker leaves them alone. The
+	 * six on-demand families take the base's road; this one turns it off where it stands.
+	 */
+	@Override
+	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
+		return false;
+	}
+
+	@Override
+	public void discardAhead() {
 	}
 
 	/**
@@ -242,33 +253,6 @@ public final class TerrainProgram implements DumpedProgram {
 		return this.body.prepare(device, atlas);
 	}
 
-	/** @see GeometryProgram#compile */
-	@Override
-	public boolean compile(GpuDevice device) {
-		return this.body.compile(device);
-	}
-
-	/** @see GeometryProgram#compiled */
-	@Override
-	public boolean compiled() {
-		return this.body.compiled();
-	}
-
-	/** @see GeometryProgram#forgetCompiled */
-	@Override
-	public void forgetCompiled() {
-		this.body.forgetCompiled();
-	}
-
-	/**
-	 * Binds this program's block and every sampler it declares, inside the pass just opened.
-	 *
-	 * @see GeometryProgram#bind
-	 */
-	void bind(RenderPass pass) {
-		this.body.bind(pass);
-	}
-
 	/**
 	 * Takes the sampler this pack's terrain reads the block atlas through, mipmaps, filtering and
 	 * anisotropy included.
@@ -306,48 +290,4 @@ public final class TerrainProgram implements DumpedProgram {
 		return this.body.covers();
 	}
 
-	/**
-	 * The pass this program is drawn into, or null to leave the chunk renderer its own.
-	 *
-	 * @see GeometryProgram#descriptor
-	 */
-	RenderPassDescriptor descriptor(GpuTextureView colour, GpuTextureView depth) {
-		return this.body.descriptor(colour, depth);
-	}
-
-	/**
-	 * Rotates the ring buffer, once the frame's draw has been recorded.
-	 *
-	 * @see GeometryProgram#rotate
-	 */
-	void rotate() {
-		this.body.rotate();
-	}
-
-	/** @see GeometryProgram#decoded */
-	@Override
-	public String decoded(WorldState world) {
-		return this.body.decoded(world);
-	}
-
-	/** @see GeometryProgram#path */
-	@Override
-	public String path() {
-		return this.body.path();
-	}
-
-	/** @see GeometryProgram#label */
-	@Override
-	public String label() {
-		return this.body.label();
-	}
-
-	/**
-	 * Closes this program's block and the placeholder textures it made.
-	 *
-	 * @see GeometryProgram#release
-	 */
-	void release() {
-		this.body.release();
-	}
 }

--- a/common/src/main/java/dev/vitrail/render/WeatherProgram.java
+++ b/common/src/main/java/dev/vitrail/render/WeatherProgram.java
@@ -3,18 +3,13 @@ package dev.vitrail.render;
 import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.TargetPlan;
-import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderPass;
-import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.textures.GpuSampler;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vulkan.VulkanDevice;
-import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 
 import java.util.List;
 import java.util.Set;
@@ -41,7 +36,7 @@ import java.util.Set;
  * {@link SkyProgram} gives: the word is what makes Sodium's mixin push twenty bytes of region offset
  * into the layout, and a weather mesh has no region.
  */
-final class WeatherProgram implements DumpedProgram {
+final class WeatherProgram extends FamilyProgram {
 
 	/** What the log calls this geometry, one word in the middle of a sentence. */
 	private static final String FAMILY = "weather";
@@ -59,10 +54,8 @@ final class WeatherProgram implements DumpedProgram {
 	 */
 	private static final Set<String> ANSWERED = Set.of();
 
-	private final GeometryProgram body;
-
 	private WeatherProgram(GeometryProgram body) {
-		this.body = body;
+		super(body);
 	}
 
 	/**
@@ -142,15 +135,6 @@ final class WeatherProgram implements DumpedProgram {
 	}
 
 	/**
-	 * The pass this program is drawn into, or null to leave the renderer the one it meant to open.
-	 *
-	 * @see GeometryProgram#descriptor
-	 */
-	RenderPassDescriptor descriptor(GpuTextureView colour, GpuTextureView depth) {
-		return this.body.descriptor(colour, depth);
-	}
-
-	/**
 	 * Whether the pass to open is the plain one, with none of the pack's own targets named.
 	 *
 	 * @see GeometryProgram#plain
@@ -168,76 +152,4 @@ final class WeatherProgram implements DumpedProgram {
 		return this.body.owns(bound);
 	}
 
-	/**
-	 * Binds this program's block and every sampler it declares, inside the pass just opened.
-	 *
-	 * @see GeometryProgram#bind
-	 */
-	void bind(RenderPass pass) {
-		this.body.bind(pass);
-	}
-
-	/** @see GeometryProgram#compile */
-	@Override
-	public boolean compile(GpuDevice device) {
-		return this.body.compile(device);
-	}
-
-	/** @see GeometryProgram#compiled */
-	@Override
-	public boolean compiled() {
-		return this.body.compiled();
-	}
-
-	/** @see GeometryProgram#forgetCompiled */
-	@Override
-	public void forgetCompiled() {
-		this.body.forgetCompiled();
-	}
-
-	@Override
-	public boolean warmAhead(VulkanDevice device, GlslCompiler compiler) {
-		return this.body.warmAhead(device, compiler);
-	}
-
-	@Override
-	public void discardAhead() {
-		this.body.discardAhead();
-	}
-
-	/** @see GeometryProgram#decoded */
-	@Override
-	public String decoded(WorldState world) {
-		return this.body.decoded(world);
-	}
-
-	/** @see GeometryProgram#path */
-	@Override
-	public String path() {
-		return this.body.path();
-	}
-
-	/** @see GeometryProgram#label */
-	@Override
-	public String label() {
-		return this.body.label();
-	}
-
-	/**
-	 * Rotates the ring buffer, once the frame's draw has been recorded.
-	 *
-	 * @see GeometryProgram#rotate
-	 */
-	void rotate() {
-		this.body.rotate();
-	}
-
-	/**
-	 * Closes this program's block and the placeholder textures it made.
-	 *
-	 * @see GeometryProgram#release
-	 */
-	void release() {
-		this.body.release();
-	}
 }


### PR DESCRIPTION
## What changes

Nothing a pack or a player sees. The seven family programs, sky, clouds, weather, particles, entities, chunk terrain and far terrain, each held a `GeometryProgram` and delegated the same ten methods to it word for word, with compiling ahead written six times over. They now extend one `FamilyProgram` that carries those delegations once, and each family keeps only what differs: how its geometry is placed and what it is drawn with. The chunk terrain, the one family that must not compile ahead, turns that road off explicitly where before it did so by leaving a method out, and the far terrain keeps its guard over the base road. Six hundred lines of identical bodies and their javadoc go.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

- `gradlew build` green.
- Every delegation the base carries was compared body for body across the seven files before it was lifted: ten methods identical in all seven, two identical in the six that had them, and the three the families keep (`owns`, `plain`, `texture`) left where they are.
- In the game: not yet. What to look at when the bench frees: a pack on the arena, sky, clouds, particles, entities and the hand drawn by the pack as before, and the log's "leftover pipelines compiled ahead of their first draw" line naming the same counts.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
