### PR TITLE
fix(render): run a mip chain down to one texel on the longer side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,32 @@ what the next one holds.
   world, so a far hill still casting into the view dropped out of the map. The light's walk is
   no longer shortened by the camera's fog.
 
+- **A colour target read at a lod carries the whole chain OpenGL would have built.** On a
+  screen wider than it is tall the chain stopped one level short, at two texels by one, and a
+  pack reading past that level was clamped to it where Iris had one more. The chain runs to one
+  texel on the longer side now, on every screen.
+
+- **A compute program that reads `centerDepthSmooth` reads the smoothed centre depth.** When
+  no fullscreen pass of the pack read the name and a compute did, the compute was handed the far
+  plane on every frame. A compute hanging off a pass now arms the fold as the pass would.
+
+- **A pack's own `smooth()` accumulators restart with a dimension.** They went on from the
+  previous world for the seconds their half-life takes while the wetness and the eye brightness
+  beside them restarted; a world change forgets them with the rest.
+
+- **A storage image the graphics card will not give stops the pack instead of drawing it wrong.**
+  The image was skipped and every program naming it drew on, with the wrong kind of resource
+  bound under the name, which no driver has to survive. The pack is refused at that screen size
+  now, and refused for the session with the reason on the settings screen when the image is of a
+  size the pack chose, since no window size changes that.
+
+- **Opening the settings of a pack from the list, then moving on to another pack, no longer
+  aims the next Apply at the first one.** The bottom line and its count of forced settings also
+  described the pack previewed rather than the one chosen until the options view was opened
+  again. And the settings file shared with Iris now reads back whole when an editor left a byte
+  order mark or old Mac line endings in it: either used to turn the first line into a setting no
+  pack declares, or the whole file into one.
+
 ## 0.9.0-beta
 
 ### Added

--- a/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
@@ -19,6 +19,7 @@ import org.lwjgl.vulkan.VkImageBlit;
 import org.lwjgl.vulkan.VkImageMemoryBarrier2;
 import org.lwjgl.vulkan.VkImageSubresourceRange;
 import org.lwjgl.vulkan.VkMemoryBarrier2;
+import org.lwjgl.vulkan.VkViewport;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -35,14 +36,17 @@ import java.util.function.Supplier;
  * <p>
  * Mip chains go through {@code vkCmdBlitImage}, which is what {@code glGenerateMipmap} is on this
  * backend: scaled copies on the same command buffer, not a render pass per level. A pass per level
- * was the only public path, and each one ends with a full memory barrier. Iris pays one driver
- * call. The blit loop is that call: transfer barriers between levels so each read sees the write
- * below it, then one barrier naming what a filled chain owes the rest of the frame.
+ * was the only public path, each one ending on a full memory barrier, and the game refuses one on a
+ * level whose shorter side shifts to nought, which every chain that runs to one texel on its longer
+ * side has. Iris pays one driver call. The blit loop is that call: transfer barriers between
+ * levels so each read sees the write below it, then one barrier naming what a filled chain owes
+ * the rest of the frame.
  * <p>
  * Closing a pass still runs the encoder's full barrier. Our own labels start with {@code Vitrail}
  * and get a write-then-sample barrier instead, the rest of the frame keeping the original wait.
- * {@link PassBarrier} puts the original wait back on ours too, and sends the mip chain back to a
- * pass per level, for a machine where the narrow one is suspected of a wrong image.
+ * {@link PassBarrier} puts the original wait back on ours too, and between the blits of a chain in
+ * place of the transfer barriers, for a machine where the narrow ones are suspected of a wrong
+ * image.
  */
 @Mixin(VulkanCommandEncoder.class)
 public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
