### PR TITLE
refactor(glsl): cut the translator along its seams

### DIFF
--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -1,0 +1,738 @@
+package dev.vitrail.glsl;
+
+import dev.vitrail.glsl.GlslTranslator.Output;
+import dev.vitrail.glsl.GlslTranslator.SplitArray;
+import dev.vitrail.glsl.GlslTranslator.SplitMatrix;
+import dev.vitrail.glsl.GlslTranslator.SplitStruct;
+import dev.vitrail.glsl.GlslTranslator.StructMember;
+import dev.vitrail.pack.program.AlphaTest;
+import dev.vitrail.pack.program.ProgramStage;
+import dev.vitrail.pack.texture.CustomImages;
+import dev.vitrail.pack.texture.VolumeAtlas;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The header written in front of one rewritten body, and nothing but that.
+ * <p>
+ * Everything the passes of {@link GlslTranslator} settled has to be declared to the compiler
+ * somewhere: the uniform block, the samplers in the order that keeps a Metal slot reachable, the
+ * attributes of the mesh the pass is drawn from, the helpers the rewrites called, the varyings
+ * both stages have to agree about, the fragment outputs from zero up with no gaps, and the
+ * {@code main} that runs the pack's own between a prologue and an epilogue. Writing that is not a
+ * pass over the text and does not belong among them, which is the whole of why it is here.
+ * <p>
+ * A record of the answers rather than a view of the translator, so that what this can see is the
+ * list below and stays the list below: every one of them is read here and not one is written back.
+ * Built once, at render, which is the first moment they are all settled.
+ */
+record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, AlphaTest alphaTest,
+		Map<String, String> engineDefines, Map<String, String> memoryQualifiers, Set<String> used,
+		Set<String> declaredNames, Map<String, String> synthesized,
+		Map<String, VolumeAtlas> readVolumes, Map<Integer, Output> packOutputs,
+		int maxFragmentOutput, Map<String, String> owedOutputs, List<SplitMatrix> splitMatrices,
+		List<SplitStruct> splitStructs, List<SplitArray> splitArrays, int gameTextureMatrix,
+		int gameModelView, int softRewrites, int trigCalls, int hashCalls, boolean mainWrapped,
+		boolean depthEpilogue, boolean terrainPrologue, boolean distantPrologue,
+		boolean entityWrapped, boolean linesWrapped, boolean alphaEpilogue, boolean covers,
+		boolean wrapsFragment, boolean ordered, boolean namesFragDepth, boolean makesOverlayColour) {
+
+	private static final String VERSION = "#version 460 core";
+
+	/** The block name has to be declared to the pipeline by hand later, so it is fixed here. */
+	private static final String UNIFORM_BLOCK = "OfGlobals";
+
+	/**
+	 * The member types that may not be interpolated, so their varying is flat whatever the pack
+	 * wrote: the integers, and the doubles the language holds to the same rule.
+	 */
+	private static final Set<String> INTEGER_MEMBER_TYPES = Set.of(
+			"int", "ivec2", "ivec3", "ivec4", "uint", "uvec2", "uvec3", "uvec4",
+			"double", "dvec2", "dvec3", "dvec4");
+
+	/** The fetch the overlay colour is made from, named so that the pack's own names cannot meet it. */
+	private static final String OVERLAY_TEXEL = "ofOverlayTexel";
+
+	private static final String FOG_STRUCT =
+			"struct OfFog { vec4 color; float density; float start; float end; float scale; };";
+
+	/**
+	 * The one output this engine adds itself: the depth the pack's geometry left at this pixel, so
+	 * that whoever puts the game's own picture into the same target can tell whether anything has
+	 * been drawn in front of it since.
+	 * <p>
+	 * A depth and not a flag, and what it buys is the whole of what a flag could not answer: the
+	 * reader compares it with the world's depth as it stands, so a pixel nothing was drawn over
+	 * compares equal and belongs to the pack, and a pixel the game drew a feature onto does not.
+	 * The pixels the pack never wrote carry a value outside zero to one instead, which every real
+	 * depth is in front of, and the reader owes them no test of their own.
+	 */
+	private static final String COVERAGE = "ofCoverage";
+
+	String header(List<TranslatedUnit.Uniform> block, List<TranslatedUnit.Uniform> samplers,
+			Set<String> varyings, Set<String> shadowed) {
+		List<String> lines = new ArrayList<>();
+		lines.add(VERSION);
+
+		for (Map.Entry<String, String> define : this.engineDefines.entrySet()) {
+			lines.add(define.getValue().isEmpty()
+					? "#define " + define.getKey()
+					: "#define " + define.getKey() + " " + define.getValue());
+		}
+
+		// The block is written in the order it was handed over, and nothing sorts it: a std140
+		// buffer is filled by walking the members, so a different order is a different buffer.
+		if (block.stream().anyMatch(member -> member.name().equals("of_Fog"))) {
+			lines.add(FOG_STRUCT);
+		}
+
+		if (!block.isEmpty()) {
+			lines.add("layout(std140) uniform " + UNIFORM_BLOCK + " {");
+			for (TranslatedUnit.Uniform member : block) {
+				lines.add("\t" + member.declaration() + ";");
+			}
+
+			lines.add("};");
+		}
+
+		// The game's own block, beside ours and never merged into it: this one is filled by the game
+		// once per draw and ours is written once per run, which is the whole reason a matrix that
+		// changes with the draw is read from over there.
+		if (this.gameTextureMatrix > 0 || this.gameModelView > 0) {
+			lines.addAll(LegacyGlsl.GAME_TRANSFORMS_BLOCK);
+		}
+
+		// Written here, in the order the program handed over, rather than left in the body. The
+		// compiler numbers a sampler by the order it first meets the name, and MoltenVK turns that
+		// number into a Metal slot that only accepts 0 through 15. Sampled names come first.
+		for (TranslatedUnit.Uniform sampler : samplers) {
+			lines.add(declareOpaque(sampler));
+		}
+
+		// Attributes stay a matter for the stage that has them. Only a vertex shader has inputs
+		// from a buffer, so there is no other side to agree with.
+		if (this.stage == ProgramStage.VERTEX) {
+			switch (this.inputs) {
+				case FULLSCREEN -> {
+					lines.addAll(LegacyGlsl.FULLSCREEN_ATTRIBUTES);
+					lines.addAll(VertexPrologue.tail(this.used, this.synthesized));
+				}
+				case TERRAIN, TERRAIN_SEPARATE_AO -> lines.addAll(SodiumVertex.prologue(this.bound,
+						this.used, this.synthesized, this.inputs.separateAo()));
+				case ENTITY, ENTITY_FULLBRIGHT -> lines.addAll(
+						EntityVertex.prologue(this.used, this.synthesized, this.inputs.fullbright()));
+				case GLINT -> lines.addAll(GlintVertex.prologue(this.used, this.synthesized));
+				case CRUMBLING -> lines.addAll(CrumblingVertex.prologue(this.used, this.synthesized));
+				case LINES -> {
+					lines.addAll(LinesVertex.prologue(this.used, this.synthesized));
+					lines.addAll(LinesVertex.widen());
+				}
+				case PARTICLE -> lines.addAll(ParticleVertex.prologue(this.used, this.synthesized));
+				case SKY -> lines.addAll(SkyVertex.prologue(this.bound, this.used, this.synthesized));
+				case CLOUDS -> lines.addAll(CloudVertex.prologue(this.used, this.synthesized));
+				case DISTANT -> lines.addAll(
+						DistantVertex.prologue(this.bound, this.used, this.synthesized));
+				case WORLD -> {
+					for (Map.Entry<String, String> attribute : LegacyGlsl.FIXED_ATTRIBUTES.entrySet()) {
+						if (this.used.contains(attribute.getKey())) {
+							lines.add("in " + attribute.getValue() + ";");
+						}
+					}
+
+					for (Map.Entry<String, String> attribute : LegacyGlsl.ENGINE_ATTRIBUTES.entrySet()) {
+						if (this.used.contains(attribute.getKey())
+								&& !this.declaredNames.contains(attribute.getKey())) {
+							lines.add("in " + attribute.getValue() + ";");
+						}
+					}
+				}
+			}
+		}
+
+		// The four taps a hardware comparison blends, for the lookups the road decision sent here:
+		// GpuSampler carries no compare mode, so when the comparison cannot ride the binding, what
+		// the hardware does is done in arithmetic instead. The hardware compares each of the four
+		// texels a bilinear filter would have taken and blends the four RESULTS, so that is what
+		// this does: textureGather brings the four back whatever filter is bound, the comparison is
+		// made on each, and the blend uses the weights of the filter. Comparing an already filtered
+		// depth is the one thing it must not do, and that is the difference: the average of four
+		// depths is a surface standing nowhere, while the average of four comparisons is a fraction
+		// of the light, which is the whole point of the thing. Iris binds GL_LINEAR plus
+		// GL_COMPARE_REF_TO_TEXTURE for it, in ShadowRenderTargets.getSamplerFor, and the hardware
+		// road binds the same pair through the descriptor instead of coming here.
+		//
+		// Not conditioned on shadowHardwareFiltering, and nothing here could condition it: the
+		// header is written per stage, before any of the pack's directives are folded. It costs
+		// nothing on this corpus. Without that directive Iris leaves the comparison mode off and
+		// what a sampler2DShadow reads is undefined, so the declaration this translation found is
+		// the only live meaning the directive has; and the harder shape the pair can ask for,
+		// NEAREST_HW, needs shadowtexNearest, which no pack of the corpus writes.
+		//
+		// The sense is LEQUAL, which is what OptiFine sets on a shadow texture and therefore what
+		// every pack is written against: one where the fragment is no further from the light than
+		// what the map holds, and the map holds the forward window where nearer is smaller.
+		//
+		// The level of detail is dropped, which is what a comparison sampler with no mipmaps would
+		// have done with it anyway: nothing ever fills a chain on the shadow map.
+		if (this.softRewrites > 0) {
+			lines.add("float " + GlslTranslator.SHADOW_COMPARE + "(sampler2D ofMap, vec3 ofAt) {"
+					+ " vec4 ofTests = step(vec4(ofAt.z), textureGather(ofMap, ofAt.xy, 0));"
+					+ " vec2 ofPart = fract(ofAt.xy * vec2(textureSize(ofMap, 0)) - 0.5);"
+					+ " return mix(mix(ofTests.w, ofTests.z, ofPart.x),"
+					+ " mix(ofTests.x, ofTests.y, ofPart.x), ofPart.y); }");
+			lines.add("float " + GlslTranslator.SHADOW_COMPARE
+					+ "(sampler2D ofMap, vec3 ofAt, float ofLod) {"
+					+ " return " + GlslTranslator.SHADOW_COMPARE + "(ofMap, ofAt); }");
+		}
+
+		// One overload per shape the builtins take, and no driver sine anywhere in it. The turn
+		// count is taken out through two constants whose sum carries two pi to thirty-three bits,
+		// so the residue keeps its low bits where a single fp32 two-pi would shed them; the residue
+		// is folded to a quarter turn and fed to the odd polynomial. Measured on the hash's own
+		// yardstick: a single-constant reduction leaves a field the uniformity test rejects at 427
+		// where white noise scores 15, and this form scores 11 to 14, alongside the reference.
+		if (this.trigCalls > 0) {
+			for (String shape : new String[] {"float", "vec2", "vec3", "vec4"}) {
+				lines.add(shape + " " + GlslTranslator.REDUCED_SIN + "(" + shape + " ofX) {"
+						+ " " + shape + " ofK = floor(ofX * 0.15915494);"
+						+ " " + shape + " ofR = ofX - ofK * 6.28125 - ofK * 1.9353072e-3;"
+						+ " ofR -= 6.2831855 * step(3.1415927, ofR);"
+						+ " " + shape + " ofS = sign(ofR);"
+						+ " " + shape + " ofA = 1.5707964 - abs(abs(ofR) - 1.5707964);"
+						+ " " + shape + " ofZ = ofA * ofA;"
+						+ " return ofS * ofA * (1.0 + ofZ * (-1.6666654611e-1"
+						+ " + ofZ * (8.3321608736e-3 + ofZ * (-1.9515295891e-4)))); }");
+				lines.add(shape + " " + GlslTranslator.REDUCED_COS + "(" + shape + " ofX) {"
+						+ " return " + GlslTranslator.REDUCED_SIN + "(ofX + 1.5707964); }");
+			}
+		}
+
+		// One overload per vector the idiom hashes. The bits are hashed rather than the sine of a
+		// huge argument, which is the whole of rewriteGoldbergHash.
+		if (this.hashCalls > 0) {
+			lines.add("float " + GlslTranslator.HASH + "(vec2 ofP) {"
+					+ " uvec2 ofV = floatBitsToUint(ofP);"
+					+ " uint ofN = (ofV.x * 1597334677u) ^ (ofV.y * 3812015801u);"
+					+ " ofN ^= ofN >> 16u;"
+					+ " ofN *= 2246822519u;"
+					+ " ofN ^= ofN >> 13u;"
+					+ " ofN *= 3266489917u;"
+					+ " ofN ^= ofN >> 16u;"
+					+ " return float(ofN) * 2.3283064365386963e-10; }");
+			lines.add("float " + GlslTranslator.HASH + "(vec3 ofP) {"
+					+ " uvec3 ofV = floatBitsToUint(ofP);"
+					+ " uint ofN = ofV.x ^ (ofV.y * 1597334677u) ^ (ofV.z * 3812015801u);"
+					+ " ofN ^= ofN >> 16u;"
+					+ " ofN *= 2246822519u;"
+					+ " ofN ^= ofN >> 13u;"
+					+ " ofN *= 3266489917u;"
+					+ " ofN ^= ofN >> 16u;"
+					+ " return float(ofN) * 2.3283064365386963e-10; }");
+		}
+
+		// Only where a lookup was moved. A stage carrying the declaration and never reading it, which
+		// is most of them, has its declaration flattened and owes no helper.
+		this.readVolumes.forEach((name, atlas) -> lines.addAll(GlslTranslator.volumeHelper(name, atlas)));
+
+		// Declared on both sides or on neither, whether this stage reads it or not. A varying the
+		// vertex writes and the fragment never mentions is accepted in silence and shifts the
+		// location of everything declared after it.
+		if (varyings.contains(GlslTranslator.FOG_COORD)) {
+			lines.add((this.stage == ProgramStage.VERTEX ? "out" : "in") + " float "
+					+ GlslTranslator.FOG_COORD + ";");
+		}
+
+		// The same rule for the overlay colour, and it arrives here by the same road: the union says
+		// yes, so both sides declare it whichever of them reads it. No interpolation qualifier, which
+		// is Iris's answer too: every vertex of one model part carries the same overlay coordinate,
+		// so what is interpolated between them is one value.
+		if (varyings.contains(GlslTranslator.ENTITY_COLOR)) {
+			lines.add((this.stage == ProgramStage.VERTEX ? "out" : "in") + " vec4 "
+					+ GlslTranslator.ENTITY_COLOR + ";");
+		}
+
+		// And the same rule again for the three identifiers, with the qualifier the language demands
+		// rather than one chosen: an integer varying may not be interpolated, so flat is not a
+		// decision here. Iris writes flat on its own ivec3 for the same reason
+		// (EntityPatcher.java:159).
+		for (String identifier : GlslTranslator.ENTITY_IDS) {
+			if (varyings.contains(identifier)) {
+				lines.add("flat " + (this.stage == ProgramStage.VERTEX ? "out" : "in") + " int "
+						+ identifier + ";");
+			}
+		}
+
+		for (SplitMatrix split : this.splitMatrices) {
+			lines.add(split.matrixType() + " " + split.name() + ";");
+			String storage = split.input() ? "in" : "out";
+			String qualified = split.qualifier().isEmpty()
+					? storage + " " + split.columnType()
+					: split.qualifier() + " " + storage + " " + split.columnType();
+			for (int column = 0; column < split.columns(); column++) {
+				lines.add(qualified + " " + GlslTranslator.matrixColumnName(split.name(), column) + ";");
+			}
+		}
+
+		// The struct's definition, once per type, then the global of the pack's name, then one
+		// varying per member in the order the struct lists them, so that both stages number them
+		// alike. The definition is written from the members read off the body, whose own copy is
+		// blank by now.
+		Set<String> defined = new HashSet<>();
+		for (SplitStruct split : this.splitStructs) {
+			if (defined.add(split.structType())) {
+				StringBuilder definition = new StringBuilder("struct ").append(split.structType())
+						.append(" { ");
+				for (StructMember member : split.members()) {
+					definition.append(member.type()).append(' ').append(member.name()).append("; ");
+				}
+
+				lines.add(definition.append("};").toString());
+			}
+
+			lines.add(split.structType() + " " + split.name() + ";");
+			String storage = split.input() ? "in" : "out";
+			for (StructMember member : split.members()) {
+				// An integer member is flat whatever the pack wrote on the struct, as the entity
+				// identifiers are: the language allows nothing else, and a struct of floats may
+				// legally carry no qualifier at all.
+				String qualifier = split.qualifier();
+				if (INTEGER_MEMBER_TYPES.contains(member.type()) && !qualifier.contains("flat")) {
+					qualifier = qualifier.isEmpty() ? "flat" : "flat " + qualifier;
+				}
+
+				String qualified = qualifier.isEmpty()
+						? storage + " " + member.type()
+						: qualifier + " " + storage + " " + member.type();
+				lines.add(qualified + " "
+						+ GlslTranslator.structMemberName(split.name(), member.name()) + ";");
+			}
+		}
+
+		// The array as a global of the pack's name, then one varying per element in index order,
+		// flat where the element may not be interpolated.
+		for (SplitArray split : this.splitArrays) {
+			lines.add(split.type() + " " + split.name() + "[" + split.size() + "];");
+			String storage = split.input() ? "in" : "out";
+			String qualifier = split.qualifier();
+			if (INTEGER_MEMBER_TYPES.contains(split.type()) && !qualifier.contains("flat")) {
+				qualifier = qualifier.isEmpty() ? "flat" : "flat " + qualifier;
+			}
+
+			String qualified = qualifier.isEmpty()
+					? storage + " " + split.type()
+					: qualifier + " " + storage + " " + split.type();
+			for (int element = 0; element < split.size(); element++) {
+				lines.add(qualified + " " + GlslTranslator.arrayElementName(split.name(), element) + ";");
+			}
+		}
+
+		// From zero up with no gaps, because a location the game finds nothing declared at is not
+		// left empty: it renumbers what is there and everything above the gap moves down one.
+		for (int slot = 0; slot <= this.maxFragmentOutput; slot++) {
+			Output output = this.packOutputs.get(slot);
+			lines.add("layout(location = " + slot + ") out "
+					+ (output == null ? "vec4" : output.type()) + " " + outputName(slot, shadowed) + ";");
+		}
+
+		// Above everything the pack declared, dead branches included, because the rank is what
+		// becomes the location and the ranks below this one are already spoken for.
+		if (this.covers) {
+			lines.add("layout(location = " + (this.maxFragmentOutput + 1) + ") out float "
+					+ COVERAGE + ";");
+		}
+
+		if (this.ordered) {
+			StringBuilder order = new StringBuilder("void " + GlslTranslator.ORDER_OUTPUTS + "() {");
+			for (int slot = 0; slot <= this.maxFragmentOutput; slot++) {
+				order.append(' ').append(outputName(slot, shadowed)).append(';');
+			}
+
+			if (this.covers) {
+				order.append(' ').append(COVERAGE).append(';');
+			}
+
+			lines.add(order.append(" }").toString());
+		}
+
+		// The same rule as the varying above, read from the other end: a varying the NEXT stage
+		// declares and this one never wrote is not a silence but a refusal, so it is declared here
+		// rather than taken out there. The qualifier travels with it, the two sides having to agree
+		// on that as well.
+		//
+		// BELOW the colour outputs and below the ascending function, for the reason the next block
+		// gives about itself: on a stage that has colour outputs, a plain out declaration met first
+		// would take location nought from the one the game writes back. Only the last stage of a
+		// pipeline has those and only a stage that is not last is ever owed anything, so the two do
+		// not meet today. They are ordered anyway rather than left to that argument holding.
+		this.owedOutputs.forEach((name, qualified) -> lines.add(outDeclaration(name, qualified)));
+
+		// Below the block, since it reads it, and below the outputs and the ascending function for a
+		// reason that decides the picture: a wrapper standing above them would be the first place the
+		// compiler met an output name, and the rank it hands out there is the location the game
+		// writes back. It has to be the ascending function that gets there first, so this goes last.
+		// The pack's body is concatenated after the header, so its own main is only a name here and
+		// has to be declared before it can be called.
+		if (this.depthEpilogue || this.terrainPrologue || this.distantPrologue || this.entityWrapped
+				|| this.linesWrapped || wrapsFragment() || owesInitialisers()
+				|| !this.splitMatrices.isEmpty() || !this.splitStructs.isEmpty()
+				|| !this.splitArrays.isEmpty()) {
+			lines.add("void " + GlslTranslator.PACK_MAIN + "();");
+			// The lines mesh runs the pack's main twice, the far end of the edge first and the
+			// vertex itself second, so that every varying holds the vertex's own value when the
+			// epilogues below read them, and widens between the two clip positions: Iris's own
+			// order (VanillaTransformer.java:214-222). The depth conversion still lands after,
+			// on the widened position, whose z the widening leaves alone.
+			String body = this.linesWrapped
+					? LinesVertex.OFFSET + " = Normal.xyz; " + GlslTranslator.PACK_MAIN
+							+ "(); vec4 of_LineEnd = "
+							+ "gl_Position; gl_Position = vec4(0.0); " + LinesVertex.OFFSET
+							+ " = vec3(0.0); " + GlslTranslator.PACK_MAIN + "(); " + LinesVertex.WIDEN
+							+ "(gl_Position, of_LineEnd);"
+					: GlslTranslator.PACK_MAIN + "();";
+			// The mask goes last of all, after the discard: a fragment the alpha test threw away
+			// covered nothing, and marking it covered would leave a hole where a leaf was.
+			lines.add("void main() { "
+					+ (this.terrainPrologue ? SodiumVertex.PROLOGUE + "(); " : "")
+					+ (this.distantPrologue ? DistantVertex.PROLOGUE + "(); " : "")
+					+ overlayPrologue()
+					+ identifierPrologue(varyings)
+					+ (wrapsFragment() ? GlslTranslator.ORDER_OUTPUTS + "(); " : "")
+					+ coveragePrologue()
+					+ owedPrologue()
+					+ matrixPrologue()
+					+ structPrologue()
+					+ arrayPrologue()
+					+ body
+					+ matrixEpilogue()
+					+ structEpilogue()
+					+ arrayEpilogue()
+					+ (this.depthEpilogue ? " gl_Position.z = " + GlslTranslator.DEPTH_CONV
+							+ ".x * gl_Position.z + " + GlslTranslator.DEPTH_CONV
+							+ ".y * gl_Position.w;" : "")
+					+ (this.alphaEpilogue
+							? " " + this.alphaTest.discard(outputName(0, shadowed) + ".a")
+							: "")
+					+ (this.covers ? " " + COVERAGE + " = " + writtenDepth() + ";" : "")
+					+ " }");
+		}
+
+		return String.join("\n", lines) + "\n";
+	}
+
+	/** Whether there is anything owed AND a wrapped main to assign it from. */
+	private boolean owesInitialisers() {
+		return this.mainWrapped && !this.owedOutputs.isEmpty();
+	}
+
+	/** The owed varyings set to their zero, ahead of the pack's own main. */
+	private String owedPrologue() {
+		if (!owesInitialisers()) {
+			return "";
+		}
+
+		StringBuilder assignments = new StringBuilder();
+		this.owedOutputs.forEach((name, qualified) ->
+				assignments.append(initialiser(name, qualified)).append(' '));
+
+		return assignments.toString();
+	}
+
+	/**
+	 * Rebuilds each input matrix from its columns before the pack body runs, so a read of the
+	 * original name still sees a {@code mat3}.
+	 */
+	private String matrixPrologue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitMatrix split : this.splitMatrices) {
+			if (!split.input()) {
+				continue;
+			}
+
+			assignments.append(split.name()).append(" = ").append(split.matrixType()).append('(');
+			for (int column = 0; column < split.columns(); column++) {
+				if (column > 0) {
+					assignments.append(", ");
+				}
+
+				assignments.append(GlslTranslator.matrixColumnName(split.name(), column));
+			}
+
+			assignments.append("); ");
+		}
+
+		return assignments.toString();
+	}
+
+	/**
+	 * Copies each output matrix onto its columns after the pack body ran, so the interface the
+	 * next stage reads is the value the pack wrote.
+	 */
+	private String matrixEpilogue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitMatrix split : this.splitMatrices) {
+			if (split.input()) {
+				continue;
+			}
+
+			for (int column = 0; column < split.columns(); column++) {
+				assignments.append(GlslTranslator.matrixColumnName(split.name(), column)).append(" = ")
+						.append(split.name()).append('[').append(column).append("]; ");
+			}
+		}
+
+		return assignments.toString();
+	}
+
+	/**
+	 * Rebuilds each input struct from its members before the pack body runs, so a read of the
+	 * original name still sees the struct. A constructor takes the members in declaration order,
+	 * which is the order they were declared in as varyings.
+	 */
+	private String structPrologue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitStruct split : this.splitStructs) {
+			if (!split.input()) {
+				continue;
+			}
+
+			assignments.append(split.name()).append(" = ").append(split.structType()).append('(');
+			for (int member = 0; member < split.members().size(); member++) {
+				if (member > 0) {
+					assignments.append(", ");
+				}
+
+				assignments.append(GlslTranslator.structMemberName(split.name(),
+						split.members().get(member).name()));
+			}
+
+			assignments.append("); ");
+		}
+
+		return assignments.toString();
+	}
+
+	/**
+	 * Copies each output struct onto its members after the pack body ran, so the interface the next
+	 * stage reads is the value the pack wrote.
+	 */
+	private String structEpilogue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitStruct split : this.splitStructs) {
+			if (split.input()) {
+				continue;
+			}
+
+			for (StructMember member : split.members()) {
+				assignments.append(GlslTranslator.structMemberName(split.name(), member.name()))
+						.append(" = ")
+						.append(split.name()).append('.').append(member.name()).append("; ");
+			}
+		}
+
+		return assignments.toString();
+	}
+
+	/** Fills each input array from its elements before the pack body runs. */
+	private String arrayPrologue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitArray split : this.splitArrays) {
+			if (!split.input()) {
+				continue;
+			}
+
+			for (int element = 0; element < split.size(); element++) {
+				assignments.append(split.name()).append('[').append(element).append("] = ")
+						.append(GlslTranslator.arrayElementName(split.name(), element)).append("; ");
+			}
+		}
+
+		return assignments.toString();
+	}
+
+	/** Copies each output array onto its elements after the pack body ran. */
+	private String arrayEpilogue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitArray split : this.splitArrays) {
+			if (split.input()) {
+				continue;
+			}
+
+			for (int element = 0; element < split.size(); element++) {
+				assignments.append(GlslTranslator.arrayElementName(split.name(), element)).append(" = ")
+						.append(split.name()).append('[').append(element).append("]; ");
+			}
+		}
+
+		return assignments.toString();
+	}
+
+	/**
+	 * What the depth attachment of this draw receives, which is what the mask is filled from.
+	 * <p>
+	 * The interpolated depth for an ordinary stage, and the stage's own where it writes one: those
+	 * are the two values the hardware may write, and the mask exists to be compared with what was
+	 * written. Neither is converted. The pack's own reads of {@code gl_FragCoord.z} are put back
+	 * into the window it was written for, and its writes to {@code gl_FragDepth} are brought out of
+	 * it again, both by {@link GlslTranslator#convertDepth}; this line is text of ours that pass
+	 * never sees, so both names here carry the value the target really holds.
+	 */
+	private String writtenDepth() {
+		return this.namesFragDepth ? "gl_FragDepth" : "gl_FragCoord.z";
+	}
+
+	/**
+	 * Gives {@code gl_FragDepth} the value the hardware would have written, before the pack's own
+	 * body runs and can write another.
+	 * <p>
+	 * <strong>Only where the mask is written and the stage names the builtin</strong>, and both
+	 * halves are paid for. A stage that names it may still leave it alone on the branch that runs -
+	 * Bliss writes it under {@code POM} and nowhere else ({@code dimensions/all_solid.fsh:359,394})
+	 * - and reading a builtin the stage never wrote is undefined, so the mask would carry whatever
+	 * the driver left there. Writing it costs the early depth test, which is why a stage that never
+	 * names it is left alone: it would pay that for a value the line below can read off
+	 * {@code gl_FragCoord} instead.
+	 */
+	private String coveragePrologue() {
+		return this.covers && this.namesFragDepth ? "gl_FragDepth = gl_FragCoord.z; " : "";
+	}
+
+	/**
+	 * Makes the hit flash and the damage tint out of the overlay the mesh carries, before the pack's
+	 * own body runs and can read it.
+	 * <p>
+	 * Iris's three lines, term for term
+	 * ({@code pipeline/transform/transformer/EntityPatcher.java:55-56} and {@code :62}, the fourth
+	 * statement of that run being a vertex colour it hands on for its own reasons), and each is the
+	 * game's rather than a choice. The image is {@code OverlayTexture}'s sixteen by sixteen, red over
+	 * the top half and white with a falling alpha over the bottom, and the element is the pair
+	 * {@code OverlayTexture.pack} wrote; the alpha is turned around because what the texture stores
+	 * is how much of the mob shows through. The third line is a workaround Iris carries for the
+	 * packs, and it stays because the packs are what this engine is written against: some read the
+	 * colour without looking at the alpha and expect a black where there is no flash.
+	 * <p>
+	 * A {@code texelFetch} and not a sample, so nothing the bound sampler does can reach it: the
+	 * coordinate is a texel of a sixteen wide image and a filter between two of them would be a
+	 * flash halfway to the tint.
+	 */
+	private String overlayPrologue() {
+		if (!this.makesOverlayColour) {
+			return "";
+		}
+
+		return "vec4 " + OVERLAY_TEXEL + " = texelFetch(" + GlslTranslator.OVERLAY + ", UV1, 0); "
+				+ GlslTranslator.ENTITY_COLOR + " = vec4(" + OVERLAY_TEXEL + ".rgb, 1.0 - "
+				+ OVERLAY_TEXEL + ".a); "
+				+ GlslTranslator.ENTITY_COLOR + ".rgb *= float(" + GlslTranslator.ENTITY_COLOR
+				+ ".a != 0.0); ";
+	}
+
+	/**
+	 * Hands the three identifiers on out of the element the mesh carries them on, before the pack's
+	 * own body runs and can read them.
+	 * <p>
+	 * Iris's one line spread over three, and the difference is only that its names are components of
+	 * one {@code ivec3} where these keep the spelling the pack wrote
+	 * ({@code EntityPatcher.java:165-166}). Only what some stage really reads is written: what is in
+	 * the union is what was declared, and writing a varying the header did not declare would not
+	 * compile.
+	 * <p>
+	 * The lane is the position in {@link GlslTranslator#ENTITY_IDS} and the element is unsigned, so
+	 * the cast is where a name the pack never mapped becomes 65535 rather than minus one. That is
+	 * Iris's number as well, its own element being unsigned and its input an {@code ivec3} the
+	 * driver zero extends into, and it is the number the packs are written against.
+	 */
+	private String identifierPrologue(Set<String> varyings) {
+		if (!this.entityWrapped) {
+			return "";
+		}
+
+		StringBuilder written = new StringBuilder();
+		for (int lane = 0; lane < GlslTranslator.ENTITY_IDS.size(); lane++) {
+			String identifier = GlslTranslator.ENTITY_IDS.get(lane);
+			if (varyings.contains(identifier)) {
+				written.append(identifier).append(" = int(")
+						.append(EntityVertex.IDENTIFIERS).append('[').append(lane).append("]); ");
+			}
+		}
+
+		return written.toString();
+	}
+
+	/** What output {@code slot} is called, which is the pack's own name when it declared one. */
+	private String outputName(int slot, Set<String> shadowed) {
+		Output output = this.packOutputs.get(slot);
+		if (output == null) {
+			return "ofFragData" + slot;
+		}
+
+		// Renamed here as well as in the body, since the declaration has moved up out of it and
+		// the two halves of one name have to keep agreeing.
+		return shadowed.contains(output.name()) ? "ofOwn_" + output.name() : output.name();
+	}
+
+	/**
+	 * Vulkan GLSL requires a format on a storage image, unless the image is write-only. Iris's GL
+	 * bind supplies the format at bind time, so Complementary writes
+	 * {@code writeonly uniform uimage3D voxel_img} with none, and BSL writes
+	 * {@code writeonly uniform image3D lightimg0} the same way. The format comes off the
+	 * {@code image.} directive and is written here, in the header: the body declaration has
+	 * already been lifted, so a layout qualifier inserted into the token stream would qualify a
+	 * statement that is no longer in the shader.
+	 * <p>
+	 * The pack's own memory qualifiers are written back for the same reason, and they are what
+	 * carries a declaration whose format we never learn: a pack switches its images off with the
+	 * setting that switches off the program reading them, and then the {@code image.} lines go
+	 * with it while the {@code writeonly} on the declaration stays. Dropping it turned a legal
+	 * declaration into one shaderc refuses.
+	 */
+	private String declareOpaque(TranslatedUnit.Uniform sampler) {
+		String memory = this.memoryQualifiers.getOrDefault(sampler.name(), "");
+		String tail = (memory.isEmpty() ? "" : memory + " ") + "uniform " + sampler.declaration()
+				+ ";";
+		if (!isImageType(sampler.type())) {
+			return tail;
+		}
+
+		return CustomImages.layoutFormat(sampler.name())
+				.map(format -> "layout(" + format + ") " + tail)
+				.orElse(tail);
+	}
+
+	private static boolean isImageType(String type) {
+		return type.startsWith("image") || type.startsWith("iimage") || type.startsWith("uimage");
+	}
+
+	/**
+	 * An owed varying written as an output declaration, with {@code out} where GLSL wants it: after
+	 * the interpolation qualifier and before the type. Writing {@code out flat float} rather than
+	 * {@code flat out float} is a syntax error, so the two cannot simply be concatenated.
+	 *
+	 * @param qualified the qualifier and the type, {@code flat float} or {@code vec3}
+	 */
+	private static String outDeclaration(String name, String qualified) {
+		int type = qualified.lastIndexOf(' ');
+
+		return type < 0
+				? "out " + qualified + " " + name + ";"
+				: qualified.substring(0, type) + " out " + qualified.substring(type + 1) + " " + name + ";";
+	}
+
+	/**
+	 * What the stage assigns an owed varying, which is the type's zero, exactly as Iris writes it at
+	 * {@code CompatibilityTransformer.java:494} out of {@code getInitializer:351-359}.
+	 * <p>
+	 * {@code type(0)} spells the zero of every type that can reach here. {@link LegacyGlsl#TYPE_NAMES}
+	 * holds the scalars, the vectors and the matrices, and the constructor of each takes a single
+	 * zero; {@code bool} and {@code bvec} are in it too and take one just as well. {@code void} is
+	 * the one member no constructor answers for, and a varying cannot be declared under it.
+	 */
+	private static String initialiser(String name, String qualified) {
+		int type = qualified.lastIndexOf(' ');
+
+		return name + " = " + qualified.substring(type + 1) + "(0);";
+	}
+}

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -26,9 +26,11 @@ import java.util.Set;
  * {@code main} that runs the pack's own between a prologue and an epilogue. Writing that is not a
  * pass over the text and does not belong among them, which is the whole of why it is here.
  * <p>
