### PR TITLE
chore(pack): drop three imports only comments still name

### DIFF
--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -5,7 +5,6 @@ import dev.vitrail.pack.model.ProgramStage;
 import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
 import dev.vitrail.pack.texture.CustomStorage;
 import dev.vitrail.pack.texture.VolumeAtlas;
-import dev.vitrail.render.storage.StorageBuffers;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -1,7 +1,6 @@
 package dev.vitrail.pack.option;
 
 import dev.vitrail.pack.model.RenderStage;
-import dev.vitrail.render.storage.StorageBuffers;
 
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/common/src/main/java/dev/vitrail/pack/texture/CustomStorage.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/CustomStorage.java
@@ -1,7 +1,6 @@
 package dev.vitrail.pack.texture;
 
 import dev.vitrail.pack.model.BufferObject;
-import dev.vitrail.render.storage.StorageBuffers;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;


### PR DESCRIPTION
## What changes

Nothing the engine draws or prints. Three files of the pack and glsl trees imported `dev.vitrail.render.storage.StorageBuffers` while naming the class only in a comment or a javadoc link written in full; the three imports go. The pack and glsl trees compile on their own again without the render tree behind them, which is how the off-game harness builds them.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

- `gradlew build` green.
- The off-game harness compiles from this tree and refuses the tip of `dev` on exactly those three imports.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