@@ -157,12 +161,7 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 
 	@Override
 	public boolean vitrail$generateMipmaps(GpuTexture texture) {
-		// Refused while the wide wait is armed, so the caller goes back to a pass per level and
-		// every one of those ends on the game's own barrier. The switch would otherwise leave the
-		// mip chain on transfer barriers alone, and a reporter whose image is still wrong with it on
-		// would clear the synchronisation for a road it never put back.
-		if (PassBarrier.full() || this.currentRenderPass != null
-				|| !(texture instanceof VulkanGpuTexture image)) {
+		if (this.currentRenderPass != null || !(texture instanceof VulkanGpuTexture image)) {
 			return false;
 		}
 
@@ -174,6 +173,10 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 		int aspect = VulkanConst.formatAspectMask(texture.getFormat());
 		int filter = integer(texture) ? VK10.VK_FILTER_NEAREST : VK10.VK_FILTER_LINEAR;
 		long vkImage = image.vkImage();
+		// The wide wait, when armed, stands where each transfer barrier would: a reporter whose
+		// image is still wrong with it on has then cleared the synchronisation of this road too,
+		// rather than of the passes alone.
+		boolean wide = PassBarrier.full();
 
 		try (MemoryStack stack = MemoryStack.stackPush()) {
 			VkCommandBuffer commands = vitrail$commandBuffer();
@@ -202,18 +205,44 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 				VK12.vkCmdBlitImage(commands, vkImage, VK10.VK_IMAGE_LAYOUT_GENERAL, vkImage,
 						VK10.VK_IMAGE_LAYOUT_GENERAL, region, filter);
 
-				if (level + 1 < levels) {
+				if (wide) {
+					VulkanCommandEncoder.memoryBarrier(commands, stack);
+				} else if (level + 1 < levels) {
 					vitrail$transferBarrier(commands, stack, vkImage, aspect, level);
 				}
 			}
 
-			vitrail$chainTailBarrier(commands, stack);
-			return true;
-		} catch (RuntimeException e) {
-			Vitrail.logger().error("Blit mipmaps failed on {}, falling back to a pass per level",
-					texture.getLabel(), e);
+			if (!wide) {
+				vitrail$chainTailBarrier(commands, stack);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * The same call the pass constructor makes, with the extent said rather than the one shifted
+	 * off the attachment. Dynamic state on the pass's own command buffer, so it holds until the
+	 * next pass opens and sets its own.
+	 */
+	@Override
+	public boolean vitrail$viewport(int width, int height) {
+		if (this.currentRenderPass == null || width <= 0 || height <= 0) {
 			return false;
 		}
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			VkViewport.Buffer viewport = VkViewport.calloc(1, stack)
+					.x(0.0F)
+					.y(0.0F)
+					.width(width)
+					.height(height)
+					.minDepth(0.0F)
+					.maxDepth(1.0F);
+			VK12.vkCmdSetViewport(vitrail$commandBuffer(), 0, viewport);
+		}
+
+		return true;
 	}
 
 	/**
@@ -254,9 +283,8 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 	 * wrote the base has already closed on its own barrier, and that is also what ordered the
 	 * first blit's read. What can touch the chain next is a sampled read from any shader stage, a
 	 * pass writing the base again, or another transfer; the image is a colour target, so no depth
-	 * stage ever meets it. The wide wait never reaches here: {@code vitrail$generateMipmaps}
-	 * refuses while it is armed, and the caller then pays a pass per level, each closing on the
-	 * game's own barrier.
+	 * stage ever meets it. The wide wait never reaches here: while it is armed, the game's own
+	 * barrier already stands after the last blit.
 	 */
 	@Unique
 	private static void vitrail$chainTailBarrier(VkCommandBuffer commands, MemoryStack stack) {

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -326,6 +326,13 @@ final class ColorTargets {
 	private int brokenHeight;
 
 	/**
+	 * Whether the refusal is about the pack after all: a storage image of a size the pack chose
+	 * and no screen can change, which another screen size would only fail at again. The latch
+	 * above never lifts on it, and the chain puts the pack away rather than asking every frame.
+	 */
+	private boolean brokenForGood;
+
+	/**
 	 * The plan describes the programs that run and no others, so what its schedule turns over is
 	 * exactly what needs a second texture. Nothing is filtered here: a set of doubled targets
 	 * worked out from anything but the schedule the samplers were bound against is a parity that
@@ -412,7 +419,8 @@ final class ColorTargets {
 		// A screen of another size is another question, so it is asked again rather than answered by
 		// the last refusal. Nothing is retried at the size that failed: a screen that stays where it
 		// is would otherwise pay a full allocation and a full log line every frame.
-		if (this.broken && (screenWidth != this.brokenWidth || screenHeight != this.brokenHeight)) {
+		if (this.broken && !this.brokenForGood
+				&& (screenWidth != this.brokenWidth || screenHeight != this.brokenHeight)) {
 			this.broken = false;
 		}
 
@@ -451,6 +459,7 @@ final class ColorTargets {
 			this.broken = true;
 			this.brokenWidth = screenWidth;
 			this.brokenHeight = screenHeight;
+			this.brokenForGood = this.storageImages.refusedForGood();
 			// The notes are printed on their own, one line each and with nothing in front of them,
 			// so this one carries its subject: the error below is written where it happened and this
 			// is read again much later, beside the notes of the plan. The size stays out of it on
@@ -458,8 +467,8 @@ final class ColorTargets {
 			// allocation keeps failing would otherwise add one line per size it passed through.
 			note(this.plan.packName() + " could not allocate its colour targets: " + e.getMessage());
 			Vitrail.logger().error("Vitrail could not allocate the colour targets of {} at {}x{}, so "
-					+ "nothing is drawn until the screen is another size", this.plan.packName(),
-					screenWidth, screenHeight, e);
+					+ "nothing is drawn {}", this.plan.packName(), screenWidth, screenHeight,
+					this.brokenForGood ? "at any size" : "until the screen is another size", e);
 
 			return false;
 		}
@@ -473,6 +482,24 @@ final class ColorTargets {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Whether {@link #ensure} has prepared this set at a real screen size and not refused it since,
+	 * at this size or at any. Read at the head of the frame, before that call is made for it, by
+	 * the one dispatch that runs there: a compute pushed over a set never prepared, or refused,
+	 * would be handed names nothing stands behind.
+	 */
+	boolean usable() {
+		return !this.broken && this.screenWidth > 0 && this.screenHeight > 0;
+	}
+
+	/**
+	 * Whether the refusal is one no screen size lifts, in which case the pack is not drawn again
+	 * this session and the reason is the one the notes carry.
+	 */
+	boolean refusedForGood() {
+		return this.brokenForGood;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -130,9 +130,11 @@ import java.util.stream.Stream;
  * moves it off the game's late call and submits it twice, and both submissions are
  * drawn by feature renderers with the pipelines of the table below, so a hand draw is indexed here
  * like a mob's. What tells it apart is the moment and not the draw, exactly as it is for a block
- * entity, and {@link #element} asks about it FIRST for the reason Iris does
- * ({@code pipeline/IrisPipelines.java:191-218}): a pipeline that would answer with the block or the
- * entity program answers with a hand program while a hand pass is up, whatever else is true of it.
+ * entity, and {@link #element} asks about it AHEAD of the block entity mark for the reason Iris
+ * does ({@code pipeline/IrisPipelines.java:191-218}): a pipeline that would answer with the block
+ * or the entity program answers with a hand program while a hand pass is up, whatever else is
+ * true of it. Only the shadow table and the fixed rows come before it, and {@link #element} says
+ * why each of those two does.
  * <p>
  * <strong>The block entities are not one of those and come in by this same door</strong>, because
  * that is where the game brings them: a chest and a mob are submitted into one phase and drawn with

--- a/common/src/main/java/dev/vitrail/render/MipmapCommands.java
+++ b/common/src/main/java/dev/vitrail/render/MipmapCommands.java
@@ -4,8 +4,10 @@ import com.mojang.blaze3d.textures.GpuTexture;
 
 /**
  * The Vulkan equivalent of {@code glGenerateMipmap}: fill every level past the base by blitting
- * each into the next, on the frame's command buffer, with one barrier at the end rather than a
- * render pass per level.
+ * each into the next, on the frame's command buffer, with one barrier at the end. The extents
+ * are floored, which is what lets a chain run to one texel on its longer side: the game's own
+ * per-level sizes shift without flooring, and it refuses a render pass on a level whose shorter
+ * side reaches nought.
  * <p>
  * Implemented on the command encoder backend. The public encoder has no such method, which is why
  * this is a duck typed onto it.
@@ -13,8 +15,21 @@ import com.mojang.blaze3d.textures.GpuTexture;
 public interface MipmapCommands {
 
 	/**
-	 * @return true when the chain was filled, false when this backend cannot, in which case the
-	 *         caller keeps the draw-based reduction
+	 * @return true when the chain was filled, false when this backend cannot or a pass is open,
+	 *         in which case the chain is left as it was
 	 */
 	boolean vitrail$generateMipmaps(GpuTexture texture);
+
+	/**
+	 * Gives the pass open on this encoder a viewport of the size said, from the origin.
+	 * <p>
+	 * The game sets a pass's viewport from the attachment's extent shifted by its level, without
+	 * flooring it, and offers no call that moves it afterwards. The last levels of a chain that
+	 * runs to one texel on the longer side have a shorter side that shifts to nought, and a draw
+	 * into one of those rasterises nothing under the viewport the game set.
+	 *
+	 * @return false when no pass is open on this encoder or this backend cannot, in which case
+	 *         the level keeps the viewport it was given
+	 */
+	boolean vitrail$viewport(int width, int height);
 }

--- a/common/src/main/java/dev/vitrail/render/MipmapReduction.java
+++ b/common/src/main/java/dev/vitrail/render/MipmapReduction.java
@@ -1,41 +1,16 @@
 package dev.vitrail.render;
 
 import dev.vitrail.mixin.access.CommandEncoderAccessor;
-import dev.vitrail.Vitrail;
 
-import com.mojang.blaze3d.GpuFormat;
-import com.mojang.blaze3d.PrimitiveTopology;
-import com.mojang.blaze3d.buffers.GpuBuffer;
-import com.mojang.blaze3d.pipeline.BindGroupLayout;
-import com.mojang.blaze3d.pipeline.ColorTargetState;
-import com.mojang.blaze3d.pipeline.RenderPipeline;
-import com.mojang.blaze3d.shaders.ShaderSource;
-import com.mojang.blaze3d.shaders.ShaderType;
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.CommandEncoderBackend;
-import com.mojang.blaze3d.systems.GpuDevice;
-import com.mojang.blaze3d.systems.RenderPass;
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.textures.FilterMode;
-import com.mojang.blaze3d.textures.GpuTextureView;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import net.minecraft.client.renderer.BindGroupLayouts;
-import net.minecraft.resources.Identifier;
-
-import java.util.EnumMap;
-import java.util.LinkedHashSet;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * Fills the mip chain of a colour target. Nothing of the pack takes part.
  * <p>
  * It exists because the public encoder has no {@code generateMipmaps}. Iris pays one
  * {@code glGenerateMipmap} per chain; the Vulkan equivalent is a blit of each level into the next
- * on the frame's command buffer. That path is taken first. The draw below is the fallback if the
- * backend is not Vulkan or the blit is refused.
+ * on the frame's command buffer, which {@link MipmapCommands} puts on the encoder.
  * <p>
  * What the packs do with those levels is not decoration: BSL drives its automatic exposure from
  * {@code texture2DLod(colortex0, vec2(0.5), log2(viewHeight * R))}, which without a chain reads
@@ -43,80 +18,15 @@ import java.util.Set;
  * wholesale the moment a jump moves that pixel from the ground to the sky. The same pack reads lods
  * for its depth of field and for the tiles of its bloom.
  * <p>
- * The blit uses the hardware linear filter, which is what {@code glGenerateMipmap} gave the packs.
- * The fallback draw is a box of four texels taken as explicit fetches, for the same reason: a
- * single bilinear fetch of the level below agrees only while both dimensions are even.
- * <p>
- * One pipeline per format, and no more: the colour state of a pipeline has to agree with the format
- * of the attachment exactly or {@code setPipeline} throws, and a pack's targets are not all of one
- * format. They are keyed by format for that reason alone, not to save compilations.
+ * The blit uses the hardware linear filter, which is what {@code glGenerateMipmap} gave the packs,
+ * and it floors the extent of every level, which is what lets a chain run to one texel on the
+ * longer side: a render pass per level was the road before it, and the game refuses a pass on a
+ * level whose shorter side shifts to nought, so that road stopped a level short of OpenGL's chain
+ * on every screen that is not as tall as it is wide.
  */
 final class MipmapReduction {
 
-	private static final Identifier VERTEX_ID =
-			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/mipmap_vertex");
-	private static final Identifier FRAGMENT_ID =
-			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/mipmap_fragment");
-
-	private static final String SAMPLER = "InSampler";
-
-	/** Two triangles, the same quad every full screen pass of the chain draws. */
-	private static final int VERTICES = 6;
-
-	private static final String VERTEX = """
-			#version 460 core
-
-			in vec3 Position;
-			in vec2 UV0;
-
-			out vec2 ofTexCoord;
-
-			void main() {
-				ofTexCoord = UV0;
-				gl_Position = vec4(Position.xy * 2.0 - 1.0, 0.0, 1.0);
-			}
-			""";
-
-	/**
-	 * The bound view carries the source level and nothing else, so {@code textureSize} at nought is
-	 * that level's size and the four fetches land on its texel centres: half a source texel either
-	 * side of the point the destination texel covers.
-	 */
-	private static final String FRAGMENT = """
-			#version 460 core
-
-			uniform sampler2D InSampler;
-
-			in vec2 ofTexCoord;
-
-			layout(location = 0) out vec4 ofFragData0;
-
-			void main() {
-				vec2 half_texel = 0.5 / vec2(textureSize(InSampler, 0));
-				ofFragData0 = 0.25 * (
-					textureLod(InSampler, ofTexCoord + vec2(-half_texel.x, -half_texel.y), 0.0)
-					+ textureLod(InSampler, ofTexCoord + vec2(half_texel.x, -half_texel.y), 0.0)
-					+ textureLod(InSampler, ofTexCoord + vec2(-half_texel.x, half_texel.y), 0.0)
-					+ textureLod(InSampler, ofTexCoord + vec2(half_texel.x, half_texel.y), 0.0));
-			}
-			""";
-
-	private static final String LABEL = "Vitrail mipmap reduction";
-
-	private final ShaderSource source;
-	private final Map<GpuFormat, RenderPipeline> pipelines = new EnumMap<>(GpuFormat.class);
-
-	/** Formats whose pipeline would not compile, so that the failure is said once and not per frame. */
-	private final Set<GpuFormat> refused = new LinkedHashSet<>();
-
-	MipmapReduction() {
-		this.source = (id, type) -> {
-			if (type == ShaderType.FRAGMENT) {
-				return FRAGMENT_ID.equals(id) ? FRAGMENT : null;
-			}
-
-			return VERTEX_ID.equals(id) ? VERTEX : null;
-		};
+	private MipmapReduction() {
 	}
 
 	/**
@@ -128,118 +38,20 @@ final class MipmapReduction {
 	 * @return false when the chain could not be filled, in which case the levels hold whatever they
 	 *         held and a lod read falls back to what it read before there were chains
 	 */
-	boolean generate(CommandEncoder encoder, GpuDevice device, GpuBuffer quad, TargetSurface surface) {
-		if (quad == null || surface == null || surface.levels() <= 1) {
+	static boolean generate(CommandEncoder encoder, TargetSurface surface) {
+		if (surface == null || surface.levels() <= 1) {
 			return false;
 		}
 
 		GeometryHold.flush(() -> "a mip chain being filled");
-		if (blit(encoder, surface)) {
-			surface.chainWritten(true);
-			return true;
-		}
-
-		RenderPipeline pipeline = pipelineFor(device, surface.texture().getFormat());
-		if (pipeline == null) {
+		CommandEncoderBackend backend = ((CommandEncoderAccessor) encoder).vitrail$backend();
+		if (!(backend instanceof MipmapCommands commands)
+				|| !commands.vitrail$generateMipmaps(surface.texture())) {
 			return false;
 		}
 
-		for (int level = 1; level < surface.levels(); level++) {
-			GpuTextureView from = surface.levelView(level - 1);
-			GpuTextureView into = surface.levelView(level);
-			if (from == null || into == null) {
-				return false;
-			}
-
-			// Loaded rather than cleared: the draw covers the level whole, so a clear would be one
-			// more write of the same texels.
-			try (RenderPass pass = encoder.createRenderPass(() -> LABEL, into, Optional.empty())) {
-				pass.setPipeline(pipeline);
-				RenderSystem.bindDefaultUniforms(pass);
-				pass.setVertexBuffer(0, quad.slice());
-				// The view holds one level, so a sampler that stops at lod nought reads exactly it.
-				pass.bindTexture(SAMPLER, from,
-						RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR));
-				pass.draw(VERTICES, 1, 0, 0);
-			}
-		}
-
-		// Only now, and only on the way out of the whole loop: a chain filled to level three out of
-		// ten is not a chain, and a reader let loose on it would climb into levels nothing wrote.
 		surface.chainWritten(true);
 
 		return true;
-	}
-
-	/** Iris's {@code glGenerateMipmap}: one blit chain, not a pass per level. */
-	private static boolean blit(CommandEncoder encoder, TargetSurface surface) {
-		CommandEncoderBackend backend = ((CommandEncoderAccessor) encoder).vitrail$backend();
-		return backend instanceof MipmapCommands commands
-				&& commands.vitrail$generateMipmaps(surface.texture());
-	}
-
-	/**
-	 * The pipeline for one attachment format, compiled the first time it is asked for and kept.
-	 * <p>
-	 * The compiled form lives in the device cache, which the game empties at every resource reload,
-	 * so this asks the device every time rather than trusting a flag of its own: that call is a
-	 * {@code computeIfAbsent} on the device side and costs nothing once it has been made.
-	 */
-	private RenderPipeline pipelineFor(GpuDevice device, GpuFormat format) {
-		if (this.refused.contains(format)) {
-			return null;
-		}
-
-		// An integer target is refused outright rather than drawn wrong. Two things break at once
-		// on one: a sampler cannot filter it at all on Vulkan, which is the rule
-		// GpuFormats.filterFor already follows for the pack's own bindings, and the shader here
-		// declares a sampler2D and a vec4 output where such a format needs a usampler2D and an
-		// ivec4. Refusing leaves the chain unwritten, which the binding now reads as level nought,
-		// so the pack gets the image it had before there were chains instead of nonsense. No pack
-		// of the corpus declares an integer format and asks for mipmaps on it; this is the guard
-		// for the one that will.
-		if (integer(format) && this.refused.add(format)) {
-			Vitrail.logger().error("The mipmap reduction cannot fill a chain on {}: an integer "
-					+ "format carries no filtering and this reduction writes floats. Targets of "
-					+ "that format keep level 0 alone and a lod read falls back to it", format);
-
-			return null;
-		}
-
-		RenderPipeline pipeline = this.pipelines.computeIfAbsent(format, MipmapReduction::build);
-		if (device.precompilePipeline(pipeline, this.source).isValid()) {
-			return pipeline;
-		}
-
-		this.refused.add(format);
-		this.pipelines.remove(format);
-		Vitrail.logger().error("The mipmap reduction did not compile for {}, the targets of that "
-				+ "format keep level 0 alone and a lod read falls back to it", format);
-
-		return null;
-	}
-
-	/** Whether a lookup on this format comes back as integers, which no sampler here can filter. */
-	private static boolean integer(GpuFormat format) {
-		return switch (format.componentType()) {
-			case UINT_8, SINT_8, UINT_16, SINT_16, UINT_32, SINT_32 -> true;
-			default -> false;
-		};
-	}
-
-	private static RenderPipeline build(GpuFormat format) {
-		return RenderPipeline.builder()
-				.withLocation(Identifier.fromNamespaceAndPath(Vitrail.MOD_ID,
-						"pipeline/mipmap_reduction/" + format.name().toLowerCase(Locale.ROOT)))
-				.withVertexShader(VERTEX_ID)
-				.withFragmentShader(FRAGMENT_ID)
-				.withBindGroupLayout(BindGroupLayouts.GLOBALS)
-				.withBindGroupLayout(BindGroupLayout.builder().withSampler(SAMPLER).build())
-				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
-				.withColorTargetState(new ColorTargetState(Optional.empty(), format,
-						ColorTargetState.WRITE_ALL))
-				.withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
-				.withCull(false)
-				.build();
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1338,13 +1338,18 @@ public final class PackChain {
 	 * half a world is worse than a pack drawing none of it: the game's own picture and the pack's own
 	 * are both credible on their own, and an image made of the two is credible and wrong. The one this
 	 * exists for puts the sky in front of the trees, and it is read as a broken sky rather than as a
-	 * family that never drew.
+	 * family that never drew. The other reason to reach it is a storage image of a size the pack
+	 * chose that the device would not give, which no screen size changes and which the frame would
+	 * otherwise ask for again at every size the window passes through.
 	 * <p>
 	 * <strong>What this does NOT do is hand the colour targets back</strong>, where the two other
-	 * places that stop a pack mid-session do. It cannot: it runs inside the chunk pass the renderer
-	 * opened, and releasing a target there tears down what that pass is drawing into. So whatever was
-	 * allocated stays held until the next load, and how much that is has not been measured, because
-	 * whether the chain had warmed by then depends on how many frames drew no section at all.
+	 * places that stop a pack mid-session do. The first reason cannot: it runs inside the chunk pass
+	 * the renderer opened, and releasing a target there tears down what that pass is drawing into.
+	 * The second reaches this outside any pass and could, and does not, so that a pack put away is
+	 * one thing and not two; what it would hand back is what stood allocated when the device
+	 * refused, which at the first frame is nothing. So whatever was allocated stays held until the
+	 * next load, and how much that is has not been measured, because whether the chain had warmed
+	 * by then depends on how many frames drew no section at all.
 	 *
 	 * @param why said in the words a player reads on the settings screen, since that is where it goes
 	 */
@@ -2131,7 +2136,7 @@ public final class PackChain {
 
 		Minecraft minecraft = Minecraft.getInstance();
 		RenderTarget main = minecraft == null ? null : minecraft.gameRenderer.mainRenderTarget();
-		if (main == null || !this.targets.ensure(main.width, main.height)) {
+		if (main == null || !ensureTargets(main)) {
 			return false;
 		}
 
@@ -3489,7 +3494,26 @@ public final class PackChain {
 		// Compared against the window every frame rather than driven by an event: the resize event
 		// fires too early, fires again when only the interface scale moved, and the panorama
 		// capture takes the main target to 4096 without going through the game's resize at all.
-		return this.targets.ensure(main.width, main.height);
+		return ensureTargets(main);
+	}
+
+	/**
+	 * The targets at the size of the game's own, and the pack put away when they refuse for a
+	 * reason no screen size lifts: an image of a size the pack chose that the device would not
+	 * give. A refusal about the screen is left to the next size, which is another question.
+	 *
+	 * @return false when nothing may be drawn this frame
+	 */
+	private boolean ensureTargets(RenderTarget main) {
+		if (this.targets.ensure(main.width, main.height)) {
+			return true;
+		}
+
+		if (this.targets.refusedForGood()) {
+			putAway("the device would not allocate an image it declares, see the log");
+		}
+
+		return false;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -3015,7 +3015,9 @@ public final class PackChain {
 
 		this.programs = List.copyOf(built);
 		this.last = built.isEmpty() ? null : built.get(built.size() - 1);
-		this.centerDepthRead = built.stream().anyMatch(PackPass::readsCenterDepth);
+		// Or a compute hanging off a pass: it is handed the same texel, so it arms the same fold.
+		this.centerDepthRead = built.stream().anyMatch(PackPass::readsCenterDepth)
+				|| this.compute.readsCenterDepth();
 		this.blockBytes = Math.max(alignment, offset);
 	}
 

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -294,9 +294,6 @@ public final class PackChain {
 	private final String world;
 	private final ColorTargets targets;
 
-	/** Fills the mip chains of the targets the programs of this place read at a lod. */
-	private final MipmapReduction mipmaps = new MipmapReduction();
-
 	/**
 	 * The chains {@link #drawRange} has filled and nothing has written over since. Held by the
 	 * surface itself and never by target and side, because the two spellings do not name surfaces
@@ -2417,15 +2414,14 @@ public final class PackChain {
 
 			// Right before the first program that reads them after a write: a chain is only true
 			// of the level nought it was built from, and every pass between the two may have
-			// written it. The reduction opens render passes of its own, which is why this is here
-			// rather than inside the draw: a pass cannot be opened while another is recording. A
-			// chain filled for an earlier reader and written over by nothing since is still true,
-			// so it is not refilled: two readers in a row used to pay two whole chains for one
-			// image.
+			// written it. The blits record outside any pass, which is why this is here rather
+			// than inside the draw: a transfer cannot be recorded while a pass is. A chain filled
+			// for an earlier reader and written over by nothing since is still true, so it is not
+			// refilled: two readers in a row used to pay two whole chains for one image.
 			for (PackPass.LodRead read : pass.lodReads()) {
 				TargetSurface surface = this.targets.surface(read.target(), read.side());
 				if (surface != null && !this.currentChains.contains(surface)
-						&& this.mipmaps.generate(encoder, device, this.quad, surface)) {
+						&& MipmapReduction.generate(encoder, surface)) {
 					this.currentChains.add(surface);
 				}
 			}

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -342,7 +342,11 @@ final class PackCompute implements AutoCloseable {
 	}
 
 	void dispatch(PackValues values, ColorTargets targets) {
-		if (this.passes.isEmpty()) {
+		// A frame the targets refused is one no pass of the chain draws, and this dispatch runs
+		// ahead of the call that would refuse it again, and of the first call of all after a
+		// load: a compute pushed here would be handed names nothing stands behind, each thrown
+		// and said once, over a frame nothing reads.
+		if (this.passes.isEmpty() || !targets.usable()) {
 			return;
 		}
 

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -159,6 +159,36 @@ final class PackCompute implements AutoCloseable {
 	}
 
 	/**
+	 * Whether a compute hanging off a full screen pass samples {@code centerDepthSmooth}, keyed
+	 * like the passes on the declaration surviving the translation. Such a compute is handed the
+	 * texel the same way its pass is, so a chain whose only reader is one has to fold it the same
+	 * way: Iris arms the fold from its compute builder as it does from a composite
+	 * ({@code pipeline/CompositeRenderer.java:466}).
+	 * <p>
+	 * The shadow computes do not count. They run at the head of the frame, before the opaque
+	 * world whose depth the fold takes exists, and Iris hands them no such sampler at all: its
+	 * shadow builder ({@code pipeline/IrisRenderingPipeline.java:544},
+	 * {@code createShadowComputes}) gives them the targets, the custom textures and images, the
+	 * level samplers, the noise and the shadow set, and the centre depth is bound nowhere but in
+	 * the composite and final builders. A shadow compute declaring the name reads here what the
+	 * fold last left, or white where nothing arms it, which is nearer what it reads under Iris
+	 * than a fold of its own would be.
+	 */
+	boolean readsCenterDepth() {
+		for (List<Pass> passes : this.chained.values()) {
+			for (Pass pass : passes) {
+				for (TranslatedUnit.Uniform sampler : pass.compute.loaded().program().samplers()) {
+					if (sampler.name().equals(SamplerPlan.centerDepth())) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Reads every compute the pack ships and the plan kept, out of the opening the load already
 	 * holds: the shadow computes for the head of the frame, and the computes hanging off a pass of
 	 * the chain for the moment before that pass.

--- a/common/src/main/java/dev/vitrail/render/PassBarrier.java
+++ b/common/src/main/java/dev/vitrail/render/PassBarrier.java
@@ -24,7 +24,7 @@ import java.nio.file.Files;
  * So: a file {@code vitrail/full-pass-barrier} in the game directory, or
  * {@code -Dvitrail.fullPassBarrier=true} where somebody has a launcher to type it in. Either puts
  * the game's own wait back on both roads where this engine traded one away: the close of a pass of
- * ours, and the mip chain, which gave up a pass per level and the barrier each of those ended on.
+ * ours, and the mip chain, whose blits are ordered by transfer barriers and a named tail instead.
  * It is slower and it cannot be the cause of anything, so an image that comes right with it names
  * the synchronisation.
  * <p>

--- a/common/src/main/java/dev/vitrail/render/StorageImages.java
+++ b/common/src/main/java/dev/vitrail/render/StorageImages.java
@@ -62,6 +62,14 @@ public final class StorageImages implements AutoCloseable {
 	private int lastHeight;
 	private boolean laidOut;
 
+	/**
+	 * Whether an image whose size does not follow the screen was refused. Another screen size is
+	 * another question for the images that follow it and for the colour targets, and not for
+	 * this one: asked again at every size the window passes through, it would fail at each with a
+	 * full allocation and a full stack trace behind it.
+	 */
+	private boolean refusedForGood;
+
 	StorageImages(ImageInformation.Reading declared) {
 		this.declared = declared;
 	}
@@ -115,9 +123,14 @@ public final class StorageImages implements AutoCloseable {
 	public record Bound(long view, boolean storage, boolean integer) {
 	}
 
+	/** Whether the last refusal was of an image no screen size can change, see {@link #ensure}. */
+	boolean refusedForGood() {
+		return this.refusedForGood;
+	}
+
 	/**
 	 * Allocates every absolute image once, and rebuilds the relative ones when the screen moves.
-	 * Failures are named and skipped: one volume is not worth taking the pack down.
+	 * A failure is the whole set given back and the frame refused, see {@link #refused}.
 	 */
 	void ensure(int screenWidth, int screenHeight) {
 		install();
@@ -136,6 +149,27 @@ public final class StorageImages implements AutoCloseable {
 			return;
 		}
 
+		// Everything or nothing: a refusal halfway through gives back what was allocated, so the
+		// next screen size the colour targets try again at starts from the first image rather
+		// than skipping the one that failed as already dealt with.
+		try {
+			allocate(vulkan, first, resized, screenWidth, screenHeight);
+		} catch (RuntimeException e) {
+			this.allocated.forEach(image -> image.destroy(vulkan));
+			this.allocated.clear();
+			this.laidOut = false;
+			rebind();
+			throw e;
+		}
+
+		this.lastWidth = screenWidth;
+		this.lastHeight = screenHeight;
+		rebind();
+		layoutIfNeeded();
+	}
+
+	private void allocate(VulkanDevice vulkan, boolean first, boolean resized, int screenWidth,
+			int screenHeight) {
 		if (first) {
 			for (ImageInformation image : this.declared.images()) {
 				if (image.relative()) {
@@ -157,8 +191,8 @@ public final class StorageImages implements AutoCloseable {
 									? ", left on the frame that filled it"
 									: "");
 				} catch (RuntimeException e) {
-					Vitrail.logger().warn("storage image {} could not be allocated: {}",
-							image.describe(), e.toString());
+					this.refusedForGood = true;
+					throw refused(image, e);
 				}
 			}
 		}
@@ -190,16 +224,26 @@ public final class StorageImages implements AutoCloseable {
 					Vitrail.logger().info("storage image {} at {}x{}", image.describe(), width,
 							height);
 				} catch (RuntimeException e) {
-					Vitrail.logger().warn("storage image {} could not be allocated: {}",
-							image.describe(), e.toString());
+					throw refused(image, e);
 				}
 			}
 		}
+	}
 
-		this.lastWidth = screenWidth;
-		this.lastHeight = screenHeight;
-		rebind();
-		layoutIfNeeded();
+	/**
+	 * An image the device would not give is the whole frame refused, and not a name skipped.
+	 * <p>
+	 * The bind group layout of every program naming the image was built off the pack's
+	 * declaration, as a storage image, before anything was allocated; the descriptor write
+	 * answers off the allocation. A name declared and not allocated would therefore be written
+	 * as a sampled image under a layout that says storage, two types under one binding, which
+	 * no driver has to survive and none reports. Thrown to the colour targets, which refuse the
+	 * frame at this size the way they do for a colour target that could not be allocated.
+	 */
+	private static IllegalStateException refused(ImageInformation image, RuntimeException cause) {
+		return new IllegalStateException("storage image " + image.describe()
+				+ " could not be allocated, and a program declaring it cannot be drawn without it",
+				cause);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/TargetSurface.java
+++ b/common/src/main/java/dev/vitrail/render/TargetSurface.java
@@ -8,8 +8,8 @@ import com.mojang.blaze3d.textures.GpuTextureView;
 import net.minecraft.util.Mth;
 
 /**
- * One colour target of a pack: its texture, the view a sampler reads it whole through, and one view
- * per mip level for the reduction to draw into.
+ * One colour target of a pack: its texture, the view a sampler reads it whole through, and the
+ * view of its base level alone for a compute to store into.
  * <p>
  * This exists because {@link com.mojang.blaze3d.pipeline.TextureTarget} cannot express a mip chain.
  * {@code RenderTarget.createBuffers} calls {@code createTexture} with a level count of one, hard
@@ -17,18 +17,11 @@ import net.minecraft.util.Mth;
  * Everything else it did for us was one texture, one view and a resize, which is what is here.
  * <p>
  * The level count is a property of the target rather than of a program: several programs may read
- * the same target at a lod, and the chain that serves them is one. It is taken from the SMALLER
- * dimension, {@code log2(min(width, height)) + 1}, and that is a correction rather than a choice.
- * The device would accept a chain as long as the larger dimension allows, but
- * {@link GpuTexture#getWidth} shifts without clamping, and the render pass that writes a level
- * takes its area straight from that shift: on an ultrawide screen a chain sized on the width
- * reaches a level whose height shifts to nought, and the pass that would fill it is asked to cover
- * nothing. Sized on the smaller dimension every level has both extents at one texel or more.
- * <p>
- * What that costs is nothing the packs can feel: on 2560x1080 the last level is two texels by one
- * instead of one by one. BSL's automatic exposure asks for
- * {@code log2(viewHeight * AUTO_EXPOSURE_RADIUS)}, which is bounded by the height, so the level it
- * lands on exists either way.
+ * the same target at a lod, and the chain that serves them is one. It runs to one texel on the
+ * LONGER side, {@code log2(max(width, height)) + 1}, which is the chain OpenGL builds and the one
+ * every pack reading a lod was written against. The shorter side floors at one texel along the
+ * way, and the blit that fills the chain floors it too; {@link GpuTexture#getWidth} does not, so
+ * a level of that tail has to be sized by hand wherever its extent is wanted.
  */
 final class TargetSurface implements AutoCloseable {
 
@@ -47,10 +40,10 @@ final class TargetSurface implements AutoCloseable {
 	private GpuTextureView view;
 
 	/**
-	 * One view per level, each covering a single level, for a render pass to attach. Null for a
-	 * surface with no chain, where the only attachment is {@link #view}.
+	 * The base level alone, for a storage descriptor. Null for a surface with no chain, where
+	 * {@link #view} is one level already.
 	 */
-	private GpuTextureView[] levelViews;
+	private GpuTextureView baseView;
 
 	private int width;
 	private int height;
@@ -90,9 +83,16 @@ final class TargetSurface implements AutoCloseable {
 		allocate(width, height);
 	}
 
-	/** The chain is as long as the smaller dimension allows, and one level when nothing reads a lod. */
+	/**
+	 * The chain runs until the LONGER side is one texel, and is one level when nothing reads a lod.
+	 * <p>
+	 * The longer side and not the shorter, which is what OpenGL's full chain is and therefore what
+	 * every pack reading a lod was written against: on a 2560 by 1440 screen a chain counted off
+	 * the shorter side stops at 2 by 1, and a lod read past that level is clamped to it where
+	 * OpenGL had one more. The shorter side floors at one texel along the way, as it does there.
+	 */
 	static int levelsFor(boolean mipped, int width, int height) {
-		return mipped ? Mth.log2(Math.min(width, height)) + 1 : 1;
+		return mipped ? Mth.log2(Math.max(width, height)) + 1 : 1;
 	}
 
 	int width() {
@@ -151,27 +151,12 @@ final class TargetSurface implements AutoCloseable {
 	 * on a surface with no chain, where the whole view is one level already.
 	 */
 	GpuTextureView storageView() {
-		GpuTextureView base = levelView(0);
-
-		return base == null ? this.view : base;
+		return this.baseView == null ? this.view : this.baseView;
 	}
 
 	/** Whether this surface was created writable from a compute, which nothing can add afterwards. */
 	boolean storage() {
 		return this.storage;
-	}
-
-	/**
-	 * One level on its own, for the reduction to draw into. A render pass attaches a view and writes
-	 * whatever it covers, so a view of one level is how a single level is written without touching
-	 * the rest of the chain.
-	 */
-	GpuTextureView levelView(int level) {
-		if (this.levelViews == null || level < 0 || level >= this.levelViews.length) {
-			return null;
-		}
-
-		return this.levelViews[level];
 	}
 
 	/**
@@ -221,10 +206,7 @@ final class TargetSurface implements AutoCloseable {
 			this.view = device.createTextureView(this.texture);
 
 			if (levels > 1) {
-				this.levelViews = new GpuTextureView[levels];
-				for (int level = 0; level < levels; level++) {
-					this.levelViews[level] = device.createTextureView(this.texture, level, 1);
-				}
+				this.baseView = device.createTextureView(this.texture, 0, 1);
 			}
 		} catch (RuntimeException e) {
 			close();
@@ -238,14 +220,9 @@ final class TargetSurface implements AutoCloseable {
 	 */
 	@Override
 	public void close() {
-		if (this.levelViews != null) {
-			for (GpuTextureView levelView : this.levelViews) {
-				if (levelView != null) {
-					levelView.close();
-				}
-			}
-
-			this.levelViews = null;
+		if (this.baseView != null) {
+			this.baseView.close();
+			this.baseView = null;
 		}
 
 		if (this.view != null) {

--- a/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
@@ -715,6 +715,17 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 	@Override
 	public void packChosen() {
 		setFocused(this.folderButton);
+		// A preview is of one pack, and the selection has left it: what was set on it would be
+		// written into that pack's file by an Apply aimed at another, and the bottom line and its
+		// forced count would go on describing a pack that is neither drawing nor chosen. Dropped
+		// here, at the click, rather than repaired on the way back to the options view.
+		PackList list = this.packList;
+		PackSession shown = this.session;
+		if (this.previewing && list != null && shown != null
+				&& !list.chosenName().equals(shown.packFileName())) {
+			giveUp(PackChain.session().orElse(null));
+		}
+
 		// The switch is live for what the list has selected, so it has to hear that the selection
 		// moved. Nothing else rebuilds this screen when a row is clicked, and without this the very
 		// first pack picked on a fresh install left the button dead until something else did.

--- a/common/src/main/java/dev/vitrail/settings/SettingsFile.java
+++ b/common/src/main/java/dev/vitrail/settings/SettingsFile.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -66,6 +67,9 @@ public final class SettingsFile {
 			"# Written by Vitrail's settings screen and by Iris, one NAME=value per line.",
 			"# Only what differs from the pack's own defaults.",
 			"# vitrail/options.txt is a different file, it is never written here, and it wins.");
+
+	/** The three bytes an editor may put in front of a UTF-8 file, which Latin-1 reads as letters. */
+	private static final byte[] BYTE_ORDER_MARK = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
 
 	private SettingsFile() {
 	}
@@ -253,14 +257,31 @@ public final class SettingsFile {
 	 * A file the player edited in another editor must not be able to take a pack down, and neither
 	 * must one this engine wrote in another encoding years ago: what is unreadable is one value, and
 	 * a lost value is what pressing Apply fixes.
+	 * <p>
+	 * A byte order mark is taken off, and the lines are cut by {@code lines()} rather than by a
+	 * split on {@code \r?\n}, for the reasons {@code SettingsLayers.text} gives: left on, the
+	 * mark rides on the first key and matches no setting, and a file saved with lone carriage
+	 * returns would come back as one line with the first key swallowing every value after it.
+	 * This is the one file shared with Iris and edited by hand, so both happen to it. The mark
+	 * is taken off the bytes and not off the text, because the format's own charset has no
+	 * notion of it: decoded as Latin-1 the three bytes come out as three letters, and a test on
+	 * the character would pass them through onto the first key.
 	 */
 	private static Map<String, String> lines(Path file, Charset charset) throws IOException {
 		if (!Files.isRegularFile(file)) {
 			return Map.of();
 		}
 
+		byte[] bytes = Files.readAllBytes(file);
+		int start = bytes.length >= BYTE_ORDER_MARK.length
+				&& Arrays.equals(bytes, 0, BYTE_ORDER_MARK.length, BYTE_ORDER_MARK, 0,
+						BYTE_ORDER_MARK.length)
+				? BYTE_ORDER_MARK.length
+				: 0;
+		String text = new String(bytes, start, bytes.length - start, charset);
+
 		Map<String, String> values = new LinkedHashMap<>();
-		for (String line : new String(Files.readAllBytes(file), charset).split("\r?\n", -1)) {
+		for (String line : text.lines().toList()) {
 			String trimmed = line.trim();
 			int equals = trimmed.indexOf('=');
 			if (trimmed.isEmpty() || trimmed.startsWith("#") || equals < 1) {

--- a/common/src/main/java/dev/vitrail/uniform/expr/ExprFunctions.java
+++ b/common/src/main/java/dev/vitrail/uniform/expr/ExprFunctions.java
@@ -24,6 +24,7 @@ import dev.vitrail.uniform.expr.kroppeb.stareval.function.TypedFunction;
 import dev.vitrail.uniform.expr.kroppeb.stareval.function.V2FFunction;
 import dev.vitrail.uniform.expr.kroppeb.stareval.function.V2IFunction;
 import dev.vitrail.uniform.Smoothed;
+import dev.vitrail.uniform.values.FrameSmoothed;
 import org.joml.Matrix4f;
 import org.joml.Vector2f;
 import org.joml.Vector2i;
@@ -1068,7 +1069,8 @@ public final class ExprFunctions {
 
 		builder.addDynamicFunction("smooth", Type.Float, () ->
 			new AbstractTypedFunction(Type.Float, parameters, withId ? 1 : 0, false) {
-				private final Smoothed smoothed = new Smoothed();
+				// Tracked, so that a world change forgets it with the engine's own smoothed values.
+				private final Smoothed smoothed = FrameSmoothed.tracked();
 
 				@Override
 				public void evaluateTo(Expression[] params, FunctionContext context, FunctionReturn functionReturn) {

--- a/common/src/main/java/dev/vitrail/uniform/values/FrameSmoothed.java
+++ b/common/src/main/java/dev/vitrail/uniform/values/FrameSmoothed.java
@@ -4,7 +4,10 @@ import dev.vitrail.uniform.Smoothed;
 import dev.vitrail.uniform.WorldState;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 /**
  * A smoothed value that steps once per frame however many passes read it.
@@ -33,6 +36,16 @@ public final class FrameSmoothed {
 	 */
 	private static final List<FrameSmoothed> ALL = new ArrayList<>();
 
+	/**
+	 * The accumulators a pack's own {@code smooth()} calls own, made when its expressions are
+	 * parsed and dropped with them. Held weakly, so that a pack that is gone takes its
+	 * accumulators with it, and forgotten with the three above: a dimension change that keeps
+	 * the pack's directory would otherwise serve the previous world's number for the seconds
+	 * its half-life takes, while wetness and the eye's brightness restart beside it.
+	 */
+	private static final Set<Smoothed> TRACKED =
+			Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+
 	private final Smoothed smoothed = new Smoothed();
 
 	private int lastFrame = -1;
@@ -42,12 +55,24 @@ public final class FrameSmoothed {
 		ALL.add(this);
 	}
 
+	/** An accumulator for a pack's own {@code smooth()}, forgotten with the engine's. */
+	public static Smoothed tracked() {
+		Smoothed smoothed = new Smoothed();
+		TRACKED.add(smoothed);
+
+		return smoothed;
+	}
+
 	/** Drops every accumulator. For a world change and for a pack load, and for nothing else. */
 	public static void forgetAll() {
 		for (FrameSmoothed smoothed : ALL) {
 			smoothed.smoothed.reset();
 			smoothed.lastFrame = -1;
 			smoothed.value = 0.0F;
+		}
+
+		synchronized (TRACKED) {
+			TRACKED.forEach(Smoothed::reset);
 		}
 	}
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -5,9 +5,9 @@ Most of it is the consequence of a single property, so that comes first.
 
 ## Most of the engine runs without the game
 
-Reading a pack, translating its GLSL, and evaluating the uniforms it expects name no Minecraft
-class. Those three source trees compile and run on their own, against a directory of real shader
-packs, with no game process, no window and no GPU.
+Reading a pack, translating its GLSL, evaluating the uniforms it expects and reading its
+settings files name no Minecraft class. Those four source trees compile and run on their own,
+against a directory of real shader packs, with no game process, no window and no GPU.
 
 That is a deliberate constraint, not an accident, and it is worth understanding what it buys:
 
@@ -19,8 +19,10 @@ The cost of breaking it is larger than it looks. Importing a Minecraft class int
 trees does not merely add a dependency, it removes a whole class of checks from everything that
 transitively touches it. Treat such an import as a design decision to be argued, not a convenience.
 
-There is one deliberate exception: a single file refers to the mod's own entry class and is
-excluded from the standalone build. One file is a maintainable seam. A growing list is a leak.
+There are two deliberate exceptions, both excluded from the standalone build: the report a pack
+gets at its first load, which writes through the mod's own logger, and the choice of graphics
+backend, which is a session's and reads the game's options. Two files are a maintainable seam.
+A growing list is a leak.
 
 ## What a contributor can run, and what they cannot
 
@@ -35,10 +37,10 @@ separate reason: it lives outside the versioned tree, so a hosted job could neit
 compile it, and wiring it in as a source set would break a fresh clone that has none of it. There is
 no hosted job that can run it either. It is local by construction, not by neglect.
 
-The practical consequence: a change under the pack, translation or uniform trees can be argued
-from the build and from reading, but the measurement that would settle it is one only a maintainer
-with a pack corpus can take. Say which of the two your change rests on rather than leaving it
-implied.
+The practical consequence: a change under the pack, translation, uniform or settings trees can be
+argued from the build and from reading, but the measurement that would settle it is one only a
+maintainer with a pack corpus can take. Say which of the two your change rests on rather than
+leaving it implied.
 
 ## What the out-of-game checks cover
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -258,9 +258,9 @@ changes need one.
 
 **The narrowed synchronisation can be put back.** An empty file `vitrail/full-pass-barrier` in the
 instance, or `-Dvitrail.fullPassBarrier=true` among the JVM arguments, closes every pass on the
-game's full memory barrier and sends the mip chain back to a pass per level. It is slower and it
-cannot be the cause of a wrong image, so it is the first thing to ask of a machine that draws one
-this one does not.
+game's full memory barrier and puts that same barrier between the levels of a mip chain. It is
+slower and it cannot be the cause of a wrong image, so it is the first thing to ask of a machine
+that draws one this one does not.
 
 **The block atlas filter can be put back the way it was.** An empty file
 `vitrail/legacy-terrain-filter` in the instance, or `-Dvitrail.legacyTerrainFilter=true`, sends a

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -117,16 +117,18 @@ a pass rather than being a clear of its own, which makes it one of those writes.
 geometry that writes the same colour and depth images stays in one pass, which is what Iris does by
 leaving `defaultFB` bound (`IrisRenderingPipeline.bindDefault`). A later composite, a copy, or a
 different framebuffer ends that hold first. Mip chains are filled with `vkCmdBlitImage` on the
-frame's command buffer, the Vulkan form of `glGenerateMipmap`, rather than a pass per level, which
-gives up the barrier each of those passes ended on and keeps transfer barriers between the levels
-instead.
+frame's command buffer, the Vulkan form of `glGenerateMipmap`, with transfer barriers between the
+levels rather than the full barrier a pass per level would have ended on. A pass per level is
+not an option in any case: the game sizes a pass off the level's extent shifted without
+flooring, and refuses one on a level whose shorter side reaches nought, which the tail of every
+chain running to one texel on its longer side has.
 
 **Both of those trades are on one switch**, because a narrow dependency that a driver honours by
 accident looks exactly like a correct one until somebody else's machine draws it. A file
 `vitrail/full-pass-barrier` in the instance, or `-Dvitrail.fullPassBarrier=true`, puts the game's own
-wait back at the close of our passes and sends the mip chain back to a pass per level. It is slower
-and it cannot be the cause of anything, which is the whole point: an image that comes right with it
-has named the synchronisation rather than the pass that shows it.
+wait back at the close of our passes and between the blits of a mip chain. It is slower and it
+cannot be the cause of anything, which is the whole point: an image that comes right with it has
+named the synchronisation rather than the pass that shows it.
 
 The practical consequence is that reading in pass N+1 what pass N wrote still requires no
 synchronisation code of our own: close, open, bind. But the barrier exists only if the pass is

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -111,8 +111,9 @@ page but the pack's first there is also the way back off it.
 - **Import** and **export** open the platform's own file window and read or write a settings file in
   the shared format. They will not open while the game is full screen, and say so: a native window
   over a full screen game hangs it on more than one platform, which is the reference's own finding.
-  What export writes is the *applied* settings, because what it copies is the file, and the file is
-  the applied settings.
+  What export writes is the *applied* settings, read from the pack's file rather than from the
+  screen, and written in Java's properties form as the reference writes it: the same keys and
+  values, with the store's own header and order rather than the file's bytes.
 - **Reset** empties this pack's settings file and applies, so the pack goes back to what it declares
   itself. It **asks first**, and it is the only control on this screen that does: it is the only one
   that can lose an evening of tuning. The reference guards the same button with shift held instead,


### PR DESCRIPTION
## What changes

Six behaviours brought back in line with the reference, none of them visible on a pack that never meets them. A colour target read at a lod now carries the chain OpenGL builds, down to one texel on the longer side: it was counted off the shorter side, because the render pass per level that filled it could not be opened on a level whose shorter side shifts to nought, so on a wide screen a pack reading past the last level was clamped to one Iris did not have. That pass per level goes; the blit fills every chain, and the `full-pass-barrier` switch puts the game's wide wait between the blits instead of sending the chain back to passes. A compute program hanging off a fullscreen pass that samples `centerDepthSmooth` now arms the fold that fills that texel, where before it read the far plane every frame; a shadow compute does not, since Iris hands it no such sampler. A pack's own `smooth()` accumulators are forgotten with a world change, as the wetness and eye brightness beside them already were. A storage image the device refuses stops the pack: it was skipped while every program naming it was drawn with a sampled image under a binding laid out as storage. The refusal is keyed on the screen size like a colour target's, and is for the session, with the reason on the settings screen, when the image is of a size the pack chose; the shadow computes dispatched at the head of the frame no longer run over a set never prepared or refused. The settings screen drops a previewed pack when the list moves to another row, so an Apply lands on the pack chosen, and the settings file shared with Iris strips a byte order mark at the byte level, where its Latin-1 charset used to decode the three bytes as three letters on the first key.

## How it differs from the reference, and for what obstacle

It does not. The one road that differed, the pass per level under the wide wait, is gone.

## What proves it

- `gradlew build` green on every commit.
- The out-of-game harness over the eight-pack corpus: `Harness`, `Chaine`, `Cibles`, `Semis`, `Expressions` identical to `dev` line for line, timings aside. `Reglages` gained a case for the shared file's byte order mark under Latin-1, which fails on `dev` and passes here; `Conditions` and `Frame` unchanged.
- In the game, Complementary Unbound on the Fabric bench, `arena bench`, 1912x1001: the mean of sixty frames against the same capture on `dev` moves only where mobs and clouds move between two launches, at the same magnitude as the earlier batches merged on that comparison. A second launch with `vitrail/full-pass-barrier` armed draws the same image through the wide wait between the blits, the log announcing the switch.

## What it leaves owing

The put-away for a refused storage image hands nothing back, like the existing put-away from the terrain: what the load allocated before its first frame stays held until the next load. The `Unreleased` section of the changelog carries two `Added` headings from an earlier merge, left as they are.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