- * A record of the answers rather than a view of the translator, so that what this can see is the
- * list below and stays the list below: every one of them is read here and not one is written back.
- * Built once, at render, which is the first moment they are all settled.
+ * A record of what the header is written from, so that what this can see is the list below and
+ * stays the list below: every one of them is read here and not one is written back. Several are
+ * the translator's own lists and maps rather than copies of them, and {@code splits} is the
+ * split itself; the record is built at render, which is after every pass has run and the last
+ * moment any of them is written, and it is read in the one expression that builds it.
  */
 record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, AlphaTest alphaTest,
 		Map<String, String> engineDefines, Map<String, String> memoryQualifiers, Set<String> used,

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -236,7 +236,7 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 
 		// Only where a lookup was moved. A stage carrying the declaration and never reading it, which
 		// is most of them, has its declaration flattened and owes no helper.
-		this.readVolumes.forEach((name, atlas) -> lines.addAll(GlslTranslator.volumeHelper(name, atlas)));
+		this.readVolumes.forEach((name, atlas) -> lines.addAll(VolumeFlattening.helper(name, atlas)));
 
 		// Declared on both sides or on neither, whether this stage reads it or not. A varying the
 		// vertex writes and the fragment never mentions is accepted in silence and shifts the

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -1,10 +1,10 @@
 package dev.vitrail.glsl;
 
 import dev.vitrail.glsl.GlslTranslator.Output;
-import dev.vitrail.glsl.GlslTranslator.SplitArray;
-import dev.vitrail.glsl.GlslTranslator.SplitMatrix;
-import dev.vitrail.glsl.GlslTranslator.SplitStruct;
-import dev.vitrail.glsl.GlslTranslator.StructMember;
+import dev.vitrail.glsl.VaryingSplit.SplitArray;
+import dev.vitrail.glsl.VaryingSplit.SplitMatrix;
+import dev.vitrail.glsl.VaryingSplit.SplitStruct;
+import dev.vitrail.glsl.VaryingSplit.StructMember;
 import dev.vitrail.pack.program.AlphaTest;
 import dev.vitrail.pack.program.ProgramStage;
 import dev.vitrail.pack.texture.CustomImages;
@@ -34,11 +34,11 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 		Map<String, String> engineDefines, Map<String, String> memoryQualifiers, Set<String> used,
 		Set<String> declaredNames, Map<String, String> synthesized,
 		Map<String, VolumeAtlas> readVolumes, Map<Integer, Output> packOutputs,
-		int maxFragmentOutput, Map<String, String> owedOutputs, List<SplitMatrix> splitMatrices,
-		List<SplitStruct> splitStructs, List<SplitArray> splitArrays, int gameTextureMatrix,
-		int gameModelView, int softRewrites, int trigCalls, int hashCalls, boolean mainWrapped,
-		boolean depthEpilogue, boolean terrainPrologue, boolean distantPrologue,
-		boolean entityWrapped, boolean linesWrapped, boolean alphaEpilogue, boolean covers,
+		int maxFragmentOutput, Map<String, String> owedOutputs, VaryingSplit splits,
+		int gameTextureMatrix, int gameModelView, int softRewrites, int trigCalls, int hashCalls,
+		boolean mainWrapped, boolean depthEpilogue, boolean terrainPrologue,
+		boolean distantPrologue, boolean entityWrapped, boolean linesWrapped,
+		boolean alphaEpilogue, boolean covers,
 		boolean wrapsFragment, boolean ordered, boolean namesFragDepth, boolean makesOverlayColour) {
 
 	private static final String VERSION = "#version 460 core";
@@ -266,14 +266,14 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 			}
 		}
 
-		for (SplitMatrix split : this.splitMatrices) {
+		for (SplitMatrix split : this.splits.matrices()) {
 			lines.add(split.matrixType() + " " + split.name() + ";");
 			String storage = split.input() ? "in" : "out";
 			String qualified = split.qualifier().isEmpty()
 					? storage + " " + split.columnType()
 					: split.qualifier() + " " + storage + " " + split.columnType();
 			for (int column = 0; column < split.columns(); column++) {
-				lines.add(qualified + " " + GlslTranslator.matrixColumnName(split.name(), column) + ";");
+				lines.add(qualified + " " + VaryingSplit.matrixColumnName(split.name(), column) + ";");
 			}
 		}
 
@@ -282,7 +282,7 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 		// alike. The definition is written from the members read off the body, whose own copy is
 		// blank by now.
 		Set<String> defined = new HashSet<>();
-		for (SplitStruct split : this.splitStructs) {
+		for (SplitStruct split : this.splits.structs()) {
 			if (defined.add(split.structType())) {
 				StringBuilder definition = new StringBuilder("struct ").append(split.structType())
 						.append(" { ");
@@ -308,13 +308,13 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 						? storage + " " + member.type()
 						: qualifier + " " + storage + " " + member.type();
 				lines.add(qualified + " "
-						+ GlslTranslator.structMemberName(split.name(), member.name()) + ";");
+						+ VaryingSplit.structMemberName(split.name(), member.name()) + ";");
 			}
 		}
 
 		// The array as a global of the pack's name, then one varying per element in index order,
 		// flat where the element may not be interpolated.
-		for (SplitArray split : this.splitArrays) {
+		for (SplitArray split : this.splits.arrays()) {
 			lines.add(split.type() + " " + split.name() + "[" + split.size() + "];");
 			String storage = split.input() ? "in" : "out";
 			String qualifier = split.qualifier();
@@ -326,7 +326,7 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 					? storage + " " + split.type()
 					: qualifier + " " + storage + " " + split.type();
 			for (int element = 0; element < split.size(); element++) {
-				lines.add(qualified + " " + GlslTranslator.arrayElementName(split.name(), element) + ";");
+				lines.add(qualified + " " + VaryingSplit.arrayElementName(split.name(), element) + ";");
 			}
 		}
 
@@ -378,8 +378,7 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 		// has to be declared before it can be called.
 		if (this.depthEpilogue || this.terrainPrologue || this.distantPrologue || this.entityWrapped
 				|| this.linesWrapped || wrapsFragment() || owesInitialisers()
-				|| !this.splitMatrices.isEmpty() || !this.splitStructs.isEmpty()
-				|| !this.splitArrays.isEmpty()) {
+				|| this.splits.any()) {
 			lines.add("void " + GlslTranslator.PACK_MAIN + "();");
 			// The lines mesh runs the pack's main twice, the far end of the edge first and the
 			// vertex itself second, so that every varying holds the vertex's own value when the
@@ -403,13 +402,13 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 					+ (wrapsFragment() ? GlslTranslator.ORDER_OUTPUTS + "(); " : "")
 					+ coveragePrologue()
 					+ owedPrologue()
-					+ matrixPrologue()
-					+ structPrologue()
-					+ arrayPrologue()
+					+ this.splits.matrixPrologue()
+					+ this.splits.structPrologue()
+					+ this.splits.arrayPrologue()
 					+ body
-					+ matrixEpilogue()
-					+ structEpilogue()
-					+ arrayEpilogue()
+					+ this.splits.matrixEpilogue()
+					+ this.splits.structEpilogue()
+					+ this.splits.arrayEpilogue()
 					+ (this.depthEpilogue ? " gl_Position.z = " + GlslTranslator.DEPTH_CONV
 							+ ".x * gl_Position.z + " + GlslTranslator.DEPTH_CONV
 							+ ".y * gl_Position.w;" : "")
@@ -437,135 +436,6 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 		StringBuilder assignments = new StringBuilder();
 		this.owedOutputs.forEach((name, qualified) ->
 				assignments.append(initialiser(name, qualified)).append(' '));
-
-		return assignments.toString();
-	}
-
-	/**
-	 * Rebuilds each input matrix from its columns before the pack body runs, so a read of the
-	 * original name still sees a {@code mat3}.
-	 */
-	private String matrixPrologue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitMatrix split : this.splitMatrices) {
-			if (!split.input()) {
-				continue;
-			}
-
-			assignments.append(split.name()).append(" = ").append(split.matrixType()).append('(');
-			for (int column = 0; column < split.columns(); column++) {
-				if (column > 0) {
-					assignments.append(", ");
-				}
-
-				assignments.append(GlslTranslator.matrixColumnName(split.name(), column));
-			}
-
-			assignments.append("); ");
-		}
-
-		return assignments.toString();
-	}
-
-	/**
-	 * Copies each output matrix onto its columns after the pack body ran, so the interface the
-	 * next stage reads is the value the pack wrote.
-	 */
-	private String matrixEpilogue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitMatrix split : this.splitMatrices) {
-			if (split.input()) {
-				continue;
-			}
-
-			for (int column = 0; column < split.columns(); column++) {
-				assignments.append(GlslTranslator.matrixColumnName(split.name(), column)).append(" = ")
-						.append(split.name()).append('[').append(column).append("]; ");
-			}
-		}
-
-		return assignments.toString();
-	}
-
-	/**
-	 * Rebuilds each input struct from its members before the pack body runs, so a read of the
-	 * original name still sees the struct. A constructor takes the members in declaration order,
-	 * which is the order they were declared in as varyings.
-	 */
-	private String structPrologue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitStruct split : this.splitStructs) {
-			if (!split.input()) {
-				continue;
-			}
-
-			assignments.append(split.name()).append(" = ").append(split.structType()).append('(');
-			for (int member = 0; member < split.members().size(); member++) {
-				if (member > 0) {
-					assignments.append(", ");
-				}
-
-				assignments.append(GlslTranslator.structMemberName(split.name(),
-						split.members().get(member).name()));
-			}
-
-			assignments.append("); ");
-		}
-
-		return assignments.toString();
-	}
-
-	/**
-	 * Copies each output struct onto its members after the pack body ran, so the interface the next
-	 * stage reads is the value the pack wrote.
-	 */
-	private String structEpilogue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitStruct split : this.splitStructs) {
-			if (split.input()) {
-				continue;
-			}
-
-			for (StructMember member : split.members()) {
-				assignments.append(GlslTranslator.structMemberName(split.name(), member.name()))
-						.append(" = ")
-						.append(split.name()).append('.').append(member.name()).append("; ");
-			}
-		}
-
-		return assignments.toString();
-	}
-
-	/** Fills each input array from its elements before the pack body runs. */
-	private String arrayPrologue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitArray split : this.splitArrays) {
-			if (!split.input()) {
-				continue;
-			}
-
-			for (int element = 0; element < split.size(); element++) {
-				assignments.append(split.name()).append('[').append(element).append("] = ")
-						.append(GlslTranslator.arrayElementName(split.name(), element)).append("; ");
-			}
-		}
-
-		return assignments.toString();
-	}
-
-	/** Copies each output array onto its elements after the pack body ran. */
-	private String arrayEpilogue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitArray split : this.splitArrays) {
-			if (split.input()) {
-				continue;
-			}
-
-			for (int element = 0; element < split.size(); element++) {
-				assignments.append(GlslTranslator.arrayElementName(split.name(), element)).append(" = ")
-						.append(split.name()).append('[').append(element).append("]; ");
-			}
-		}
 
 		return assignments.toString();
 	}

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -73,22 +73,22 @@ import java.util.stream.Stream;
  * what stands within eight centimetres of the camera, so it blurred nothing at all.
  * <p>
  * The fragment outputs carry one rule that is not GLSL's and cannot be read off the language.
