### PR TITLE
docs: say which half the terrain filter switch moves

### DIFF
--- a/common/src/main/java/dev/vitrail/render/pbr/PbrAtlases.java
+++ b/common/src/main/java/dev/vitrail/render/pbr/PbrAtlases.java
@@ -45,7 +45,7 @@ import java.util.Properties;
  * {@code specular} are added by {@code IrisSamplers.addLevelSamplers} and by nothing else
  * ({@code samplers/IrisSamplers.java:215-216}). What a composite declaring one of the names reads
  * is NOT the same on both sides and this file does not claim it is: here the full screen binding
- * resolves such a name to one black pixel ({@code render/PackPass.java:610}), where Iris leaves the
+ * resolves such a name to one black pixel ({@code render/PackPass.java:646}), where Iris leaves the
  * sampler unassigned and it falls to whatever texture unit nought holds. The flat texel this class
  * falls back on answers a different question, which is a GEOMETRY program reading a sprite the
  * resource pack ships no map for.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -265,14 +265,17 @@ slower and it cannot be the cause of a wrong image, so it is the first thing to 
 that draws one this one does not.
 
 **The block atlas filter can be put back the way it was.** An empty file
-`vitrail/legacy-terrain-filter` in the instance, or `-Dvitrail.legacyTerrainFilter=true`, sends a
-pack's terrain and its shadow back through the game's filtered sampler, which is what this engine
-bound before it took Iris's unfiltered one. It exists because what a filter can change is the
-silhouette of cutout foliage, and an eye judges that badly across two launches and worse across
-two builds. One world, one variable, and the Reload Shaders key between the two states: F3 + T
-rebuilds the pipelines without reading the pack again, so it does not switch. The state is written
-to the log once per pack load, at the first terrain the pack draws, whether the file is there or
-not, so a reading always names the state it belongs to.
+`vitrail/legacy-terrain-filter` in the instance, or `-Dvitrail.legacyTerrainFilter=true`, sends the
+terrain the camera sees back through the game's filtered sampler, which is what this engine
+bound before it took Iris's unfiltered one. The shadow map stays unfiltered either way: what the
+switch restores is the sampler the chunk renderer was handed, and the shadow draw hands it a
+NEAREST one of its own, so a comparison taken with the switch is a comparison of the camera's half
+alone. It exists because what a filter can change is the silhouette of cutout foliage, and an eye
+judges that badly across two launches and worse across two builds. One world, one variable, and the
+Reload Shaders key between the two states: F3 + T rebuilds the pipelines without reading the pack
+again, so it does not switch. The state is written to the log once per pack load, at the first
+terrain the pack draws, whether the file is there or not, so a reading always names the state it
+belongs to.
 
 **The sine substitution can be taken off.** Every `sin` and `cos` a pack writes is replaced at load
 time by a reduced-argument helper of the translation's own, whatever the argument. An empty file


### PR DESCRIPTION
## What changes

Nothing the engine does. Two sentences said what the code does not do. The developer guide had the legacy terrain filter switch send a pack's terrain and its shadow back through the game's filtered sampler, where the shadow draw hands the chunk renderer a NEAREST sampler of its own whatever the switch says, so a comparison taken with it is the camera's half alone; the guide says so now. The javadoc of the material map atlases pointed at a line of the full-screen binding that binds a depth name, where the sentence describes the line resolving `normals` or `specular` to one black pixel; it points at that line now.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

- `gradlew build` green.
- Each sentence read against the code it describes: the NEAREST sampler the shadow draw hands the chunk renderer, and the black fallback of the full-screen binding.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
