### PR TITLE
fix(render): fold the centre depth before the hand is drawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,13 @@ what the next one holds.
   no fullscreen pass of the pack read the name and a compute did, the compute was handed the far
   plane on every frame. A compute hanging off a pass now arms the fold as the pass would.
 
+- **A pack's depth of field focuses past the item in your hand.** The depth the focus is taken
+  from was read after the held item had been drawn into it, so whenever the item covered the
+  middle of the screen the focus jumped onto it and everything behind went soft, sharpening again
+  as the hand swung away. It is now read from the depth kept a step earlier, before the hand is
+  drawn, which is where Iris takes it, so the focus stays on what you are holding the item in
+  front of.
+
 - **An array handed between a pack's stages arrives whole.** Photon hands its sky harmonics to
   its deferred shading as an array of nine values, and the two values declared after it reached
   that stage read off the wrong slots. An array is now taken apart and put back together the way

--- a/common/src/main/java/dev/vitrail/render/CenterDepth.java
+++ b/common/src/main/java/dev/vitrail/render/CenterDepth.java
@@ -194,8 +194,8 @@ final class CenterDepth {
 	 * of Iris's frame that is. A frame that draws nothing here leaves the accumulator where it
 	 * stands, so the pack reads what it read before rather than a nought.
 	 *
-	 * @param opaque   the depth of the opaque world, already converted into the pack's own window.
-	 *                 Null on a frame that kept none
+	 * @param opaque   the depth of the opaque world as it stood before the hand was drawn, already
+	 *                 converted into the pack's own window. Null on a frame that kept none
 	 * @param halfLife the pack's {@code centerDepthHalflife}, in deciseconds
 	 * @param seconds  the previous frame's duration
 	 */

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1431,8 +1431,22 @@ public final class PackChain {
 	}
 
 	/** The same question for the depth taken before the hand, which a pack reads as depthtex2. */
-	boolean mayReadPreHandDepth() {
+	private boolean mayReadPreHandDepth() {
 		return this.chain.mentions().maybe("depthtex2");
+	}
+
+	/**
+	 * Whether that image is worth keeping at all, which is the pack's own read of it and the centre
+	 * depth fold together.
+	 * <p>
+	 * The fold is a reader that reaches the image by no name of the pack's, and
+	 * {@link #sampleCenterDepth} says why the depth the hand is in cannot be what it folds. Its half
+	 * of the question is answered off the built chain rather than off the pack's text, which is
+	 * early enough: the declarations are read while the pipelines are still compiling and the chain
+	 * draws nothing at all until they are done.
+	 */
+	private boolean wantsPreHandDepth() {
+		return mayReadPreHandDepth() || this.centerDepthRead;
 	}
 
 	/**
@@ -1447,6 +1461,12 @@ public final class PackChain {
 	 * {@code depthtex2} is the only depth of the pair the hand is missing from. A pack reads it to
 	 * see what the hand it is holding stands in front of, and served the image with the hand in it
 	 * that read finds the hand.
+	 * <p>
+	 * <strong>The centre depth is folded from it too</strong>, by no name of the pack's:
+	 * {@link #sampleCenterDepth} runs after the hand where Iris folds before it, so the image is
+	 * kept for a pack that reads {@code centerDepthSmooth} and never names {@code depthtex2}.
+	 * {@link #wantsPreHandDepth} is the pair of questions, and what the second one costs such a pack
+	 * is the third image and one conversion on the frames a hand is really drawn.
 	 * <p>
 	 * <strong>Only on the frames this engine really draws a hand</strong>, which is
 	 * {@link HandDraw#draws} and not {@link HandDraw#diverted}: the hand's solid pass is the one
@@ -1473,7 +1493,7 @@ public final class PackChain {
 		GpuDevice device = RenderSystem.tryGetDevice();
 		Minecraft minecraft = Minecraft.getInstance();
 		if (disabled || chain == null || device == null || minecraft == null || !chainWanted
-				|| !HandDraw.draws() || !chain.mayReadPreHandDepth()) {
+				|| !HandDraw.draws() || !chain.wantsPreHandDepth()) {
 			return;
 		}
 
@@ -1702,9 +1722,10 @@ public final class PackChain {
 		// Here and not after the deferreds, because here is Iris's beginHand: it is called at the
 		// head of iris$beginTranslucents, MixinLevelRenderer.java:277-279, which is before the solid
 		// hand, before the world's translucents and before beginTranslucents runs the deferred
-		// stage. So the depth it folds is the opaque world's, the image this line has just taken,
-		// and the deferreds below read the value of THIS frame rather than of the one before.
-		// Outside any render pass, since it opens one.
+		// stage. So the deferreds below read the value of THIS frame rather than of the one before.
+		// What is NOT the same is that the hand has already been drawn by the time this line is
+		// reached, which is why the fold reads the copy kept before it rather than the image the
+		// line above has just taken. Outside any render pass, since it opens one.
 		//
 		// The begins and the prepares are in the range below too, so they read this frame's texel
 		// where under Iris they would read the previous frame's: it runs both before beginHand,
@@ -1795,11 +1816,20 @@ public final class PackChain {
 	 * Folds this frame's centre depth into the texel the pack reads it out of, on the packs that read
 	 * it at all.
 	 * <p>
-	 * The opaque world's depth, and Iris reads the same image: what it hands
-	 * {@code CenterDepthSampler} is the live depth attachment, sampled at a moment when nothing
-	 * translucent and no hand has been drawn into it yet. The scene's depth would put the surface of
-	 * water and glass under the focus point, so a pack looking through either would focus on the
-	 * pane rather than on what is behind it.
+	 * <strong>The opaque world's depth from before the hand</strong>, which is the copy
+	 * {@link #markPreHandDepth} keeps and not the image {@link #drawEarly} has just taken. Iris folds
+	 * the live depth attachment inside {@code beginHand}
+	 * ({@code pipeline/IrisRenderingPipeline.java:1051-1052}), which its level renderer mixin calls
+	 * on the line before the solid hand is drawn ({@code mixin/MixinLevelRenderer.java:279-280}), so
+	 * what it folds has no hand in it. This chain runs a step later, and folded from the image the
+	 * hand is in, one texel wide, the focus lands on the item being held whenever it covers the
+	 * middle of the screen and the whole scene behind it goes soft. The image with the hand is the
+	 * fall back, and it is exact on the frames no hand of this engine's was drawn, the two moments
+	 * holding one depth there; {@link PackDepth#preHand} carries the failures that reach it as well.
+	 * <p>
+	 * Neither of the two is the whole scene's depth, which would put the surface of water and glass
+	 * under the focus point, so a pack looking through either would focus on the pane rather than on
+	 * what is behind it.
 	 * <p>
 	 * Skipped where nothing reads the name, which is Iris's own rule rather than a saving of ours:
 	 * {@code CenterDepthSampler.sampleCenterDepth} returns without drawing once it has seen that no
@@ -1812,9 +1842,11 @@ public final class PackChain {
 			return;
 		}
 
+		GpuTextureView preHand = this.targets.depth().preHand();
 		WorldState world = this.values.world();
 		this.targets.centerDepth().sample(device.createCommandEncoder(), device, this.quad,
-				this.targets.depth().opaque(), world.centerDepthHalfLife(), world.frameTime());
+				preHand != null ? preHand : this.targets.depth().opaque(),
+				world.centerDepthHalfLife(), world.frameTime());
 	}
 
 	/**
@@ -2588,17 +2620,19 @@ public final class PackChain {
 
 		// Said whichever way it went, because what is worth reading here is the work NOT done and
 		// a silence would look the same as a guard that never fired. Off the whole pack's text
-		// rather than off this chain's programs: that is the reading the two guards go by, and a
-		// line quoting a narrower one would send whoever chases a missing shadow to the wrong
-		// place.
+		// rather than off this chain's programs: that is the reading the guards go by, and a line
+		// quoting a narrower one would send whoever chases a missing shadow to the wrong place. The
+		// depth from before the hand has the centre depth fold beside that text, since the fold
+		// reaches the image by no name a pack could be searched for, so its line names both.
 		if (!mayReadShadowWithoutTranslucents()) {
 			Vitrail.logger().info("No source of this pack names shadowtex1 or watershadow, so the "
 					+ "copy of the shadow map taken before its translucents is not taken at all");
 		}
 
-		if (!mayReadPreHandDepth()) {
-			Vitrail.logger().info("No source of this pack names depthtex2, so the depth of the "
-					+ "world from before the hand is neither converted nor kept");
+		if (!wantsPreHandDepth()) {
+			Vitrail.logger().info("No source of this pack names depthtex2 and nothing in this chain "
+					+ "folds the centre depth, so the depth of the world from before the hand is "
+					+ "neither converted nor kept");
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/render/PackDepth.java
+++ b/common/src/main/java/dev/vitrail/render/PackDepth.java
@@ -311,7 +311,8 @@ final class PackDepth {
 
 	/**
 	 * Converts the depth of the world as it stood before the player's own hand was drawn, which the
-	 * pack reads as {@code depthtex2}. Must run on the render thread and outside any render pass.
+	 * pack reads as {@code depthtex2} and the smoothed centre depth is folded from. Must run on the
+	 * render thread and outside any render pass.
 	 * <p>
 	 * The caller has to take it before the hand's solid pass and may only take it on the frames that
 	 * pass really draws something, which is {@code HandDraw.draws} and not the load's own answer: an
@@ -411,8 +412,9 @@ final class PackDepth {
 	 * <p>
 	 * The rest are failures. A refused allocation of this image alone leaves the pair standing, so
 	 * {@code depthtex2} falls exactly where {@code depthtex1} falls: the world WITH the hand wherever
-	 * the opaque image answers, and the far plane wherever it does not. {@link #ensurePreHand} logs
-	 * that. A refused pair ({@link #ensure}) leaves nothing allocated at all, and a refused
+	 * the opaque image answers, and the far plane wherever it does not, and the centre depth is
+	 * folded from that same image, the held item back in front of a pack's focus.
+	 * {@link #ensurePreHand} logs that. A refused pair ({@link #ensure}) leaves nothing allocated at all, and a refused
 	 * conversion ({@link #pipeline(GpuDevice)}) leaves all three allocated and none of them written,
 	 * which comes to the same thing for a reader: every depth lookup of the pack reads the far plane.
 	 * Each of those two says so on its own line, once.
@@ -591,7 +593,8 @@ final class PackDepth {
 	 * @return false when there is nothing to draw into, in which case {@code depthtex2} falls back
 	 *         to whatever the reading pass answers a depth copy with: the opaque world's image after
 	 *         the deferred stage, which carries the one thing the name excludes, and the far plane
-	 *         on the hand's own solid pass, which carries nothing
+	 *         on the hand's own solid pass, which carries nothing; the centre depth fold falls back
+	 *         to that opaque image as well
 	 */
 	private boolean ensurePreHand(int width, int height) {
 		if (this.preHandBroken) {
@@ -613,7 +616,9 @@ final class PackDepth {
 			Vitrail.logger().error("Vitrail could not allocate the depth image the pack reads past the "
 					+ "hand with at {}x{}, so until the screen is another size depthtex2 answers "
 					+ "exactly as depthtex1 does: the world with the hand in it where that one is "
-					+ "served, and the far plane elsewhere, the hand's own pass included",
+					+ "served, and the far plane elsewhere, the hand's own pass included; the centre "
+					+ "depth is folded from that same image, so a depth of field focuses on the held "
+					+ "item again",
 					width, height, e);
 
 			return false;

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -720,9 +720,9 @@ final class PackPass {
 	 * <p>
 	 * The two part company over the hand, and only over the hand: {@code depthtex2} is taken one step
 	 * earlier, before the hand's solid pass, so that a pack can read what the hand stands in front
-	 * of. On every frame no hand of this engine's was drawn - the game keeping its own, which is what
-	 * the {@code hand} line of {@code vitrail/options.txt} still leaves it doing by default, or
-	 * nothing being on screen to draw - there is no such image and none is needed, the two moments
+	 * of. On every frame no hand of this engine's was drawn - the game keeping its own where the
+	 * {@code hand} line of {@code vitrail/options.txt} was turned off, or nothing being on screen to
+	 * draw - there is no such image and none is needed, the two moments
 	 * holding the same depth, and the fall through below is that answer rather than a gap. It is
 	 * also reached when an image was wanted and could not be had, which is not the same thing:
 	 * {@link PackDepth#preHand} carries the cases apart and says which of them reach the log.


### PR DESCRIPTION
## What changes

A pack's depth of field no longer focuses on the item in the hand. `centerDepthSmooth` was folded from the depth image copied after the hand's solid pass, so whenever the held item covered the middle of the screen the focus landed on it and the world behind went soft, the value being one texel wide. The fold now reads the copy the engine keeps from just before the hand is drawn, and falls back to the image with the hand only on the frames no hand of this engine's was drawn, where the two moments hold one depth. That copy used to be taken for a pack naming `depthtex2` alone; a pack reading `centerDepthSmooth` now gets it too, at the price of one full-screen depth image and one conversion on the frames a hand is drawn.

## How it differs from the reference, and for what obstacle

It does not: Iris folds the live depth inside `beginHand` (`pipeline/IrisRenderingPipeline.java:1051-1052`), called on the line before the hand's solid pass (`mixin/MixinLevelRenderer.java:279-280`), so nothing of the hand is in what it folds.

## What proves it

- `gradlew build` green.
- Read against the game's stage order on both loaders: the pre-hand copy, the hand's solid pass, then the pack's early draws, in that order.
- In the game, on the Fabric bench with BSL and its depth of field on, an empty map held in the main hand: the picture is the same as under `dev`, the arena row as sharp (Laplacian variance 233 against 223) and the ground and the map as soft, because a held item never reaches the middle of the screen in first person from where the camera stands; what the branch changes only shows where it does, so this is a no-regression reading and not a reading of the fix.

## What it leaves owing

A reading with the held item over the centre, on a pack whose depth of field reads `centerDepthSmooth`, which needs a scene the bench does not offer.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