-	 * 26.2 does not keep the location a stage declares: {@code IntermediaryShaderModule.createFromSpirv}
-	 * asks SPIR-V reflection for the outputs and writes the rank of each one over its own location
-	 * decoration. The order reflection answers in is the order the compiler first met the names in, so
-	 * a stage that writes output one before output zero has the two swapped, and nothing says a word
-	 * about it. Everything below about outputs exists for that: they are all declared here, from zero
-	 * up with no gaps, and named once each in ascending order by a function ahead of anything the pack
-	 * wrote and called first thing in {@code main}. The rank is then the location and the rewrite is
-	 * the identity.
-	 * <p>
-	 * The same rank-is-location rewrite is why a {@code varying mat3} cannot be left as one variable.
-	 * A GLSL matrix occupies one location per column, three for a {@code mat3}, but it is still one
-	 * reflected name, so the next varying is numbered onto column two. OpenGL links by name and
-	 * never asks the question; the workaround here is to split each matrix varying into that many
-	 * vectors before compilation and rebuild the matrix as a local. A struct varying is the same
-	 * case with a member per location and an array varying with an element per location, and
-	 * {@link VaryingSplit} answers all three. Iris is not copied.
+ * 26.2 does not keep the location a stage declares: {@code IntermediaryShaderModule.createFromSpirv}
+ * asks SPIR-V reflection for the outputs and writes the rank of each one over its own location
+ * decoration. The order reflection answers in is the order the compiler first met the names in, so
+ * a stage that writes output one before output zero has the two swapped, and nothing says a word
+ * about it. Everything below about outputs exists for that: they are all declared here, from zero
+ * up with no gaps, and named once each in ascending order by a function ahead of anything the pack
+ * wrote and called first thing in {@code main}. The rank is then the location and the rewrite is
+ * the identity.
+ * <p>
+ * The same rank-is-location rewrite is why a {@code varying mat3} cannot be left as one variable.
+ * A GLSL matrix occupies one location per column, three for a {@code mat3}, but it is still one
+ * reflected name, so the next varying is numbered onto column two. OpenGL links by name and
+ * never asks the question; the workaround here is to split each matrix varying into that many
+ * vectors before compilation and rebuild the matrix as a local. A struct varying is the same
+ * case with a member per location and an array varying with an element per location, and
+ * {@link VaryingSplit} answers all three. Iris is not copied.
  */
 public final class GlslTranslator {
 

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -410,6 +410,9 @@ public final class GlslTranslator {
 	private int functionEndFor = -1;
 	private int functionEndAt;
 
+	/** What {@link #lineNumbers} last built, or null where a token has moved since. */
+	private int[] lineTable;
+
 	/** Names the pack defines as macros. Their uses belong to the preprocessor, not to us. */
 	private final Set<String> packMacros = new HashSet<>();
 
@@ -1593,10 +1596,10 @@ public final class GlslTranslator {
 		}
 
 		// Inserting shifts every index after it, so the last insertion is made first. It also ends
-		// every position taken before it: this loop and insertClosings are the only two places that
-		// move a token, so anything a later pass still has to know about a token is carried on the
-		// token, as Token#macroName is. A position kept across here would be read against somebody
-		// else's token, and the reading pass has no way to notice.
+		// every position taken before it, insertClosings being the one place that moves a token, so
+		// anything a later pass still has to know about a token is carried on the token, as
+		// Token#macroName is. A position kept across here would be read against somebody else's
+		// token, and the reading pass has no way to notice.
 		List<Closing> parentheses = new ArrayList<>(closings.size());
 		for (int at : closings) {
 			parentheses.add(new Closing(at, ")", null));
@@ -2700,11 +2703,12 @@ public final class GlslTranslator {
 	/**
 	 * Inserting shifts every index after it, so the last insertion is made first.
 	 * <p>
-	 * This and the closing loop at the end of {@link #rewriteIdentifiers} are the only two places
-	 * that move a token, and so the only two that can make a position stale. What a later pass has
-	 * to know about a token is carried on the token for that reason, as {@link Token#macroName()}
-	 * is: a position kept across either of them would be read against somebody else's token, and
-	 * nothing downstream can tell.
+	 * This is the one place that moves a token, both passes that close a wrap coming through it,
+	 * and so the one place that can make a position stale. What a later pass has to know about a
+	 * token is carried on the token for that reason, as {@link Token#macroName()} is: a position
+	 * kept across here would be read against somebody else's token, and nothing downstream can
+	 * tell. The two answers this class does keep about the list, the function end and the line
+	 * table, are thrown away here for the same reason.
 	 */
 	private void insertClosings(List<Closing> closings) {
 		if (closings.isEmpty()) {
@@ -2712,6 +2716,7 @@ public final class GlslTranslator {
 		}
 
 		this.functionEndFor = -1;
+		this.lineTable = null;
 
 		// One walk that copies the list with the closings dropped in, rather than one shift of
 		// every later token per closing: a stage carries hundreds of thousands of tokens and a
@@ -6174,10 +6179,20 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Which line of the expanded unit each token sits on. Recomputed rather than kept, because
-	 * wrapping a shadow lookup inserts tokens and moves every index after it.
+	 * Which line of the expanded unit each token sits on.
+	 * <p>
+	 * Kept between calls, which a stage makes twenty three times, and thrown away by
+	 * {@link #insertClosings}, the one pass that moves a token. Nothing else can make it stale:
+	 * every other helper that touches the list leaves the line breaks where they were, which
+	 * {@link #blankRange} goes out of its way to do. That is not this table's rule either, it is
+	 * the unit's: a break lost anywhere would move every line after it away from the one
+	 * {@link ExpandedUnit#isLive} is asked about, and no pass would have a way to notice.
 	 */
 	private int[] lineNumbers() {
+		if (this.lineTable != null) {
+			return this.lineTable;
+		}
+
 		int[] lines = new int[this.tokens.size()];
 		int line = 0;
 
@@ -6190,6 +6205,8 @@ public final class GlslTranslator {
 				}
 			}
 		}
+
+		this.lineTable = lines;
 
 		return lines;
 	}

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -2,6 +2,7 @@ package dev.vitrail.glsl;
 
 import dev.vitrail.glsl.GlslLexer.Kind;
 import dev.vitrail.glsl.GlslLexer.Token;
+import dev.vitrail.glsl.TokenStream.Closing;
 import dev.vitrail.pack.option.EngineDefines;
 import dev.vitrail.pack.program.AlphaTest;
 import dev.vitrail.pack.program.ProgramNames;
@@ -19,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -43,6 +43,10 @@ import java.util.stream.Stream;
  * and {@code attribute}, texture lookups renamed twenty years ago, and plain uniforms declared
  * loose at file scope, which Vulkan does not allow at all. None of that needs the program to be
  * understood, only read, so the work here is a rewrite over a token stream rather than a compiler.
+ * <p>
+ * The tokens themselves, and every way of reading them or changing them, belong to
+ * {@link TokenStream} rather than to this class. What is left here is the pipeline: one pass per
+ * rule, in the order {@link #rewrite} runs them, and the header written around what they leave.
  * <p>
  * Two things are deliberately left undone, and both were done by the measuring prototype.
  * No {@code layout(binding = )} is emitted, and no {@code layout(location = )} except on fragment
@@ -363,13 +367,6 @@ public final class GlslTranslator {
 	private static final int MAX_SOURCE_CHARACTERS = 4_000_000;
 
 	/**
-	 * How far a declaration may reach for its semicolon. A pack that leaves one out would
-	 * otherwise have the rest of the file scanned once per {@code uniform} it declares, which is
-	 * quadratic: forty thousand such lines took twenty-seven seconds.
-	 */
-	private static final int MAX_STATEMENT_TOKENS = 4096;
-
-	/**
 	 * How far one macro may lead to another before the name is taken as non-constant, the same
 	 * figure {@code PreprocessorExpression} allows a chain of settings.
 	 */
@@ -404,14 +401,7 @@ public final class GlslTranslator {
 
 	/** Whether the fragment stage is asked for the coverage mask on top of what the pack writes. */
 	private final boolean coverage;
-	private final List<Token> tokens;
-
-	/** The parameter list {@link #functionEnd} last answered for, and its answer. */
-	private int functionEndFor = -1;
-	private int functionEndAt;
-
-	/** What {@link #lineNumbers} last built, or null where a token has moved since. */
-	private int[] lineTable;
+	private final TokenStream tokens;
 
 	/** Names the pack defines as macros. Their uses belong to the preprocessor, not to us. */
 	private final Set<String> packMacros = new HashSet<>();
@@ -688,7 +678,7 @@ public final class GlslTranslator {
 					+ " characters, past the " + MAX_SOURCE_CHARACTERS + " a unit is allowed");
 		}
 
-		this.tokens = new ArrayList<>(GlslLexer.lex(text));
+		this.tokens = new TokenStream(GlslLexer.lex(text));
 	}
 
 	/**
@@ -1103,7 +1093,7 @@ public final class GlslTranslator {
 	 */
 	private String body(Set<String> shadowed) {
 		if (shadowed.isEmpty()) {
-			return GlslLexer.join(this.tokens);
+			return this.tokens.join();
 		}
 
 		StringBuilder text = new StringBuilder();
@@ -1208,19 +1198,19 @@ public final class GlslTranslator {
 	 * macro name or leave a shadowed read on the block value with nothing logged either way.
 	 */
 	private void collectMacroNames() {
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (token.kind() != Kind.HASH || !LegacyGlsl.NAMING_DIRECTIVES.contains(token.directive())) {
 				continue;
 			}
 
-			int name = macroNameAfter(index);
+			int name = this.tokens.macroNameAfter(index);
 			if (name < 0) {
 				continue;
 			}
 
-			this.tokens.set(name, this.tokens.get(name).naming());
+			this.tokens.naming(name);
 			if (token.directive().equals("define")) {
 				String macro = this.tokens.get(name).text();
 				this.packMacros.add(macro);
@@ -1318,14 +1308,14 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int before = significantBefore(index);
+			int before = this.tokens.significantBefore(index);
 			if (before < 0 || !LegacyGlsl.TYPE_NAMES.contains(this.tokens.get(before).text())) {
 				continue;
 			}
 
 			this.declaredNames.add(token.text());
 			this.declaredNames.addAll(continuationDeclarators(index));
-			if (LegacyGlsl.POST_120_BUILTINS.contains(token.text()) && callOpener(index) >= 0) {
+			if (LegacyGlsl.POST_120_BUILTINS.contains(token.text()) && this.tokens.callOpener(index) >= 0) {
 				this.shadowedBuiltins.add(token.text());
 			}
 		}
@@ -1349,7 +1339,7 @@ public final class GlslTranslator {
 	 * @param first the first declarator of the statement, the one the type stands in front of
 	 */
 	private List<String> continuationDeclarators(int first) {
-		int end = statementEnd(first);
+		int end = this.tokens.statementEnd(first);
 		if (end < 0) {
 			return List.of();
 		}
@@ -1358,8 +1348,8 @@ public final class GlslTranslator {
 		int depth = 0;
 		boolean expectName = false;
 
-		for (int index = significantAfter(first); index >= 0 && index <= end;
-				index = significantAfter(index)) {
+		for (int index = this.tokens.significantAfter(first); index >= 0 && index <= end;
+				index = this.tokens.significantAfter(index)) {
 			Token token = this.tokens.get(index);
 			if (token.operator("(") || token.operator("[") || token.operator("{")) {
 				depth++;
@@ -1390,7 +1380,7 @@ public final class GlslTranslator {
 	 * bracket of an array.
 	 */
 	private boolean declaratorFollows(int name) {
-		int next = significantAfter(name);
+		int next = this.tokens.significantAfter(name);
 		if (next < 0) {
 			return false;
 		}
@@ -1437,13 +1427,13 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			blankDirective(index);
+			this.tokens.blankDirective(index);
 		}
 	}
 
 	private void rewriteIdentifiers() {
 		List<Integer> closings = new ArrayList<>();
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
@@ -1466,7 +1456,7 @@ public final class GlslTranslator {
 			}
 
 			if (this.shadowedBuiltins.contains(name)) {
-				replace(index, "of_" + name);
+				this.tokens.replace(index, "of_" + name);
 				continue;
 			}
 
@@ -1486,12 +1476,13 @@ public final class GlslTranslator {
 
 			String fixed = LegacyGlsl.FIXED_FUNCTION.get(name);
 			if (fixed != null) {
-				replace(index, fixed);
+				this.tokens.replace(index, fixed);
 				continue;
 			}
 
 			if (name.equals("gl_VertexID") || name.equals("gl_InstanceID")) {
-				replace(index, name.equals("gl_VertexID") ? "gl_VertexIndex" : "gl_InstanceIndex");
+				this.tokens.replace(index,
+						name.equals("gl_VertexID") ? "gl_VertexIndex" : "gl_InstanceIndex");
 				continue;
 			}
 
@@ -1500,8 +1491,8 @@ public final class GlslTranslator {
 			}
 
 			String shadow = LegacyGlsl.SHADOW_FUNCTIONS.get(name);
-			if (shadow != null && callOpener(index) >= 0) {
-				int close = matchingBracket(callOpener(index));
+			if (shadow != null && this.tokens.callOpener(index) >= 0) {
+				int close = this.tokens.matchingBracket(this.tokens.callOpener(index));
 				if (close < 0) {
 					// Unbalanced from here, usually because a macro opened the parenthesis. The
 					// call is left alone and the compiler will say so, but silence here would
@@ -1513,7 +1504,7 @@ public final class GlslTranslator {
 					// A legacy shadow lookup is rewritten here rather than later: the injection
 					// below fuses the name into one token with the parenthesis, and the depth
 					// conversion matches names.
-					int first = significantAfter(callOpener(index));
+					int first = this.tokens.significantAfter(this.tokens.callOpener(index));
 					String argument = first >= 0
 							&& this.tokens.get(first).kind() == Kind.IDENTIFIER
 							? this.tokens.get(first).text() : null;
@@ -1541,7 +1532,7 @@ public final class GlslTranslator {
 					// The wrap adds an opening parenthesis, so it has to add a closing one too.
 					// Substituting the head alone is what left the prototype with eighty-six
 					// units ending in "unexpected SEMICOLON, expecting RIGHT_PAREN".
-					inject(index, "vec4(" + (compared ? SHADOW_COMPARE : shadow));
+					this.tokens.inject(index, "vec4(" + (compared ? SHADOW_COMPARE : shadow));
 					closings.add(close + 1);
 					this.shadowCalls++;
 					continue;
@@ -1549,8 +1540,8 @@ public final class GlslTranslator {
 			}
 
 			String modern = LegacyGlsl.DEPRECATED_FUNCTIONS.get(name);
-			if (modern != null && callOpener(index) >= 0) {
-				replace(index, modern);
+			if (modern != null && this.tokens.callOpener(index) >= 0) {
+				this.tokens.replace(index, modern);
 				continue;
 			}
 
@@ -1562,11 +1553,11 @@ public final class GlslTranslator {
 			// on the driver's own two can still say what the substitution would have had to bite
 			// on. With the switch off nothing is replaced and the token falls through to the
 			// readings below, exactly as any other name the pack calls does.
-			if ((name.equals("sin") || name.equals("cos")) && callOpener(index) >= 0
+			if ((name.equals("sin") || name.equals("cos")) && this.tokens.callOpener(index) >= 0
 					&& !this.declaredNames.contains(name)) {
 				this.trigSites++;
 				if (reduceTrig) {
-					replace(index, name.equals("sin") ? REDUCED_SIN : REDUCED_COS);
+					this.tokens.replace(index, name.equals("sin") ? REDUCED_SIN : REDUCED_COS);
 					this.trigCalls++;
 					continue;
 				}
@@ -1580,18 +1571,18 @@ public final class GlslTranslator {
 				// A geometry shader has varyings running both ways and the keyword cannot say
 				// which. Every other stage is unambiguous, and the corpus has few enough geometry
 				// programs that guessing wrong here is visible rather than silent.
-				replace(index, this.stage == ProgramStage.VERTEX ? "out" : "in");
+				this.tokens.replace(index, this.stage == ProgramStage.VERTEX ? "out" : "in");
 				continue;
 			}
 
 			if (name.equals("attribute")) {
-				replace(index, "in");
+				this.tokens.replace(index, "in");
 				continue;
 			}
 
 			String reserved = LegacyGlsl.RESERVED_NAMES.get(name);
-			if (reserved != null && callOpener(index) < 0) {
-				replace(index, reserved);
+			if (reserved != null && this.tokens.callOpener(index) < 0) {
+				this.tokens.replace(index, reserved);
 			}
 		}
 
@@ -1605,7 +1596,7 @@ public final class GlslTranslator {
 			parentheses.add(new Closing(at, ")", null));
 		}
 
-		insertClosings(parentheses);
+		this.tokens.insertClosings(parentheses);
 	}
 
 	/**
@@ -1629,27 +1620,27 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int fractOpen = callOpener(index);
-			int sine = fractOpen < 0 ? -1 : significantAfter(fractOpen);
+			int fractOpen = this.tokens.callOpener(index);
+			int sine = fractOpen < 0 ? -1 : this.tokens.significantAfter(fractOpen);
 			if (sine < 0 || !goldbergSine(this.tokens.get(sine))) {
 				continue;
 			}
 
-			int sineOpen = callOpener(sine);
-			int dot = sineOpen < 0 ? -1 : significantAfter(sineOpen);
+			int sineOpen = this.tokens.callOpener(sine);
+			int dot = sineOpen < 0 ? -1 : this.tokens.significantAfter(sineOpen);
 			if (dot < 0 || !this.tokens.get(dot).identifier("dot")) {
 				continue;
 			}
 
-			int dotOpen = callOpener(dot);
-			int dotClose = matchingBracket(dotOpen);
+			int dotOpen = this.tokens.callOpener(dot);
+			int dotClose = this.tokens.matchingBracket(dotOpen);
 			int comma = firstCallComma(dotOpen);
-			int argStart = dotOpen < 0 ? -1 : significantAfter(dotOpen);
-			int argEnd = comma < 0 ? -1 : significantBefore(comma);
-			int sineClose = matchingBracket(sineOpen);
-			int times = sineClose < 0 ? -1 : significantAfter(sineClose);
-			int scale = times < 0 ? -1 : significantAfter(times);
-			int fractClose = matchingBracket(fractOpen);
+			int argStart = dotOpen < 0 ? -1 : this.tokens.significantAfter(dotOpen);
+			int argEnd = comma < 0 ? -1 : this.tokens.significantBefore(comma);
+			int sineClose = this.tokens.matchingBracket(sineOpen);
+			int times = sineClose < 0 ? -1 : this.tokens.significantAfter(sineClose);
+			int scale = times < 0 ? -1 : this.tokens.significantAfter(times);
+			int fractClose = this.tokens.matchingBracket(fractOpen);
 			if (argStart < 0 || argEnd < argStart || times < 0 || scale < 0 || fractClose < 0
 					|| !this.tokens.get(times).operator("*")
 					|| !goldbergScale(this.tokens.get(scale))
@@ -1657,15 +1648,15 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int afterScale = significantAfter(scale);
+			int afterScale = this.tokens.significantAfter(scale);
 			if (afterScale != fractClose) {
 				continue;
 			}
 
 			boolean reduced = this.tokens.get(sine).identifier(REDUCED_SIN);
 			String argument = tokenText(argStart, argEnd);
-			blankRange(index, fractClose);
-			inject(index, HASH + "(" + argument + ")");
+			this.tokens.blankRange(index, fractClose);
+			this.tokens.inject(index, HASH + "(" + argument + ")");
 			// Off both counts, and the site comes off whichever name its sine still went under: the
 			// idiom is erased here, so it is not a call either helper was ever going to take.
 			if (this.trigSites > 0) {
@@ -1739,7 +1730,7 @@ public final class GlslTranslator {
 
 	/** The comma that separates the first argument of the call that opens here, or -1. */
 	private int firstCallComma(int open) {
-		int close = matchingBracket(open);
+		int close = this.tokens.matchingBracket(open);
 		if (open < 0 || close < 0) {
 			return -1;
 		}
@@ -1802,22 +1793,22 @@ public final class GlslTranslator {
 	 * @return whether this was a read of unit nought, false leaving the name to the ordinary rename
 	 */
 	private boolean rewriteGameTextureMatrix(int index) {
-		int open = significantAfter(index);
+		int open = this.tokens.significantAfter(index);
 		if (open < 0 || !this.tokens.get(open).operator("[")) {
 			return false;
 		}
 
-		int unit = significantAfter(open);
-		int close = matchingBracket(open);
-		if (unit < 0 || close < 0 || significantAfter(unit) != close
+		int unit = this.tokens.significantAfter(open);
+		int close = this.tokens.matchingBracket(open);
+		if (unit < 0 || close < 0 || this.tokens.significantAfter(unit) != close
 				|| !this.tokens.get(unit).text().equals("0")) {
 			return false;
 		}
 
-		inject(index, LegacyGlsl.GAME_TEXTURE_MATRIX);
-		blank(open);
-		blank(unit);
-		blank(close);
+		this.tokens.inject(index, LegacyGlsl.GAME_TEXTURE_MATRIX);
+		this.tokens.blank(open);
+		this.tokens.blank(unit);
+		this.tokens.blank(close);
 		this.injectedNames.add(LegacyGlsl.GAME_TEXTURE_MATRIX);
 		this.gameTextureMatrix++;
 
@@ -1857,24 +1848,24 @@ public final class GlslTranslator {
 	 *         ordinary rename
 	 */
 	private boolean rewriteDistantTextureMatrix(int index) {
-		int open = significantAfter(index);
+		int open = this.tokens.significantAfter(index);
 		if (open < 0 || !this.tokens.get(open).operator("[")) {
 			return false;
 		}
 
-		int unit = significantAfter(open);
-		int close = matchingBracket(open);
-		if (unit < 0 || close < 0 || significantAfter(unit) != close
+		int unit = this.tokens.significantAfter(open);
+		int close = this.tokens.matchingBracket(open);
+		if (unit < 0 || close < 0 || this.tokens.significantAfter(unit) != close
 				|| !(this.tokens.get(unit).text().equals("0")
 						|| this.tokens.get(unit).text().equals("1")
 						|| this.tokens.get(unit).text().equals("2"))) {
 			return false;
 		}
 
-		inject(index, "mat4(1.0)");
-		blank(open);
-		blank(unit);
-		blank(close);
+		this.tokens.inject(index, "mat4(1.0)");
+		this.tokens.blank(open);
+		this.tokens.blank(unit);
+		this.tokens.blank(close);
 
 		return true;
 	}
@@ -1938,7 +1929,7 @@ public final class GlslTranslator {
 	 */
 	private boolean rewriteGameModelView(int index, String name) {
 		if (name.equals("gl_ModelViewMatrix")) {
-			inject(index, DRAW_MODEL_VIEW);
+			this.tokens.inject(index, DRAW_MODEL_VIEW);
 		} else if (name.equals("modelViewMatrix")) {
 			// The one name here a pack may declare for itself, the {@code gl_} prefix being reserved,
 			// so the one that has to tell a use from a declaration. Without this the declarator is
@@ -1951,9 +1942,9 @@ public final class GlslTranslator {
 				return false;
 			}
 
-			inject(index, DRAW_MODEL_VIEW);
+			this.tokens.inject(index, DRAW_MODEL_VIEW);
 		} else if (name.equals("gl_ModelViewProjectionMatrix")) {
-			inject(index, "(of_ProjectionMatrix * " + DRAW_MODEL_VIEW + ")");
+			this.tokens.inject(index, "(of_ProjectionMatrix * " + DRAW_MODEL_VIEW + ")");
 			this.injectedNames.add("of_ProjectionMatrix");
 		} else {
 			return false;
@@ -1978,15 +1969,15 @@ public final class GlslTranslator {
 	 * first-name-only test for the block, so the two move together or neither does.
 	 */
 	private boolean declaring(int index) {
-		int before = significantBefore(index);
+		int before = this.tokens.significantBefore(index);
 
 		return before >= 0 && LegacyGlsl.TYPE_NAMES.contains(this.tokens.get(before).text());
 	}
 
 	private boolean rewriteFtransform(int index) {
-		int open = callOpener(index);
-		int close = matchingBracket(open);
-		if (close < 0 || significantAfter(open) != close) {
+		int open = this.tokens.callOpener(index);
+		int close = this.tokens.matchingBracket(open);
+		if (close < 0 || this.tokens.significantAfter(open) != close) {
 			return false;
 		}
 
@@ -1994,25 +1985,21 @@ public final class GlslTranslator {
 		// the spelling the corpus really uses for a glint, and a pack writing ftransform() would
 		// otherwise get the pass's matrix back through the door rewriteGameModelView closed.
 		if (LegacyGlsl.readsDrawModelView(this.program)) {
-			inject(index, "(of_ProjectionMatrix * " + DRAW_MODEL_VIEW + " * of_Vertex)");
+			this.tokens.inject(index, "(of_ProjectionMatrix * " + DRAW_MODEL_VIEW + " * of_Vertex)");
 			this.injectedNames.add("of_ProjectionMatrix");
 			this.injectedNames.add(LegacyGlsl.CAMERA_BOB);
 			this.injectedNames.add(LegacyGlsl.GAME_MODEL_VIEW);
 			this.gameModelView++;
 		} else {
-			inject(index, "(of_ModelViewProjectionMatrix * of_Vertex)");
+			this.tokens.inject(index, "(of_ModelViewProjectionMatrix * of_Vertex)");
 			this.injectedNames.add("of_ModelViewProjectionMatrix");
 		}
 
 		this.injectedNames.add("of_Vertex");
-		blank(open);
-		blank(close);
+		this.tokens.blank(open);
+		this.tokens.blank(close);
 
 		return true;
-	}
-
-	/** One closing the wrap owes, put in once the scan that found it has finished reading. */
-	private record Closing(int at, String text, String directive) {
 	}
 
 	/** A sampler parameter, by the function taking it and its position in that function's list. */
@@ -2055,7 +2042,7 @@ public final class GlslTranslator {
 	 */
 	private void convertDepth() {
 		List<Closing> closings = new ArrayList<>();
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
@@ -2104,7 +2091,7 @@ public final class GlslTranslator {
 			}
 		}
 
-		insertClosings(closings);
+		this.tokens.insertClosings(closings);
 	}
 
 	/**
@@ -2133,8 +2120,8 @@ public final class GlslTranslator {
 			return false;
 		}
 
-		int open = callOpener(index);
-		int first = open < 0 ? -1 : significantAfter(open);
+		int open = this.tokens.callOpener(index);
+		int first = open < 0 ? -1 : this.tokens.significantAfter(open);
 		if (first < 0 || this.tokens.get(first).kind() != Kind.IDENTIFIER) {
 			return false;
 		}
@@ -2158,7 +2145,7 @@ public final class GlslTranslator {
 		// The name alone: the arguments of texture(sampler, vec3) are the arguments the comparison
 		// takes, so nothing has to be found or balanced. textureLod carries a level this ignores,
 		// which is what a comparison sampler with no mipmaps would have done anyway.
-		replace(index, SHADOW_COMPARE);
+		this.tokens.replace(index, SHADOW_COMPARE);
 		this.softRewrites++;
 
 		return true;
@@ -2177,8 +2164,8 @@ public final class GlslTranslator {
 	 * fall in neither count and are the reason the two are read together rather than differenced.
 	 */
 	private void countDepthLookup(int index, int line) {
-		int open = callOpener(index);
-		int first = open < 0 ? -1 : significantAfter(open);
+		int open = this.tokens.callOpener(index);
+		int first = open < 0 ? -1 : this.tokens.significantAfter(open);
 		if (first < 0 || this.tokens.get(first).kind() != Kind.IDENTIFIER) {
 			return;
 		}
@@ -2259,7 +2246,7 @@ public final class GlslTranslator {
 		}
 
 		Set<Scoped> proven = provenParameters(pinned, fullScreen && chained.isEmpty());
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		List<Closing> levels = new ArrayList<>();
 
 		for (int index = 0; index < this.tokens.size(); index++) {
@@ -2270,9 +2257,9 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int open = callOpener(index);
-			int close = matchingBracket(open);
-			int first = significantAfter(open);
+			int open = this.tokens.callOpener(index);
+			int close = this.tokens.matchingBracket(open);
+			int first = this.tokens.significantAfter(open);
 			if (close < 0 || first < 0 || this.tokens.get(first).kind() != Kind.IDENTIFIER) {
 				continue;
 			}
@@ -2300,7 +2287,7 @@ public final class GlslTranslator {
 			}
 		}
 
-		insertClosings(levels);
+		this.tokens.insertClosings(levels);
 	}
 
 	/**
@@ -2339,7 +2326,7 @@ public final class GlslTranslator {
 		}
 
 		Map<String, List<Integer>> sites = sitesOf(functions);
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		boolean grew = true;
 		while (grew) {
 			grew = false;
@@ -2398,14 +2385,14 @@ public final class GlslTranslator {
 				return false;
 			}
 
-			int open = callOpener(index);
-			int before = significantBefore(index);
+			int open = this.tokens.callOpener(index);
+			int before = this.tokens.significantBefore(index);
 			if (open < 0 || (before >= 0 && this.tokens.get(before).kind() == Kind.IDENTIFIER
 					&& returnsAType(this.tokens.get(before).text()))) {
 				continue;
 			}
 
-			int close = matchingBracket(open);
+			int close = this.tokens.matchingBracket(open);
 			if (close < 0) {
 				return false;
 			}
@@ -2417,8 +2404,8 @@ public final class GlslTranslator {
 
 			int start = parameter.position() == 0 ? open : commas.get(parameter.position() - 1);
 			int end = commas.size() > parameter.position() ? commas.get(parameter.position()) : close;
-			int argument = significantAfter(start);
-			if (argument < 0 || significantAfter(argument) != end
+			int argument = this.tokens.significantAfter(start);
+			if (argument < 0 || this.tokens.significantAfter(argument) != end
 					|| this.tokens.get(argument).kind() != Kind.IDENTIFIER) {
 				return false;
 			}
@@ -2532,7 +2519,7 @@ public final class GlslTranslator {
 
 				// The bias of the one and the two derivatives of the other are what the level was
 				// computed from, and the level is a literal now.
-				replace(index, "textureLod");
+				this.tokens.replace(index, "textureLod");
 				dropArgumentsFrom(commas, 2, close);
 				levels.add(new Closing(close, ", " + BASE_LEVEL, directive));
 			}
@@ -2541,7 +2528,7 @@ public final class GlslTranslator {
 					return false;
 				}
 
-				replace(index, "textureLodOffset");
+				this.tokens.replace(index, "textureLodOffset");
 				dropArgumentsFrom(commas, 3, close);
 				levels.add(new Closing(commas.get(1), ", " + BASE_LEVEL, directive));
 			}
@@ -2551,7 +2538,7 @@ public final class GlslTranslator {
 				}
 
 				// The two derivatives make way for the literal and the offset stays where it is.
-				replace(index, "textureLodOffset");
+				this.tokens.replace(index, "textureLodOffset");
 				setArgument(commas, 2, close, BASE_LEVEL);
 				dropArgument(commas, 3, close);
 			}
@@ -2593,22 +2580,22 @@ public final class GlslTranslator {
 	/** Blanks the argument at this position, counted from nought, and every one after it. */
 	private void dropArgumentsFrom(List<Integer> commas, int at, int close) {
 		if (commas.size() >= at) {
-			blankRange(commas.get(at - 1), close - 1);
+			this.tokens.blankRange(commas.get(at - 1), close - 1);
 		}
 	}
 
 	/** Blanks the argument at this position alone, counted from nought, with the comma before it. */
 	private void dropArgument(List<Integer> commas, int at, int close) {
 		int end = commas.size() > at ? commas.get(at) - 1 : close - 1;
-		blankRange(commas.get(at - 1), end);
+		this.tokens.blankRange(commas.get(at - 1), end);
 	}
 
 	/** Puts a literal in place of the argument at this position, counted from nought. */
 	private void setArgument(List<Integer> commas, int at, int close, String text) {
-		int first = significantAfter(commas.get(at - 1));
+		int first = this.tokens.significantAfter(commas.get(at - 1));
 		int end = commas.size() > at ? commas.get(at) - 1 : close - 1;
-		blankRange(commas.get(at - 1) + 1, end);
-		inject(first, text);
+		this.tokens.blankRange(commas.get(at - 1) + 1, end);
+		this.tokens.inject(first, text);
 	}
 
 	/**
@@ -2621,8 +2608,10 @@ public final class GlslTranslator {
 	 * every one of them.
 	 */
 	private void convertFragCoord(int index) {
-		int dot = significantAfter(index);
-		int swizzle = dot >= 0 && this.tokens.get(dot).operator(".") ? significantAfter(dot) : -1;
+		int dot = this.tokens.significantAfter(index);
+		int swizzle = dot >= 0 && this.tokens.get(dot).operator(".")
+				? this.tokens.significantAfter(dot)
+				: -1;
 		if (swizzle < 0 || this.tokens.get(swizzle).kind() != Kind.IDENTIFIER) {
 			// Reached some other way, a subscript or a whole vector handed to a function. Nothing
 			// in the corpus does it, and a pack that starts has to be visible rather than wrong.
@@ -2632,12 +2621,12 @@ public final class GlslTranslator {
 
 		String field = this.tokens.get(swizzle).text();
 		if (field.equals("z")) {
-			inject(index, "(" + DEPTH_CONV + ".z * gl_FragCoord.z + " + DEPTH_CONV + ".w)");
+			this.tokens.inject(index, "(" + DEPTH_CONV + ".z * gl_FragCoord.z + " + DEPTH_CONV + ".w)");
 			this.fragCoordZ++;
 		} else if (field.equals("xyz")) {
 			// Two screen components that convert to nothing and one depth that does not, so the
 			// vector has to be rebuilt. Seven sites, all in gbuffers.
-			inject(index, "vec3(gl_FragCoord.xy, " + DEPTH_CONV + ".z * gl_FragCoord.z + "
+			this.tokens.inject(index, "vec3(gl_FragCoord.xy, " + DEPTH_CONV + ".z * gl_FragCoord.z + "
 					+ DEPTH_CONV + ".w)");
 			this.fragCoordXyz++;
 		} else {
@@ -2648,8 +2637,8 @@ public final class GlslTranslator {
 			return;
 		}
 
-		blank(dot);
-		blank(swizzle);
+		this.tokens.blank(dot);
+		this.tokens.blank(swizzle);
 		takeDepthConv();
 	}
 
@@ -2677,11 +2666,11 @@ public final class GlslTranslator {
 			return;
 		}
 
-		int eq = significantAfter(index);
-		int after = significantAfter(eq);
+		int eq = this.tokens.significantAfter(index);
+		int after = this.tokens.significantAfter(eq);
 		boolean assignment = eq >= 0 && this.tokens.get(eq).operator("=")
 				&& (after < 0 || !this.tokens.get(after).operator("="));
-		int end = assignment ? statementEnd(eq) : -1;
+		int end = assignment ? this.tokens.statementEnd(eq) : -1;
 		if (end < 0) {
 			// Anything but a plain assignment ending in a semicolon. A compound one reads the
 			// value back before writing it and a fragment stage has no readable depth to start
@@ -2694,56 +2683,10 @@ public final class GlslTranslator {
 		// The pack's expression is parenthesised, which is not decoration: the right hand side may
 		// be a ternary, and multiplying into one without brackets changes what it means.
 		String directive = this.tokens.get(eq).directive();
-		inject(eq, "= (" + DEPTH_CONV + ".z * (");
+		this.tokens.inject(eq, "= (" + DEPTH_CONV + ".z * (");
 		closings.add(new Closing(end, ") + " + DEPTH_CONV + ".w)", directive));
 		takeDepthConv();
 		this.fragDepthWrites++;
-	}
-
-	/**
-	 * Inserting shifts every index after it, so the last insertion is made first.
-	 * <p>
-	 * This is the one place that moves a token, both passes that close a wrap coming through it,
-	 * and so the one place that can make a position stale. What a later pass has to know about a
-	 * token is carried on the token for that reason, as {@link Token#macroName()} is: a position
-	 * kept across here would be read against somebody else's token, and nothing downstream can
-	 * tell. The two answers this class does keep about the list, the function end and the line
-	 * table, are thrown away here for the same reason.
-	 */
-	private void insertClosings(List<Closing> closings) {
-		if (closings.isEmpty()) {
-			return;
-		}
-
-		this.functionEndFor = -1;
-		this.lineTable = null;
-
-		// One walk that copies the list with the closings dropped in, rather than one shift of
-		// every later token per closing: a stage carries hundreds of thousands of tokens and a
-		// few hundred closings, and the shifts were the whole cost of the pass. The order is the
-		// one the shifts produced: closings sharing a position land latest first, because each
-		// shift pushed the one inserted before it along.
-		closings.sort(Comparator.comparingInt(Closing::at));
-		List<Token> rebuilt = new ArrayList<>(this.tokens.size() + closings.size());
-		int next = 0;
-		for (int at = 0; at <= this.tokens.size(); at++) {
-			int first = next;
-			while (next < closings.size() && closings.get(next).at() == at) {
-				next++;
-			}
-
-			for (int closing = next - 1; closing >= first; closing--) {
-				Closing one = closings.get(closing);
-				rebuilt.add(new Token(Kind.RAW, one.text(), one.directive()));
-			}
-
-			if (at < this.tokens.size()) {
-				rebuilt.add(this.tokens.get(at));
-			}
-		}
-
-		this.tokens.clear();
-		this.tokens.addAll(rebuilt);
 	}
 
 	/**
@@ -2819,9 +2762,9 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int end = statementEnd(index);
+			int end = this.tokens.statementEnd(index);
 			if (end >= 0 && nonConstantInitialiser(index, end)) {
-				blank(index);
+				this.tokens.blank(index);
 			}
 		}
 	}
@@ -2917,7 +2860,7 @@ public final class GlslTranslator {
 			}
 
 			if (LegacyGlsl.PRECISION_QUALIFIERS.contains(token.text())) {
-				blank(index);
+				this.tokens.blank(index);
 				continue;
 			}
 
@@ -2925,11 +2868,12 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int qualifier = significantAfter(index);
-			if (qualifier >= 0 && LegacyGlsl.PRECISION_QUALIFIERS.contains(this.tokens.get(qualifier).text())) {
-				int end = statementEnd(index);
+			int qualifier = this.tokens.significantAfter(index);
+			if (qualifier >= 0
+					&& LegacyGlsl.PRECISION_QUALIFIERS.contains(this.tokens.get(qualifier).text())) {
+				int end = this.tokens.statementEnd(index);
 				if (end >= 0) {
-					blankRange(index, end);
+					this.tokens.blankRange(index, end);
 				}
 			}
 		}
@@ -2957,7 +2901,7 @@ public final class GlslTranslator {
 			}
 
 			if (token.identifier("gl_FragColor")) {
-				inject(index, "ofFragData0");
+				this.tokens.inject(index, "ofFragData0");
 				fragColor = true;
 				continue;
 			}
@@ -2975,12 +2919,12 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int open = significantAfter(index);
-			int number = significantAfter(open);
-			inject(index, "ofFragData" + slot);
-			blank(open);
-			blank(number);
-			blank(significantAfter(number));
+			int open = this.tokens.significantAfter(index);
+			int number = this.tokens.significantAfter(open);
+			this.tokens.inject(index, "ofFragData" + slot);
+			this.tokens.blank(open);
+			this.tokens.blank(number);
+			this.tokens.blank(this.tokens.significantAfter(number));
 			this.maxFragmentOutput = Math.max(this.maxFragmentOutput, slot);
 		}
 
@@ -2991,17 +2935,17 @@ public final class GlslTranslator {
 
 	/** The subscript of {@code gl_FragData[n]} when it is a literal in range, otherwise -1. */
 	private int literalIndexAfter(int index) {
-		int open = significantAfter(index);
+		int open = this.tokens.significantAfter(index);
 		if (open < 0 || !this.tokens.get(open).operator("[")) {
 			return -1;
 		}
 
-		int number = significantAfter(open);
+		int number = this.tokens.significantAfter(open);
 		if (number < 0 || this.tokens.get(number).kind() != Kind.NUMBER) {
 			return -1;
 		}
 
-		int close = significantAfter(number);
+		int close = this.tokens.significantAfter(number);
 		if (close < 0 || !this.tokens.get(close).operator("]")) {
 			return -1;
 		}
@@ -3040,7 +2984,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (!token.identifier("out") || token.directive() != null) {
@@ -3063,7 +3007,7 @@ public final class GlslTranslator {
 	 * a declaration follows the end of the last one or a layout qualifier.
 	 */
 	private boolean opensDeclaration(int index) {
-		int before = significantBefore(index);
+		int before = this.tokens.significantBefore(index);
 		if (before < 0) {
 			return true;
 		}
@@ -3074,13 +3018,13 @@ public final class GlslTranslator {
 	}
 
 	private void liftOutput(int keyword) {
-		int start = statementStart(keyword);
-		int end = statementEnd(keyword);
+		int start = this.tokens.statementStart(keyword);
+		int end = this.tokens.statementEnd(keyword);
 		if (start < 0 || end < 0) {
 			return;
 		}
 
-		List<Integer> parts = significantRange(start, end);
+		List<Integer> parts = this.tokens.significantRange(start, end);
 		int cursor = parts.indexOf(keyword);
 
 		// A type, one declarator and the semicolon, and nothing else. A pack that declares two
@@ -3106,7 +3050,7 @@ public final class GlslTranslator {
 		}
 
 		if (this.packOutputs.putIfAbsent(location, new Output(name.text(), type)) == null) {
-			blankRange(start, end);
+			this.tokens.blankRange(start, end);
 		}
 	}
 
@@ -3156,7 +3100,7 @@ public final class GlslTranslator {
 
 		int brace = mainBrace();
 		if (brace >= 0) {
-			inject(brace, "{ " + ORDER_OUTPUTS + "();");
+			this.tokens.inject(brace, "{ " + ORDER_OUTPUTS + "();");
 			this.ordered = true;
 		}
 	}
@@ -3247,12 +3191,13 @@ public final class GlslTranslator {
 	 * after the fact, once, whereas rewriting each write would compose the conversion once per write.
 	 * <p>
 	 * It is a wrapper around {@code main} and not an injection before its closing brace because
-	 * {@link #matchingBracket} cannot close a brace and, more to the point, counts operators without
-	 * looking at whether their line is live: {@link #liftUniforms} refuses to count brace depth for
-	 * that very reason, a pack opening a brace in one branch of an {@code #if} and closing it in
-	 * another. A misplaced closing brace would put the epilogue in the middle of the code. Wrapping
-	 * also survives an early {@code return} from {@code main}, which no vertex stage in the corpus
-	 * does, and the header is already where code of ours is written.
+	 * {@link TokenStream#matchingBracket} cannot close a brace and, more to the point, counts
+	 * operators without looking at whether their line is live: {@link #liftUniforms} refuses to
+	 * count brace depth for that very reason, a pack opening a brace in one branch of an
+	 * {@code #if} and closing it in another. A misplaced closing brace would put the epilogue in
+	 * the middle of the code. Wrapping also survives an early {@code return} from {@code main},
+	 * which no vertex stage in the corpus does, and the header is already where code of ours is
+	 * written.
 	 * <p>
 	 * The depth conversion is for vertex stages only. A geometry stage writes {@code gl_Position}
 	 * once per {@code EmitVertex}, so an epilogue would land in the wrong place, and a program
@@ -3267,7 +3212,7 @@ public final class GlslTranslator {
 	private void wrapMain() {
 		if (this.stage == ProgramStage.FRAGMENT) {
 			if (wrapsFragment()) {
-				replace(this.packMainName, PACK_MAIN);
+				this.tokens.replace(this.packMainName, PACK_MAIN);
 				this.mainWrapped = true;
 			}
 
@@ -3306,7 +3251,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		replace(name, PACK_MAIN);
+		this.tokens.replace(name, PACK_MAIN);
 		this.terrainPrologue = terrain;
 		this.distantPrologue = distant;
 		this.entityWrapped = overlay;
@@ -3359,7 +3304,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (token.directive() != null || !this.unit.isLive(lines[index])) {
@@ -3392,7 +3337,7 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			blankRange(declared.start(), declared.end());
+			this.tokens.blankRange(declared.start(), declared.end());
 
 			for (String name : declared.names()) {
 				this.splitMatrices.add(new SplitMatrix(name, declared.type(), layout.columnType(),
@@ -3427,7 +3372,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		replace(name, PACK_MAIN);
+		this.tokens.replace(name, PACK_MAIN);
 		this.mainWrapped = true;
 	}
 
@@ -3437,7 +3382,7 @@ public final class GlslTranslator {
 	 * counts as the body.
 	 */
 	private int mainNameAfterOutputOrder() {
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (!token.identifier("main") || token.directive() != null
@@ -3445,8 +3390,8 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int close = matchingBracket(callOpener(index));
-			int brace = significantAfter(close);
+			int close = this.tokens.matchingBracket(this.tokens.callOpener(index));
+			int brace = this.tokens.significantAfter(close);
 			if (brace >= 0) {
 				Token after = this.tokens.get(brace);
 				if (after.kind() == Kind.RAW && after.text().startsWith("{")) {
@@ -3542,7 +3487,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (token.directive() != null || !this.unit.isLive(lines[index])) {
@@ -3574,7 +3519,7 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			blankRange(declared.start(), declared.end());
+			this.tokens.blankRange(declared.start(), declared.end());
 
 			for (String name : declared.names()) {
 				this.splitStructs.add(new SplitStruct(name, declared.type(), members,
@@ -3593,7 +3538,7 @@ public final class GlslTranslator {
 
 			int[] definition = definitionRange(split.structType());
 			if (definition != null) {
-				blankRange(definition[0], definition[1]);
+				this.tokens.blankRange(definition[0], definition[1]);
 			}
 		}
 	}
@@ -3604,7 +3549,7 @@ public final class GlslTranslator {
 	 */
 	private Map<String, List<StructMember>> structDefinitions() {
 		Map<String, List<StructMember>> definitions = new LinkedHashMap<>();
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (!token.identifier("struct") || token.directive() != null
@@ -3612,15 +3557,15 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int name = significantAfter(index);
-			int open = significantAfter(name);
+			int name = this.tokens.significantAfter(index);
+			int open = this.tokens.significantAfter(name);
 			if (name < 0 || open < 0 || this.tokens.get(name).kind() != Kind.IDENTIFIER
 					|| !this.tokens.get(open).operator("{")) {
 				continue;
 			}
 
-			int close = matchingBracket(open);
-			int semicolon = significantAfter(close);
+			int close = this.tokens.matchingBracket(open);
+			int semicolon = this.tokens.significantAfter(close);
 			// A definition that declares an instance in the same breath, "struct T { ... } t;",
 			// is left alone: taking it out of the body would take the instance with it.
 			if (close < 0 || semicolon < 0 || !this.tokens.get(semicolon).operator(";")) {
@@ -3643,7 +3588,7 @@ public final class GlslTranslator {
 	private List<StructMember> structMembers(int start, int end) {
 		List<StructMember> members = new ArrayList<>();
 		List<Integer> statement = new ArrayList<>();
-		for (int scan : significantRange(start, end)) {
+		for (int scan : this.tokens.significantRange(start, end)) {
 			Token token = this.tokens.get(scan);
 			if (!token.operator(";")) {
 				statement.add(scan);
@@ -3683,7 +3628,7 @@ public final class GlslTranslator {
 	 * closing it, or null where the unit holds none.
 	 */
 	private int[] definitionRange(String structType) {
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (!token.identifier("struct") || token.directive() != null
@@ -3691,15 +3636,15 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int name = significantAfter(index);
-			int open = significantAfter(name);
+			int name = this.tokens.significantAfter(index);
+			int open = this.tokens.significantAfter(name);
 			if (name < 0 || open < 0 || !this.tokens.get(name).identifier(structType)
 					|| !this.tokens.get(open).operator("{")) {
 				continue;
 			}
 
-			int close = matchingBracket(open);
-			int semicolon = significantAfter(close);
+			int close = this.tokens.matchingBracket(open);
+			int semicolon = this.tokens.significantAfter(close);
 			if (close >= 0 && semicolon >= 0 && this.tokens.get(semicolon).operator(";")) {
 				return new int[] {index, semicolon};
 			}
@@ -3742,7 +3687,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (token.directive() != null || !this.unit.isLive(lines[index])
@@ -3775,7 +3720,7 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			blankRange(declared.start(), declared.end());
+			this.tokens.blankRange(declared.start(), declared.end());
 			this.splitArrays.addAll(found);
 		}
 	}
@@ -3809,7 +3754,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		replace(name, PACK_MAIN);
+		this.tokens.replace(name, PACK_MAIN);
 		this.mainWrapped = true;
 	}
 
@@ -3830,7 +3775,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (token.directive() != null || !this.unit.isLive(lines[index])) {
@@ -3854,7 +3799,7 @@ public final class GlslTranslator {
 		}
 
 		declared.names().forEach(name -> this.synthesized.putIfAbsent(name, declared.type()));
-		blankRange(declared.start(), declared.end());
+		this.tokens.blankRange(declared.start(), declared.end());
 	}
 
 	/**
@@ -3874,7 +3819,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (token.directive() != null || !this.unit.isLive(lines[index])) {
@@ -3930,7 +3875,7 @@ public final class GlslTranslator {
 		boolean dropped = false;
 		for (FileScope declared : unprovided) {
 			if (declared.names().stream().noneMatch(read::contains)) {
-				blankRange(declared.start(), declared.end());
+				this.tokens.blankRange(declared.start(), declared.end());
 				this.droppedInputs.addAll(declared.names());
 				dropped = true;
 				continue;
@@ -4022,13 +3967,13 @@ public final class GlslTranslator {
 			// From the start of the statement up to the type, which is the first token that is
 			// neither the keyword nor a qualifier. Either order has to be taken: GLSL accepts both,
 			// Mellow opens with flat, and fileScopeDeclaration already gathers them both ways.
-			for (int index : significantRange(scope.start(), scope.end())) {
+			for (int index : this.tokens.significantRange(scope.start(), scope.end())) {
 				String text = this.tokens.get(index).text();
 				if (!text.equals("out") && !LegacyGlsl.INTERPOLATION_QUALIFIERS.contains(text)) {
 					break;
 				}
 
-				blank(index);
+				this.tokens.blank(index);
 			}
 
 			this.declaredOutputs.removeAll(scope.names());
@@ -4093,7 +4038,7 @@ public final class GlslTranslator {
 		}
 
 		int[] region = this.regions;
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		Map<String, Set<Integer>> shadowed = new HashMap<>();
 		Set<String> read = new HashSet<>();
 
@@ -4106,7 +4051,7 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int before = significantBefore(index);
+			int before = this.tokens.significantBefore(index);
 			boolean declares = before >= 0
 					&& LegacyGlsl.TYPE_NAMES.contains(this.tokens.get(before).text());
 			if (declares && region[index] >= 0) {
@@ -4141,7 +4086,7 @@ public final class GlslTranslator {
 					current++;
 					// Back over the signature, so that a parameter counts as declared inside the
 					// body it names things for rather than at file scope beside it.
-					int from = statementStart(index);
+					int from = this.tokens.statementStart(index);
 					for (int back = from < 0 ? index : from; back <= index; back++) {
 						region[back] = current;
 					}
@@ -4211,13 +4156,13 @@ public final class GlslTranslator {
 	 * and nothing else asks for.
 	 */
 	private FileScope fileScopeDeclaration(int keyword, Set<String> types) {
-		int end = statementEnd(keyword);
-		int start = end < 0 ? -1 : statementStart(keyword);
+		int end = this.tokens.statementEnd(keyword);
+		int start = end < 0 ? -1 : this.tokens.statementStart(keyword);
 		if (start < 0) {
 			return null;
 		}
 
-		List<Integer> parts = significantRange(start, end);
+		List<Integer> parts = this.tokens.significantRange(start, end);
 		int cursor = parts.indexOf(keyword);
 		if (cursor < 0) {
 			return null;
@@ -4237,7 +4182,8 @@ public final class GlslTranslator {
 
 		cursor++;
 		while (cursor < parts.size() && (isQualifier(this.tokens.get(parts.get(cursor)))
-				|| LegacyGlsl.INTERPOLATION_QUALIFIERS.contains(this.tokens.get(parts.get(cursor)).text()))) {
+				|| LegacyGlsl.INTERPOLATION_QUALIFIERS
+						.contains(this.tokens.get(parts.get(cursor)).text()))) {
 			String text = this.tokens.get(parts.get(cursor)).text();
 			if (LegacyGlsl.INTERPOLATION_QUALIFIERS.contains(text)) {
 				qualifiers.add(text);
@@ -4280,7 +4226,10 @@ public final class GlslTranslator {
 	private int mainBrace() {
 		int name = mainName();
 
-		return name < 0 ? -1 : significantAfter(matchingBracket(callOpener(name)));
+		return name < 0
+				? -1
+				: this.tokens.significantAfter(
+						this.tokens.matchingBracket(this.tokens.callOpener(name)));
 	}
 
 	/**
@@ -4292,7 +4241,7 @@ public final class GlslTranslator {
 	 * compiler actually sees would name its outputs in whatever order the pack wrote them in.
 	 */
 	private int mainName() {
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (!token.identifier("main") || token.directive() != null
@@ -4300,8 +4249,8 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int close = matchingBracket(callOpener(index));
-			int brace = significantAfter(close);
+			int close = this.tokens.matchingBracket(this.tokens.callOpener(index));
+			int brace = this.tokens.significantAfter(close);
 			if (brace >= 0 && this.tokens.get(brace).operator("{")) {
 				return index;
 			}
@@ -4321,7 +4270,7 @@ public final class GlslTranslator {
 	 * the file.
 	 */
 	private void liftUniforms() {
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
@@ -4397,19 +4346,19 @@ public final class GlslTranslator {
 	}
 
 	private void liftOne(int keyword) {
-		int end = statementEnd(keyword);
+		int end = this.tokens.statementEnd(keyword);
 		if (end < 0) {
 			// Either a uniform block, which is already legal, or a declaration with no semicolon,
 			// which is a pack problem and not ours to paper over.
 			return;
 		}
 
-		int start = statementStart(keyword);
+		int start = this.tokens.statementStart(keyword);
 		if (start < 0) {
 			return;
 		}
 
-		List<Integer> parts = significantRange(start, end);
+		List<Integer> parts = this.tokens.significantRange(start, end);
 		int keywordAt = parts.indexOf(keyword);
 		if (keywordAt < 0) {
 			return;
@@ -4453,7 +4402,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		blankRange(start, end);
+		this.tokens.blankRange(start, end);
 	}
 
 	/**
@@ -4498,7 +4447,7 @@ public final class GlslTranslator {
 	 * whose soft-compare switch is armed.
 	 */
 	private void collectComparisonSamplers() {
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		int depth = 0;
 		int parameters = -1;
 		boolean arithmetic = softCompare() || this.stage == ProgramStage.COMPUTE;
@@ -4529,10 +4478,11 @@ public final class GlslTranslator {
 
 			// Every identifier this declaration introduces, and how far what it introduces them
 			// into reaches. Array bounds and commas are not identifiers, so they are stepped over.
-			int last = depth > 0 ? functionEnd(parameters) : this.tokens.size() - 1;
+			int last = depth > 0 ? this.tokens.functionEnd(parameters) : this.tokens.size() - 1;
 			List<Scoped> introduced = new ArrayList<>();
 			boolean bindable = !arithmetic;
-			for (int scan = significantAfter(index); scan >= 0; scan = significantAfter(scan)) {
+			for (int scan = this.tokens.significantAfter(index); scan >= 0;
+					scan = this.tokens.significantAfter(scan)) {
 				Token next = this.tokens.get(scan);
 				if (next.operator(";") || (depth > 0 && (next.operator(",") || next.operator(")")))) {
 					break;
@@ -4556,7 +4506,7 @@ public final class GlslTranslator {
 			} else if (bindable) {
 				this.hardwareComparisonSamplers.addAll(introduced);
 			} else {
-				replace(index, plain);
+				this.tokens.replace(index, plain);
 				this.comparisonSamplers.addAll(introduced);
 			}
 		}
@@ -4568,7 +4518,7 @@ public final class GlslTranslator {
 		}
 
 		for (int index : parameterTypes) {
-			replace(index, withoutComparison(this.tokens.get(index).text()));
+			this.tokens.replace(index, withoutComparison(this.tokens.get(index).text()));
 		}
 
 		this.comparisonSamplers.addAll(parameterNames);
@@ -4583,7 +4533,7 @@ public final class GlslTranslator {
 	 * counter, so the one thing it could not do was also the one thing nothing measured.
 	 */
 	private void collectSamplerParameters() {
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		int depth = 0;
 		int parameters = -1;
 		int position = 0;
@@ -4611,16 +4561,16 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int name = significantAfter(index);
+			int name = this.tokens.significantAfter(index);
 			if (name >= 0 && this.tokens.get(name).kind() == Kind.IDENTIFIER) {
 				Scoped parameter = new Scoped(this.tokens.get(name).text(), lines[index],
-						lines[functionEnd(parameters)]);
+						lines[this.tokens.functionEnd(parameters)]);
 				this.samplerParameters.add(parameter);
 				if (!levelled(token.text())) {
 					this.unlevelledParameters.add(parameter);
 				}
 
-				int function = significantBefore(parameters);
+				int function = this.tokens.significantBefore(parameters);
 				if (function >= 0 && this.tokens.get(function).kind() == Kind.IDENTIFIER) {
 					this.typedParameters.add(new SamplerParameter(this.tokens.get(function).text(),
 							position, parameter));
@@ -4698,7 +4648,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		List<Integer> members = new ArrayList<>();
 		List<Integer> reads = new ArrayList<>();
 
@@ -4729,7 +4679,7 @@ public final class GlslTranslator {
 		members.forEach(this::detachMember);
 
 		this.samplers.put(texel, SAMPLER_2D + " " + texel);
-		reads.forEach(read -> inject(read, LOOKUP + "(" + texel + ", vec2(0.5)).r"));
+		reads.forEach(read -> this.tokens.inject(read, LOOKUP + "(" + texel + ", vec2(0.5)).r"));
 	}
 
 	/**
@@ -4771,7 +4721,7 @@ public final class GlslTranslator {
 	private int declarationType(int name) {
 		int cursor = name;
 		while (cursor > 0) {
-			int before = significantBefore(cursor);
+			int before = this.tokens.significantBefore(cursor);
 			if (before < 0) {
 				return -1;
 			}
@@ -4787,7 +4737,7 @@ public final class GlslTranslator {
 
 			// The declarator this comma binds to the list. Anything else there, an initialiser or a
 			// closing bracket, is an expression and not a list this pass knows how to read.
-			int previous = significantBefore(before);
+			int previous = this.tokens.significantBefore(before);
 			if (previous < 0 || this.tokens.get(previous).kind() != Kind.IDENTIFIER) {
 				return -1;
 			}
@@ -4807,9 +4757,9 @@ public final class GlslTranslator {
 			return false;
 		}
 
-		int cursor = significantBefore(type);
+		int cursor = this.tokens.significantBefore(type);
 		while (cursor >= 0 && isQualifier(this.tokens.get(cursor))) {
-			cursor = significantBefore(cursor);
+			cursor = this.tokens.significantBefore(cursor);
 		}
 
 		return cursor >= 0 && this.tokens.get(cursor).identifier("uniform");
@@ -4825,31 +4775,31 @@ public final class GlslTranslator {
 	 * nothing, it is a syntax error.
 	 */
 	private void detachMember(int name) {
-		int before = significantBefore(name);
+		int before = this.tokens.significantBefore(name);
 		if (before >= 0 && this.tokens.get(before).operator(",")) {
-			blank(before);
-			blank(name);
+			this.tokens.blank(before);
+			this.tokens.blank(name);
 
 			return;
 		}
 
-		int after = significantAfter(name);
+		int after = this.tokens.significantAfter(name);
 		if (after >= 0 && this.tokens.get(after).operator(",")) {
-			blank(name);
-			blank(after);
+			this.tokens.blank(name);
+			this.tokens.blank(after);
 
 			return;
 		}
 
-		int start = statementStart(name);
-		int end = statementEnd(name);
+		int start = this.tokens.statementStart(name);
+		int end = this.tokens.statementEnd(name);
 		if (start < 0 || end < 0) {
 			// A declaration with no semicolon, which is a pack problem and not ours to paper over.
 			// Left whole rather than half emptied, the way the lifting leaves it.
 			return;
 		}
 
-		blankRange(start, end);
+		this.tokens.blankRange(start, end);
 	}
 
 	/**
@@ -4881,7 +4831,7 @@ public final class GlslTranslator {
 			return;
 		}
 
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		this.volumes.forEach((name, atlas) -> flattenOne(name, atlas, lines));
 	}
 
@@ -4935,13 +4885,13 @@ public final class GlslTranslator {
 
 		String forged = SamplerPlan.forged(name);
 		for (int declaration : declarations) {
-			replace(significantBefore(declaration), "sampler2D");
-			replace(declaration, forged);
+			this.tokens.replace(this.tokens.significantBefore(declaration), "sampler2D");
+			this.tokens.replace(declaration, forged);
 		}
 
 		lookups.forEach((argument, callee) -> {
-			replace(callee, VOLUME_LOOKUP + name);
-			replace(argument, forged);
+			this.tokens.replace(callee, VOLUME_LOOKUP + name);
+			this.tokens.replace(argument, forged);
 		});
 
 		this.volumeLookups += lookups.size();
@@ -4993,15 +4943,15 @@ public final class GlslTranslator {
 	 * that would leave the body reading a parameter nobody passes.
 	 */
 	private boolean volumeDeclaration(int index) {
-		int type = significantBefore(index);
+		int type = this.tokens.significantBefore(index);
 		if (type < 0 || this.tokens.get(type).kind() != Kind.IDENTIFIER
 				|| !"3D".equals(SamplerTypes.shapeOf(this.tokens.get(type).text()))) {
 			return false;
 		}
 
-		int cursor = significantBefore(type);
+		int cursor = this.tokens.significantBefore(type);
 		while (cursor >= 0 && isQualifier(this.tokens.get(cursor))) {
-			cursor = significantBefore(cursor);
+			cursor = this.tokens.significantBefore(cursor);
 		}
 
 		return cursor >= 0 && this.tokens.get(cursor).identifier("uniform");
@@ -5013,17 +4963,17 @@ public final class GlslTranslator {
 	 * and means something else, and the helper takes two.
 	 */
 	private int plainLookup(int index) {
-		int open = significantBefore(index);
+		int open = this.tokens.significantBefore(index);
 		if (open < 0 || !this.tokens.get(open).operator("(")) {
 			return -1;
 		}
 
-		int callee = significantBefore(open);
+		int callee = this.tokens.significantBefore(open);
 		if (callee < 0 || !this.tokens.get(callee).identifier(LOOKUP)) {
 			return -1;
 		}
 
-		int close = matchingBracket(open);
+		int close = this.tokens.matchingBracket(open);
 
 		return close >= 0 && arguments(open, close) == LOOKUP_ARGUMENTS ? callee : -1;
 	}
@@ -5122,7 +5072,7 @@ public final class GlslTranslator {
 	 * the reason a uniform in one is: the compiler will not see it either.
 	 */
 	private void collectStorageBlocks() {
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
@@ -5131,20 +5081,20 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int name = significantAfter(index);
+			int name = this.tokens.significantAfter(index);
 			if (name < 0 || this.tokens.get(name).kind() != Kind.IDENTIFIER) {
 				continue;
 			}
 
-			int brace = significantAfter(name);
+			int brace = this.tokens.significantAfter(name);
 			if (brace < 0 || !this.tokens.get(brace).operator("{")) {
 				continue;
 			}
 
 			int binding = layoutBinding(index);
 			note(this.tokens.get(name).text(), binding);
-			int close = matchingBracket(brace);
-			int instance = close < 0 ? -1 : significantAfter(close);
+			int close = this.tokens.matchingBracket(brace);
+			int instance = close < 0 ? -1 : this.tokens.significantAfter(close);
 			if (instance >= 0 && this.tokens.get(instance).kind() == Kind.IDENTIFIER) {
 				note(this.tokens.get(instance).text(), binding);
 			}
@@ -5186,12 +5136,12 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int equals = significantAfter(scan);
+			int equals = this.tokens.significantAfter(scan);
 			if (equals < 0 || !this.tokens.get(equals).operator("=")) {
 				continue;
 			}
 
-			int number = significantAfter(equals);
+			int number = this.tokens.significantAfter(equals);
 			if (number < 0 || this.tokens.get(number).kind() != Kind.NUMBER) {
 				continue;
 			}
@@ -5204,37 +5154,6 @@ public final class GlslTranslator {
 		}
 
 		return -1;
-	}
-
-	/**
-	 * The last token of the function a parameter list opens, which is the brace that closes the
-	 * body, or the parenthesis itself when the function is only declared.
-	 */
-	private int functionEnd(int parameters) {
-		// Asked once per parameter of a list and answered once per list: the walk to the
-		// function's closing brace is the same for every parameter, and every helper that
-		// touches a token forgets this first.
-		if (parameters == this.functionEndFor) {
-			return this.functionEndAt;
-		}
-
-		int end = walkFunctionEnd(parameters);
-		this.functionEndFor = parameters;
-		this.functionEndAt = end;
-
-		return end;
-	}
-
-	private int walkFunctionEnd(int parameters) {
-		int close = matchingBracket(parameters);
-		int brace = close < 0 ? -1 : significantAfter(close);
-		if (brace < 0 || !this.tokens.get(brace).operator("{")) {
-			return close < 0 ? this.tokens.size() - 1 : close;
-		}
-
-		int end = matchingBracket(brace);
-
-		return end < 0 ? this.tokens.size() - 1 : end;
 	}
 
 	/**
@@ -5308,7 +5227,7 @@ public final class GlslTranslator {
 			cursor++;
 
 			while (cursor < parts.size() && this.tokens.get(parts.get(cursor)).operator("[")) {
-				int close = matchingBracket(parts.get(cursor));
+				int close = this.tokens.matchingBracket(parts.get(cursor));
 				if (close < 0) {
 					return false;
 				}
@@ -5956,7 +5875,7 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			int before = significantBefore(index);
+			int before = this.tokens.significantBefore(index);
 			if (before >= 0 && LegacyGlsl.TYPE_NAMES.contains(this.tokens.get(before).text())) {
 				names.add(token.text());
 			}
@@ -5972,7 +5891,7 @@ public final class GlslTranslator {
 	 */
 	private Set<String> sampledNames() {
 		boolean[] declared = new boolean[this.tokens.size()];
-		int[] lines = lineNumbers();
+		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (!token.identifier("uniform") || token.directive() != null
@@ -6057,276 +5976,6 @@ public final class GlslTranslator {
 				.toList();
 	}
 
-
-	private void replace(int index, String text) {
-		this.functionEndFor = -1;
-		this.tokens.set(index, this.tokens.get(index).as(text));
-	}
-
-	/** Replaces a token with text of our own, which no later pass will match again. */
-	private void inject(int index, String text) {
-		this.functionEndFor = -1;
-		this.tokens.set(index, new Token(Kind.RAW, text, this.tokens.get(index).directive()));
-	}
-
-	private void blank(int index) {
-		this.functionEndFor = -1;
-		if (index >= 0) {
-			this.tokens.set(index, Token.BLANK);
-		}
-	}
-
-	/** Empties a range but keeps its line breaks, so error messages still point at the right line. */
-	private void blankRange(int start, int end) {
-		this.functionEndFor = -1;
-		for (int index = start; index <= end; index++) {
-			Token token = this.tokens.get(index);
-			if (token.kind() == Kind.NEWLINE) {
-				continue;
-			}
-
-			// A comment or a spliced line carries its breaks inside one token, and they are kept
-			// as well: the passes that ask which line a name is on take their numbers once and
-			// read them after blanking, so a break lost here moves every name after it.
-			long breaks = token.text().chars().filter(c -> c == '\n').count();
-			this.tokens.set(index, breaks == 0
-					? Token.BLANK
-					: new Token(Kind.SPACE, "\n".repeat((int) breaks), token.directive()));
-		}
-	}
-
-	private void blankDirective(int hash) {
-		this.functionEndFor = -1;
-		for (int index = hash; index < this.tokens.size(); index++) {
-			if (this.tokens.get(index).kind() == Kind.NEWLINE) {
-				return;
-			}
-
-			this.tokens.set(index, Token.BLANK);
-		}
-	}
-
-	/**
-	 * The next token that is neither space nor comment. A line break ends the search inside a
-	 * directive, since a directive is one line, and is stepped over everywhere else.
-	 */
-	private int significantAfter(int index) {
-		if (index < 0) {
-			return -1;
-		}
-
-		boolean directive = this.tokens.get(index).directive() != null;
-		for (int scan = index + 1; scan < this.tokens.size(); scan++) {
-			Token token = this.tokens.get(scan);
-			if (token.trivia()) {
-				continue;
-			}
-
-			if (token.kind() == Kind.NEWLINE) {
-				if (directive) {
-					return -1;
-				}
-
-				continue;
-			}
-
-			return scan;
-		}
-
-		return -1;
-	}
-
-	/**
-	 * The identifier a directive declares or tests, which is the second one on its line. The first
-	 * is the directive keyword itself.
-	 */
-	private int macroNameAfter(int hash) {
-		boolean keywordSeen = false;
-
-		for (int scan = hash + 1; scan < this.tokens.size(); scan++) {
-			Token token = this.tokens.get(scan);
-			if (token.kind() == Kind.NEWLINE) {
-				return -1;
-			}
-
-			if (token.trivia()) {
-				continue;
-			}
-
-			if (!keywordSeen) {
-				keywordSeen = true;
-				continue;
-			}
-
-			return token.kind() == Kind.IDENTIFIER ? scan : -1;
-		}
-
-		return -1;
-	}
-
-	/** The previous token that is neither space, comment nor line break, staying out of directives. */
-	private int significantBefore(int index) {
-		for (int scan = index - 1; scan >= 0; scan--) {
-			Token token = this.tokens.get(scan);
-			if (token.trivia() || token.kind() == Kind.NEWLINE) {
-				continue;
-			}
-
-			return token.directive() == null ? scan : -1;
-		}
-
-		return -1;
-	}
-
-	/**
-	 * Which line of the expanded unit each token sits on.
-	 * <p>
-	 * Kept between calls, which a stage makes twenty three times, and thrown away by
-	 * {@link #insertClosings}, the one pass that moves a token. Nothing else can make it stale:
-	 * every other helper that touches the list leaves the line breaks where they were, which
-	 * {@link #blankRange} goes out of its way to do. That is not this table's rule either, it is
-	 * the unit's: a break lost anywhere would move every line after it away from the one
-	 * {@link ExpandedUnit#isLive} is asked about, and no pass would have a way to notice.
-	 */
-	private int[] lineNumbers() {
-		if (this.lineTable != null) {
-			return this.lineTable;
-		}
-
-		int[] lines = new int[this.tokens.size()];
-		int line = 0;
-
-		for (int index = 0; index < this.tokens.size(); index++) {
-			lines[index] = line;
-			String text = this.tokens.get(index).text();
-			for (int at = 0; at < text.length(); at++) {
-				if (text.charAt(at) == '\n') {
-					line++;
-				}
-			}
-		}
-
-		this.lineTable = lines;
-
-		return lines;
-	}
-
-	/** The opening parenthesis of a call on the identifier at this index, or -1 if it is not one. */
-	private int callOpener(int index) {
-		int next = significantAfter(index);
-
-		return next >= 0 && this.tokens.get(next).operator("(") ? next : -1;
-	}
-
-	private int matchingBracket(int open) {
-		if (open < 0) {
-			return -1;
-		}
-
-		String opening = this.tokens.get(open).text();
-		String closing = switch (opening) {
-			case "(" -> ")";
-			case "{" -> "}";
-			default -> "]";
-		};
-		int depth = 0;
-
-		for (int scan = open; scan < this.tokens.size(); scan++) {
-			Token token = this.tokens.get(scan);
-			if (token.kind() != Kind.OPERATOR) {
-				continue;
-			}
-
-			if (token.operator(opening)) {
-				depth++;
-			} else if (token.operator(closing)) {
-				depth--;
-				if (depth == 0) {
-					return scan;
-				}
-			}
-		}
-
-		return -1;
-	}
-
-	/**
-	 * Where the statement containing this token starts: just past whatever ended the last one.
-	 * Returns -1 when no end to the previous statement is within reach, since blanking a range
-	 * whose beginning was guessed would erase code that is none of our business.
-	 */
-	private int statementStart(int index) {
-		int limit = Math.max(0, index - MAX_STATEMENT_TOKENS);
-		int start = -1;
-
-		for (int scan = index - 1; scan >= limit; scan--) {
-			Token token = this.tokens.get(scan);
-			boolean boundary = token.kind() == Kind.HASH || token.directive() != null
-					|| token.operator(";") || token.operator("{") || token.operator("}");
-			if (boundary) {
-				start = scan + 1;
-				break;
-			}
-		}
-
-		if (start < 0) {
-			// Reaching the first token is a real answer; running out of budget is not.
-			if (limit > 0) {
-				return -1;
-			}
-
-			start = 0;
-		}
-
-		while (start < index) {
-			Token token = this.tokens.get(start);
-			if (!token.trivia() && token.kind() != Kind.NEWLINE) {
-				break;
-			}
-
-			start++;
-		}
-
-		return start;
-	}
-
-	/** The semicolon closing this statement, or -1 if a brace opens first or none is found. */
-	private int statementEnd(int index) {
-		int depth = 0;
-		int last = Math.min(this.tokens.size(), index + MAX_STATEMENT_TOKENS);
-
-		for (int scan = index; scan < last; scan++) {
-			Token token = this.tokens.get(scan);
-			if (token.kind() != Kind.OPERATOR || token.directive() != null) {
-				continue;
-			}
-
-			String text = token.text();
-			if (text.equals("(") || text.equals("[")) {
-				depth++;
-			} else if (text.equals(")") || text.equals("]")) {
-				depth--;
-			} else if (depth == 0 && text.equals("{")) {
-				return -1;
-			} else if (depth == 0 && text.equals(";")) {
-				return scan;
-			}
-		}
-
-		return -1;
-	}
-
-	private List<Integer> significantRange(int start, int end) {
-		List<Integer> found = new ArrayList<>();
-		for (int scan = start; scan <= end; scan++) {
-			Token token = this.tokens.get(scan);
-			if (!token.trivia() && token.kind() != Kind.NEWLINE) {
-				found.add(scan);
-			}
-		}
-
-		return found;
-	}
 
 	/** Adds a memory qualifier to what a declaration carries, in the order the pack wrote it. */
 	private static void rememberMemoryQualifier(List<String> memory, Token token) {

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -32,8 +32,6 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -47,7 +45,8 @@ import java.util.stream.Stream;
  * The tokens themselves, and every way of reading them or changing them, belong to
  * {@link TokenStream} rather than to this class, and the header written in front of what the
  * passes leave belongs to {@link Emitter}. What is left here is the pipeline: one pass per rule,
- * in the order {@link #rewrite} runs them.
+ * in the order {@link #rewrite} runs them, one of them being {@link VaryingSplit}, which is a
+ * class of its own for the state it carries out of the text.
  * <p>
  * Two things are deliberately left undone, and both were done by the measuring prototype.
  * No {@code layout(binding = )} is emitted, and no {@code layout(location = )} except on fragment
@@ -86,41 +85,14 @@ import java.util.stream.Stream;
 	 * A GLSL matrix occupies one location per column, three for a {@code mat3}, but it is still one
 	 * reflected name, so the next varying is numbered onto column two. OpenGL links by name and
 	 * never asks the question; the workaround here is to split each matrix varying into that many
-	 * vectors before compilation and rebuild the matrix as a local, which is what
-	 * {@link #splitMatrixVaryings} does. A struct varying is the same case with a member per
-	 * location, an array varying with an element per location, and {@link #splitStructVaryings}
-	 * and {@link #splitArrayVaryings} do the same to them. Iris is not copied.
+	 * vectors before compilation and rebuild the matrix as a local. A struct varying is the same
+	 * case with a member per location and an array varying with an element per location, and
+	 * {@link VaryingSplit} answers all three. Iris is not copied.
  */
 public final class GlslTranslator {
 
 	/** The one varying the engine names itself, so the one both stages have to agree about. */
 	static final String FOG_COORD = "of_FogFragCoord";
-
-	/**
-	 * Prefix of the vectors a matrix varying is split into. Pack names never start with {@code of_},
-	 * so a column cannot collide with a varying the pack already declared.
-	 */
-	private static final String MATRIX_COLUMN = "of_vmat_";
-
-	/** The prefix of a varying standing for one member of a struct varying. */
-	private static final String STRUCT_MEMBER = "of_vstruct_";
-
-	/** The prefix of a varying standing for one element of an array varying. */
-	private static final String ARRAY_ELEMENT = "of_varr_";
-
-	/**
-	 * A declarator's array suffix, one dimension sized by a number the pack wrote out: one to
-	 * a few hundred elements, since no interface has that many locations and a zero is no array.
-	 */
-	private static final Pattern ARRAY_SUFFIX = Pattern.compile("\\[\\s*([1-9]\\d{0,2})\\s*\\]$");
-
-	/**
-	 * The member types a struct varying is split over: one location apiece, nothing nested, and
-	 * nothing a varying may not be, which rules the booleans out.
-	 */
-	private static final Set<String> STRUCT_MEMBER_TYPES = Set.of(
-			"float", "vec2", "vec3", "vec4", "int", "ivec2", "ivec3", "ivec4",
-			"uint", "uvec2", "uvec3", "uvec4", "double", "dvec2", "dvec3", "dvec4");
 
 	/**
 	 * The hit flash and the damage tint, which is a varying wherever the mesh carries the overlay and
@@ -372,6 +344,9 @@ public final class GlslTranslator {
 	private final boolean coverage;
 	private final TokenStream tokens;
 
+	/** The varyings this stage had to hand over one location at a time. */
+	private final VaryingSplit splits;
+
 	/** Names the pack defines as macros. Their uses belong to the preprocessor, not to us. */
 	private final Set<String> packMacros = new HashSet<>();
 
@@ -471,24 +446,6 @@ public final class GlslTranslator {
 
 	/** The same, as the declarations they came from, so that one can be taken back out whole. */
 	private final List<FileScope> declaredOutputScopes = new ArrayList<>();
-
-	/**
-	 * Matrix varyings rewritten as one vector per column, so {@code createFromSpirv} can number
-	 * them without overlap. Empty when the stage declared none.
-	 */
-	private final List<SplitMatrix> splitMatrices = new ArrayList<>();
-
-	/**
-	 * Struct varyings rewritten as one varying per member, for the same numbering. Empty when the
-	 * stage declared none, which is every stage of the corpus but Photon's.
-	 */
-	private final List<SplitStruct> splitStructs = new ArrayList<>();
-
-	/**
-	 * Array varyings rewritten as one varying per element, for the same numbering again. Empty
-	 * when the stage declared none.
-	 */
-	private final List<SplitArray> splitArrays = new ArrayList<>();
 
 	/** Inputs {@link #dropUnprovidedInputs} took out, which this stage no longer declares. */
 	private final Set<String> droppedInputs = new LinkedHashSet<>();
@@ -648,6 +605,7 @@ public final class GlslTranslator {
 		}
 
 		this.tokens = new TokenStream(GlslLexer.lex(text));
+		this.splits = new VaryingSplit(this.tokens, unit, stage, this::fileScopeDeclaration);
 	}
 
 	/**
@@ -812,9 +770,7 @@ public final class GlslTranslator {
 		// After wrapMain, because the wrapper is where the columns are copied and reconstructed, and
 		// before collectVaryings, because a matrix left as one out is one SPIR-V variable occupying
 		// three locations and createFromSpirv then numbers the next name onto the second column.
-		splitMatrixVaryings();
-		splitStructVaryings();
-		splitArrayVaryings();
+		this.splits.split();
 		wrapMainForSplits();
 		// Last, and it has to be: rewriteIdentifiers is where varying becomes in or out, and
 		// dropUnprovidedInputs blanks the ranges recorded here, so nothing may move between the two.
@@ -3245,77 +3201,6 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * One matrix varying rewritten as one vector per column.
-	 *
-	 * @param input true when this stage reads the matrix ({@code in}), false when it writes it
-	 */
-	record SplitMatrix(String name, String matrixType, String columnType, int columns,
-			String qualifier, boolean input) {
-	}
-
-	/**
-	 * Turns each file-scope matrix {@code in} / {@code out} into one vector per column.
-	 * <p>
-	 * {@code IntermediaryShaderModule.createFromSpirv} numbers locations by the rank of each
-	 * reflected variable, {@code 0..n-1} with no stride. A GLSL {@code mat3} is one variable and
-	 * occupies three consecutive locations, so the next varying is numbered onto the second
-	 * column and the rotation the pack stored is no longer orthonormal. AstraLex's night planet
-	 * is the image of that: a billboard {@code xy / z} through a walked-on {@code mat3}.
-	 * <p>
-	 * OpenGL links by name and never asks. The workaround here is to take the declaration out of
-	 * the body and emit the matrix as a local in the header, beside one vector per column: the pack
-	 * body still writes and reads the original name, and the wrapper copies the columns. Arrays
-	 * of matrices are left alone; no pack of the corpus writes one, and AstraLex's four matrices
-	 * are not arrays.
-	 */
-	private void splitMatrixVaryings() {
-		if (this.stage == ProgramStage.COMPUTE) {
-			return;
-		}
-
-		int[] lines = this.tokens.lineNumbers();
-		for (int index = 0; index < this.tokens.size(); index++) {
-			Token token = this.tokens.get(index);
-			if (token.directive() != null || !this.unit.isLive(lines[index])) {
-				continue;
-			}
-
-			boolean input = token.identifier("in");
-			boolean output = token.identifier("out");
-			if (!input && !output) {
-				continue;
-			}
-
-			if (input && this.stage == ProgramStage.VERTEX) {
-				continue;
-			}
-
-			FileScope declared = fileScopeDeclaration(index);
-			if (declared == null) {
-				continue;
-			}
-
-			MatrixColumns layout = matrixColumns(declared.type());
-			if (layout == null) {
-				continue;
-			}
-
-			boolean anyArray = declared.names().stream().anyMatch(name ->
-					declared.declarators().getOrDefault(name, "").contains("["));
-			if (anyArray) {
-				continue;
-			}
-
-			this.tokens.blankRange(declared.start(), declared.end());
-
-			for (String name : declared.names()) {
-				this.splitMatrices.add(new SplitMatrix(name, declared.type(), layout.columnType(),
-						layout.columns(), declared.qualifier(), input));
-			}
-		}
-	}
-
-	/**
 	 * Wraps {@code main} when a matrix was split and nothing else had wrapped it, so the columns
 	 * have a place to be copied from and the reconstructed matrix has a place to be assigned.
 	 * <p>
@@ -3327,8 +3212,7 @@ public final class GlslTranslator {
 	 * The injected brace is still a body of {@code main}, so it is accepted here.
 	 */
 	private void wrapMainForSplits() {
-		if (this.mainWrapped || (this.splitMatrices.isEmpty() && this.splitStructs.isEmpty()
-				&& this.splitArrays.isEmpty())) {
+		if (this.mainWrapped || !this.splits.any()) {
 			return;
 		}
 
@@ -3370,332 +3254,6 @@ public final class GlslTranslator {
 		}
 
 		return -1;
-	}
-
-	/** Column count and vector type of a GLSL matrix, or null when the type is not a matrix. */
-	private record MatrixColumns(String columnType, int columns) {
-	}
-
-	/**
-	 * {@code mat3} is three {@code vec3}, {@code mat4x3} is four {@code vec3}, {@code dmat2} is two
-	 * {@code dvec2}. Anything else, including a vector, answers null.
-	 */
-	private static MatrixColumns matrixColumns(String type) {
-		String prefix = "";
-		String rest = type;
-		if (rest.startsWith("dmat")) {
-			prefix = "d";
-			rest = rest.substring(1);
-		}
-
-		if (!rest.startsWith("mat")) {
-			return null;
-		}
-
-		rest = rest.substring(3);
-		int columns;
-		int rows;
-		int by = rest.indexOf('x');
-		try {
-			if (by < 0) {
-				columns = Integer.parseInt(rest);
-				rows = columns;
-			} else {
-				columns = Integer.parseInt(rest.substring(0, by));
-				rows = Integer.parseInt(rest.substring(by + 1));
-			}
-		} catch (NumberFormatException ignored) {
-			return null;
-		}
-
-		if (columns < 2 || columns > 4 || rows < 2 || rows > 4) {
-			return null;
-		}
-
-		return new MatrixColumns(prefix + "vec" + rows, columns);
-	}
-
-	static String matrixColumnName(String matrix, int column) {
-		return MATRIX_COLUMN + matrix + "_" + column;
-	}
-
-	/** One member of a struct a varying is declared under, in the order the struct lists it. */
-	record StructMember(String type, String name) {
-	}
-
-	/**
-	 * One struct varying rewritten as one varying per member.
-	 *
-	 * @param input true when this stage reads the struct ({@code in}), false when it writes it
-	 */
-	record SplitStruct(String name, String structType, List<StructMember> members,
-			String qualifier, boolean input) {
-	}
-
-	/**
-	 * Turns each file-scope struct {@code in} / {@code out} into one varying per member, for the
-	 * reason {@link #splitMatrixVaryings} turns a matrix into its columns: a struct is one
-	 * reflected variable occupying as many locations as it has members, and the rank the game
-	 * numbers it by is one. Photon's {@code flat in OverworldFogParameters fog_params}, three
-	 * {@code vec3} of fog coefficients, reached its water fragment stage wrong under that
-	 * numbering, and the fog its reflections computed with them painted every distant lake red;
-	 * handed over as three varyings, the same program draws the lake as the reference does.
-	 * <p>
-	 * The definition is read off the unit itself, since the type is the pack's own. Only a struct
-	 * whose members are all scalars or vectors is split: a member that is a matrix, an array or a
-	 * struct of its own would need the same treatment one level down, and no pack of the corpus
-	 * writes one. Arrays of structs are left alone as arrays of matrices are.
-	 */
-	private void splitStructVaryings() {
-		if (this.stage == ProgramStage.COMPUTE) {
-			return;
-		}
-
-		Map<String, List<StructMember>> definitions = structDefinitions();
-		if (definitions.isEmpty()) {
-			return;
-		}
-
-		int[] lines = this.tokens.lineNumbers();
-		for (int index = 0; index < this.tokens.size(); index++) {
-			Token token = this.tokens.get(index);
-			if (token.directive() != null || !this.unit.isLive(lines[index])) {
-				continue;
-			}
-
-			boolean input = token.identifier("in");
-			boolean output = token.identifier("out");
-			if (!input && !output) {
-				continue;
-			}
-
-			if (input && this.stage == ProgramStage.VERTEX) {
-				continue;
-			}
-
-			// Read against the struct types the unit defines: the plain reader only knows the
-			// language's own types, which is why a struct varying was never a declaration to it.
-			FileScope declared = fileScopeDeclaration(index, definitions.keySet());
-			if (declared == null) {
-				continue;
-			}
-
-			List<StructMember> members = definitions.get(declared.type());
-
-			boolean anyArray = declared.names().stream().anyMatch(name ->
-					declared.declarators().getOrDefault(name, "").contains("["));
-			if (anyArray) {
-				continue;
-			}
-
-			this.tokens.blankRange(declared.start(), declared.end());
-
-			for (String name : declared.names()) {
-				this.splitStructs.add(new SplitStruct(name, declared.type(), members,
-						declared.qualifier(), input));
-			}
-		}
-
-		// The definition moves to the header with the global that carries the pack's name: the
-		// wrapper that rebuilds the struct stands in the header, above the body, and the type has
-		// to exist there. The body's own definition goes blank so the type is not defined twice.
-		Set<String> moved = new HashSet<>();
-		for (SplitStruct split : this.splitStructs) {
-			if (!moved.add(split.structType())) {
-				continue;
-			}
-
-			int[] definition = definitionRange(split.structType());
-			if (definition != null) {
-				this.tokens.blankRange(definition[0], definition[1]);
-			}
-		}
-	}
-
-	/**
-	 * Every struct the unit defines on a live line whose members are all scalars or vectors, by
-	 * type name. A struct with any other member is left out, so its varyings stay as they are.
-	 */
-	private Map<String, List<StructMember>> structDefinitions() {
-		Map<String, List<StructMember>> definitions = new LinkedHashMap<>();
-		int[] lines = this.tokens.lineNumbers();
-		for (int index = 0; index < this.tokens.size(); index++) {
-			Token token = this.tokens.get(index);
-			if (!token.identifier("struct") || token.directive() != null
-					|| !this.unit.isLive(lines[index])) {
-				continue;
-			}
-
-			int name = this.tokens.significantAfter(index);
-			int open = this.tokens.significantAfter(name);
-			if (name < 0 || open < 0 || this.tokens.get(name).kind() != Kind.IDENTIFIER
-					|| !this.tokens.get(open).operator("{")) {
-				continue;
-			}
-
-			int close = this.tokens.matchingBracket(open);
-			int semicolon = this.tokens.significantAfter(close);
-			// A definition that declares an instance in the same breath, "struct T { ... } t;",
-			// is left alone: taking it out of the body would take the instance with it.
-			if (close < 0 || semicolon < 0 || !this.tokens.get(semicolon).operator(";")) {
-				continue;
-			}
-
-			List<StructMember> members = structMembers(open + 1, close - 1);
-			if (members != null && !members.isEmpty()) {
-				definitions.putIfAbsent(this.tokens.get(name).text(), members);
-			}
-		}
-
-		return definitions;
-	}
-
-	/**
-	 * The members declared between a struct's braces, or null where one of them is not a scalar
-	 * or a vector: a member with brackets, a matrix, a sampler or another struct.
-	 */
-	private List<StructMember> structMembers(int start, int end) {
-		List<StructMember> members = new ArrayList<>();
-		List<Integer> statement = new ArrayList<>();
-		for (int scan : this.tokens.significantRange(start, end)) {
-			Token token = this.tokens.get(scan);
-			if (!token.operator(";")) {
-				statement.add(scan);
-				continue;
-			}
-
-			if (statement.size() < 2) {
-				return null;
-			}
-
-			String type = this.tokens.get(statement.get(0)).text();
-			if (!STRUCT_MEMBER_TYPES.contains(type)) {
-				return null;
-			}
-
-			for (int part = 1; part < statement.size(); part++) {
-				Token piece = this.tokens.get(statement.get(part));
-				if (piece.operator(",")) {
-					continue;
-				}
-
-				if (piece.kind() != Kind.IDENTIFIER) {
-					return null;
-				}
-
-				members.add(new StructMember(type, piece.text()));
-			}
-
-			statement.clear();
-		}
-
-		return statement.isEmpty() ? members : null;
-	}
-
-	/**
-	 * The first live definition of that struct, from its {@code struct} keyword to the semicolon
-	 * closing it, or null where the unit holds none.
-	 */
-	private int[] definitionRange(String structType) {
-		int[] lines = this.tokens.lineNumbers();
-		for (int index = 0; index < this.tokens.size(); index++) {
-			Token token = this.tokens.get(index);
-			if (!token.identifier("struct") || token.directive() != null
-					|| !this.unit.isLive(lines[index])) {
-				continue;
-			}
-
-			int name = this.tokens.significantAfter(index);
-			int open = this.tokens.significantAfter(name);
-			if (name < 0 || open < 0 || !this.tokens.get(name).identifier(structType)
-					|| !this.tokens.get(open).operator("{")) {
-				continue;
-			}
-
-			int close = this.tokens.matchingBracket(open);
-			int semicolon = this.tokens.significantAfter(close);
-			if (close >= 0 && semicolon >= 0 && this.tokens.get(semicolon).operator(";")) {
-				return new int[] {index, semicolon};
-			}
-		}
-
-		return null;
-	}
-
-	static String structMemberName(String struct, String member) {
-		return STRUCT_MEMBER + struct + "_" + member;
-	}
-
-	/**
-	 * One array varying rewritten as one varying per element.
-	 *
-	 * @param input true when this stage reads the array ({@code in}), false when it writes it
-	 */
-	record SplitArray(String name, String type, int size, String qualifier, boolean input) {
-	}
-
-	/**
-	 * Turns each file-scope array {@code in} / {@code out} of scalars or vectors into one varying
-	 * per element, for the reason the matrices and the structs are split: an array is one
-	 * reflected variable over as many locations as it has elements, and one rank. Photon's
-	 * {@code flat in vec3 sky_sh[9]} carries its sky harmonics into the deferred shading, and the
-	 * two varyings after it were numbered onto its elements.
-	 * <p>
-	 * Only a single dimension sized by a number the pack wrote out is split: a size written as a
-	 * name, a macro the unit still carries or a constant expression, is left alone with the
-	 * declaration. A statement declaring an array beside a plain name is left alone too, so that
-	 * the two are not pulled apart.
-	 * <p>
-	 * Only what the vertex stage writes and the fragment stage reads: a geometry or tessellation
-	 * stage declares its per-vertex inputs as arrays that are no varying arrays, and a fragment
-	 * stage's output array is a set of colour outputs, which the header numbers on its own.
-	 */
-	private void splitArrayVaryings() {
-		boolean output = this.stage == ProgramStage.VERTEX;
-		if (!output && this.stage != ProgramStage.FRAGMENT) {
-			return;
-		}
-
-		int[] lines = this.tokens.lineNumbers();
-		for (int index = 0; index < this.tokens.size(); index++) {
-			Token token = this.tokens.get(index);
-			if (token.directive() != null || !this.unit.isLive(lines[index])
-					|| !token.identifier(output ? "out" : "in")) {
-				continue;
-			}
-
-			FileScope declared = fileScopeDeclaration(index);
-			if (declared == null || !STRUCT_MEMBER_TYPES.contains(declared.type())) {
-				continue;
-			}
-
-			List<SplitArray> found = new ArrayList<>();
-			for (String name : declared.names()) {
-				String prefix = declared.type() + " " + name;
-				String declarator = declared.declarators().getOrDefault(name, "");
-				Matcher size = declarator.startsWith(prefix)
-						? ARRAY_SUFFIX.matcher(declarator.substring(prefix.length()))
-						: null;
-				if (size == null || !size.matches()) {
-					found.clear();
-					break;
-				}
-
-				found.add(new SplitArray(name, declared.type(), Integer.parseInt(size.group(1)),
-						declared.qualifier(), !output));
-			}
-
-			if (found.isEmpty()) {
-				continue;
-			}
-
-			this.tokens.blankRange(declared.start(), declared.end());
-			this.splitArrays.addAll(found);
-		}
-	}
-
-	static String arrayElementName(String array, int element) {
-		return ARRAY_ELEMENT + array + "_" + element;
 	}
 
 	/**
@@ -4055,10 +3613,10 @@ public final class GlslTranslator {
 	 * @param declarators each name with the text that declares it, array brackets included, which is
 	 *                    what lets a declaration be written again rather than described
 	 */
-	private record FileScope(List<String> names, String type, String qualifier,
+	record FileScope(List<String> names, String type, String qualifier,
 			Map<String, String> declarators, int start, int end) {
 
-		private FileScope {
+		FileScope {
 			names = List.copyOf(names);
 			declarators = Map.copyOf(declarators);
 		}
@@ -5184,7 +4742,7 @@ public final class GlslTranslator {
 		return new Emitter(this.stage, this.inputs, this.bound, this.alphaTest, this.engineDefines,
 				this.memoryQualifiers, this.used, this.declaredNames, this.synthesized,
 				this.readVolumes, this.packOutputs, this.maxFragmentOutput, this.owedOutputs,
-				this.splitMatrices, this.splitStructs, this.splitArrays, this.gameTextureMatrix,
+				this.splits, this.gameTextureMatrix,
 				this.gameModelView, this.softRewrites, this.trigCalls, this.hashCalls,
 				this.mainWrapped, this.depthEpilogue, this.terrainPrologue, this.distantPrologue,
 				this.entityWrapped, this.linesWrapped, this.alphaEpilogue, this.covers,

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -45,8 +45,9 @@ import java.util.stream.Stream;
  * The tokens themselves, and every way of reading them or changing them, belong to
  * {@link TokenStream} rather than to this class, and the header written in front of what the
  * passes leave belongs to {@link Emitter}. What is left here is the pipeline: one pass per rule,
- * in the order {@link #rewrite} runs them, one of them being {@link VaryingSplit}, which is a
- * class of its own for the state it carries out of the text.
+ * in the order {@link #rewrite} runs them. Two of those passes carry enough state out of the text
+ * to be classes of their own, {@link VaryingSplit} and {@link VolumeFlattening}, and the pipeline
+ * calls them where it would have run them.
  * <p>
  * Two things are deliberately left undone, and both were done by the measuring prototype.
  * No {@code layout(binding = )} is emitted, and no {@code layout(location = )} except on fragment
@@ -264,9 +265,6 @@ public final class GlslTranslator {
 	 */
 	static final String HASH = "ofHash";
 
-	/** What a lookup on a volume the pack ships is called once the volume has been laid out flat. */
-	private static final String VOLUME_LOOKUP = "ofTexture3D_";
-
 	/** The depth at the centre of the screen, which is accumulated in a texel rather than in a value. */
 	private static final String CENTER_DEPTH = "centerDepthSmooth";
 
@@ -285,9 +283,8 @@ public final class GlslTranslator {
 	private static final String DRAW_MODEL_VIEW =
 			"(" + LegacyGlsl.CAMERA_BOB + " * " + LegacyGlsl.GAME_MODEL_VIEW + ")";
 
-	/** The one call a volume lookup may be written as, and the number of arguments it takes. */
-	private static final String LOOKUP = "texture";
-	private static final int LOOKUP_ARGUMENTS = 2;
+	/** The one call a volume lookup may be written as. */
+	static final String LOOKUP = "texture";
 
 	/** What the word sampler is followed by when the declaration asks for a comparison. */
 	private static final String SHADOW_SHAPE = "Shadow";
@@ -332,10 +329,10 @@ public final class GlslTranslator {
 	private final String program;
 
 	/**
-	 * The volumes the pack ships and this engine serves flat, by the name the pack samples them
-	 * under. Empty everywhere but the two packs of the corpus that ship one.
+	 * The volumes the pack ships and this engine serves flat, and what moving them onto an atlas
+	 * left behind. Nothing to do everywhere but the two packs of the corpus that ship one.
 	 */
-	private final Map<String, VolumeAtlas> volumes;
+	private final VolumeFlattening volumes;
 
 	/** What the fragment stage discards at, which the fixed function pipeline used to hold. */
 	private final AlphaTest alphaTest;
@@ -390,9 +387,6 @@ public final class GlslTranslator {
 
 	/** Storage blocks this unit declares at file scope, each under the binding it was written at. */
 	private final List<TranslatedUnit.StorageBlock> storageBlocks = new ArrayList<>();
-
-	/** The volumes this unit reads, and so the helpers its header owes, by the pack's own name. */
-	private final Map<String, VolumeAtlas> readVolumes = new LinkedHashMap<>();
 
 	/**
 	 * The comparison samplers whose comparison is made in arithmetic, their declarations rewritten
@@ -471,8 +465,6 @@ public final class GlslTranslator {
 	private int dynamicFragData;
 	private int shadowCalls;
 	private int unwrappedShadowCalls;
-	private int volumeLookups;
-	private int volumesLeftAlone;
 
 	/** The lookups of those that were really rewritten onto {@link #SHADOW_COMPARE}, which is what
 	 * says whether the header owes the helper at all. */
@@ -592,7 +584,6 @@ public final class GlslTranslator {
 		this.alphaTest = alphaTest;
 		this.coverage = coverage;
 		this.program = program;
-		this.volumes = Collections.unmodifiableMap(new LinkedHashMap<>(volumes));
 
 		// Tokens cost far more than the text they came from, roughly seventy bytes each, so a unit
 		// the expander should never have produced has to be refused before it is read rather than
@@ -606,6 +597,8 @@ public final class GlslTranslator {
 
 		this.tokens = new TokenStream(GlslLexer.lex(text));
 		this.splits = new VaryingSplit(this.tokens, unit, stage, this::fileScopeDeclaration);
+		this.volumes = new VolumeFlattening(this.tokens, unit, volumes, this.packMacros,
+				this.macroAliases);
 	}
 
 	/**
@@ -735,7 +728,7 @@ public final class GlslTranslator {
 		// After the identifiers and before the depth, and both halves of that matter: the legacy
 		// spellings have to have become texture() before a lookup can be recognised, and what comes
 		// out of here is a call under a name of ours that the depth pass will not look at twice.
-		flattenVolumes();
+		this.volumes.flatten();
 		convertDepth();
 		dropPrecision();
 		// After precision, so a leftover highp does not sit between const and the type this pass
@@ -4268,261 +4261,6 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Moves every volume the pack ships onto a flat atlas: the declaration to a {@code sampler2D}
-	 * under a forged name, and each lookup to a helper that reads two slices and mixes them.
-	 * <p>
-	 * <strong>The declaration is what has to go, not the lookup.</strong>
-	 * {@code GlslCompiler.addToBindGroup} refuses anything the reflection reports as neither
-	 * {@code SpvDim2D} nor {@code SpvDimCube}, and the reflection lists a module's whole resource
-	 * list at optimisation level zero, so a {@code sampler3D} declared in a shared include and never
-	 * read costs the program its pipeline exactly as one sampled on every pixel does. Supplying a
-	 * real volume would not help either: the type is the refusal.
-	 * <p>
-	 * <strong>Every program carrying the declaration is rewritten, and Iris rewrites only the stage
-	 * the directive names.</strong> Its {@code TextureTransformer} runs per stage, so under it
-	 * Mellow's composites and its final keep a live {@code sampler3D colortex6} bound to nothing,
-	 * which GL tolerates and Vulkan does not. Renaming everywhere invents nothing: the pack has
-	 * named exactly one file for that identifier, with its shape, its size and its format written
-	 * out, and that file is what every one of those declarations was going to read.
-	 * <p>
-	 * Nothing is moved unless everything can be. A name this unit reaches any other way than as
-	 * {@code texture(name, vec3)}, the name being the declared one or a macro the unit defines as
-	 * exactly that name, is counted and left exactly as it stands, declaration included, so the
-	 * program stays refused with the message it had. There is no site in the corpus like that, and
-	 * the count is what would say one had appeared.
-	 */
-	private void flattenVolumes() {
-		if (this.volumes.isEmpty()) {
-			return;
-		}
-
-		int[] lines = this.tokens.lineNumbers();
-		this.volumes.forEach((name, atlas) -> flattenOne(name, atlas, lines));
-	}
-
-	private void flattenOne(String name, VolumeAtlas atlas, int[] lines) {
-		// The name token of a declaration, and the pair of tokens each lookup rewrites: the callee
-		// and the argument. Held rather than found again below, so that what is rewritten is what
-		// was judged.
-		List<Integer> declarations = new ArrayList<>();
-		Map<Integer, Integer> lookups = new LinkedHashMap<>();
-		boolean elsewhere = this.packMacros.contains(name);
-		Set<String> spellings = spellingsOf(name);
-
-		for (int index = 0; index < this.tokens.size(); index++) {
-			Token token = this.tokens.get(index);
-			if (token.kind() != Kind.IDENTIFIER || !spellings.contains(token.text())
-					|| !this.unit.isLive(lines[index])) {
-				continue;
-			}
-
-			if (token.directive() != null) {
-				// The preprocessor's own lines: an alias being defined or tested is its business,
-				// and the name standing as an alias's replacement text IS the alias. The name on
-				// any other directive is a use this pass cannot follow.
-				if (token.text().equals(name) && !aliasBody(index)) {
-					elsewhere = true;
-				}
-
-				continue;
-			}
-
-			int callee = plainLookup(index);
-			if (token.text().equals(name) && volumeDeclaration(index)) {
-				declarations.add(index);
-			} else if (callee >= 0) {
-				lookups.put(index, callee);
-			} else {
-				elsewhere = true;
-			}
-		}
-
-		// A unit that reads the name without declaring it has been handed the sampler by something
-		// this pass has not seen, so there is nothing here to rename it against.
-		if (declarations.isEmpty()) {
-			return;
-		}
-
-		if (elsewhere) {
-			this.volumesLeftAlone++;
-			return;
-		}
-
-		String forged = SamplerPlan.forged(name);
-		for (int declaration : declarations) {
-			this.tokens.replace(this.tokens.significantBefore(declaration), "sampler2D");
-			this.tokens.replace(declaration, forged);
-		}
-
-		lookups.forEach((argument, callee) -> {
-			this.tokens.replace(callee, VOLUME_LOOKUP + name);
-			this.tokens.replace(argument, forged);
-		});
-
-		this.volumeLookups += lookups.size();
-		if (!lookups.isEmpty()) {
-			this.readVolumes.put(name, atlas);
-		}
-	}
-
-	/** The name and every macro the unit defines as exactly that name, aliases of aliases included. */
-	private Set<String> spellingsOf(String name) {
-		Set<String> spellings = new HashSet<>();
-		spellings.add(name);
-		boolean grew = true;
-		while (grew) {
-			grew = false;
-			for (Map.Entry<String, String> alias : this.macroAliases.entrySet()) {
-				if (spellings.contains(alias.getValue()) && spellings.add(alias.getKey())) {
-					grew = true;
-				}
-			}
-		}
-
-		return spellings;
-	}
-
-	/**
-	 * Whether this token, on a directive, is the whole replacement text of a macro standing for it:
-	 * the {@code depthtex0} of {@code #define ATMOSPHERE_SCATTERING_LUT depthtex0}.
-	 */
-	private boolean aliasBody(int index) {
-		for (int scan = index - 1; scan >= 0; scan--) {
-			Token token = this.tokens.get(scan);
-			if (token.trivia()) {
-				continue;
-			}
-
-			return token.macroName()
-					&& this.tokens.get(index).text().equals(this.macroAliases.get(token.text()));
-		}
-
-		return false;
-	}
-
-	/**
-	 * Whether this name is being declared as a uniform of a three dimensional shape here.
-	 * <p>
-	 * The {@code uniform} is demanded and the type is not enough on its own: a function taking a
-	 * {@code sampler3D} parameter of the same name declares a name inside its own body, and renaming
-	 * that would leave the body reading a parameter nobody passes.
-	 */
-	private boolean volumeDeclaration(int index) {
-		int type = this.tokens.significantBefore(index);
-		if (type < 0 || this.tokens.get(type).kind() != Kind.IDENTIFIER
-				|| !"3D".equals(SamplerTypes.shapeOf(this.tokens.get(type).text()))) {
-			return false;
-		}
-
-		int cursor = this.tokens.significantBefore(type);
-		while (cursor >= 0 && isQualifier(this.tokens.get(cursor))) {
-			cursor = this.tokens.significantBefore(cursor);
-		}
-
-		return cursor >= 0 && this.tokens.get(cursor).identifier("uniform");
-	}
-
-	/**
-	 * The {@code texture} this name is the first argument of, or -1 when it is reached any other
-	 * way. The argument count is checked as well as the name: {@code texture(s, p, bias)} compiles
-	 * and means something else, and the helper takes two.
-	 */
-	private int plainLookup(int index) {
-		int open = this.tokens.significantBefore(index);
-		if (open < 0 || !this.tokens.get(open).operator("(")) {
-			return -1;
-		}
-
-		int callee = this.tokens.significantBefore(open);
-		if (callee < 0 || !this.tokens.get(callee).identifier(LOOKUP)) {
-			return -1;
-		}
-
-		int close = this.tokens.matchingBracket(open);
-
-		return close >= 0 && arguments(open, close) == LOOKUP_ARGUMENTS ? callee : -1;
-	}
-
-	/** How many arguments a call holds, counting the commas that belong to it and not to a nested one. */
-	private int arguments(int open, int close) {
-		int depth = 0;
-		int count = 1;
-
-		for (int index = open; index < close; index++) {
-			Token token = this.tokens.get(index);
-			if (token.kind() != Kind.OPERATOR || token.directive() != null) {
-				continue;
-			}
-
-			String text = token.text();
-			if (text.equals("(") || text.equals("[")) {
-				depth++;
-			} else if (text.equals(")") || text.equals("]")) {
-				depth--;
-			} else if (depth == 1 && text.equals(",")) {
-				count++;
-			}
-		}
-
-		return count;
-	}
-
-	/**
-	 * The trilinear read of a volume, over the atlas its slices were laid out in.
-	 * <p>
-	 * The hardware does the two dimensional half: each slice carries one texel of gutter holding
-	 * what lies past its edge, the far edge for a volume that repeats and the edge itself for one
-	 * that clamps, so a bilinear tap at the edge of a tile reads what {@code REPEAT} or
-	 * {@code CLAMP} would have read on a real volume rather than the slice next door. Only the depth
-	 * is done here, two taps and a mix, because nothing interpolates between tiles of an atlas, and
-	 * the slice index repeats or clamps as the pack asked.
-	 * <p>
-	 * The half texel is the whole of the arithmetic: a lookup at {@code u} samples the volume at
-	 * {@code u * size - 0.5} in texels, and the atlas coordinate has to land on the same pair of
-	 * texels the hardware would have blended. Every constant here comes from {@link VolumeAtlas} so
-	 * that this and the upload cannot drift apart; a layout written twice reads as noise, and noise
-	 * that is wrong looks exactly like noise that is right.
-	 */
-	static List<String> volumeHelper(String name, VolumeAtlas atlas) {
-		String depth = whole(atlas.depth());
-		String last = Integer.toString(atlas.depth() - 1);
-		String tiles = Integer.toString(atlas.tilesPerRow());
-
-		List<String> lines = new ArrayList<>();
-		lines.add("vec4 " + VOLUME_LOOKUP + name + "(sampler2D ofMap, vec3 ofAt) {");
-		lines.add(atlas.clamp() ? "\tvec3 ofQ = clamp(ofAt, 0.0, 1.0);" : "\tvec3 ofQ = fract(ofAt);");
-		lines.add("\tfloat ofZ = ofQ.z * " + depth + " - 0.5;");
-		lines.add("\tfloat ofBase = floor(ofZ);");
-		lines.add("\tvec2 ofIn = ofQ.xy * vec2(" + whole(atlas.width()) + ", " + whole(atlas.height())
-				+ ") + " + whole(VolumeAtlas.GUTTER) + ";");
-		if (atlas.clamp()) {
-			lines.add("\tint ofNear = clamp(int(ofBase), 0, " + last + ");");
-			lines.add("\tint ofFar = clamp(int(ofBase) + 1, 0, " + last + ");");
-		} else {
-			lines.add("\tint ofNear = int(mod(ofBase, " + depth + "));");
-			lines.add("\tint ofFar = int(mod(ofBase + 1.0, " + depth + "));");
-		}
-
-		lines.add("\tvec2 ofTile = vec2(" + whole(atlas.tileStride()) + ", " + whole(atlas.tileHeight())
-				+ ");");
-		lines.add("\tvec2 ofSize = vec2(" + whole(atlas.atlasWidth()) + ", " + whole(atlas.atlasHeight())
-				+ ");");
-		lines.add("\tvec2 ofA = (vec2(ofNear % " + tiles + ", ofNear / " + tiles
-				+ ") * ofTile + ofIn) / ofSize;");
-		lines.add("\tvec2 ofB = (vec2(ofFar % " + tiles + ", ofFar / " + tiles
-				+ ") * ofTile + ofIn) / ofSize;");
-		lines.add("\treturn mix(texture(ofMap, ofA), texture(ofMap, ofB), clamp(ofZ - ofBase, 0.0, 1.0));");
-		lines.add("}");
-
-		return lines;
-	}
-
-	/** An integer as a GLSL float literal, spelled by hand so that no locale can put a comma in it. */
-	private static String whole(int value) {
-		return value + ".0";
-	}
-
-	/**
 	 * Records every storage block the unit declares, so a {@code bufferObject} can be bound to it.
 	 * <p>
 	 * Named rather than rewritten because the game never looks for one.
@@ -4741,7 +4479,7 @@ public final class GlslTranslator {
 	private Emitter emitter() {
 		return new Emitter(this.stage, this.inputs, this.bound, this.alphaTest, this.engineDefines,
 				this.memoryQualifiers, this.used, this.declaredNames, this.synthesized,
-				this.readVolumes, this.packOutputs, this.maxFragmentOutput, this.owedOutputs,
+				this.volumes.read(), this.packOutputs, this.maxFragmentOutput, this.owedOutputs,
 				this.splits, this.gameTextureMatrix,
 				this.gameModelView, this.softRewrites, this.trigCalls, this.hashCalls,
 				this.mainWrapped, this.depthEpilogue, this.terrainPrologue, this.distantPrologue,
@@ -4838,7 +4576,7 @@ public final class GlslTranslator {
 				this.fragCoordUnhandled, this.fragDepthWrites, this.fragDepthUnhandled,
 				List.copyOf(this.conflicts), comparedSamplers(), hardwareComparedSamplers(),
 				List.copyOf(this.storageBlocks),
-				this.volumeLookups, this.volumesLeftAlone, this.trigCalls, this.gameTextureMatrix,
+				this.volumes.lookups(), this.volumes.leftAlone(), this.trigCalls, this.gameTextureMatrix,
 				this.gameModelView);
 	}
 
@@ -4875,7 +4613,7 @@ public final class GlslTranslator {
 		}
 	}
 
-	private static boolean isQualifier(Token token) {
+	static boolean isQualifier(Token token) {
 		return token.kind() == Kind.IDENTIFIER
 				&& (LegacyGlsl.MEMORY_QUALIFIERS.contains(token.text())
 						|| LegacyGlsl.PRECISION_QUALIFIERS.contains(token.text()));

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -17,10 +17,12 @@ import dev.vitrail.pack.texture.VolumeAtlas;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -477,7 +479,7 @@ public final class GlslTranslator {
 	 * Those of {@link #samplerParameters} whose type has no level to pin, a rectangle, a buffer or
 	 * a multisample sampler, so that {@link #pinLookupLevels} leaves a lookup through one alone.
 	 */
-	private final List<Scoped> unlevelledParameters = new ArrayList<>();
+	private final Set<Scoped> unlevelledParameters = new LinkedHashSet<>();
 
 	/**
 	 * The same parameters again, each with the function that takes it and its place in that
@@ -2253,7 +2255,7 @@ public final class GlslTranslator {
 			}
 		}
 
-		List<Scoped> proven = provenParameters(pinned, fullScreen && chained.isEmpty());
+		Set<Scoped> proven = provenParameters(pinned, fullScreen && chained.isEmpty());
 		int[] lines = lineNumbers();
 		List<Closing> levels = new ArrayList<>();
 
@@ -2308,8 +2310,8 @@ public final class GlslTranslator {
 	 * @param all whether every parameter of a levelled type is proven outright, call sites unread,
 	 *            which is the case of a program drawn over the screen asking for no chain
 	 */
-	private List<Scoped> provenParameters(Set<String> pinned, boolean all) {
-		List<Scoped> proven = new ArrayList<>();
+	private Set<Scoped> provenParameters(Set<String> pinned, boolean all) {
+		Set<Scoped> proven = new LinkedHashSet<>();
 		if (all) {
 			for (Scoped parameter : this.samplerParameters) {
 				if (!this.unlevelledParameters.contains(parameter)) {
@@ -2320,23 +2322,56 @@ public final class GlslTranslator {
 			return proven;
 		}
 
+		// One walk that records where each of these functions is named, rather than a walk of the
+		// whole token list per parameter and per round. The rounds are bounded by the number of
+		// parameters, each one proving at least one or ending the loop, so a stage taking a
+		// hundred samplers as parameters walked its few hundred thousand tokens a hundred times.
+		List<SamplerParameter> waiting = new ArrayList<>();
+		Set<String> functions = new HashSet<>();
+		for (SamplerParameter parameter : this.typedParameters) {
+			if (!this.unlevelledParameters.contains(parameter.scope())) {
+				waiting.add(parameter);
+				functions.add(parameter.function());
+			}
+		}
+
+		Map<String, List<Integer>> sites = sitesOf(functions);
 		int[] lines = lineNumbers();
 		boolean grew = true;
 		while (grew) {
 			grew = false;
-			for (SamplerParameter parameter : this.typedParameters) {
-				if (proven.contains(parameter.scope())
-						|| this.unlevelledParameters.contains(parameter.scope())
-						|| !callsHandOver(parameter, pinned, proven, lines)) {
+			for (Iterator<SamplerParameter> pending = waiting.iterator(); pending.hasNext(); ) {
+				SamplerParameter parameter = pending.next();
+				if (proven.contains(parameter.scope())) {
+					pending.remove();
+					continue;
+				}
+
+				if (!callsHandOver(parameter, pinned, proven, lines,
+						sites.getOrDefault(parameter.function(), List.of()))) {
 					continue;
 				}
 
 				proven.add(parameter.scope());
+				pending.remove();
 				grew = true;
 			}
 		}
 
 		return proven;
+	}
+
+	/** Where each of these names is written, in the order the tokens run. */
+	private Map<String, List<Integer>> sitesOf(Set<String> names) {
+		Map<String, List<Integer>> found = new HashMap<>();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.kind() == Kind.IDENTIFIER && names.contains(token.text())) {
+				found.computeIfAbsent(token.text(), _ -> new ArrayList<>()).add(index);
+			}
+		}
+
+		return found;
 	}
 
 	/**
@@ -2347,16 +2382,15 @@ public final class GlslTranslator {
 	 * parameter, its declaration being no sampler's name. A function named on a preprocessor line
 	 * is called from wherever that macro is used, which no scan of the tokens can see, so such a
 	 * function proves nothing.
+	 *
+	 * @param sites every place the function is named, in the order the tokens run, which is what
+	 *              this used to walk the whole list for
 	 */
 	private boolean callsHandOver(SamplerParameter parameter, Set<String> pinned,
-			List<Scoped> proven, int[] lines) {
+			Set<Scoped> proven, int[] lines, List<Integer> sites) {
 		boolean called = false;
-		for (int index = 0; index < this.tokens.size(); index++) {
+		for (int index : sites) {
 			Token token = this.tokens.get(index);
-			if (!token.identifier(parameter.function())) {
-				continue;
-			}
-
 			if (token.directive() != null) {
 				return false;
 			}
@@ -5214,7 +5248,7 @@ public final class GlslTranslator {
 	}
 
 	/** Whether one of these names means what the list says it does on this line. */
-	private static boolean scoped(List<Scoped> names, String name, int line) {
+	private static boolean scoped(Collection<Scoped> names, String name, int line) {
 		for (Scoped scoped : names) {
 			if (scoped.name().equals(name) && line >= scoped.from() && line <= scoped.to()) {
 				return true;

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -45,8 +45,9 @@ import java.util.stream.Stream;
  * understood, only read, so the work here is a rewrite over a token stream rather than a compiler.
  * <p>
  * The tokens themselves, and every way of reading them or changing them, belong to
- * {@link TokenStream} rather than to this class. What is left here is the pipeline: one pass per
- * rule, in the order {@link #rewrite} runs them, and the header written around what they leave.
+ * {@link TokenStream} rather than to this class, and the header written in front of what the
+ * passes leave belongs to {@link Emitter}. What is left here is the pipeline: one pass per rule,
+ * in the order {@link #rewrite} runs them.
  * <p>
  * Two things are deliberately left undone, and both were done by the measuring prototype.
  * No {@code layout(binding = )} is emitted, and no {@code layout(location = )} except on fragment
@@ -92,13 +93,8 @@ import java.util.stream.Stream;
  */
 public final class GlslTranslator {
 
-	private static final String VERSION = "#version 460 core";
-
-	/** The block name has to be declared to the pipeline by hand later, so it is fixed here. */
-	private static final String UNIFORM_BLOCK = "OfGlobals";
-
 	/** The one varying the engine names itself, so the one both stages have to agree about. */
-	private static final String FOG_COORD = "of_FogFragCoord";
+	static final String FOG_COORD = "of_FogFragCoord";
 
 	/**
 	 * Prefix of the vectors a matrix varying is split into. Pack names never start with {@code of_},
@@ -127,14 +123,6 @@ public final class GlslTranslator {
 			"uint", "uvec2", "uvec3", "uvec4", "double", "dvec2", "dvec3", "dvec4");
 
 	/**
-	 * The member types that may not be interpolated, so their varying is flat whatever the pack
-	 * wrote: the integers, and the doubles the language holds to the same rule.
-	 */
-	private static final Set<String> INTEGER_MEMBER_TYPES = Set.of(
-			"int", "ivec2", "ivec3", "ivec4", "uint", "uvec2", "uvec3", "uvec4",
-			"double", "dvec2", "dvec3", "dvec4");
-
-	/**
 	 * The hit flash and the damage tint, which is a varying wherever the mesh carries the overlay and
 	 * a uniform everywhere else.
 	 * <p>
@@ -144,7 +132,7 @@ public final class GlslTranslator {
 	 * and hands it on ({@code pipeline/transform/transformer/EntityPatcher.java:39-56}). Answering it
 	 * from the block instead is one number for every mob on screen, which is a mob that never flashes.
 	 */
-	private static final String ENTITY_COLOR = "entityColor";
+	static final String ENTITY_COLOR = "entityColor";
 
 	/**
 	 * The three identifiers, which are varyings wherever the mesh carries them and uniforms
@@ -172,7 +160,7 @@ public final class GlslTranslator {
 	 * type than {@code int}: Iris would keep that declaration and lose the pass to a redefinition,
 	 * and this loses the type. No pack of the corpus writes one.
 	 */
-	private static final List<String> ENTITY_IDS = List.copyOf(LegacyGlsl.ENTITY_UNIFORMS.keySet());
+	static final List<String> ENTITY_IDS = List.copyOf(LegacyGlsl.ENTITY_UNIFORMS.keySet());
 
 	/**
 	 * The game's own overlay image, sixteen by sixteen, under a name no pack writes.
@@ -180,13 +168,7 @@ public final class GlslTranslator {
 	 * What the two coordinates mean is the game's: {@code OverlayTexture.pack} puts the white
 	 * progress in u and the red flash in v, and the element the mesh carries is that pair.
 	 */
-	private static final String OVERLAY = LegacyGlsl.OVERLAY_SAMPLER;
-
-	/** The fetch the overlay colour is made from, named so that the pack's own names cannot meet it. */
-	private static final String OVERLAY_TEXEL = "ofOverlayTexel";
-
-	private static final String FOG_STRUCT =
-			"struct OfFog { vec4 color; float density; float start; float end; float scale; };";
+	static final String OVERLAY = LegacyGlsl.OVERLAY_SAMPLER;
 
 	/**
 	 * How many outputs a fragment stage may declare. Not OptiFine's sixteen colour targets, which
@@ -197,29 +179,16 @@ public final class GlslTranslator {
 	private static final int MAX_FRAGMENT_OUTPUTS = 8;
 
 	/** Names the ascending prologue, which nothing else in a pack is going to be called. */
-	private static final String ORDER_OUTPUTS = "ofOrderOutputs";
+	static final String ORDER_OUTPUTS = "ofOrderOutputs";
 
 	/** What the pack's own {@code main} is called once the epilogue has taken the name over. */
-	private static final String PACK_MAIN = "ofPackMain";
-
-	/**
-	 * The one output this engine adds itself: the depth the pack's geometry left at this pixel, so
-	 * that whoever puts the game's own picture into the same target can tell whether anything has
-	 * been drawn in front of it since.
-	 * <p>
-	 * A depth and not a flag, and what it buys is the whole of what a flag could not answer: the
-	 * reader compares it with the world's depth as it stands, so a pixel nothing was drawn over
-	 * compares equal and belongs to the pack, and a pixel the game drew a feature onto does not.
-	 * The pixels the pack never wrote carry a value outside zero to one instead, which every real
-	 * depth is in front of, and the reader owes them no test of their own.
-	 */
-	private static final String COVERAGE = "ofCoverage";
+	static final String PACK_MAIN = "ofPackMain";
 
 	/** {@code (clipA, clipB, readA, readB)}: how to write a depth, then how to read one. */
-	private static final String DEPTH_CONV = "of_DepthConv";
+	static final String DEPTH_CONV = "of_DepthConv";
 
 	/** The comparison a {@code sampler2DShadow} would have had the hardware make. */
-	private static final String SHADOW_COMPARE = "ofShadowCompare";
+	static final String SHADOW_COMPARE = "ofShadowCompare";
 
 	/**
 	 * Whether every comparison goes back to the arithmetic of {@link #SHADOW_COMPARE} instead of
@@ -253,10 +222,10 @@ public final class GlslTranslator {
 	 * place and emits neither of these. See {@code reduceTrig} below, which is on wherever nobody
 	 * has said otherwise.
 	 */
-	private static final String REDUCED_SIN = "ofReducedSin";
+	static final String REDUCED_SIN = "ofReducedSin";
 
 	/** See {@link #REDUCED_SIN}. */
-	private static final String REDUCED_COS = "ofReducedCos";
+	static final String REDUCED_COS = "ofReducedCos";
 
 	/**
 	 * Whether a pack's {@code sin} and {@code cos} are sent through {@link #REDUCED_SIN} at all.
@@ -321,7 +290,7 @@ public final class GlslTranslator {
 	 * What it costs the image is a different noise field, not Iris's gusts. The interpolation
 	 * around the lattice, and the amplitude the pack asked for, stay the pack's.
 	 */
-	private static final String HASH = "ofHash";
+	static final String HASH = "ofHash";
 
 	/** What a lookup on a volume the pack ships is called once the volume has been laid out flat. */
 	private static final String VOLUME_LOOKUP = "ofTexture3D_";
@@ -1078,7 +1047,7 @@ public final class GlslTranslator {
 	private TranslatedUnit render(List<TranslatedUnit.Uniform> block,
 			List<TranslatedUnit.Uniform> samplers, Set<String> varyings, Set<String> shadowed) {
 		return new TranslatedUnit(this.unit.entry(), this.stage,
-				header(block, samplers, varyings, shadowed) + body(shadowed) + "\n", notes(),
+				emitter().header(block, samplers, varyings, shadowed) + body(shadowed) + "\n", notes(),
 				List.copyOf(this.drawBuffers), List.copyOf(block), List.copyOf(samplers));
 	}
 
@@ -2961,7 +2930,7 @@ public final class GlslTranslator {
 	}
 
 	/** One fragment output the pack declared for itself, once its declaration has been moved. */
-	private record Output(String name, String type) {
+	record Output(String name, String type) {
 	}
 
 	/**
@@ -3280,7 +3249,7 @@ public final class GlslTranslator {
 	 *
 	 * @param input true when this stage reads the matrix ({@code in}), false when it writes it
 	 */
-	private record SplitMatrix(String name, String matrixType, String columnType, int columns,
+	record SplitMatrix(String name, String matrixType, String columnType, int columns,
 			String qualifier, boolean input) {
 	}
 
@@ -3446,12 +3415,12 @@ public final class GlslTranslator {
 		return new MatrixColumns(prefix + "vec" + rows, columns);
 	}
 
-	private static String matrixColumnName(String matrix, int column) {
+	static String matrixColumnName(String matrix, int column) {
 		return MATRIX_COLUMN + matrix + "_" + column;
 	}
 
 	/** One member of a struct a varying is declared under, in the order the struct lists it. */
-	private record StructMember(String type, String name) {
+	record StructMember(String type, String name) {
 	}
 
 	/**
@@ -3459,7 +3428,7 @@ public final class GlslTranslator {
 	 *
 	 * @param input true when this stage reads the struct ({@code in}), false when it writes it
 	 */
-	private record SplitStruct(String name, String structType, List<StructMember> members,
+	record SplitStruct(String name, String structType, List<StructMember> members,
 			String qualifier, boolean input) {
 	}
 
@@ -3653,7 +3622,7 @@ public final class GlslTranslator {
 		return null;
 	}
 
-	private static String structMemberName(String struct, String member) {
+	static String structMemberName(String struct, String member) {
 		return STRUCT_MEMBER + struct + "_" + member;
 	}
 
@@ -3662,7 +3631,7 @@ public final class GlslTranslator {
 	 *
 	 * @param input true when this stage reads the array ({@code in}), false when it writes it
 	 */
-	private record SplitArray(String name, String type, int size, String qualifier, boolean input) {
+	record SplitArray(String name, String type, int size, String qualifier, boolean input) {
 	}
 
 	/**
@@ -3725,7 +3694,7 @@ public final class GlslTranslator {
 		}
 	}
 
-	private static String arrayElementName(String array, int element) {
+	static String arrayElementName(String array, int element) {
 		return ARRAY_ELEMENT + array + "_" + element;
 	}
 
@@ -3978,36 +3947,6 @@ public final class GlslTranslator {
 
 			this.declaredOutputs.removeAll(scope.names());
 		}
-	}
-
-	/**
-	 * An owed varying written as an output declaration, with {@code out} where GLSL wants it: after
-	 * the interpolation qualifier and before the type. Writing {@code out flat float} rather than
-	 * {@code flat out float} is a syntax error, so the two cannot simply be concatenated.
-	 *
-	 * @param qualified the qualifier and the type, {@code flat float} or {@code vec3}
-	 */
-	private static String outDeclaration(String name, String qualified) {
-		int type = qualified.lastIndexOf(' ');
-
-		return type < 0
-				? "out " + qualified + " " + name + ";"
-				: qualified.substring(0, type) + " out " + qualified.substring(type + 1) + " " + name + ";";
-	}
-
-	/**
-	 * What the stage assigns an owed varying, which is the type's zero, exactly as Iris writes it at
-	 * {@code CompatibilityTransformer.java:494} out of {@code getInitializer:351-359}.
-	 * <p>
-	 * {@code type(0)} spells the zero of every type that can reach here. {@link LegacyGlsl#TYPE_NAMES}
-	 * holds the scalars, the vectors and the matrices, and the constructor of each takes a single
-	 * zero; {@code bool} and {@code bvec} are in it too and take one just as well. {@code void} is
-	 * the one member no constructor answers for, and a varying cannot be declared under it.
-	 */
-	private static String initialiser(String name, String qualified) {
-		int type = qualified.lastIndexOf(' ');
-
-		return name + " = " + qualified.substring(type + 1) + "(0);";
 	}
 
 	/**
@@ -4311,38 +4250,6 @@ public final class GlslTranslator {
 			this.blockMembers.remove(ENTITY_COLOR);
 			ENTITY_IDS.forEach(this.blockMembers::remove);
 		}
-	}
-
-	/**
-	 * Vulkan GLSL requires a format on a storage image, unless the image is write-only. Iris's GL
-	 * bind supplies the format at bind time, so Complementary writes
-	 * {@code writeonly uniform uimage3D voxel_img} with none, and BSL writes
-	 * {@code writeonly uniform image3D lightimg0} the same way. The format comes off the
-	 * {@code image.} directive and is written here, in the header: the body declaration has
-	 * already been lifted, so a layout qualifier inserted into the token stream would qualify a
-	 * statement that is no longer in the shader.
-	 * <p>
-	 * The pack's own memory qualifiers are written back for the same reason, and they are what
-	 * carries a declaration whose format we never learn: a pack switches its images off with the
-	 * setting that switches off the program reading them, and then the {@code image.} lines go
-	 * with it while the {@code writeonly} on the declaration stays. Dropping it turned a legal
-	 * declaration into one shaderc refuses.
-	 */
-	private String declareOpaque(TranslatedUnit.Uniform sampler) {
-		String memory = this.memoryQualifiers.getOrDefault(sampler.name(), "");
-		String tail = (memory.isEmpty() ? "" : memory + " ") + "uniform " + sampler.declaration()
-				+ ";";
-		if (!isImageType(sampler.type())) {
-			return tail;
-		}
-
-		return CustomImages.layoutFormat(sampler.name())
-				.map(format -> "layout(" + format + ") " + tail)
-				.orElse(tail);
-	}
-
-	private static boolean isImageType(String type) {
-		return type.startsWith("image") || type.startsWith("iimage") || type.startsWith("uimage");
 	}
 
 	private void liftOne(int keyword) {
@@ -5018,7 +4925,7 @@ public final class GlslTranslator {
 	 * that this and the upload cannot drift apart; a layout written twice reads as noise, and noise
 	 * that is wrong looks exactly like noise that is right.
 	 */
-	private static List<String> volumeHelper(String name, VolumeAtlas atlas) {
+	static List<String> volumeHelper(String name, VolumeAtlas atlas) {
 		String depth = whole(atlas.depth());
 		String last = Integer.toString(atlas.depth() - 1);
 		String tiles = Integer.toString(atlas.tilesPerRow());
@@ -5269,595 +5176,19 @@ public final class GlslTranslator {
 	}
 
 
-	private String header(List<TranslatedUnit.Uniform> block, List<TranslatedUnit.Uniform> samplers,
-			Set<String> varyings, Set<String> shadowed) {
-		List<String> lines = new ArrayList<>();
-		lines.add(VERSION);
-
-		for (Map.Entry<String, String> define : this.engineDefines.entrySet()) {
-			lines.add(define.getValue().isEmpty()
-					? "#define " + define.getKey()
-					: "#define " + define.getKey() + " " + define.getValue());
-		}
-
-		// The block is written in the order it was handed over, and nothing sorts it: a std140
-		// buffer is filled by walking the members, so a different order is a different buffer.
-		if (block.stream().anyMatch(member -> member.name().equals("of_Fog"))) {
-			lines.add(FOG_STRUCT);
-		}
-
-		if (!block.isEmpty()) {
-			lines.add("layout(std140) uniform " + UNIFORM_BLOCK + " {");
-			for (TranslatedUnit.Uniform member : block) {
-				lines.add("\t" + member.declaration() + ";");
-			}
-
-			lines.add("};");
-		}
-
-		// The game's own block, beside ours and never merged into it: this one is filled by the game
-		// once per draw and ours is written once per run, which is the whole reason a matrix that
-		// changes with the draw is read from over there.
-		if (this.gameTextureMatrix > 0 || this.gameModelView > 0) {
-			lines.addAll(LegacyGlsl.GAME_TRANSFORMS_BLOCK);
-		}
-
-		// Written here, in the order the program handed over, rather than left in the body. The
-		// compiler numbers a sampler by the order it first meets the name, and MoltenVK turns that
-		// number into a Metal slot that only accepts 0 through 15. Sampled names come first.
-		for (TranslatedUnit.Uniform sampler : samplers) {
-			lines.add(declareOpaque(sampler));
-		}
-
-		// Attributes stay a matter for the stage that has them. Only a vertex shader has inputs
-		// from a buffer, so there is no other side to agree with.
-		if (this.stage == ProgramStage.VERTEX) {
-			switch (this.inputs) {
-				case FULLSCREEN -> {
-					lines.addAll(LegacyGlsl.FULLSCREEN_ATTRIBUTES);
-					lines.addAll(VertexPrologue.tail(this.used, this.synthesized));
-				}
-				case TERRAIN, TERRAIN_SEPARATE_AO -> lines.addAll(SodiumVertex.prologue(this.bound,
-						this.used, this.synthesized, this.inputs.separateAo()));
-				case ENTITY, ENTITY_FULLBRIGHT -> lines.addAll(
-						EntityVertex.prologue(this.used, this.synthesized, this.inputs.fullbright()));
-				case GLINT -> lines.addAll(GlintVertex.prologue(this.used, this.synthesized));
-				case CRUMBLING -> lines.addAll(CrumblingVertex.prologue(this.used, this.synthesized));
-				case LINES -> {
-					lines.addAll(LinesVertex.prologue(this.used, this.synthesized));
-					lines.addAll(LinesVertex.widen());
-				}
-				case PARTICLE -> lines.addAll(ParticleVertex.prologue(this.used, this.synthesized));
-				case SKY -> lines.addAll(SkyVertex.prologue(this.bound, this.used, this.synthesized));
-				case CLOUDS -> lines.addAll(CloudVertex.prologue(this.used, this.synthesized));
-				case DISTANT -> lines.addAll(
-						DistantVertex.prologue(this.bound, this.used, this.synthesized));
-				case WORLD -> {
-					for (Map.Entry<String, String> attribute : LegacyGlsl.FIXED_ATTRIBUTES.entrySet()) {
-						if (this.used.contains(attribute.getKey())) {
-							lines.add("in " + attribute.getValue() + ";");
-						}
-					}
-
-					for (Map.Entry<String, String> attribute : LegacyGlsl.ENGINE_ATTRIBUTES.entrySet()) {
-						if (this.used.contains(attribute.getKey())
-								&& !this.declaredNames.contains(attribute.getKey())) {
-							lines.add("in " + attribute.getValue() + ";");
-						}
-					}
-				}
-			}
-		}
-
-		// The four taps a hardware comparison blends, for the lookups the road decision sent here:
-		// GpuSampler carries no compare mode, so when the comparison cannot ride the binding, what
-		// the hardware does is done in arithmetic instead. The hardware compares each of the four
-		// texels a bilinear filter would have taken and blends the four RESULTS, so that is what
-		// this does: textureGather brings the four back whatever filter is bound, the comparison is
-		// made on each, and the blend uses the weights of the filter. Comparing an already filtered
-		// depth is the one thing it must not do, and that is the difference: the average of four
-		// depths is a surface standing nowhere, while the average of four comparisons is a fraction
-		// of the light, which is the whole point of the thing. Iris binds GL_LINEAR plus
-		// GL_COMPARE_REF_TO_TEXTURE for it, in ShadowRenderTargets.getSamplerFor, and the hardware
-		// road binds the same pair through the descriptor instead of coming here.
-		//
-		// Not conditioned on shadowHardwareFiltering, and nothing here could condition it: the
-		// header is written per stage, before any of the pack's directives are folded. It costs
-		// nothing on this corpus. Without that directive Iris leaves the comparison mode off and
-		// what a sampler2DShadow reads is undefined, so the declaration this translation found is
-		// the only live meaning the directive has; and the harder shape the pair can ask for,
-		// NEAREST_HW, needs shadowtexNearest, which no pack of the corpus writes.
-		//
-		// The sense is LEQUAL, which is what OptiFine sets on a shadow texture and therefore what
-		// every pack is written against: one where the fragment is no further from the light than
-		// what the map holds, and the map holds the forward window where nearer is smaller.
-		//
-		// The level of detail is dropped, which is what a comparison sampler with no mipmaps would
-		// have done with it anyway: nothing ever fills a chain on the shadow map.
-		if (this.softRewrites > 0) {
-			lines.add("float " + SHADOW_COMPARE + "(sampler2D ofMap, vec3 ofAt) {"
-					+ " vec4 ofTests = step(vec4(ofAt.z), textureGather(ofMap, ofAt.xy, 0));"
-					+ " vec2 ofPart = fract(ofAt.xy * vec2(textureSize(ofMap, 0)) - 0.5);"
-					+ " return mix(mix(ofTests.w, ofTests.z, ofPart.x),"
-					+ " mix(ofTests.x, ofTests.y, ofPart.x), ofPart.y); }");
-			lines.add("float " + SHADOW_COMPARE + "(sampler2D ofMap, vec3 ofAt, float ofLod) {"
-					+ " return " + SHADOW_COMPARE + "(ofMap, ofAt); }");
-		}
-
-		// One overload per shape the builtins take, and no driver sine anywhere in it. The turn
-		// count is taken out through two constants whose sum carries two pi to thirty-three bits,
-		// so the residue keeps its low bits where a single fp32 two-pi would shed them; the residue
-		// is folded to a quarter turn and fed to the odd polynomial. Measured on the hash's own
-		// yardstick: a single-constant reduction leaves a field the uniformity test rejects at 427
-		// where white noise scores 15, and this form scores 11 to 14, alongside the reference.
-		if (this.trigCalls > 0) {
-			for (String shape : new String[] {"float", "vec2", "vec3", "vec4"}) {
-				lines.add(shape + " " + REDUCED_SIN + "(" + shape + " ofX) {"
-						+ " " + shape + " ofK = floor(ofX * 0.15915494);"
-						+ " " + shape + " ofR = ofX - ofK * 6.28125 - ofK * 1.9353072e-3;"
-						+ " ofR -= 6.2831855 * step(3.1415927, ofR);"
-						+ " " + shape + " ofS = sign(ofR);"
-						+ " " + shape + " ofA = 1.5707964 - abs(abs(ofR) - 1.5707964);"
-						+ " " + shape + " ofZ = ofA * ofA;"
-						+ " return ofS * ofA * (1.0 + ofZ * (-1.6666654611e-1"
-						+ " + ofZ * (8.3321608736e-3 + ofZ * (-1.9515295891e-4)))); }");
-				lines.add(shape + " " + REDUCED_COS + "(" + shape + " ofX) {"
-						+ " return " + REDUCED_SIN + "(ofX + 1.5707964); }");
-			}
-		}
-
-		// One overload per vector the idiom hashes. The bits are hashed rather than the sine of a
-		// huge argument, which is the whole of rewriteGoldbergHash.
-		if (this.hashCalls > 0) {
-			lines.add("float " + HASH + "(vec2 ofP) {"
-					+ " uvec2 ofV = floatBitsToUint(ofP);"
-					+ " uint ofN = (ofV.x * 1597334677u) ^ (ofV.y * 3812015801u);"
-					+ " ofN ^= ofN >> 16u;"
-					+ " ofN *= 2246822519u;"
-					+ " ofN ^= ofN >> 13u;"
-					+ " ofN *= 3266489917u;"
-					+ " ofN ^= ofN >> 16u;"
-					+ " return float(ofN) * 2.3283064365386963e-10; }");
-			lines.add("float " + HASH + "(vec3 ofP) {"
-					+ " uvec3 ofV = floatBitsToUint(ofP);"
-					+ " uint ofN = ofV.x ^ (ofV.y * 1597334677u) ^ (ofV.z * 3812015801u);"
-					+ " ofN ^= ofN >> 16u;"
-					+ " ofN *= 2246822519u;"
-					+ " ofN ^= ofN >> 13u;"
-					+ " ofN *= 3266489917u;"
-					+ " ofN ^= ofN >> 16u;"
-					+ " return float(ofN) * 2.3283064365386963e-10; }");
-		}
-
-		// Only where a lookup was moved. A stage carrying the declaration and never reading it, which
-		// is most of them, has its declaration flattened and owes no helper.
-		this.readVolumes.forEach((name, atlas) -> lines.addAll(volumeHelper(name, atlas)));
-
-		// Declared on both sides or on neither, whether this stage reads it or not. A varying the
-		// vertex writes and the fragment never mentions is accepted in silence and shifts the
-		// location of everything declared after it.
-		if (varyings.contains(FOG_COORD)) {
-			lines.add((this.stage == ProgramStage.VERTEX ? "out" : "in") + " float " + FOG_COORD + ";");
-		}
-
-		// The same rule for the overlay colour, and it arrives here by the same road: the union says
-		// yes, so both sides declare it whichever of them reads it. No interpolation qualifier, which
-		// is Iris's answer too: every vertex of one model part carries the same overlay coordinate,
-		// so what is interpolated between them is one value.
-		if (varyings.contains(ENTITY_COLOR)) {
-			lines.add((this.stage == ProgramStage.VERTEX ? "out" : "in") + " vec4 " + ENTITY_COLOR + ";");
-		}
-
-		// And the same rule again for the three identifiers, with the qualifier the language demands
-		// rather than one chosen: an integer varying may not be interpolated, so flat is not a
-		// decision here. Iris writes flat on its own ivec3 for the same reason
-		// (EntityPatcher.java:159).
-		for (String identifier : ENTITY_IDS) {
-			if (varyings.contains(identifier)) {
-				lines.add("flat " + (this.stage == ProgramStage.VERTEX ? "out" : "in") + " int "
-						+ identifier + ";");
-			}
-		}
-
-		for (SplitMatrix split : this.splitMatrices) {
-			lines.add(split.matrixType() + " " + split.name() + ";");
-			String storage = split.input() ? "in" : "out";
-			String qualified = split.qualifier().isEmpty()
-					? storage + " " + split.columnType()
-					: split.qualifier() + " " + storage + " " + split.columnType();
-			for (int column = 0; column < split.columns(); column++) {
-				lines.add(qualified + " " + matrixColumnName(split.name(), column) + ";");
-			}
-		}
-
-		// The struct's definition, once per type, then the global of the pack's name, then one
-		// varying per member in the order the struct lists them, so that both stages number them
-		// alike. The definition is written from the members read off the body, whose own copy is
-		// blank by now.
-		Set<String> defined = new HashSet<>();
-		for (SplitStruct split : this.splitStructs) {
-			if (defined.add(split.structType())) {
-				StringBuilder definition = new StringBuilder("struct ").append(split.structType())
-						.append(" { ");
-				for (StructMember member : split.members()) {
-					definition.append(member.type()).append(' ').append(member.name()).append("; ");
-				}
-
-				lines.add(definition.append("};").toString());
-			}
-
-			lines.add(split.structType() + " " + split.name() + ";");
-			String storage = split.input() ? "in" : "out";
-			for (StructMember member : split.members()) {
-				// An integer member is flat whatever the pack wrote on the struct, as the entity
-				// identifiers are: the language allows nothing else, and a struct of floats may
-				// legally carry no qualifier at all.
-				String qualifier = split.qualifier();
-				if (INTEGER_MEMBER_TYPES.contains(member.type()) && !qualifier.contains("flat")) {
-					qualifier = qualifier.isEmpty() ? "flat" : "flat " + qualifier;
-				}
-
-				String qualified = qualifier.isEmpty()
-						? storage + " " + member.type()
-						: qualifier + " " + storage + " " + member.type();
-				lines.add(qualified + " " + structMemberName(split.name(), member.name()) + ";");
-			}
-		}
-
-		// The array as a global of the pack's name, then one varying per element in index order,
-		// flat where the element may not be interpolated.
-		for (SplitArray split : this.splitArrays) {
-			lines.add(split.type() + " " + split.name() + "[" + split.size() + "];");
-			String storage = split.input() ? "in" : "out";
-			String qualifier = split.qualifier();
-			if (INTEGER_MEMBER_TYPES.contains(split.type()) && !qualifier.contains("flat")) {
-				qualifier = qualifier.isEmpty() ? "flat" : "flat " + qualifier;
-			}
-
-			String qualified = qualifier.isEmpty()
-					? storage + " " + split.type()
-					: qualifier + " " + storage + " " + split.type();
-			for (int element = 0; element < split.size(); element++) {
-				lines.add(qualified + " " + arrayElementName(split.name(), element) + ";");
-			}
-		}
-
-		// From zero up with no gaps, because a location the game finds nothing declared at is not
-		// left empty: it renumbers what is there and everything above the gap moves down one.
-		for (int slot = 0; slot <= this.maxFragmentOutput; slot++) {
-			Output output = this.packOutputs.get(slot);
-			lines.add("layout(location = " + slot + ") out "
-					+ (output == null ? "vec4" : output.type()) + " " + outputName(slot, shadowed) + ";");
-		}
-
-		// Above everything the pack declared, dead branches included, because the rank is what
-		// becomes the location and the ranks below this one are already spoken for.
-		if (this.covers) {
-			lines.add("layout(location = " + (this.maxFragmentOutput + 1) + ") out float "
-					+ COVERAGE + ";");
-		}
-
-		if (this.ordered) {
-			StringBuilder order = new StringBuilder("void " + ORDER_OUTPUTS + "() {");
-			for (int slot = 0; slot <= this.maxFragmentOutput; slot++) {
-				order.append(' ').append(outputName(slot, shadowed)).append(';');
-			}
-
-			if (this.covers) {
-				order.append(' ').append(COVERAGE).append(';');
-			}
-
-			lines.add(order.append(" }").toString());
-		}
-
-		// The same rule as the varying above, read from the other end: a varying the NEXT stage
-		// declares and this one never wrote is not a silence but a refusal, so it is declared here
-		// rather than taken out there. The qualifier travels with it, the two sides having to agree
-		// on that as well.
-		//
-		// BELOW the colour outputs and below the ascending function, for the reason the next block
-		// gives about itself: on a stage that has colour outputs, a plain out declaration met first
-		// would take location nought from the one the game writes back. Only the last stage of a
-		// pipeline has those and only a stage that is not last is ever owed anything, so the two do
-		// not meet today. They are ordered anyway rather than left to that argument holding.
-		this.owedOutputs.forEach((name, qualified) -> lines.add(outDeclaration(name, qualified)));
-
-		// Below the block, since it reads it, and below the outputs and the ascending function for a
-		// reason that decides the picture: a wrapper standing above them would be the first place the
-		// compiler met an output name, and the rank it hands out there is the location the game
-		// writes back. It has to be the ascending function that gets there first, so this goes last.
-		// The pack's body is concatenated after the header, so its own main is only a name here and
-		// has to be declared before it can be called.
-		if (this.depthEpilogue || this.terrainPrologue || this.distantPrologue || this.entityWrapped
-				|| this.linesWrapped || wrapsFragment() || owesInitialisers()
-				|| !this.splitMatrices.isEmpty() || !this.splitStructs.isEmpty()
-				|| !this.splitArrays.isEmpty()) {
-			lines.add("void " + PACK_MAIN + "();");
-			// The lines mesh runs the pack's main twice, the far end of the edge first and the
-			// vertex itself second, so that every varying holds the vertex's own value when the
-			// epilogues below read them, and widens between the two clip positions: Iris's own
-			// order (VanillaTransformer.java:214-222). The depth conversion still lands after,
-			// on the widened position, whose z the widening leaves alone.
-			String body = this.linesWrapped
-					? LinesVertex.OFFSET + " = Normal.xyz; " + PACK_MAIN + "(); vec4 of_LineEnd = "
-							+ "gl_Position; gl_Position = vec4(0.0); " + LinesVertex.OFFSET
-							+ " = vec3(0.0); " + PACK_MAIN + "(); " + LinesVertex.WIDEN
-							+ "(gl_Position, of_LineEnd);"
-					: PACK_MAIN + "();";
-			// The mask goes last of all, after the discard: a fragment the alpha test threw away
-			// covered nothing, and marking it covered would leave a hole where a leaf was.
-			lines.add("void main() { "
-					+ (this.terrainPrologue ? SodiumVertex.PROLOGUE + "(); " : "")
-					+ (this.distantPrologue ? DistantVertex.PROLOGUE + "(); " : "")
-					+ overlayPrologue()
-					+ identifierPrologue(varyings)
-					+ (wrapsFragment() ? ORDER_OUTPUTS + "(); " : "")
-					+ coveragePrologue()
-					+ owedPrologue()
-					+ matrixPrologue()
-					+ structPrologue()
-					+ arrayPrologue()
-					+ body
-					+ matrixEpilogue()
-					+ structEpilogue()
-					+ arrayEpilogue()
-					+ (this.depthEpilogue ? " gl_Position.z = " + DEPTH_CONV
-							+ ".x * gl_Position.z + " + DEPTH_CONV + ".y * gl_Position.w;" : "")
-					+ (this.alphaEpilogue
-							? " " + this.alphaTest.discard(outputName(0, shadowed) + ".a")
-							: "")
-					+ (this.covers ? " " + COVERAGE + " = " + writtenDepth() + ";" : "")
-					+ " }");
-		}
-
-		return String.join("\n", lines) + "\n";
-	}
-
-	/** Whether there is anything owed AND a wrapped main to assign it from. */
-	private boolean owesInitialisers() {
-		return this.mainWrapped && !this.owedOutputs.isEmpty();
-	}
-
-	/** The owed varyings set to their zero, ahead of the pack's own main. */
-	private String owedPrologue() {
-		if (!owesInitialisers()) {
-			return "";
-		}
-
-		StringBuilder assignments = new StringBuilder();
-		this.owedOutputs.forEach((name, qualified) ->
-				assignments.append(initialiser(name, qualified)).append(' '));
-
-		return assignments.toString();
-	}
-
 	/**
-	 * Rebuilds each input matrix from its columns before the pack body runs, so a read of the
-	 * original name still sees a {@code mat3}.
+	 * The answers the header is written from, taken once every pass has run. Nothing here is
+	 * written back, which is why {@link Emitter} is handed these rather than this object.
 	 */
-	private String matrixPrologue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitMatrix split : this.splitMatrices) {
-			if (!split.input()) {
-				continue;
-			}
-
-			assignments.append(split.name()).append(" = ").append(split.matrixType()).append('(');
-			for (int column = 0; column < split.columns(); column++) {
-				if (column > 0) {
-					assignments.append(", ");
-				}
-
-				assignments.append(matrixColumnName(split.name(), column));
-			}
-
-			assignments.append("); ");
-		}
-
-		return assignments.toString();
-	}
-
-	/**
-	 * Copies each output matrix onto its columns after the pack body ran, so the interface the
-	 * next stage reads is the value the pack wrote.
-	 */
-	private String matrixEpilogue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitMatrix split : this.splitMatrices) {
-			if (split.input()) {
-				continue;
-			}
-
-			for (int column = 0; column < split.columns(); column++) {
-				assignments.append(matrixColumnName(split.name(), column)).append(" = ")
-						.append(split.name()).append('[').append(column).append("]; ");
-			}
-		}
-
-		return assignments.toString();
-	}
-
-	/**
-	 * Rebuilds each input struct from its members before the pack body runs, so a read of the
-	 * original name still sees the struct. A constructor takes the members in declaration order,
-	 * which is the order they were declared in as varyings.
-	 */
-	private String structPrologue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitStruct split : this.splitStructs) {
-			if (!split.input()) {
-				continue;
-			}
-
-			assignments.append(split.name()).append(" = ").append(split.structType()).append('(');
-			for (int member = 0; member < split.members().size(); member++) {
-				if (member > 0) {
-					assignments.append(", ");
-				}
-
-				assignments.append(structMemberName(split.name(), split.members().get(member).name()));
-			}
-
-			assignments.append("); ");
-		}
-
-		return assignments.toString();
-	}
-
-	/**
-	 * Copies each output struct onto its members after the pack body ran, so the interface the next
-	 * stage reads is the value the pack wrote.
-	 */
-	private String structEpilogue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitStruct split : this.splitStructs) {
-			if (split.input()) {
-				continue;
-			}
-
-			for (StructMember member : split.members()) {
-				assignments.append(structMemberName(split.name(), member.name())).append(" = ")
-						.append(split.name()).append('.').append(member.name()).append("; ");
-			}
-		}
-
-		return assignments.toString();
-	}
-
-	/** Fills each input array from its elements before the pack body runs. */
-	private String arrayPrologue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitArray split : this.splitArrays) {
-			if (!split.input()) {
-				continue;
-			}
-
-			for (int element = 0; element < split.size(); element++) {
-				assignments.append(split.name()).append('[').append(element).append("] = ")
-						.append(arrayElementName(split.name(), element)).append("; ");
-			}
-		}
-
-		return assignments.toString();
-	}
-
-	/** Copies each output array onto its elements after the pack body ran. */
-	private String arrayEpilogue() {
-		StringBuilder assignments = new StringBuilder();
-		for (SplitArray split : this.splitArrays) {
-			if (split.input()) {
-				continue;
-			}
-
-			for (int element = 0; element < split.size(); element++) {
-				assignments.append(arrayElementName(split.name(), element)).append(" = ")
-						.append(split.name()).append('[').append(element).append("]; ");
-			}
-		}
-
-		return assignments.toString();
-	}
-
-	/**
-	 * What the depth attachment of this draw receives, which is what the mask is filled from.
-	 * <p>
-	 * The interpolated depth for an ordinary stage, and the stage's own where it writes one: those
-	 * are the two values the hardware may write, and the mask exists to be compared with what was
-	 * written. Neither is converted. The pack's own reads of {@code gl_FragCoord.z} are put back
-	 * into the window it was written for, and its writes to {@code gl_FragDepth} are brought out of
-	 * it again, both by {@link #convertDepth}; this line is text of ours that pass never sees, so
-	 * both names here carry the value the target really holds.
-	 */
-	private String writtenDepth() {
-		return this.namesFragDepth ? "gl_FragDepth" : "gl_FragCoord.z";
-	}
-
-	/**
-	 * Gives {@code gl_FragDepth} the value the hardware would have written, before the pack's own
-	 * body runs and can write another.
-	 * <p>
-	 * <strong>Only where the mask is written and the stage names the builtin</strong>, and both
-	 * halves are paid for. A stage that names it may still leave it alone on the branch that runs -
-	 * Bliss writes it under {@code POM} and nowhere else ({@code dimensions/all_solid.fsh:359,394})
-	 * - and reading a builtin the stage never wrote is undefined, so the mask would carry whatever
-	 * the driver left there. Writing it costs the early depth test, which is why a stage that never
-	 * names it is left alone: it would pay that for a value the line below can read off
-	 * {@code gl_FragCoord} instead.
-	 */
-	private String coveragePrologue() {
-		return this.covers && this.namesFragDepth ? "gl_FragDepth = gl_FragCoord.z; " : "";
-	}
-
-	/**
-	 * Makes the hit flash and the damage tint out of the overlay the mesh carries, before the pack's
-	 * own body runs and can read it.
-	 * <p>
-	 * Iris's three lines, term for term
-	 * ({@code pipeline/transform/transformer/EntityPatcher.java:55-56} and {@code :62}, the fourth
-	 * statement of that run being a vertex colour it hands on for its own reasons), and each is the
-	 * game's rather than a choice. The image is {@code OverlayTexture}'s sixteen by sixteen, red over
-	 * the top half and white with a falling alpha over the bottom, and the element is the pair
-	 * {@code OverlayTexture.pack} wrote; the alpha is turned around because what the texture stores
-	 * is how much of the mob shows through. The third line is a workaround Iris carries for the
-	 * packs, and it stays because the packs are what this engine is written against: some read the
-	 * colour without looking at the alpha and expect a black where there is no flash.
-	 * <p>
-	 * A {@code texelFetch} and not a sample, so nothing the bound sampler does can reach it: the
-	 * coordinate is a texel of a sixteen wide image and a filter between two of them would be a
-	 * flash halfway to the tint.
-	 */
-	private String overlayPrologue() {
-		if (!this.makesOverlayColour) {
-			return "";
-		}
-
-		return "vec4 " + OVERLAY_TEXEL + " = texelFetch(" + OVERLAY + ", UV1, 0); "
-				+ ENTITY_COLOR + " = vec4(" + OVERLAY_TEXEL + ".rgb, 1.0 - " + OVERLAY_TEXEL + ".a); "
-				+ ENTITY_COLOR + ".rgb *= float(" + ENTITY_COLOR + ".a != 0.0); ";
-	}
-
-	/**
-	 * Hands the three identifiers on out of the element the mesh carries them on, before the pack's
-	 * own body runs and can read them.
-	 * <p>
-	 * Iris's one line spread over three, and the difference is only that its names are components of
-	 * one {@code ivec3} where these keep the spelling the pack wrote
-	 * ({@code EntityPatcher.java:165-166}). Only what some stage really reads is written: what is in
-	 * the union is what was declared, and writing a varying the header did not declare would not
-	 * compile.
-	 * <p>
-	 * The lane is the position in {@link #ENTITY_IDS} and the element is unsigned, so the cast is
-	 * where a name the pack never mapped becomes 65535 rather than minus one. That is Iris's number
-	 * as well, its own element being unsigned and its input an {@code ivec3} the driver zero extends
-	 * into, and it is the number the packs are written against.
-	 */
-	private String identifierPrologue(Set<String> varyings) {
-		if (!this.entityWrapped) {
-			return "";
-		}
-
-		StringBuilder written = new StringBuilder();
-		for (int lane = 0; lane < ENTITY_IDS.size(); lane++) {
-			String identifier = ENTITY_IDS.get(lane);
-			if (varyings.contains(identifier)) {
-				written.append(identifier).append(" = int(")
-						.append(EntityVertex.IDENTIFIERS).append('[').append(lane).append("]); ");
-			}
-		}
-
-		return written.toString();
-	}
-
-	/** What output {@code slot} is called, which is the pack's own name when it declared one. */
-	private String outputName(int slot, Set<String> shadowed) {
-		Output output = this.packOutputs.get(slot);
-		if (output == null) {
-			return "ofFragData" + slot;
-		}
-
-		// Renamed here as well as in the body, since the declaration has moved up out of it and
-		// the two halves of one name have to keep agreeing.
-		return shadowed.contains(output.name()) ? "ofOwn_" + output.name() : output.name();
+	private Emitter emitter() {
+		return new Emitter(this.stage, this.inputs, this.bound, this.alphaTest, this.engineDefines,
+				this.memoryQualifiers, this.used, this.declaredNames, this.synthesized,
+				this.readVolumes, this.packOutputs, this.maxFragmentOutput, this.owedOutputs,
+				this.splitMatrices, this.splitStructs, this.splitArrays, this.gameTextureMatrix,
+				this.gameModelView, this.softRewrites, this.trigCalls, this.hashCalls,
+				this.mainWrapped, this.depthEpilogue, this.terrainPrologue, this.distantPrologue,
+				this.entityWrapped, this.linesWrapped, this.alphaEpilogue, this.covers,
+				wrapsFragment(), this.ordered, this.namesFragDepth, this.makesOverlayColour);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/TokenStream.java
+++ b/common/src/main/java/dev/vitrail/glsl/TokenStream.java
@@ -1,0 +1,424 @@
+package dev.vitrail.glsl;
+
+import dev.vitrail.glsl.GlslLexer.Kind;
+import dev.vitrail.glsl.GlslLexer.Token;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * The tokens one unit is rewritten in, and every way there is of reading them or changing them.
+ * <p>
+ * {@link GlslTranslator} is a pipeline of passes over this list, and every one of them works by
+ * index: the next token that is not space, the bracket that closes this one, the statement a name
+ * sits in, the line the pack wrote it on. That is the substrate the whole rewrite stands on rather
+ * than a pass of its own, so it lives here, and the list is this class's alone. A pass reaches it
+ * through the methods below or not at all, and cannot leave it in a shape they would misread.
+ * <p>
+ * Two answers are kept between calls instead of being worked out again, where a function ends and
+ * which line each token is on, and they belong here for the same reason: what makes either stale is
+ * this class's own {@link #insertClosings}, and nothing else in the rewrite moves a token at all.
+ */
+final class TokenStream implements Iterable<Token> {
+
+	/**
+	 * How far a declaration may reach for its semicolon. A pack that leaves one out would
+	 * otherwise have the rest of the file scanned once per {@code uniform} it declares, which is
+	 * quadratic: forty thousand such lines took twenty-seven seconds.
+	 */
+	private static final int MAX_STATEMENT_TOKENS = 4096;
+
+	private final List<Token> tokens;
+
+	/** The parameter list {@link #functionEnd} last answered for, and its answer. */
+	private int functionEndFor = -1;
+	private int functionEndAt;
+
+	/** What {@link #lineNumbers} last built, or null where a token has moved since. */
+	private int[] lineTable;
+
+	TokenStream(List<Token> tokens) {
+		this.tokens = new ArrayList<>(tokens);
+	}
+
+	int size() {
+		return this.tokens.size();
+	}
+
+	Token get(int index) {
+		return this.tokens.get(index);
+	}
+
+	/** Read only, so that a walk over the list cannot take a token out of it on the way. */
+	@Override
+	public Iterator<Token> iterator() {
+		return Collections.unmodifiableList(this.tokens).iterator();
+	}
+
+	/** The text of every token, which is the body a header is written in front of. */
+	String join() {
+		return GlslLexer.join(this.tokens);
+	}
+
+	/**
+	 * Marks a token as the name a naming directive gives, which is the one thing a pass may put on
+	 * a token from outside. Everything else the passes leave behind is a rewrite of its text.
+	 */
+	void naming(int index) {
+		this.tokens.set(index, this.tokens.get(index).naming());
+	}
+
+	/** One closing the wrap owes, put in once the scan that found it has finished reading. */
+	record Closing(int at, String text, String directive) {
+	}
+
+	/**
+	 * Inserting shifts every index after it, so the last insertion is made first.
+	 * <p>
+	 * This is the one place that moves a token, both passes that close a wrap coming through it,
+	 * and so the one place that can make a position stale. What a later pass has to know about a
+	 * token is carried on the token for that reason, as {@link Token#macroName()} is: a position
+	 * kept across here would be read against somebody else's token, and nothing downstream can
+	 * tell. The two answers this class keeps about the list, the function end and the line table,
+	 * are thrown away here for the same reason.
+	 */
+	void insertClosings(List<Closing> closings) {
+		if (closings.isEmpty()) {
+			return;
+		}
+
+		this.functionEndFor = -1;
+		this.lineTable = null;
+
+		// One walk that copies the list with the closings dropped in, rather than one shift of
+		// every later token per closing: a stage carries hundreds of thousands of tokens and a
+		// few hundred closings, and the shifts were the whole cost of the pass. The order is the
+		// one the shifts produced: closings sharing a position land latest first, because each
+		// shift pushed the one inserted before it along.
+		closings.sort(Comparator.comparingInt(Closing::at));
+		List<Token> rebuilt = new ArrayList<>(this.tokens.size() + closings.size());
+		int next = 0;
+		for (int at = 0; at <= this.tokens.size(); at++) {
+			int first = next;
+			while (next < closings.size() && closings.get(next).at() == at) {
+				next++;
+			}
+
+			for (int closing = next - 1; closing >= first; closing--) {
+				Closing one = closings.get(closing);
+				rebuilt.add(new Token(Kind.RAW, one.text(), one.directive()));
+			}
+
+			if (at < this.tokens.size()) {
+				rebuilt.add(this.tokens.get(at));
+			}
+		}
+
+		this.tokens.clear();
+		this.tokens.addAll(rebuilt);
+	}
+
+	void replace(int index, String text) {
+		this.functionEndFor = -1;
+		this.tokens.set(index, this.tokens.get(index).as(text));
+	}
+
+	/** Replaces a token with text of our own, which no later pass will match again. */
+	void inject(int index, String text) {
+		this.functionEndFor = -1;
+		this.tokens.set(index, new Token(Kind.RAW, text, this.tokens.get(index).directive()));
+	}
+
+	void blank(int index) {
+		this.functionEndFor = -1;
+		if (index >= 0) {
+			this.tokens.set(index, Token.BLANK);
+		}
+	}
+
+	/** Empties a range but keeps its line breaks, so error messages still point at the right line. */
+	void blankRange(int start, int end) {
+		this.functionEndFor = -1;
+		for (int index = start; index <= end; index++) {
+			Token token = this.tokens.get(index);
+			if (token.kind() == Kind.NEWLINE) {
+				continue;
+			}
+
+			// A comment or a spliced line carries its breaks inside one token, and they are kept
+			// as well: the passes that ask which line a name is on take their numbers once and
+			// read them after blanking, so a break lost here moves every name after it.
+			long breaks = token.text().chars().filter(c -> c == '\n').count();
+			this.tokens.set(index, breaks == 0
+					? Token.BLANK
+					: new Token(Kind.SPACE, "\n".repeat((int) breaks), token.directive()));
+		}
+	}
+
+	void blankDirective(int hash) {
+		this.functionEndFor = -1;
+		for (int index = hash; index < this.tokens.size(); index++) {
+			if (this.tokens.get(index).kind() == Kind.NEWLINE) {
+				return;
+			}
+
+			this.tokens.set(index, Token.BLANK);
+		}
+	}
+
+	/**
+	 * The next token that is neither space nor comment. A line break ends the search inside a
+	 * directive, since a directive is one line, and is stepped over everywhere else.
+	 */
+	int significantAfter(int index) {
+		if (index < 0) {
+			return -1;
+		}
+
+		boolean directive = this.tokens.get(index).directive() != null;
+		for (int scan = index + 1; scan < this.tokens.size(); scan++) {
+			Token token = this.tokens.get(scan);
+			if (token.trivia()) {
+				continue;
+			}
+
+			if (token.kind() == Kind.NEWLINE) {
+				if (directive) {
+					return -1;
+				}
+
+				continue;
+			}
+
+			return scan;
+		}
+
+		return -1;
+	}
+
+	/**
+	 * The identifier a directive declares or tests, which is the second one on its line. The first
+	 * is the directive keyword itself.
+	 */
+	int macroNameAfter(int hash) {
+		boolean keywordSeen = false;
+
+		for (int scan = hash + 1; scan < this.tokens.size(); scan++) {
+			Token token = this.tokens.get(scan);
+			if (token.kind() == Kind.NEWLINE) {
+				return -1;
+			}
+
+			if (token.trivia()) {
+				continue;
+			}
+
+			if (!keywordSeen) {
+				keywordSeen = true;
+				continue;
+			}
+
+			return token.kind() == Kind.IDENTIFIER ? scan : -1;
+		}
+
+		return -1;
+	}
+
+	/** The previous token that is neither space, comment nor line break, staying out of directives. */
+	int significantBefore(int index) {
+		for (int scan = index - 1; scan >= 0; scan--) {
+			Token token = this.tokens.get(scan);
+			if (token.trivia() || token.kind() == Kind.NEWLINE) {
+				continue;
+			}
+
+			return token.directive() == null ? scan : -1;
+		}
+
+		return -1;
+	}
+
+	/**
+	 * Which line of the expanded unit each token sits on.
+	 * <p>
+	 * Kept between calls, which a stage makes twenty three times, and thrown away by
+	 * {@link #insertClosings}, the one pass that moves a token. Nothing else can make it stale:
+	 * every other method here leaves the line breaks where they were, which {@link #blankRange}
+	 * goes out of its way to do. That is not this table's rule either, it is the unit's: a break
+	 * lost anywhere would move every line after it away from the one the expander is asked about,
+	 * and no pass would have a way to notice.
+	 */
+	int[] lineNumbers() {
+		if (this.lineTable != null) {
+			return this.lineTable;
+		}
+
+		int[] lines = new int[this.tokens.size()];
+		int line = 0;
+
+		for (int index = 0; index < this.tokens.size(); index++) {
+			lines[index] = line;
+			String text = this.tokens.get(index).text();
+			for (int at = 0; at < text.length(); at++) {
+				if (text.charAt(at) == '\n') {
+					line++;
+				}
+			}
+		}
+
+		this.lineTable = lines;
+
+		return lines;
+	}
+
+	/** The opening parenthesis of a call on the identifier at this index, or -1 if it is not one. */
+	int callOpener(int index) {
+		int next = significantAfter(index);
+
+		return next >= 0 && this.tokens.get(next).operator("(") ? next : -1;
+	}
+
+	int matchingBracket(int open) {
+		if (open < 0) {
+			return -1;
+		}
+
+		String opening = this.tokens.get(open).text();
+		String closing = switch (opening) {
+			case "(" -> ")";
+			case "{" -> "}";
+			default -> "]";
+		};
+		int depth = 0;
+
+		for (int scan = open; scan < this.tokens.size(); scan++) {
+			Token token = this.tokens.get(scan);
+			if (token.kind() != Kind.OPERATOR) {
+				continue;
+			}
+
+			if (token.operator(opening)) {
+				depth++;
+			} else if (token.operator(closing)) {
+				depth--;
+				if (depth == 0) {
+					return scan;
+				}
+			}
+		}
+
+		return -1;
+	}
+
+	/**
+	 * The last token of the function a parameter list opens, which is the brace that closes the
+	 * body, or the parenthesis itself when the function is only declared.
+	 */
+	int functionEnd(int parameters) {
+		// Asked once per parameter of a list and answered once per list: the walk to the
+		// function's closing brace is the same for every parameter, and every helper that
+		// touches a token forgets this first.
+		if (parameters == this.functionEndFor) {
+			return this.functionEndAt;
+		}
+
+		int end = walkFunctionEnd(parameters);
+		this.functionEndFor = parameters;
+		this.functionEndAt = end;
+
+		return end;
+	}
+
+	private int walkFunctionEnd(int parameters) {
+		int close = matchingBracket(parameters);
+		int brace = close < 0 ? -1 : significantAfter(close);
+		if (brace < 0 || !this.tokens.get(brace).operator("{")) {
+			return close < 0 ? this.tokens.size() - 1 : close;
+		}
+
+		int end = matchingBracket(brace);
+
+		return end < 0 ? this.tokens.size() - 1 : end;
+	}
+
+	/**
+	 * Where the statement containing this token starts: just past whatever ended the last one.
+	 * Returns -1 when no end to the previous statement is within reach, since blanking a range
+	 * whose beginning was guessed would erase code that is none of our business.
+	 */
+	int statementStart(int index) {
+		int limit = Math.max(0, index - MAX_STATEMENT_TOKENS);
+		int start = -1;
+
+		for (int scan = index - 1; scan >= limit; scan--) {
+			Token token = this.tokens.get(scan);
+			boolean boundary = token.kind() == Kind.HASH || token.directive() != null
+					|| token.operator(";") || token.operator("{") || token.operator("}");
+			if (boundary) {
+				start = scan + 1;
+				break;
+			}
+		}
+
+		if (start < 0) {
+			// Reaching the first token is a real answer; running out of budget is not.
+			if (limit > 0) {
+				return -1;
+			}
+
+			start = 0;
+		}
+
+		while (start < index) {
+			Token token = this.tokens.get(start);
+			if (!token.trivia() && token.kind() != Kind.NEWLINE) {
+				break;
+			}
+
+			start++;
+		}
+
+		return start;
+	}
+
+	/** The semicolon closing this statement, or -1 if a brace opens first or none is found. */
+	int statementEnd(int index) {
+		int depth = 0;
+		int last = Math.min(this.tokens.size(), index + MAX_STATEMENT_TOKENS);
+
+		for (int scan = index; scan < last; scan++) {
+			Token token = this.tokens.get(scan);
+			if (token.kind() != Kind.OPERATOR || token.directive() != null) {
+				continue;
+			}
+
+			String text = token.text();
+			if (text.equals("(") || text.equals("[")) {
+				depth++;
+			} else if (text.equals(")") || text.equals("]")) {
+				depth--;
+			} else if (depth == 0 && text.equals("{")) {
+				return -1;
+			} else if (depth == 0 && text.equals(";")) {
+				return scan;
+			}
+		}
+
+		return -1;
+	}
+
+	List<Integer> significantRange(int start, int end) {
+		List<Integer> found = new ArrayList<>();
+		for (int scan = start; scan <= end; scan++) {
+			Token token = this.tokens.get(scan);
+			if (!token.trivia() && token.kind() != Kind.NEWLINE) {
+				found.add(scan);
+			}
+		}
+
+		return found;
+	}
+}

--- a/common/src/main/java/dev/vitrail/glsl/TokenStream.java
+++ b/common/src/main/java/dev/vitrail/glsl/TokenStream.java
@@ -19,8 +19,9 @@ import java.util.List;
  * through the methods below or not at all, and cannot leave it in a shape they would misread.
  * <p>
  * Two answers are kept between calls instead of being worked out again, where a function ends and
- * which line each token is on, and they belong here for the same reason: what makes either stale is
- * this class's own {@link #insertClosings}, and nothing else in the rewrite moves a token at all.
+ * which line each token is on, and they belong here for the same reason: only an edit made
+ * through this class can make either stale, and every edit goes through {@link #set} or
+ * {@link #insertClosings}, which is where each answer is dropped.
  */
 final class TokenStream implements Iterable<Token> {
 
@@ -68,7 +69,7 @@ final class TokenStream implements Iterable<Token> {
 	 * a token from outside. Everything else the passes leave behind is a rewrite of its text.
 	 */
 	void naming(int index) {
-		this.tokens.set(index, this.tokens.get(index).naming());
+		set(index, this.tokens.get(index).naming());
 	}
 
 	/** One closing the wrap owes, put in once the scan that found it has finished reading. */
@@ -122,51 +123,80 @@ final class TokenStream implements Iterable<Token> {
 	}
 
 	void replace(int index, String text) {
-		this.functionEndFor = -1;
-		this.tokens.set(index, this.tokens.get(index).as(text));
+		set(index, this.tokens.get(index).as(text));
 	}
 
 	/** Replaces a token with text of our own, which no later pass will match again. */
 	void inject(int index, String text) {
-		this.functionEndFor = -1;
-		this.tokens.set(index, new Token(Kind.RAW, text, this.tokens.get(index).directive()));
+		set(index, new Token(Kind.RAW, text, this.tokens.get(index).directive()));
 	}
 
 	void blank(int index) {
-		this.functionEndFor = -1;
 		if (index >= 0) {
-			this.tokens.set(index, Token.BLANK);
+			set(index, Token.BLANK);
 		}
 	}
 
 	/** Empties a range but keeps its line breaks, so error messages still point at the right line. */
 	void blankRange(int start, int end) {
-		this.functionEndFor = -1;
 		for (int index = start; index <= end; index++) {
-			Token token = this.tokens.get(index);
-			if (token.kind() == Kind.NEWLINE) {
-				continue;
+			if (this.tokens.get(index).kind() != Kind.NEWLINE) {
+				set(index, blanked(this.tokens.get(index)));
 			}
-
-			// A comment or a spliced line carries its breaks inside one token, and they are kept
-			// as well: the passes that ask which line a name is on take their numbers once and
-			// read them after blanking, so a break lost here moves every name after it.
-			long breaks = token.text().chars().filter(c -> c == '\n').count();
-			this.tokens.set(index, breaks == 0
-					? Token.BLANK
-					: new Token(Kind.SPACE, "\n".repeat((int) breaks), token.directive()));
 		}
 	}
 
+	/** Empties a directive from its hash to the end of its line, spliced lines kept as breaks. */
 	void blankDirective(int hash) {
-		this.functionEndFor = -1;
 		for (int index = hash; index < this.tokens.size(); index++) {
 			if (this.tokens.get(index).kind() == Kind.NEWLINE) {
 				return;
 			}
 
-			this.tokens.set(index, Token.BLANK);
+			set(index, blanked(this.tokens.get(index)));
 		}
+	}
+
+	/**
+	 * A token emptied of everything but its line breaks. A comment or a spliced line carries its
+	 * breaks inside one token, and they are kept: the passes that ask which line a name is on
+	 * take their numbers once and read them after blanking, so a break lost here would move every
+	 * name after it, and the table {@link #lineNumbers} keeps would be right about a text that no
+	 * longer exists.
+	 */
+	private static Token blanked(Token token) {
+		int breaks = breaks(token.text());
+
+		return breaks == 0
+				? Token.BLANK
+				: new Token(Kind.SPACE, "\n".repeat(breaks), token.directive());
+	}
+
+	/**
+	 * Puts one token in place of another, which is the one way a token changes short of
+	 * {@link #insertClosings}. The function end is forgotten every time, since a brace may have
+	 * gone or come. The line table is kept unless the count of breaks moved: no caller hands in a
+	 * text with a break in it, and none takes a token that had one, but the rule is kept here
+	 * and not by every caller remembering it.
+	 */
+	private void set(int index, Token token) {
+		this.functionEndFor = -1;
+		if (breaks(this.tokens.get(index).text()) != breaks(token.text())) {
+			this.lineTable = null;
+		}
+
+		this.tokens.set(index, token);
+	}
+
+	private static int breaks(String text) {
+		int breaks = 0;
+		for (int at = 0; at < text.length(); at++) {
+			if (text.charAt(at) == '\n') {
+				breaks++;
+			}
+		}
+
+		return breaks;
 	}
 
 	/**
@@ -244,12 +274,13 @@ final class TokenStream implements Iterable<Token> {
 	/**
 	 * Which line of the expanded unit each token sits on.
 	 * <p>
-	 * Kept between calls, which a stage makes twenty three times, and thrown away by
-	 * {@link #insertClosings}, the one pass that moves a token. Nothing else can make it stale:
-	 * every other method here leaves the line breaks where they were, which {@link #blankRange}
-	 * goes out of its way to do. That is not this table's rule either, it is the unit's: a break
-	 * lost anywhere would move every line after it away from the one the expander is asked about,
-	 * and no pass would have a way to notice.
+	 * Kept between calls, which the passes make many times over a stage, some of them once per
+	 * name, and thrown away by {@link #insertClosings}, the one pass that moves a token, and by
+	 * any edit that changes how many breaks a token holds, which none does today. Every other
+	 * edit leaves the line breaks where they were, which the blanking goes out of its way to do.
+	 * That is not this table's rule either, it is the unit's: a break lost anywhere would move
+	 * every line after it away from the one the expander is asked about, and no pass would have
+	 * a way to notice.
 	 */
 	int[] lineNumbers() {
 		if (this.lineTable != null) {
@@ -261,12 +292,7 @@ final class TokenStream implements Iterable<Token> {
 
 		for (int index = 0; index < this.tokens.size(); index++) {
 			lines[index] = line;
-			String text = this.tokens.get(index).text();
-			for (int at = 0; at < text.length(); at++) {
-				if (text.charAt(at) == '\n') {
-					line++;
-				}
-			}
+			line += breaks(this.tokens.get(index).text());
 		}
 
 		this.lineTable = lines;
@@ -319,8 +345,8 @@ final class TokenStream implements Iterable<Token> {
 	 */
 	int functionEnd(int parameters) {
 		// Asked once per parameter of a list and answered once per list: the walk to the
-		// function's closing brace is the same for every parameter, and every helper that
-		// touches a token forgets this first.
+		// function's closing brace is the same for every parameter, and every edit of a token
+		// forgets this first.
 		if (parameters == this.functionEndFor) {
 			return this.functionEndAt;
 		}

--- a/common/src/main/java/dev/vitrail/glsl/VaryingSplit.java
+++ b/common/src/main/java/dev/vitrail/glsl/VaryingSplit.java
@@ -1,0 +1,659 @@
+package dev.vitrail.glsl;
+
+import dev.vitrail.glsl.GlslLexer.Kind;
+import dev.vitrail.glsl.GlslLexer.Token;
+import dev.vitrail.glsl.GlslTranslator.FileScope;
+import dev.vitrail.pack.program.ProgramStage;
+import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The varyings this stage cannot hand over as the pack declared them, and what it hands over
+ * instead.
+ * <p>
+ * {@code IntermediaryShaderModule.createFromSpirv} numbers a varying by the rank of its reflected
+ * name, with no stride, so a name occupying several locations has the next one numbered onto its
+ * second. A matrix is one such name, a struct is another and an array is a third, and all three
+ * are answered the same way: the declaration comes out of the body, one varying per column, per
+ * member or per element goes into the header, and the pack's own name is rebuilt as a local
+ * around its {@code main}. The three cases share the numbering they exist for, the shape of the
+ * rewrite and the wrapper they are copied in, which is why they are one class and not three.
+ * <p>
+ * What it can see is the token list, the unit's own liveness, the stage, and one reader handed to
+ * it: a declaration at file scope is {@link GlslTranslator}'s to recognise, and reading one a
+ * second way here would be a second answer to drift from the first.
+ */
+final class VaryingSplit {
+
+	/**
+	 * Prefix of the vectors a matrix varying is split into. Pack names never start with {@code of_},
+	 * so a column cannot collide with a varying the pack already declared.
+	 */
+	private static final String MATRIX_COLUMN = "of_vmat_";
+
+	/** The prefix of a varying standing for one member of a struct varying. */
+	private static final String STRUCT_MEMBER = "of_vstruct_";
+
+	/** The prefix of a varying standing for one element of an array varying. */
+	private static final String ARRAY_ELEMENT = "of_varr_";
+
+	/**
+	 * A declarator's array suffix, one dimension sized by a number the pack wrote out: one to
+	 * a few hundred elements, since no interface has that many locations and a zero is no array.
+	 */
+	private static final Pattern ARRAY_SUFFIX = Pattern.compile("\\[\\s*([1-9]\\d{0,2})\\s*\\]$");
+
+	/**
+	 * The member types a struct varying is split over: one location apiece, nothing nested, and
+	 * nothing a varying may not be, which rules the booleans out.
+	 */
+	private static final Set<String> STRUCT_MEMBER_TYPES = Set.of(
+			"float", "vec2", "vec3", "vec4", "int", "ivec2", "ivec3", "ivec4",
+			"uint", "uvec2", "uvec3", "uvec4", "double", "dvec2", "dvec3", "dvec4");
+
+	private final TokenStream tokens;
+	private final ExpandedUnit unit;
+	private final ProgramStage stage;
+	private final Declarations declarations;
+
+	/**
+	 * Matrix varyings rewritten as one vector per column, so {@code createFromSpirv} can number
+	 * them without overlap. Empty when the stage declared none.
+	 */
+	private final List<SplitMatrix> matrices = new ArrayList<>();
+
+	/**
+	 * Struct varyings rewritten as one varying per member, for the same numbering. Empty when the
+	 * stage declared none, which is every stage of the corpus but Photon's.
+	 */
+	private final List<SplitStruct> structs = new ArrayList<>();
+
+	/**
+	 * Array varyings rewritten as one varying per element, for the same numbering again. Empty
+	 * when the stage declared none.
+	 */
+	private final List<SplitArray> arrays = new ArrayList<>();
+
+	VaryingSplit(TokenStream tokens, ExpandedUnit unit, ProgramStage stage,
+			Declarations declarations) {
+		this.tokens = tokens;
+		this.unit = unit;
+		this.stage = stage;
+		this.declarations = declarations;
+	}
+
+	/**
+	 * How this reads one declaration at file scope, which is the translator's own reader handed
+	 * over rather than copied.
+	 */
+	@FunctionalInterface
+	interface Declarations {
+
+		/**
+		 * The declaration the storage keyword at this index opens, or null where it opens
+		 * something else.
+		 *
+		 * @param types the type names a declaration may be written under: the language's own, or
+		 *              the struct types the unit defines
+		 */
+		FileScope read(int keyword, Set<String> types);
+	}
+
+	/** Every varying that has to be taken apart, in the order the numbering needs them split. */
+	void split() {
+		splitMatrixVaryings();
+		splitStructVaryings();
+		splitArrayVaryings();
+	}
+
+	/** Whether anything was split at all, and so whether the header owes a wrapper. */
+	boolean any() {
+		return !this.matrices.isEmpty() || !this.structs.isEmpty() || !this.arrays.isEmpty();
+	}
+
+	List<SplitMatrix> matrices() {
+		return this.matrices;
+	}
+
+	List<SplitStruct> structs() {
+		return this.structs;
+	}
+
+	List<SplitArray> arrays() {
+		return this.arrays;
+	}
+
+	/**
+	 * One matrix varying rewritten as one vector per column.
+	 *
+	 * @param input true when this stage reads the matrix ({@code in}), false when it writes it
+	 */
+	record SplitMatrix(String name, String matrixType, String columnType, int columns,
+			String qualifier, boolean input) {
+	}
+
+	/**
+	 * Turns each file-scope matrix {@code in} / {@code out} into one vector per column.
+	 * <p>
+	 * {@code IntermediaryShaderModule.createFromSpirv} numbers locations by the rank of each
+	 * reflected variable, {@code 0..n-1} with no stride. A GLSL {@code mat3} is one variable and
+	 * occupies three consecutive locations, so the next varying is numbered onto the second
+	 * column and the rotation the pack stored is no longer orthonormal. AstraLex's night planet
+	 * is the image of that: a billboard {@code xy / z} through a walked-on {@code mat3}.
+	 * <p>
+	 * OpenGL links by name and never asks. The workaround here is to take the declaration out of
+	 * the body and emit the matrix as a local in the header, beside one vector per column: the pack
+	 * body still writes and reads the original name, and the wrapper copies the columns. Arrays
+	 * of matrices are left alone; no pack of the corpus writes one, and AstraLex's four matrices
+	 * are not arrays.
+	 */
+	private void splitMatrixVaryings() {
+		if (this.stage == ProgramStage.COMPUTE) {
+			return;
+		}
+
+		int[] lines = this.tokens.lineNumbers();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.directive() != null || !this.unit.isLive(lines[index])) {
+				continue;
+			}
+
+			boolean input = token.identifier("in");
+			boolean output = token.identifier("out");
+			if (!input && !output) {
+				continue;
+			}
+
+			if (input && this.stage == ProgramStage.VERTEX) {
+				continue;
+			}
+
+			FileScope declared = this.declarations.read(index, LegacyGlsl.TYPE_NAMES);
+			if (declared == null) {
+				continue;
+			}
+
+			MatrixColumns layout = matrixColumns(declared.type());
+			if (layout == null) {
+				continue;
+			}
+
+			boolean anyArray = declared.names().stream().anyMatch(name ->
+					declared.declarators().getOrDefault(name, "").contains("["));
+			if (anyArray) {
+				continue;
+			}
+
+			this.tokens.blankRange(declared.start(), declared.end());
+
+			for (String name : declared.names()) {
+				this.matrices.add(new SplitMatrix(name, declared.type(), layout.columnType(),
+						layout.columns(), declared.qualifier(), input));
+			}
+		}
+	}
+
+	/** Column count and vector type of a GLSL matrix, or null when the type is not a matrix. */
+	record MatrixColumns(String columnType, int columns) {
+	}
+
+	/**
+	 * {@code mat3} is three {@code vec3}, {@code mat4x3} is four {@code vec3}, {@code dmat2} is two
+	 * {@code dvec2}. Anything else, including a vector, answers null.
+	 */
+	private static MatrixColumns matrixColumns(String type) {
+		String prefix = "";
+		String rest = type;
+		if (rest.startsWith("dmat")) {
+			prefix = "d";
+			rest = rest.substring(1);
+		}
+
+		if (!rest.startsWith("mat")) {
+			return null;
+		}
+
+		rest = rest.substring(3);
+		int columns;
+		int rows;
+		int by = rest.indexOf('x');
+		try {
+			if (by < 0) {
+				columns = Integer.parseInt(rest);
+				rows = columns;
+			} else {
+				columns = Integer.parseInt(rest.substring(0, by));
+				rows = Integer.parseInt(rest.substring(by + 1));
+			}
+		} catch (NumberFormatException ignored) {
+			return null;
+		}
+
+		if (columns < 2 || columns > 4 || rows < 2 || rows > 4) {
+			return null;
+		}
+
+		return new MatrixColumns(prefix + "vec" + rows, columns);
+	}
+
+	static String matrixColumnName(String matrix, int column) {
+		return MATRIX_COLUMN + matrix + "_" + column;
+	}
+
+	/** One member of a struct a varying is declared under, in the order the struct lists it. */
+	record StructMember(String type, String name) {
+	}
+
+	/**
+	 * One struct varying rewritten as one varying per member.
+	 *
+	 * @param input true when this stage reads the struct ({@code in}), false when it writes it
+	 */
+	record SplitStruct(String name, String structType, List<StructMember> members,
+			String qualifier, boolean input) {
+	}
+
+	/**
+	 * Turns each file-scope struct {@code in} / {@code out} into one varying per member, for the
+	 * reason {@link #splitMatrixVaryings} turns a matrix into its columns: a struct is one
+	 * reflected variable occupying as many locations as it has members, and the rank the game
+	 * numbers it by is one. Photon's {@code flat in OverworldFogParameters fog_params}, three
+	 * {@code vec3} of fog coefficients, reached its water fragment stage wrong under that
+	 * numbering, and the fog its reflections computed with them painted every distant lake red;
+	 * handed over as three varyings, the same program draws the lake as the reference does.
+	 * <p>
+	 * The definition is read off the unit itself, since the type is the pack's own. Only a struct
+	 * whose members are all scalars or vectors is split: a member that is a matrix, an array or a
+	 * struct of its own would need the same treatment one level down, and no pack of the corpus
+	 * writes one. Arrays of structs are left alone as arrays of matrices are.
+	 */
+	private void splitStructVaryings() {
+		if (this.stage == ProgramStage.COMPUTE) {
+			return;
+		}
+
+		Map<String, List<StructMember>> definitions = structDefinitions();
+		if (definitions.isEmpty()) {
+			return;
+		}
+
+		int[] lines = this.tokens.lineNumbers();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.directive() != null || !this.unit.isLive(lines[index])) {
+				continue;
+			}
+
+			boolean input = token.identifier("in");
+			boolean output = token.identifier("out");
+			if (!input && !output) {
+				continue;
+			}
+
+			if (input && this.stage == ProgramStage.VERTEX) {
+				continue;
+			}
+
+			// Read against the struct types the unit defines: the plain reader only knows the
+			// language's own types, which is why a struct varying was never a declaration to it.
+			FileScope declared = this.declarations.read(index, definitions.keySet());
+			if (declared == null) {
+				continue;
+			}
+
+			List<StructMember> members = definitions.get(declared.type());
+
+			boolean anyArray = declared.names().stream().anyMatch(name ->
+					declared.declarators().getOrDefault(name, "").contains("["));
+			if (anyArray) {
+				continue;
+			}
+
+			this.tokens.blankRange(declared.start(), declared.end());
+
+			for (String name : declared.names()) {
+				this.structs.add(new SplitStruct(name, declared.type(), members,
+						declared.qualifier(), input));
+			}
+		}
+
+		// The definition moves to the header with the global that carries the pack's name: the
+		// wrapper that rebuilds the struct stands in the header, above the body, and the type has
+		// to exist there. The body's own definition goes blank so the type is not defined twice.
+		Set<String> moved = new HashSet<>();
+		for (SplitStruct split : this.structs) {
+			if (!moved.add(split.structType())) {
+				continue;
+			}
+
+			int[] definition = definitionRange(split.structType());
+			if (definition != null) {
+				this.tokens.blankRange(definition[0], definition[1]);
+			}
+		}
+	}
+
+	/**
+	 * Every struct the unit defines on a live line whose members are all scalars or vectors, by
+	 * type name. A struct with any other member is left out, so its varyings stay as they are.
+	 */
+	private Map<String, List<StructMember>> structDefinitions() {
+		Map<String, List<StructMember>> definitions = new LinkedHashMap<>();
+		int[] lines = this.tokens.lineNumbers();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (!token.identifier("struct") || token.directive() != null
+					|| !this.unit.isLive(lines[index])) {
+				continue;
+			}
+
+			int name = this.tokens.significantAfter(index);
+			int open = this.tokens.significantAfter(name);
+			if (name < 0 || open < 0 || this.tokens.get(name).kind() != Kind.IDENTIFIER
+					|| !this.tokens.get(open).operator("{")) {
+				continue;
+			}
+
+			int close = this.tokens.matchingBracket(open);
+			int semicolon = this.tokens.significantAfter(close);
+			// A definition that declares an instance in the same breath, "struct T { ... } t;",
+			// is left alone: taking it out of the body would take the instance with it.
+			if (close < 0 || semicolon < 0 || !this.tokens.get(semicolon).operator(";")) {
+				continue;
+			}
+
+			List<StructMember> members = structMembers(open + 1, close - 1);
+			if (members != null && !members.isEmpty()) {
+				definitions.putIfAbsent(this.tokens.get(name).text(), members);
+			}
+		}
+
+		return definitions;
+	}
+
+	/**
+	 * The members declared between a struct's braces, or null where one of them is not a scalar
+	 * or a vector: a member with brackets, a matrix, a sampler or another struct.
+	 */
+	private List<StructMember> structMembers(int start, int end) {
+		List<StructMember> members = new ArrayList<>();
+		List<Integer> statement = new ArrayList<>();
+		for (int scan : this.tokens.significantRange(start, end)) {
+			Token token = this.tokens.get(scan);
+			if (!token.operator(";")) {
+				statement.add(scan);
+				continue;
+			}
+
+			if (statement.size() < 2) {
+				return null;
+			}
+
+			String type = this.tokens.get(statement.get(0)).text();
+			if (!STRUCT_MEMBER_TYPES.contains(type)) {
+				return null;
+			}
+
+			for (int part = 1; part < statement.size(); part++) {
+				Token piece = this.tokens.get(statement.get(part));
+				if (piece.operator(",")) {
+					continue;
+				}
+
+				if (piece.kind() != Kind.IDENTIFIER) {
+					return null;
+				}
+
+				members.add(new StructMember(type, piece.text()));
+			}
+
+			statement.clear();
+		}
+
+		return statement.isEmpty() ? members : null;
+	}
+
+	/**
+	 * The first live definition of that struct, from its {@code struct} keyword to the semicolon
+	 * closing it, or null where the unit holds none.
+	 */
+	private int[] definitionRange(String structType) {
+		int[] lines = this.tokens.lineNumbers();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (!token.identifier("struct") || token.directive() != null
+					|| !this.unit.isLive(lines[index])) {
+				continue;
+			}
+
+			int name = this.tokens.significantAfter(index);
+			int open = this.tokens.significantAfter(name);
+			if (name < 0 || open < 0 || !this.tokens.get(name).identifier(structType)
+					|| !this.tokens.get(open).operator("{")) {
+				continue;
+			}
+
+			int close = this.tokens.matchingBracket(open);
+			int semicolon = this.tokens.significantAfter(close);
+			if (close >= 0 && semicolon >= 0 && this.tokens.get(semicolon).operator(";")) {
+				return new int[] {index, semicolon};
+			}
+		}
+
+		return null;
+	}
+
+	static String structMemberName(String struct, String member) {
+		return STRUCT_MEMBER + struct + "_" + member;
+	}
+
+	/**
+	 * One array varying rewritten as one varying per element.
+	 *
+	 * @param input true when this stage reads the array ({@code in}), false when it writes it
+	 */
+	record SplitArray(String name, String type, int size, String qualifier, boolean input) {
+	}
+
+	/**
+	 * Turns each file-scope array {@code in} / {@code out} of scalars or vectors into one varying
+	 * per element, for the reason the matrices and the structs are split: an array is one
+	 * reflected variable over as many locations as it has elements, and one rank. Photon's
+	 * {@code flat in vec3 sky_sh[9]} carries its sky harmonics into the deferred shading, and the
+	 * two varyings after it were numbered onto its elements.
+	 * <p>
+	 * Only a single dimension sized by a number the pack wrote out is split: a size written as a
+	 * name, a macro the unit still carries or a constant expression, is left alone with the
+	 * declaration. A statement declaring an array beside a plain name is left alone too, so that
+	 * the two are not pulled apart.
+	 * <p>
+	 * Only what the vertex stage writes and the fragment stage reads: a geometry or tessellation
+	 * stage declares its per-vertex inputs as arrays that are no varying arrays, and a fragment
+	 * stage's output array is a set of colour outputs, which the header numbers on its own.
+	 */
+	private void splitArrayVaryings() {
+		boolean output = this.stage == ProgramStage.VERTEX;
+		if (!output && this.stage != ProgramStage.FRAGMENT) {
+			return;
+		}
+
+		int[] lines = this.tokens.lineNumbers();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.directive() != null || !this.unit.isLive(lines[index])
+					|| !token.identifier(output ? "out" : "in")) {
+				continue;
+			}
+
+			FileScope declared = this.declarations.read(index, LegacyGlsl.TYPE_NAMES);
+			if (declared == null || !STRUCT_MEMBER_TYPES.contains(declared.type())) {
+				continue;
+			}
+
+			List<SplitArray> found = new ArrayList<>();
+			for (String name : declared.names()) {
+				String prefix = declared.type() + " " + name;
+				String declarator = declared.declarators().getOrDefault(name, "");
+				Matcher size = declarator.startsWith(prefix)
+						? ARRAY_SUFFIX.matcher(declarator.substring(prefix.length()))
+						: null;
+				if (size == null || !size.matches()) {
+					found.clear();
+					break;
+				}
+
+				found.add(new SplitArray(name, declared.type(), Integer.parseInt(size.group(1)),
+						declared.qualifier(), !output));
+			}
+
+			if (found.isEmpty()) {
+				continue;
+			}
+
+			this.tokens.blankRange(declared.start(), declared.end());
+			this.arrays.addAll(found);
+		}
+	}
+
+	static String arrayElementName(String array, int element) {
+		return ARRAY_ELEMENT + array + "_" + element;
+	}
+
+	/**
+	 * Rebuilds each input matrix from its columns before the pack body runs, so a read of the
+	 * original name still sees a {@code mat3}.
+	 */
+	String matrixPrologue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitMatrix split : this.matrices) {
+			if (!split.input()) {
+				continue;
+			}
+
+			assignments.append(split.name()).append(" = ").append(split.matrixType()).append('(');
+			for (int column = 0; column < split.columns(); column++) {
+				if (column > 0) {
+					assignments.append(", ");
+				}
+
+				assignments.append(matrixColumnName(split.name(), column));
+			}
+
+			assignments.append("); ");
+		}
+
+		return assignments.toString();
+	}
+
+	/**
+	 * Copies each output matrix onto its columns after the pack body ran, so the interface the
+	 * next stage reads is the value the pack wrote.
+	 */
+	String matrixEpilogue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitMatrix split : this.matrices) {
+			if (split.input()) {
+				continue;
+			}
+
+			for (int column = 0; column < split.columns(); column++) {
+				assignments.append(matrixColumnName(split.name(), column)).append(" = ")
+						.append(split.name()).append('[').append(column).append("]; ");
+			}
+		}
+
+		return assignments.toString();
+	}
+
+	/**
+	 * Rebuilds each input struct from its members before the pack body runs, so a read of the
+	 * original name still sees the struct. A constructor takes the members in declaration order,
+	 * which is the order they were declared in as varyings.
+	 */
+	String structPrologue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitStruct split : this.structs) {
+			if (!split.input()) {
+				continue;
+			}
+
+			assignments.append(split.name()).append(" = ").append(split.structType()).append('(');
+			for (int member = 0; member < split.members().size(); member++) {
+				if (member > 0) {
+					assignments.append(", ");
+				}
+
+				assignments.append(structMemberName(split.name(),
+						split.members().get(member).name()));
+			}
+
+			assignments.append("); ");
+		}
+
+		return assignments.toString();
+	}
+
+	/**
+	 * Copies each output struct onto its members after the pack body ran, so the interface the next
+	 * stage reads is the value the pack wrote.
+	 */
+	String structEpilogue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitStruct split : this.structs) {
+			if (split.input()) {
+				continue;
+			}
+
+			for (StructMember member : split.members()) {
+				assignments.append(structMemberName(split.name(), member.name()))
+						.append(" = ")
+						.append(split.name()).append('.').append(member.name()).append("; ");
+			}
+		}
+
+		return assignments.toString();
+	}
+
+	/** Fills each input array from its elements before the pack body runs. */
+	String arrayPrologue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitArray split : this.arrays) {
+			if (!split.input()) {
+				continue;
+			}
+
+			for (int element = 0; element < split.size(); element++) {
+				assignments.append(split.name()).append('[').append(element).append("] = ")
+						.append(arrayElementName(split.name(), element)).append("; ");
+			}
+		}
+
+		return assignments.toString();
+	}
+
+	/** Copies each output array onto its elements after the pack body ran. */
+	String arrayEpilogue() {
+		StringBuilder assignments = new StringBuilder();
+		for (SplitArray split : this.arrays) {
+			if (split.input()) {
+				continue;
+			}
+
+			for (int element = 0; element < split.size(); element++) {
+				assignments.append(arrayElementName(split.name(), element)).append(" = ")
+						.append(split.name()).append('[').append(element).append("]; ");
+			}
+		}
+
+		return assignments.toString();
+	}
+}

--- a/common/src/main/java/dev/vitrail/glsl/VolumeFlattening.java
+++ b/common/src/main/java/dev/vitrail/glsl/VolumeFlattening.java
@@ -25,7 +25,9 @@ import java.util.Set;
  * <p>
  * Apart because what it needs is its own and narrow: the tokens, the unit's liveness, the volumes
  * the pack declared and the two tables of macro names, since a pack reads a volume through an
- * alias as readily as through the name it declared. What it leaves behind is the helpers the
+ * alias as readily as through the name it declared. The volumes are copied; the two tables are
+ * the translator's own, empty when this is made and filled by the pass that collects the macro
+ * names, which runs before {@link #flatten} does. What it leaves behind is the helpers the
  * header owes and the two counts that say a name could not be moved.
  */
 final class VolumeFlattening {

--- a/common/src/main/java/dev/vitrail/glsl/VolumeFlattening.java
+++ b/common/src/main/java/dev/vitrail/glsl/VolumeFlattening.java
@@ -1,0 +1,336 @@
+package dev.vitrail.glsl;
+
+import dev.vitrail.glsl.GlslLexer.Kind;
+import dev.vitrail.glsl.GlslLexer.Token;
+import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
+import dev.vitrail.pack.target.SamplerPlan;
+import dev.vitrail.pack.target.SamplerTypes;
+import dev.vitrail.pack.texture.VolumeAtlas;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The volumes a pack ships, laid out flat, and every read of one sent through a helper.
+ * <p>
+ * A three dimensional sampler is refused by the game's own compiler wherever it is declared, read
+ * or not, so a pack that ships one has to be rewritten rather than served. The declaration becomes
+ * a {@code sampler2D} over an atlas of slices and each lookup becomes a helper that reads two of
+ * them and mixes them, which is one rewrite over the token list with a table of what it found.
+ * <p>
+ * Apart because what it needs is its own and narrow: the tokens, the unit's liveness, the volumes
+ * the pack declared and the two tables of macro names, since a pack reads a volume through an
+ * alias as readily as through the name it declared. What it leaves behind is the helpers the
+ * header owes and the two counts that say a name could not be moved.
+ */
+final class VolumeFlattening {
+
+	/** What a lookup on a volume the pack ships is called once the volume has been laid out flat. */
+	private static final String VOLUME_LOOKUP = "ofTexture3D_";
+
+	/** The number of arguments {@link GlslTranslator#LOOKUP} takes where it reads a volume. */
+	private static final int LOOKUP_ARGUMENTS = 2;
+
+	private final TokenStream tokens;
+	private final ExpandedUnit unit;
+
+	/**
+	 * The volumes the pack ships and this engine serves flat, by the name the pack samples them
+	 * under. Empty everywhere but the two packs of the corpus that ship one.
+	 */
+	private final Map<String, VolumeAtlas> volumes;
+
+	/** Names the pack defines as macros, and the ones standing for exactly one other name. */
+	private final Set<String> packMacros;
+	private final Map<String, String> macroAliases;
+
+	/** The volumes this unit reads, and so the helpers its header owes, by the pack's own name. */
+	private final Map<String, VolumeAtlas> readVolumes = new LinkedHashMap<>();
+
+	private int volumeLookups;
+	private int volumesLeftAlone;
+
+	VolumeFlattening(TokenStream tokens, ExpandedUnit unit, Map<String, VolumeAtlas> volumes,
+			Set<String> packMacros, Map<String, String> macroAliases) {
+		this.tokens = tokens;
+		this.unit = unit;
+		this.volumes = Collections.unmodifiableMap(new LinkedHashMap<>(volumes));
+		this.packMacros = packMacros;
+		this.macroAliases = macroAliases;
+	}
+
+	/** The volumes really read, and so the helpers the header owes, by the pack's own name. */
+	Map<String, VolumeAtlas> read() {
+		return this.readVolumes;
+	}
+
+	/** How many lookups were moved onto a helper. */
+	int lookups() {
+		return this.volumeLookups;
+	}
+
+	/** How many volumes were left exactly as the pack wrote them, and so left the program refused. */
+	int leftAlone() {
+		return this.volumesLeftAlone;
+	}
+
+	/**
+	 * Moves every volume the pack ships onto a flat atlas: the declaration to a {@code sampler2D}
+	 * under a forged name, and each lookup to a helper that reads two slices and mixes them.
+	 * <p>
+	 * <strong>The declaration is what has to go, not the lookup.</strong>
+	 * {@code GlslCompiler.addToBindGroup} refuses anything the reflection reports as neither
+	 * {@code SpvDim2D} nor {@code SpvDimCube}, and the reflection lists a module's whole resource
+	 * list at optimisation level zero, so a {@code sampler3D} declared in a shared include and never
+	 * read costs the program its pipeline exactly as one sampled on every pixel does. Supplying a
+	 * real volume would not help either: the type is the refusal.
+	 * <p>
+	 * <strong>Every program carrying the declaration is rewritten, and Iris rewrites only the stage
+	 * the directive names.</strong> Its {@code TextureTransformer} runs per stage, so under it
+	 * Mellow's composites and its final keep a live {@code sampler3D colortex6} bound to nothing,
+	 * which GL tolerates and Vulkan does not. Renaming everywhere invents nothing: the pack has
+	 * named exactly one file for that identifier, with its shape, its size and its format written
+	 * out, and that file is what every one of those declarations was going to read.
+	 * <p>
+	 * Nothing is moved unless everything can be. A name this unit reaches any other way than as
+	 * {@code texture(name, vec3)}, the name being the declared one or a macro the unit defines as
+	 * exactly that name, is counted and left exactly as it stands, declaration included, so the
+	 * program stays refused with the message it had. There is no site in the corpus like that, and
+	 * the count is what would say one had appeared.
+	 */
+	void flatten() {
+		if (this.volumes.isEmpty()) {
+			return;
+		}
+
+		int[] lines = this.tokens.lineNumbers();
+		this.volumes.forEach((name, atlas) -> flattenOne(name, atlas, lines));
+	}
+
+	private void flattenOne(String name, VolumeAtlas atlas, int[] lines) {
+		// The name token of a declaration, and the pair of tokens each lookup rewrites: the callee
+		// and the argument. Held rather than found again below, so that what is rewritten is what
+		// was judged.
+		List<Integer> declarations = new ArrayList<>();
+		Map<Integer, Integer> lookups = new LinkedHashMap<>();
+		boolean elsewhere = this.packMacros.contains(name);
+		Set<String> spellings = spellingsOf(name);
+
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.kind() != Kind.IDENTIFIER || !spellings.contains(token.text())
+					|| !this.unit.isLive(lines[index])) {
+				continue;
+			}
+
+			if (token.directive() != null) {
+				// The preprocessor's own lines: an alias being defined or tested is its business,
+				// and the name standing as an alias's replacement text IS the alias. The name on
+				// any other directive is a use this pass cannot follow.
+				if (token.text().equals(name) && !aliasBody(index)) {
+					elsewhere = true;
+				}
+
+				continue;
+			}
+
+			int callee = plainLookup(index);
+			if (token.text().equals(name) && volumeDeclaration(index)) {
+				declarations.add(index);
+			} else if (callee >= 0) {
+				lookups.put(index, callee);
+			} else {
+				elsewhere = true;
+			}
+		}
+
+		// A unit that reads the name without declaring it has been handed the sampler by something
+		// this pass has not seen, so there is nothing here to rename it against.
+		if (declarations.isEmpty()) {
+			return;
+		}
+
+		if (elsewhere) {
+			this.volumesLeftAlone++;
+			return;
+		}
+
+		String forged = SamplerPlan.forged(name);
+		for (int declaration : declarations) {
+			this.tokens.replace(this.tokens.significantBefore(declaration), "sampler2D");
+			this.tokens.replace(declaration, forged);
+		}
+
+		lookups.forEach((argument, callee) -> {
+			this.tokens.replace(callee, VOLUME_LOOKUP + name);
+			this.tokens.replace(argument, forged);
+		});
+
+		this.volumeLookups += lookups.size();
+		if (!lookups.isEmpty()) {
+			this.readVolumes.put(name, atlas);
+		}
+	}
+
+	/** The name and every macro the unit defines as exactly that name, aliases of aliases included. */
+	private Set<String> spellingsOf(String name) {
+		Set<String> spellings = new HashSet<>();
+		spellings.add(name);
+		boolean grew = true;
+		while (grew) {
+			grew = false;
+			for (Map.Entry<String, String> alias : this.macroAliases.entrySet()) {
+				if (spellings.contains(alias.getValue()) && spellings.add(alias.getKey())) {
+					grew = true;
+				}
+			}
+		}
+
+		return spellings;
+	}
+
+	/**
+	 * Whether this token, on a directive, is the whole replacement text of a macro standing for it:
+	 * the {@code depthtex0} of {@code #define ATMOSPHERE_SCATTERING_LUT depthtex0}.
+	 */
+	private boolean aliasBody(int index) {
+		for (int scan = index - 1; scan >= 0; scan--) {
+			Token token = this.tokens.get(scan);
+			if (token.trivia()) {
+				continue;
+			}
+
+			return token.macroName()
+					&& this.tokens.get(index).text().equals(this.macroAliases.get(token.text()));
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether this name is being declared as a uniform of a three dimensional shape here.
+	 * <p>
+	 * The {@code uniform} is demanded and the type is not enough on its own: a function taking a
+	 * {@code sampler3D} parameter of the same name declares a name inside its own body, and renaming
+	 * that would leave the body reading a parameter nobody passes.
+	 */
+	private boolean volumeDeclaration(int index) {
+		int type = this.tokens.significantBefore(index);
+		if (type < 0 || this.tokens.get(type).kind() != Kind.IDENTIFIER
+				|| !"3D".equals(SamplerTypes.shapeOf(this.tokens.get(type).text()))) {
+			return false;
+		}
+
+		int cursor = this.tokens.significantBefore(type);
+		while (cursor >= 0 && GlslTranslator.isQualifier(this.tokens.get(cursor))) {
+			cursor = this.tokens.significantBefore(cursor);
+		}
+
+		return cursor >= 0 && this.tokens.get(cursor).identifier("uniform");
+	}
+
+	/**
+	 * The {@code texture} this name is the first argument of, or -1 when it is reached any other
+	 * way. The argument count is checked as well as the name: {@code texture(s, p, bias)} compiles
+	 * and means something else, and the helper takes two.
+	 */
+	private int plainLookup(int index) {
+		int open = this.tokens.significantBefore(index);
+		if (open < 0 || !this.tokens.get(open).operator("(")) {
+			return -1;
+		}
+
+		int callee = this.tokens.significantBefore(open);
+		if (callee < 0 || !this.tokens.get(callee).identifier(GlslTranslator.LOOKUP)) {
+			return -1;
+		}
+
+		int close = this.tokens.matchingBracket(open);
+
+		return close >= 0 && arguments(open, close) == LOOKUP_ARGUMENTS ? callee : -1;
+	}
+
+	/** How many arguments a call holds, counting the commas that belong to it and not to a nested one. */
+	private int arguments(int open, int close) {
+		int depth = 0;
+		int count = 1;
+
+		for (int index = open; index < close; index++) {
+			Token token = this.tokens.get(index);
+			if (token.kind() != Kind.OPERATOR || token.directive() != null) {
+				continue;
+			}
+
+			String text = token.text();
+			if (text.equals("(") || text.equals("[")) {
+				depth++;
+			} else if (text.equals(")") || text.equals("]")) {
+				depth--;
+			} else if (depth == 1 && text.equals(",")) {
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+	/**
+	 * The trilinear read of a volume, over the atlas its slices were laid out in.
+	 * <p>
+	 * The hardware does the two dimensional half: each slice carries one texel of gutter holding
+	 * what lies past its edge, the far edge for a volume that repeats and the edge itself for one
+	 * that clamps, so a bilinear tap at the edge of a tile reads what {@code REPEAT} or
+	 * {@code CLAMP} would have read on a real volume rather than the slice next door. Only the depth
+	 * is done here, two taps and a mix, because nothing interpolates between tiles of an atlas, and
+	 * the slice index repeats or clamps as the pack asked.
+	 * <p>
+	 * The half texel is the whole of the arithmetic: a lookup at {@code u} samples the volume at
+	 * {@code u * size - 0.5} in texels, and the atlas coordinate has to land on the same pair of
+	 * texels the hardware would have blended. Every constant here comes from {@link VolumeAtlas} so
+	 * that this and the upload cannot drift apart; a layout written twice reads as noise, and noise
+	 * that is wrong looks exactly like noise that is right.
+	 */
+	static List<String> helper(String name, VolumeAtlas atlas) {
+		String depth = whole(atlas.depth());
+		String last = Integer.toString(atlas.depth() - 1);
+		String tiles = Integer.toString(atlas.tilesPerRow());
+
+		List<String> lines = new ArrayList<>();
+		lines.add("vec4 " + VOLUME_LOOKUP + name + "(sampler2D ofMap, vec3 ofAt) {");
+		lines.add(atlas.clamp() ? "\tvec3 ofQ = clamp(ofAt, 0.0, 1.0);" : "\tvec3 ofQ = fract(ofAt);");
+		lines.add("\tfloat ofZ = ofQ.z * " + depth + " - 0.5;");
+		lines.add("\tfloat ofBase = floor(ofZ);");
+		lines.add("\tvec2 ofIn = ofQ.xy * vec2(" + whole(atlas.width()) + ", " + whole(atlas.height())
+				+ ") + " + whole(VolumeAtlas.GUTTER) + ";");
+		if (atlas.clamp()) {
+			lines.add("\tint ofNear = clamp(int(ofBase), 0, " + last + ");");
+			lines.add("\tint ofFar = clamp(int(ofBase) + 1, 0, " + last + ");");
+		} else {
+			lines.add("\tint ofNear = int(mod(ofBase, " + depth + "));");
+			lines.add("\tint ofFar = int(mod(ofBase + 1.0, " + depth + "));");
+		}
+
+		lines.add("\tvec2 ofTile = vec2(" + whole(atlas.tileStride()) + ", " + whole(atlas.tileHeight())
+				+ ");");
+		lines.add("\tvec2 ofSize = vec2(" + whole(atlas.atlasWidth()) + ", " + whole(atlas.atlasHeight())
+				+ ");");
+		lines.add("\tvec2 ofA = (vec2(ofNear % " + tiles + ", ofNear / " + tiles
+				+ ") * ofTile + ofIn) / ofSize;");
+		lines.add("\tvec2 ofB = (vec2(ofFar % " + tiles + ", ofFar / " + tiles
+				+ ") * ofTile + ofIn) / ofSize;");
+		lines.add("\treturn mix(texture(ofMap, ofA), texture(ofMap, ofB), clamp(ofZ - ofBase, 0.0, 1.0));");
+		lines.add("}");
+
+		return lines;
+	}
+
+	/** An integer as a GLSL float literal, spelled by hand so that no locale can put a comma in it. */
+	private static String whole(int value) {
+		return value + ".0";
+	}
+}


### PR DESCRIPTION
## What changes

Nothing a pack sees. The GLSL translator, one class of six thousand lines doing three jobs, is cut along its seams: `TokenStream` owns the token list and the helpers every pass walks it with, and it alone can move a token; `Emitter` writes the header from a record of what the passes settled; `VaryingSplit` takes a matrix, struct or array varying apart into locations and puts it back; `VolumeFlattening` lays a pack's 3D samplers flat. The translator keeps the passes. Two costs that grew faster than the text go with it: proving which sampler parameters are handed a base-level read walked the whole token list once per parameter and per round, and now reads an index of the call sites built once; the line each token sits on was recomputed from scratch at every ask, and is now kept until a token moves. One defect met on the way is fixed: blanking a `#version` or `#extension` line spliced with a backslash lost its line break, so every line after it was reported one short.

## How it differs from the reference, and for what obstacle

It does not. Iris has no translator of this shape to compare against; the reference for this branch is the text the translator emitted before it, which is unchanged.

## What proves it

- `gradlew build` green on every commit.
- The out-of-game harness over the eight-pack corpus: the translated GLSL and the SPIR-V of all 2771 units are byte-identical to `dev`, `diff -rq` printing nothing, after every commit of the series.
- In the game, Complementary Unbound on the Fabric bench, `arena bench`: every one of the 446 modules of the load was served from the module store, which is keyed on the translated text, so the translation under the bench's own settings is identical to `dev`'s to the byte; the mean of sixty frames against the same capture on `dev` moves only where mobs move between two launches.

## What it leaves owing

Three costs met and left, each linear today: the function-end memo is dropped by every edit where only an edit under a brace could move it; the bracket walk counts operators without asking whether their line is live; and the volume flattening walks the token list once per volume, two on the whole corpus.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
