### PR TITLE
fix(pack): read a per target blend override where the targets agree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,19 @@ what the next one holds.
 
 ### Fixed
 
+- **A blend override a pack writes for one target is honoured wherever the program's targets
+  agree on it.** A `blend.<program>.<target>` line was thrown away whole, one pipeline carrying
+  one blend function for every target it writes, and the log said so. Most such lines are
+  written for a program that writes that one target and nothing else: the seven programs
+  Photon draws its translucent layer with, rain, held water, textured pieces, translucent mobs,
+  blocks and particles, each ask to be laid over that layer premultiplied, its armour glint
+  asks to add to it, and Complementary's rain writes a droplet's data and asks for it
+  unblended. Those lines are read now, as Iris reads them: on the target's
+  rank among the program's draw buffers, for the geometry programs only, a line naming a
+  target the program does not write dropped as the reference drops it. A program whose
+  targets would end up blending two ways, which one pipeline cannot carry here, keeps its whole
+  program function as before, and the log names it at load.
+
 - **A `#if` decides like the compiler where one side of an `&&` or `||` cannot be worked out.**
   A condition such as `X != 0 && 100 / X > 5` with `X` at zero was left undecided, because the
   right side was worked out whatever the left one said, and an undecided condition kept its

--- a/common/src/main/java/dev/vitrail/pack/model/BlendMode.java
+++ b/common/src/main/java/dev/vitrail/pack/model/BlendMode.java
@@ -16,9 +16,11 @@ import java.util.Optional;
  * {@code off} for a program that must not blend at all. Two factors are accepted as well and mean
  * what {@code glBlendFunc} means: the same pair for colour and for alpha.
  * <p>
- * The per buffer form, {@code blend.<program>.<buffer>}, is NOT this: one pipeline carries one
- * blend function for every target it writes, so a pack that asks for different blending per draw
- * buffer is named in the plan's notes instead of being half honoured.
+ * The per buffer form, {@code blend.<program>.<buffer>}, reads into this same record, one per
+ * directive, and the plan folds it into the program's one function where every target the
+ * program writes agrees on it. One pipeline carries one blend function for every target it
+ * writes, so a pack that asks two targets of one program for two functions is named in the
+ * plan's notes instead of being half honoured.
  */
 public record BlendMode(boolean off, String srcRgb, String dstRgb, String srcAlpha, String dstAlpha) {
 

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -20,12 +20,15 @@ import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
@@ -102,9 +105,10 @@ public final class TargetPlan {
 	private final Map<String, List<Integer>> writes;
 
 	/**
-	 * What each program asks to blend with, by its bare name, for the whole program form of the
-	 * directive. Only the programs that say something are in here; a program that says nothing is
-	 * answered by whatever the engine would have used anyway, which is not this plan's business.
+	 * What each program asks to blend with, by its bare name, the whole program form and the per
+	 * buffer form folded into one function by {@link #blendsOf}. Only the programs that say
+	 * something are in here; a program that says nothing is answered by whatever the engine would
+	 * have used anyway, which is not this plan's business.
 	 */
 	private final Map<String, BlendMode> blend;
 
@@ -126,7 +130,8 @@ public final class TargetPlan {
 		this.running = List.copyOf(draft.running);
 		this.disabled = Collections.unmodifiableMap(new LinkedHashMap<>(draft.disabled));
 		this.writes = Collections.unmodifiableMap(new LinkedHashMap<>(draft.effective));
-		this.blend = blendOf(draft);
+		Blends blends = blendsOf(draft);
+		this.blend = blends.byProgram();
 		this.inferred = Collections.unmodifiableSet(new TreeSet<>(draft.inferred));
 		this.samples = Collections.unmodifiableMap(new LinkedHashMap<>(draft.samples));
 		this.geometryAt = draft.geometryAt;
@@ -148,7 +153,7 @@ public final class TargetPlan {
 		this.unreadable = List.copyOf(draft.unreadable);
 		this.programsRead = draft.programsRead;
 		this.expandMillis = draft.expandMillis;
-		this.notes = List.copyOf(notesFor(draft, this.ordered, this.persistent));
+		this.notes = List.copyOf(notesFor(draft, this.ordered, this.persistent, blends));
 	}
 
 	/**
@@ -724,7 +729,8 @@ public final class TargetPlan {
 		return total;
 	}
 
-	private static List<String> notesFor(Draft draft, List<Integer> ordered, Set<Integer> persistent) {
+	private static List<String> notesFor(Draft draft, List<Integer> ordered, Set<Integer> persistent,
+			Blends blends) {
 		List<String> notes = new ArrayList<>(draft.directives.notes());
 		TargetDirectives directives = draft.directives;
 
@@ -760,23 +766,36 @@ public final class TargetPlan {
 					+ directives.mipmapRequests());
 		}
 
-		List<String> unreadable = draft.blend.stream()
-				.filter(directive -> directive.buffer() == null)
-				.filter(directive -> BlendMode.parse(directive.value()).isEmpty())
-				.map(directive -> directive.program() + "=" + directive.value())
-				.toList();
-		if (!unreadable.isEmpty()) {
-			notes.add("blend directives in a form this engine does not express, so those programs "
-					+ "keep the blending the engine would have used: " + unreadable);
+		if (!blends.unreadable().isEmpty()) {
+			notes.add("blend directives in a form this engine does not read, left out, the programs "
+					+ "keeping what their other directives give them: " + blends.unreadable());
 		}
 
-		List<String> perBuffer = draft.blend.stream()
-				.filter(directive -> directive.buffer() != null)
-				.map(directive -> directive.program() + "." + directive.buffer())
-				.toList();
-		if (!perBuffer.isEmpty()) {
-			notes.add("per buffer blending is not expressible, one pipeline carries one blend "
-					+ "function for every target it writes: " + perBuffer);
+		if (!blends.honoured().isEmpty()) {
+			notes.add("per buffer blend directives honoured, every target their program writes "
+					+ "taking the same function: " + blends.honoured());
+		}
+
+		if (!blends.shadow().isEmpty()) {
+			notes.add("per buffer blend directives on a program drawn from the light, whose passes "
+					+ "this engine builds without blending whatever the pack asks: " + blends.shadow());
+		}
+
+		if (!blends.fullscreen().isEmpty()) {
+			notes.add("per buffer blend directives on a full screen program, which the reference "
+					+ "reads for its geometry programs only, so they change nothing on either engine: "
+					+ blends.fullscreen());
+		}
+
+		if (!blends.dropped().isEmpty()) {
+			notes.add("per buffer blend directives naming a target their program does not write, "
+					+ "dropped as the reference drops them: " + blends.dropped());
+		}
+
+		if (!blends.apart().isEmpty()) {
+			notes.add("per buffer blend directives that would blend two targets of one program "
+					+ "differently, which one pipeline does not carry here, so those programs keep "
+					+ "the whole program function: " + blends.apart());
 		}
 
 		if (!draft.computes.isEmpty()) {
@@ -901,30 +920,127 @@ public final class TargetPlan {
 	}
 
 	/**
-	 * The whole program blend directives, read once and kept by bare name.
+	 * Every blend directive of the place settled to one function per program, the whole program
+	 * form and the per buffer form folded together the way the reference applies them: the whole
+	 * program function first, on every attachment, then each per buffer directive on the
+	 * attachment whose RANK among the program's draw buffers is the target it names, a directive
+	 * naming a target the program does not write being dropped ({@code ShaderCreator.java:142-147}
+	 * and {@code SodiumPrograms.java:145-153} resolve the rank, {@code ExtendedShader.java:225-233}
+	 * applies the two forms in that order). The reference reads the per buffer form for its
+	 * geometry programs only: a composite takes the whole program form and nothing else
+	 * ({@code CompositeRenderer.java:510-517}), the final takes neither
+	 * ({@code FinalPassRenderer.java:256-257}), so a per buffer line on one is dropped here as
+	 * well. A program drawn from the light is left out too: this engine builds every shadow
+	 * pass without blending, and the plan holds no draw buffer list for it to rank against.
 	 * <p>
-	 * The per buffer form is left out here and named in the notes instead: one pipeline carries one
-	 * blend function for every target it writes, so honouring half of such a directive would be
+	 * One pipeline carries one blend function for every attachment here, so the per buffer form
+	 * is honoured exactly when every attachment of its program comes out with the same function:
+	 * a program writing one target, which is what most such directives are written for, or several
+	 * targets under directives that agree. A program whose attachments would come out apart keeps
+	 * its whole program function, and the notes name it, honouring half of such a directive being
 	 * worse than honouring none of it. A value in a form this engine cannot read is left out too,
 	 * and named the same way.
 	 */
-	private static Map<String, BlendMode> blendOf(Draft draft) {
-		Map<String, BlendMode> blend = new LinkedHashMap<>();
+	private static Blends blendsOf(Draft draft) {
+		Map<String, BlendMode> whole = new LinkedHashMap<>();
+		Map<String, List<ShaderProperties.BlendDirective>> perBuffer = new LinkedHashMap<>();
+		List<String> unreadable = new ArrayList<>();
 		for (ShaderProperties.BlendDirective directive : draft.blend) {
-			if (directive.buffer() != null) {
-				continue;
+			String program = TargetName.bareName(directive.program());
+			Optional<BlendMode> mode = BlendMode.parse(directive.value());
+			if (mode.isEmpty()) {
+				unreadable.add(spelling(directive) + "=" + directive.value());
+			} else if (directive.buffer() == null) {
+				whole.put(program, mode.get());
+			} else {
+				perBuffer.computeIfAbsent(program, key -> new ArrayList<>()).add(directive);
 			}
-
-			BlendMode.parse(directive.value())
-					.ifPresent(mode -> blend.put(TargetName.bareName(directive.program()), mode));
 		}
 
-		return Collections.unmodifiableMap(blend);
+		Map<String, BlendMode> resolved = new LinkedHashMap<>(whole);
+		List<String> honoured = new ArrayList<>();
+		List<String> shadow = new ArrayList<>();
+		List<String> fullscreen = new ArrayList<>();
+		List<String> dropped = new ArrayList<>();
+		List<String> apart = new ArrayList<>();
+		perBuffer.forEach((program, directives) -> {
+			String family = ProgramNames.familyOf(program);
+			if (ProgramNames.shadowGeometry(family)) {
+				directives.forEach(directive -> shadow.add(spelling(directive)));
+				return;
+			}
+
+			if (!ProgramNames.geometry(family)) {
+				directives.forEach(directive -> fullscreen.add(spelling(directive)));
+				return;
+			}
+
+			// A program this place does not run has no attachment for a directive to land on.
+			List<Integer> writes = draft.effective.get(program);
+			if (writes == null) {
+				return;
+			}
+
+			// Null stands for the engine's own choice, which is what an attachment no directive
+			// names is left with, and it is as much a function as the others when they are compared.
+			// By rank, so that two lines naming the same target leave the last one standing, in the
+			// notes as in the function.
+			BlendMode[] functions = new BlendMode[writes.size()];
+			Arrays.fill(functions, whole.get(program));
+			Map<Integer, String> landed = new LinkedHashMap<>();
+			for (ShaderProperties.BlendDirective directive : directives) {
+				// A token that is no colour target refuses the whole pack under the reference
+				// (ShaderProperties.java:334-336); the line is left out here instead, and named.
+				OptionalInt index = TargetName.index(directive.buffer());
+				if (index.isEmpty()) {
+					unreadable.add(spelling(directive) + "=" + directive.value());
+					continue;
+				}
+
+				int rank = writes.indexOf(index.getAsInt());
+				if (rank < 0) {
+					dropped.add(spelling(directive));
+					continue;
+				}
+
+				functions[rank] = BlendMode.parse(directive.value()).orElseThrow();
+				landed.put(rank, spelling(directive) + "=" + directive.value());
+			}
+
+			if (landed.isEmpty()) {
+				return;
+			}
+
+			BlendMode first = functions[0];
+			if (Arrays.stream(functions).allMatch(function -> Objects.equals(function, first))) {
+				resolved.put(program, first);
+				honoured.addAll(landed.values());
+			} else {
+				apart.addAll(landed.values());
+			}
+		});
+
+		return new Blends(Collections.unmodifiableMap(resolved), List.copyOf(unreadable),
+				List.copyOf(honoured), List.copyOf(shadow), List.copyOf(fullscreen),
+				List.copyOf(dropped), List.copyOf(apart));
+	}
+
+	/** The directive as the pack spelt its key, {@code gbuffers_water.colortex13} or bare. */
+	private static String spelling(ShaderProperties.BlendDirective directive) {
+		return directive.buffer() == null ? directive.program()
+				: directive.program() + "." + directive.buffer();
+	}
+
+	/** What {@link #blendsOf} settled: the map the plan answers from, and the lines the notes carry. */
+	private record Blends(Map<String, BlendMode> byProgram, List<String> unreadable,
+			List<String> honoured, List<String> shadow, List<String> fullscreen, List<String> dropped,
+			List<String> apart) {
 	}
 
 	/**
 	 * What this program asks to blend with, or empty when it asks for nothing and the engine's own
-	 * choice stands.
+	 * choice stands. A per buffer directive is in the answer where every target the program writes
+	 * agreed on it, and in {@link #notes()} where they did not.
 	 *
 	 * @param program the bare name, {@code gbuffers_water}, not the file that ends up serving it
 	 */

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -858,8 +858,11 @@ final class GeometryProgram {
 
 	/**
 	 * What the pack asked to blend with, falling back to what the pass wants when it asked nothing,
-	 * on every attachment alike. The per buffer form, {@code blend.<program>.<buffer>}, is still
-	 * not read: one pipeline carries one blend function for every target it writes.
+	 * on every attachment alike. The per buffer form, {@code blend.<program>.<buffer>}, reaches
+	 * here folded into that one answer by the plan, where every attachment of the program comes
+	 * out with the same function; where two would come out apart the plan keeps the whole program
+	 * function and says so in its notes, one pipeline carrying one blend function for every target
+	 * it writes.
 	 * <p>
 	 * Four packs of the corpus name the translucent chunk pass here. Reverie asks for no blending
 	 * at all on its water, which is the opposite of what the pass would have chosen, and Bliss and


### PR DESCRIPTION
## What changes

A pack's `blend.<program>.<target>` line was thrown away whole, whatever the program wrote, and the load log named it as inexpressible: one pipeline carries one blend function for every attachment here. The plan now folds that line into the program's single function wherever every attachment of the program comes out the same, which is what such a line is nearly always written for, a program writing that one target. The seven programs Photon draws its translucent layer with lay their piece over that layer premultiplied, its armour glint adds to it, where each draw used to replace what was there; Complementary's rain writes its droplet data unblended where one drop used to blend over the previous. A program whose attachments would come out with two functions keeps its whole program function as before, and the load log names it, beside the lines left out for naming a target the program does not write, a full screen pass, or a shadow program.

## How it differs from the reference, and for what obstacle

Where the fold applies, it does not: Iris resolves the line to the target's rank among the program's draw buffers (`pipeline/programs/ShaderCreator.java:142-147`, `SodiumPrograms.java:145-153`), drops one naming a target the program does not write, applies it after the whole program function (`ExtendedShader.java:225-233`), and reads it for the geometry programs only (`CompositeRenderer.java:510-517` takes the whole program form alone, `FinalPassRenderer.java:256-257` neither).

Where two attachments of one program would blend differently, Iris blends them differently, one `glBlendFuncSeparatei` per attachment (`gl/blending/BlendModeStorage.java:44-62`), and this engine keeps the whole program function on both. The game's pipeline builder refuses two blend functions on one pipeline (`RenderPipeline$Builder.build`, "Blend functions must currently be the same for all color targets") and creates its device without `independentBlend`. What it costs the image: Photon's far water and untextured geometry replace the scene colour where they should blend over it, and its water surface replaces its translucent layer; a handful of programs of Bliss and BSL asking one target of several to stop blending keep blending it. All of it unchanged from before, and named in the log at load. Two smaller ones: a line whose target token is no colour target, or whose value has two factors, refuses the whole pack under Iris and is left out or read as `glBlendFunc` here, as the whole program form already was; and a line on a shadow program is left out, every shadow pass being built without blending here.

## What proves it

- `gradlew build` green.
- The off-game harness built from `dev` and from this branch, `Cibles` over the eight-pack corpus: the target tables are byte-identical, and only the plan's notes move, exactly as read off the packs. Seven lines of Photon and the rain line of both Complementary packs are honoured, the lines naming a target their program does not write are dropped, the per-target lines on the composites of BSL and Bliss are dropped as Iris drops them, and the rest is named as kept apart.
- In the game: not yet, the Fabric bench is held. What to look at when it frees: Photon at its shipped settings, bubbles seen through the water surface, against the same spot under Iris; and Complementary in the rain, the droplets as under Iris.

## What it leaves owing

The programs whose attachments would blend two ways. Serving them takes the device created with `independentBlend` and the builder's guard lifted, which is a batch of its own.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
