### PR TITLE
docs: read every page back against the code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,10 +222,11 @@ records the fast-forward.
 | `pack compatibility` | a pack does not draw as it should |
 | `upstream` | the cause is in another project or in the backend, and nothing here closes it |
 
-beside GitHub's own `bug`, `enhancement` and `question`, which the issue forms set themselves. The
-two sets do not overlap: a type says what a change does, and these say what a report is about. A
-known limitation is open as an issue rather than living in a file for that reason, so that a branch
-can point at one.
+beside GitHub's own `bug` and `enhancement`. The three issue forms set one label each and set it
+themselves, `bug`, `enhancement` and `pack compatibility`, and a blank issue cannot be opened, so
+every report arrives with one. The two sets do not overlap: a type says what a change does, and
+these say what a report is about. A known limitation is open as an issue rather than living in a
+file for that reason, so that a branch can point at one.
 
 ## Changelog
 
@@ -378,8 +379,9 @@ javadoc lint and the two promotions.
 
 The vendored stareval sources under `uniform/expr/kroppeb/` are left out of the javadoc lint and out
 of the static analyser, promotions included, so that borrowed code stays as its author wrote it. The
-analyser is pointed away from `vitrail/mixin/` as well. Nothing guards either package, so a change
-made in one is worth reading twice.
+analyser is pointed away from `vitrail/mixin/` as well, and only the analyser: the compiler warnings
+and the javadoc lint still apply to a mixin and still fail the build. The vendored package is the
+one left with the compiler warnings alone, so a change made in it is worth reading twice.
 
 Why each of those gates exists, what the two promotions are really about and what none of them
 covers is in [developing](docs/developing.md). Run the build before pushing rather than after:

--- a/NOTICE
+++ b/NOTICE
@@ -13,14 +13,14 @@ Iris, https://github.com/IrisShaders/Iris
 Copyright the Iris contributors
 GNU Lesser General Public License version 3
 
-  common/src/main/java/dev/vitrail/pack/program/ProgramFallbacks.java contains the gbuffers, shadow and
-  Distant Horizons fallback table, adapted in 2026 from the enum
+  common/src/main/java/dev/vitrail/pack/model/ProgramFallbacks.java contains the gbuffers, shadow
+  and Distant Horizons fallback table, adapted in 2026 from the enum
   net.irisshaders.iris.shaderpack.loading.ProgramId. The table was reorganised into a name to
   parent map. The blend mode overrides and the IrisProgram API mapping carried by the original
   enum were not reused.
 
-  common/src/main/java/dev/vitrail/pack/target/TargetFormat.java transcribes the colour format table of
-  net.irisshaders.iris.gl.texture.InternalTextureFormat, so that a pack is read against the names
+  common/src/main/java/dev/vitrail/pack/model/TargetFormat.java transcribes the colour format table
+  of net.irisshaders.iris.gl.texture.InternalTextureFormat, so that a pack is read against the names
   it was written for. The promotion of the three component formats and the replacement of the
   fixed function relics are this project's own, and are needed because Vulkan attaches neither.
 
@@ -118,7 +118,7 @@ GNU Lesser General Public License version 3
   index buffer Iris draws it through, lines 95 to 106, is not reused either: the ten vertices are
   drawn unindexed, as SkyRenderer.renderSkyDisc draws its own ten.
 
-  common/src/main/java/dev/vitrail/pack/target/TargetSize.java reimplements
+  common/src/main/java/dev/vitrail/pack/model/TargetSize.java reimplements
   net.irisshaders.iris.gl.texture.TextureScaleOverride, down to the dot in the value being what
   tells a fraction of the screen from a count of pixels, together with the rule of
   net.irisshaders.iris.shaderpack.properties.PackDirectives.getTextureScaleOverride that looks the
@@ -126,7 +126,7 @@ GNU Lesser General Public License version 3
   flag here where Iris carries one each.
 
   common/src/main/java/dev/vitrail/pack/texture/PackTextures.java and
-  common/src/main/java/dev/vitrail/pack/texture/PackTexture.java read the custom texture
+  common/src/main/java/dev/vitrail/pack/model/PackTexture.java read the custom texture
   directives with the rules of net.irisshaders.iris.shaderpack.ShaderPack.readTexture and of the
   properties parsing beside it, because none of them can be reasoned out: a location is truncated
   at its first dot, an override is looked up under every name of the unit, a word carrying a colon
@@ -136,7 +136,7 @@ GNU Lesser General Public License version 3
   blob shorter than the size it announces keeps its name here where Iris throws while reading it,
   and the stage a directive names is not consulted.
 
-  common/src/main/java/dev/vitrail/pack/texture/TextureStage.java carries the seven stages of
+  common/src/main/java/dev/vitrail/pack/model/TextureStage.java carries the seven stages of
   net.irisshaders.iris.shaderpack.texture.TextureStage and what each of them covers, gbuffers
   answering for the shadow passes and composite for the final, the set being closed in Iris and in
   OptiFine both.
@@ -169,13 +169,13 @@ GNU Lesser General Public License version 3
   built with the map rather than each at its first use, because the shadow programs of this engine
   are not all built before the first frame is drawn.
 
-  common/src/main/java/dev/vitrail/render/StorageBuffers.java keeps the rule that a bufferObject
-  starts life at zero, which net.irisshaders.iris.gl.buffer.ShaderStorageBuffer applies at line 79
-  for an absolute buffer and at line 64 every time a relative one is rebuilt. Packs are written
-  against it: Complementary tells a face it never voxelised from one it did by the cell reading
-  zero, having no written flag of its own. Line 79 sits in the else of a test on inline content,
-  which Iris uploads in place of the clear when a pack gave any; the clear is unconditional here
-  because the bufferObject grammar this engine reads carries no content.
+  common/src/main/java/dev/vitrail/render/storage/StorageBuffers.java keeps the rule that a
+  bufferObject starts life at zero, which net.irisshaders.iris.gl.buffer.ShaderStorageBuffer
+  applies at line 79 for an absolute buffer and at line 64 every time a relative one is rebuilt.
+  Packs are written against it: Complementary tells a face it never voxelised from one it did by
+  the cell reading zero, having no written flag of its own. Line 79 sits in the else of a test on
+  inline content, which Iris uploads in place of the clear when a pack gave any; the clear is
+  unconditional here because the bufferObject grammar this engine reads carries no content.
 
   common/src/main/java/dev/vitrail/render/PackPass.java binds what a full screen pass samples with
   Iris's filters, the packs blurring and interpolating against them: the noise image LINEAR, a
@@ -192,7 +192,7 @@ GNU Lesser General Public License version 3
   The lists are arguments here rather than calls into a device, so that the table can be built
   without one.
 
-  common/src/main/java/dev/vitrail/pack/program/RenderStage.java is
+  common/src/main/java/dev/vitrail/pack/model/RenderStage.java is
   net.irisshaders.iris.pipeline.WorldRenderingPhase, reproduced in its order because the value a
   pack reads is the ordinal and nothing else: a constant inserted in the middle would silently
   renumber every branch every pack of the corpus takes.
@@ -203,7 +203,7 @@ GNU Lesser General Public License version 3
   packs are written against Iris and against nothing else. The shadow halves of the enum and
   everything the passes drive are this project's own.
 
-  common/src/main/java/dev/vitrail/pack/program/AlphaTest.java emits the comparison in the negated
+  common/src/main/java/dev/vitrail/pack/model/AlphaTest.java emits the comparison in the negated
   form Iris emits, if (!(a > r)) discard, with Iris's translucent threshold of one ten
   thousandth, and looks an alphaTest override up under the name of the file that really serves
   the pass, which is Iris's lookup too.
@@ -700,10 +700,10 @@ GNU Lesser General Public License version 3
   normal rather than the quad's own, which is what keeps the encoder and the generated decoder in
   one basis.
 
-  common/src/main/java/dev/vitrail/render/PbrMap.java,
-  common/src/main/java/dev/vitrail/render/PbrAtlas.java,
-  common/src/main/java/dev/vitrail/render/PbrAtlases.java and
-  common/src/main/java/dev/vitrail/render/PbrTextures.java build the normal and specular maps a
+  common/src/main/java/dev/vitrail/render/pbr/PbrMap.java,
+  common/src/main/java/dev/vitrail/render/pbr/PbrAtlas.java,
+  common/src/main/java/dev/vitrail/render/pbr/PbrAtlases.java and
+  common/src/main/java/dev/vitrail/render/pbr/PbrTextures.java build the normal and specular maps a
   resource pack ships, and the following answers are Iris's, read in August 2026. The layout, one
   companion image per atlas with each map at the base sprite's own x and y, is that of
   net.irisshaders.iris.pbr.loader.AtlasPBRLoader, lines 55 to 74, with the suffixes and the two
@@ -859,7 +859,7 @@ GNU Lesser General Public License version 3
   binds it, with both of the lines Iris says in the chat afterwards, Iris.java:184 and Iris.java:191. The key that opens
   the settings screen is on I and is NOT Iris's, which binds that screen to O, Iris.java:787; the two
   it binds that have no counterpart here are toggleShaders on K and an unbound wireframe.
-  common/src/main/java/dev/vitrail/screen/ScreenText.java keeps the English of these screens word
+  common/src/main/java/dev/vitrail/ScreenText.java keeps the English of these screens word
   for word wherever Iris has a string for the same thing, so that a player who has configured a
   pack before reads the words they already know; what Iris has no string for is this project's
   own.
@@ -886,8 +886,8 @@ GNU Lesser General Public License version 3
   element draws its arrow with seven hex digits rather than eight, LinkElementWidget line 64, so the
   arrow comes out at six per cent alpha; it is drawn opaque here.
 
-  common/src/main/java/dev/vitrail/pack/texture/BufferObject.java and
-  common/src/main/java/dev/vitrail/pack/texture/ImageInformation.java read the bufferObject and
+  common/src/main/java/dev/vitrail/pack/model/BufferObject.java and
+  common/src/main/java/dev/vitrail/pack/model/ImageInformation.java read the bufferObject and
   image directives with the grammars of net.irisshaders.iris.shaderpack.properties.ShaderProperties,
   the two-word and four-word forms of a buffer and the sampler, formats, clear and size words of an
   image, together with the two ceilings that file enforces: no buffer index past twelve, lines 407

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -101,11 +101,12 @@ public final class PackProgram {
 		 * Whether this program voxelises, in Iris's sense: a geometry stage is present, or an image
 		 * load / store uniform survived translation.
 		 * <p>
-		 * Iris reads the geometry file at {@code shadows/ShadowRenderer.java:163-165} and then ORs
-		 * in {@code setUsesImages} when the compiled shadow program has image bindings
-		 * ({@code :224-225}, {@code ExtendedShader.hasActiveImages}). A {@code .gsh} is enough even
-		 * when this engine never binds it; an image uniform that the preprocessor left standing is
-		 * enough without one. A name gated off, Complementary LOW's {@code voxel_img} behind
+		 * Iris reads the geometry file at {@code shadows/ShadowRenderer.java:163-165}. It has a
+		 * {@code setUsesImages} for the image half ({@code :224-225}) and calls it from nowhere: the
+		 * flag is computed at {@code pipeline/IrisRenderingPipeline.java:453-456} and never read, so
+		 * an image alone decides nothing there. Here it does count, which is this engine's own
+		 * answer and not the reference's. A {@code .gsh} is enough even when this engine never
+		 * binds it; an image uniform that the preprocessor left standing is enough without one. A name gated off, Complementary LOW's {@code voxel_img} behind
 		 * {@code COLORED_LIGHTING_INTERNAL}, does not count.
 		 */
 		public boolean voxelises() {

--- a/common/src/main/java/dev/vitrail/glsl/VolumeFlattening.java
+++ b/common/src/main/java/dev/vitrail/glsl/VolumeFlattening.java
@@ -85,12 +85,15 @@ final class VolumeFlattening {
 	 * Moves every volume the pack ships onto a flat atlas: the declaration to a {@code sampler2D}
 	 * under a forged name, and each lookup to a helper that reads two slices and mixes them.
 	 * <p>
-	 * <strong>The declaration is what has to go, not the lookup.</strong>
-	 * {@code GlslCompiler.addToBindGroup} refuses anything the reflection reports as neither
-	 * {@code SpvDim2D} nor {@code SpvDimCube}, and the reflection lists a module's whole resource
-	 * list at optimisation level zero, so a {@code sampler3D} declared in a shared include and never
-	 * read costs the program its pipeline exactly as one sampled on every pixel does. Supplying a
-	 * real volume would not help either: the type is the refusal.
+	 * <strong>The declaration is what has to go, not the lookup.</strong> A name is judged on its
+	 * declared type: {@link dev.vitrail.pack.target.SamplerTypes} refuses a program for a
+	 * {@code sampler3D} nothing stands behind, and the reflection lists a module's whole resource
+	 * list at optimisation level zero, so one declared in a shared include and never read costs the
+	 * program its pipeline exactly as one sampled on every pixel does. Supplying a real volume is
+	 * not the way out here either: a texture a pack ships is uploaded flat and there is no 3D view
+	 * to put behind the name. The game's own walk no longer refuses the type,
+	 * {@code GlslCompilerMixin} making {@code GlslCompiler.addToBindGroup} read {@code SpvDim3D} as
+	 * {@code SpvDim2D} for the volumes an {@code image} directive fills.
 	 * <p>
 	 * <strong>Every program carrying the declaration is rewritten, and Iris rewrites only the stage
 	 * the directive names.</strong> Its {@code TextureTransformer} runs per stage, so under it

--- a/common/src/main/java/dev/vitrail/pack/target/SamplerTypes.java
+++ b/common/src/main/java/dev/vitrail/pack/target/SamplerTypes.java
@@ -5,11 +5,15 @@ import java.util.Set;
 /**
  * Which sampler declarations this backend can build a pipeline for, decided on the type alone.
  * <p>
- * The rule belongs to the game and is not ours to bend. {@code GlslCompiler.addToBindGroup} walks
- * every sampler the SPIR-V reflection hands back and throws
+ * The rule belongs to the game. {@code GlslCompiler.addToBindGroup} walks every sampler the SPIR-V
+ * reflection hands back and throws
  * {@code Sampled texture (X) must have type of SpvDim2D or SpvDimCube} for anything whose
  * dimensionality is neither of those two, so one {@code sampler3D} anywhere in a program stops that
- * program's whole pipeline from being built.
+ * program's whole pipeline from being built. It is bent in one place and for one shape:
+ * {@code GlslCompilerMixin} makes that walk read {@code SpvDim3D} as {@code SpvDim2D}, so the
+ * volumes an {@code image} directive fills reach a pipeline. Every other dimensionality is refused
+ * as it always was, and so is a {@code sampler3D} with nothing behind it, which
+ * {@code PackProgram.unbindable} decides off this list.
  * <p>
  * Two things measured in 26.2 make the declaration alone enough, and both are worth knowing before
  * anyone tries to be cleverer about it. {@code IntermediaryShaderModule.createFromSpirv} asks for

--- a/common/src/main/java/dev/vitrail/pack/texture/VolumeAtlas.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/VolumeAtlas.java
@@ -10,8 +10,9 @@ import java.util.Set;
  * Where every texel of a volume ends up once the volume is laid out flat, decided once and read
  * by both sides.
  * <p>
- * This backend binds nothing but 2D and cube samplers, so a pack's {@code sampler3D} is served by
- * a 2D atlas of slices and a helper that reads two of them and mixes. Two readers therefore have
+ * A pack's {@code sampler3D} over a blob it ships is served by a 2D atlas of slices and a helper
+ * that reads two of them and mixes: the blob is uploaded flat and nothing builds a 3D view over
+ * it, the one volume the backend binds as such being the kind an {@code image} directive fills. Two readers therefore have
  * to agree texel for texel: the one that fills the atlas out of the pack's blob, and the one that
  * prints the arithmetic into the shader. They agree because they both come here. A layout written
  * twice would come out as noise on the screen, and a noise texture that is wrong looks exactly

--- a/common/src/main/java/dev/vitrail/render/BoxShadowCull.java
+++ b/common/src/main/java/dev/vitrail/render/BoxShadowCull.java
@@ -33,13 +33,12 @@ import java.nio.file.Files;
  * twelve to twenty-eight percent depending on what stands around, and never nothing.</li>
  * </ul>
  * <p>
- * <strong>What the box was hiding is a defect of ours, and it has its own cause now.</strong> The
- * light's walk reuses the visibility lists the camera's walk filled
- * ({@link dev.vitrail.sodium.ShadowTerrain}), so
- * anything that narrows the camera's visible set takes casters out of the shadow map with it. A
- * third-party zoom mod's smart occlusion does that, which is what the popping was; the workshop
- * dossier carries the negative control taken both ways. The answer is a separate traversal for
- * the light, not a wider walk, and it is not this file.
+ * <strong>What the box was hiding is a defect of ours, and the shape is not it.</strong> A
+ * third-party zoom mod's smart occlusion is what the popping came with, and the workshop dossier
+ * carries the negative control taken both ways. The shape cannot be the cause: the light walks the
+ * world for itself ({@link dev.vitrail.sodium.ShadowTerrain}), Sodium's synchronous traversal of
+ * every renderable section under the light's own volume, so nothing the camera's walk kept or
+ * dropped decides which sections that walk visits. Wherever the answer is, it is not this file.
  * <p>
  * A file {@code vitrail/box-shadow-cull} in the game directory, or
  * {@code -Dvitrail.boxShadowCull=true}, puts the box back for a machine that needs to name the

--- a/common/src/main/java/dev/vitrail/render/GeometryHold.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryHold.java
@@ -259,9 +259,9 @@ public final class GeometryHold {
 	}
 
 	/**
-	 * Sodium scissors each region inside the pass. Keeping the hold without clearing that scissor
-	 * leaves the next family's draws clipped to the last region's rectangle: half the screen of
-	 * stale colour, which is the band that comes and goes as chunks stream.
+	 * A scissor belongs to the draw that set it and the pass outlives it. Keeping the hold without
+	 * clearing that scissor leaves the next family's draws clipped to the last rectangle: half the
+	 * screen of stale colour, which is the band that copies the top onto the bottom.
 	 */
 	private static void resetArea(RenderPass pass) {
 		pass.disableScissor();

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -493,8 +493,10 @@ public final class PackChain {
 	 * once - it went on naming the weather after the weather had landed, and it never named the
 	 * particles at all.
 	 * <p>
-	 * The entities are the one family that is here in both states, their blending half never having
-	 * landed at all. Every other switch names its family only when it is off.
+	 * The entities are the one family that is here in both states: off, the whole family is the
+	 * game's; on, the two pieces nobody serves yet still are, the beacon beam and the lightning,
+	 * which the feature layer carries across. Every other switch names its family only when it is
+	 * off.
 	 * <p>
 	 * <strong>Every family the seed carries that has no line of its own, and the sky is one of
 	 * them.</strong> It was left out of the first version of this method, which is the same fault as
@@ -540,10 +542,10 @@ public final class PackChain {
 		}
 
 		if (EntityDraw.wanted()) {
-			// Named apart, because a reader who has just turned the entities on and still sees a flat
-			// player would otherwise have nothing to go on: the opaque ones go through the pack and
-			// the ones that blend do not.
-			carried.add("the entities that blend, the player's own body among them,");
+			// Named apart, because a reader who has just turned the entities on and still sees a
+			// beam or a bolt of the game's would otherwise have nothing to go on: both halves of the
+			// entities go through the pack, and these two pieces are what FeatureLayer still carries.
+			carried.add("the beacon beam and the lightning");
 		}
 
 		// The conjunction the hand-written sentence carried, kept: this is a line of prose in the log

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -316,10 +316,12 @@ public final class PackValues {
 	 * of it: it reaches for {@code DHCompat.getProjection()} only under
 	 * {@code shouldRenderDH && DHCompat.hasRenderingEnabled()}
 	 * ({@code shadows/ShadowRenderer.java:366}), and its left half is the pack asking for the far
-	 * terrain in its SHADOW map ({@code :150}, the {@code dhShadow} directive). Nothing puts the far
-	 * terrain into this engine's shadow map at all, so that half can only be answered false here and
-	 * the branch Iris takes is the frame's own projection. Widening the volume to Distant Horizons'
-	 * would walk further out for casters that have nowhere to be drawn.
+	 * terrain in its SHADOW map ({@code :150}, the {@code dhShadow} directive). The far terrain does
+	 * reach this engine's map, {@code dh_shadow} drawing it at both of the moments the world's own
+	 * chunk groups are drawn there ({@link DistantDraw#shadow}), but it does not come through the
+	 * walk this volume bounds: that mod hands its geometry over once a frame, from the camera, so
+	 * what this volume decides is the world's own sections and nothing else. Widening it to Distant
+	 * Horizons' would walk further out for casters that have nowhere to be drawn.
 	 *
 	 * <strong>The two distances are settled here and not at the frustum</strong>, because two of the
 	 * four states step outside the arbitration {@link #shadowRenderDistance} performs and the

--- a/common/src/main/java/dev/vitrail/render/SceneSeed.java
+++ b/common/src/main/java/dev/vitrail/render/SceneSeed.java
@@ -89,9 +89,11 @@ import java.util.Optional;
  * format, which a {@code vec4} output does not write at all.
  * <p>
  * A draw and not a copy. {@code copyTextureToTexture} ends up on {@code vkCmdCopyImage}, which
- * reinterprets bits instead of converting them, and the Java side only checks that both formats
- * carry a colour aspect. The main target is RGBA8_UNORM and colortex0 is RG11B10_FLOAT on most
- * packs; both are thirty two bits wide, so a copy passes every check and hands back nonsense.
+ * reinterprets bits instead of converting them, and the Java side lets two colour formats through
+ * whatever they hold: the bare game checks no format at all, and the NeoForge build checks only
+ * that the two agree on whether they carry a colour aspect, plus an identical format where the
+ * source carries depth or stencil. The main target is RGBA8_UNORM and colortex0 is RG11B10_FLOAT on
+ * most packs; both are thirty two bits wide, so a copy passes every check and hands back nonsense.
  * <p>
  * What the seed cannot repair has to be said out loud rather than assumed: the scene it carries
  * is already tone mapped, already gamma corrected, and already has vanilla fog. A pack that

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -698,10 +698,11 @@ public final class TerrainDraw {
 	}
 
 	/**
-	 * Whether any shadow terrain program of this pack voxelises, a geometry stage present or an
-	 * image load / store still standing on it. Iris asks the same of
-	 * {@code SHADOW_TERRAIN_CUTOUT}; the three shadow halves share one file on every pack that
-	 * ships one, and any of them answering is enough. Settled when the programs are read: the
+	 * Whether any shadow terrain program of this pack voxelises, a geometry stage present, which
+	 * is what Iris asks of {@code SHADOW_TERRAIN_CUTOUT}, or an image load / store still standing
+	 * on it, which this engine counts as well where Iris computes it and reads it nowhere. The
+	 * three shadow halves share one file on every pack that ships one, and any of them answering
+	 * is enough. Settled when the programs are read: the
 	 * shadow walk asks once a frame, and the answer is a property of the pack.
 	 */
 	private boolean voxelisesShadow() {

--- a/common/src/main/java/dev/vitrail/screen/ProfileWidget.java
+++ b/common/src/main/java/dev/vitrail/screen/ProfileWidget.java
@@ -23,8 +23,9 @@ import java.util.Optional;
  * value of its own, and every setting it moved is already marked amber by its own cell, so a
  * selector that went amber as well would be saying the same thing a second time.
  * <p>
- * Shift and a click do nothing here, a profile being a whole set of values rather than one of them.
- * Iris's own note gives the way back: reset the settings.
+ * Nothing to hand back, a profile being a whole set of values rather than one of them, so
+ * {@link #originalValue()} answers no and shift and a click walk the profile on like an unmodified
+ * click. Iris's own note gives the way back: reset the settings.
  * <p>
  * A pack declaring no profile never reaches this class, {@link dev.vitrail.pack.menu.PackMenu}
  * dropping the token rather than leaving a blank where the selector would have been.

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
@@ -187,8 +187,9 @@ public final class ShadowCullFrustum implements Frustum {
 	 * {@link dev.vitrail.pack.source.ShadowCullState#DEFAULT} where the shadow program voxelises,
 	 * keep a box around the player and no planes, which is Iris's
 	 * {@code BoxCullingFrustum} ({@code :302-323}). Voxelisation is a geometry stage present
-	 * <em>or</em> an image load / store still standing on that program ({@code :163-165},
-	 * {@code setUsesImages}), not a {@code .gsh} this engine binds. A bound wider than the loaded
+	 * ({@code :163-165}) <em>or</em>, here alone, an image load / store still standing on that
+	 * program: Iris computes that half and reads it nowhere, its {@code setUsesImages} having no
+	 * caller. Not a {@code .gsh} this engine binds. A bound wider than the loaded
 	 * world, or not positive, drops the box too and keeps everything, which is Iris's
 	 * {@code NonCullingFrustum} ({@code :317-318}), not the light's own volume.
 	 * {@link dev.vitrail.pack.source.ShadowCullState#SAFE_ZONE} still sweeps along the light.

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,11 +50,12 @@ into SPIR-V. No frame is ever spent translating something that is already on scr
 a program has drawn once there is no legacy GLSL behind it.
 
 Where the pauses come from is worth knowing, because "once" is not the same as "at selection". The
-chain is translated when the pack is chosen. The programs that draw the world and the sky are
-translated on demand, at the first frame that needs them, so the first frame of a place does wait
-on one. And **changing dimension is a full reload**, because a dimension directory replaces the root
-rather than layering over it: the whole pack is read, translated and its colour targets allocated
-again. That is the hitch at the portal, and the log names it as it happens.
+chain and the programs that draw the world are translated at the load. The sky, the entities and
+the other families are translated and compiled on a background worker while you play, so a first
+frame waits on one of those only where it outruns that work. And **changing dimension is a full
+reload**, because a dimension directory replaces the root rather than layering over it: the whole
+pack is read, translated and its colour targets allocated again. That is the hitch at the portal,
+and the log names it as it happens.
 
 That choice has consequences worth knowing about, because they explain most of what you will
 observe:
@@ -76,15 +77,15 @@ observe:
 
 Not every family of geometry goes through the pack yet. Rather than repeat a list here that
 would quietly go stale, the engine states it itself: when a place first draws, it logs which
-families still come from the game, already tone mapped, and are carried across by the full-screen
-layer. **That line is the authority.** Anything a page here says about scope is written to agree
-with it, never to replace it.
+families still come from the game, already tone mapped, and are carried across by the scene seed.
+**That line is the authority.** Anything a page here says about scope is written to agree with it,
+never to replace it.
 
 Two things about that line rather than one, since a reader who does not find it should know why.
 It names what still comes from the *game*, so the families that do go through the pack are the ones
-it does not name. And it does not always appear: a place whose plan has no layer in it, or a run
-with the layer switched off, says something else instead, because there the targets simply keep
-their clear colour.
+it does not name. And it does not always appear: a place whose plan has no seed in it, or a run
+with `seed=off` in `vitrail/options.txt`, says something else instead, because there the targets
+simply keep their clear colour.
 
 The visible consequence of a family not going through the pack is always the same, and it is
 worth recognising: that geometry is composited in flat, carrying the game's own lighting,

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,8 +14,8 @@ quietly stale.
 | Pack | What I have seen |
 | --- | --- |
 | BSL v10.1.3 | Drawn whole, and the one watched most closely. Terrain, water, shadow map, sky, clouds, weather, particles, mobs, block entities and the held hand all go through it. |
-| Complementary Unbound r5.8.1 | Drawn whole, and watched as closely. Its colour targets, its deferred chain and its shadow map all come up; the log prints how many targets it allocated and at what size. Its two top profiles are the exception, and the pack announces it itself: see [the pack asks for Iris](#the-pack-asks-for-iris). |
-| Complementary Reimagined r5.8.1 | Drawn whole, seen beside Unbound, and visually as close to it as the two packs are to each other. Same top-profile exception as Unbound. |
+| Complementary Unbound r5.8.1 | Drawn whole, and watched as closely. Its colour targets, its deferred chain and its shadow map all come up; the log prints how many targets it allocated and at what size. Its two top profiles, Very High and Ultra, draw with their colored lighting on: the voxel pipe they ask for is served, and [the pack asks for Iris](#the-pack-asks-for-iris) says how to read a pack that asks for something else. |
+| Complementary Reimagined r5.8.1 | Drawn whole, seen beside Unbound, and visually as close to it as the two packs are to each other. Its two top profiles draw the same way. |
 | Bliss v2.1.2 | Drawn, water included. The flat wrong colours its mobs and its held arm used to come out in are gone: that was this engine sending their first output through a target of the game's, eight bits to a channel where the pack stacks two values in sixteen, and both now write the pack's own. It is the pack that reads the light map raw where BSL and Complementary multiply the matrix in, which is why the far terrain's pair is served normalised. |
 | Sildur's Vibrant Extreme v2.01 | Drawn, except for its water, which is an open case here. It is the pack that exercises the paths least travelled: it keeps the overworld's programs at the root of `shaders/` and gives the other two dimensions folders of their own, several families reach its textured program through the fallback tree rather than shipping one, and the target its terrain writes first is not target zero. |
 | Mellow v3.3 | Drawn, and it exercises two more of them: it ships a three-dimensional volume as a raw blob, and it asks for a single-channel shadow buffer. |
@@ -467,7 +467,7 @@ A short reference, if you are writing a pack or wondering why yours is treated d
   the user's own cloud setting so that the pack's cloud program is handed the geometry it was
   written for. It is honoured only where this engine really draws the clouds, because with the
   game's own shader behind it `off` would take the clouds away and put nothing in their place.
-- **Most packs write `clouds=off`**, six of the eight measured, and it is not a refusal of clouds
+- **Most packs write `clouds=off`**, six of the nine measured, and it is not a refusal of clouds
   but a redirection: they draw their own, volumetric, inside a composite. Complementary goes further
   and ships a `gbuffers_clouds` that discards outright unless its own cloud style is set to the
   vanilla one. So a pack whose clouds visibly change when the engine starts drawing them is the

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -21,8 +21,9 @@ transitively touches it. Treat such an import as a design decision to be argued,
 
 There are two deliberate exceptions, both excluded from the standalone build: the report a pack
 gets at its first load, which writes through the mod's own logger, and the choice of graphics
-backend, which is a session's and reads the game's options. Two files are a maintainable seam.
-A growing list is a leak.
+backend, which reads a file of its own under the game's directory and names `Minecraft` for nothing
+but finding that directory. Putting the answer back into the game's options is done outside these
+four trees, where it costs nothing. Two files are a maintainable seam. A growing list is a leak.
 
 ## What a contributor can run, and what they cannot
 
@@ -64,8 +65,9 @@ By family, so you can tell whether a change is in scope:
   checked the same way, then run over the declarations the corpus really contains, which does.
 - **Path confinement.** What a path written by a pack can reach.
 
-Two of those run on a bare clone: the uniform block invariants and path confinement. Everything else
-wants the corpus.
+Two of those need no corpus: the uniform block invariants and path confinement. Everything else
+wants one. None of them run on a bare clone even so, since the harness that drives them is the one
+absent above, and what `check` adds to a compile is the text rule and nothing else.
 
 ## What makes a measurement trustworthy
 
@@ -289,15 +291,16 @@ replacement a pack feeding whole world coordinates to a sine gets whatever the d
 them.
 
 **Where a pack load's time goes is in the log at every load that installs a chain.** A first
-report prints beside the pack-opened line and carries the translation alone, that being all the
-load itself runs; the modules follow on the first draws and the compile workers, counted at the
-game's own compiler so that every road lands in the tally, and the report that closes the
-background warmup reads both figures with the families in. What a first draw pays after that
-report stays in the tally rather than in any line. The spans are summed per program across the
-compile workers, so the two figures compare with each other rather than with the wall clock,
-and the driver's own pipeline build is in neither. The split is what says whether a faster load
-needs a translation cache or a reflection cache, which are different designs keyed on different
-things.
+report prints beside the pack-opened line and carries flattening and translation, those two being
+all the load itself runs; the modules follow on the first draws and the compile workers, counted at
+the game's own compiler so that every road lands in the tally, and the report that closes the
+background warmup reads all three with the families in. How much of the translating a cache on disk
+took off is said at both points, on a line of its own beside the first and inside the second. What a
+first draw pays after that report stays in the tally rather than in any line. The spans are summed
+per program across the compile workers, so the figures compare with each other rather than with the
+wall clock, and the driver's own pipeline build is in none of them. The split is what says whether a
+faster load needs a translation cache or a reflection cache, which are different designs keyed on
+different things.
 
 **The card's time per pass is in the log on request.** Started with `-Dvitrail.passTimings=N`
 among the JVM arguments, the game prints every N seconds a table of GPU time per render pass

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -107,12 +107,14 @@ accident to debug.
 
 The one copy left on a target is between the two halves of the shadow depth pair, where the format
 is the same on both sides by construction. The doubled colour targets are not copied at all: the two
-surfaces swap names at the end of the frame, which is the same fact for nothing. Copying between two
-*different* formats passes every check and hands back nonsense: the texture copy reinterprets bits
-rather than converting them, and the only thing checked on the way in is that both formats carry a
-colour aspect. The game's colour target is
-eight-bit RGBA and a typical pack target is a packed float triple; both are thirty-two bits per
-pixel and hold completely different things.
+surfaces swap names at the end of the frame, and only for those still flipped when the last pass has
+run and kept between frames, which is the same fact for nothing. Copying between two *different*
+formats passes every check and hands back nonsense: the texture copy reinterprets bits rather than
+converting them, and what checks it on the way in depends on the loader. The bare game checks no
+format at all; the NeoForge build checks that the two agree on whether they carry a colour aspect,
+and that they are the same format where the source carries depth or stencil. Two colour formats pass
+either way. The game's colour target is eight-bit RGBA and a typical pack target is a packed float
+triple; both are thirty-two bits per pixel and hold completely different things.
 
 This is why the game's image is brought into a pack target by a **full-screen draw** and never by a
 texture copy.
@@ -178,8 +180,8 @@ program takes a different one, with a fault of its own described in
 [pack compatibility](compatibility.md).
 
 **A pixel the pack's own geometry has covered must not be seeded over.** That is what the coverage
-mask is for, and it carries a **depth** rather than a flag: every program of the pack drawn before
-the seed writes into it the value it handed the depth attachment, and the seed compares that with
+mask is for, and it carries a **depth** rather than a flag: a program of the pack drawn before the
+seed writes into it the value it handed the depth attachment, and the seed compares that with
 the world's depth as it stands. A pixel nothing has been drawn over since compares equal and is the
 pack's; a pixel the game has drawn a feature onto compares closer and is the seed's. Where the pack
 wrote nothing at all the mask holds a value outside zero to one, which every real depth is in front
@@ -209,32 +211,32 @@ not reach: the log names the reason at the moment it happens. Neither case is th
 `gbuffers_block` rather than `gbuffers_entities`, the hand rides its own switch, and a mob's glowing
 eyes are asked for `gbuffers_spidereyes`, and an enchantment's shine for `gbuffers_armor_glint`.
 
-The eyes answer two things differently from every other piece here, and both come from the game
-drawing them as a light rather than as a surface. They are **blended additively**, which is what
-makes an eye add to the skin under it instead of replacing it. A pack displaces that with a `blend`
-directive like any other, with one catch worth knowing: that directive is read under the name of the
-file that really serves the piece, so a pack shipping no `gbuffers_spidereyes` of its own has to
-write the line under whatever the fallback tree lands its eyes on. And they are drawn at
-**full light**: the light map
-coordinate the pack reads is the brightest one whatever the mob is standing in, and the light map
-image itself is one white texel, so a pack that multiplies by it is left where it started. Given
-only one of those two, an eye comes out darker than the game would have drawn it, and the additive
-blend then adds that darkness.
+The eyes answer two things differently, and both come from the game drawing them as a light rather
+than as a surface. They are **blended additively**, which is theirs alone here and is what makes an
+eye add to the skin under it instead of replacing it. A pack displaces that with a `blend` directive
+like any other, with one catch worth knowing: that directive is read under the name of the file that
+really serves the piece, so a pack shipping no `gbuffers_spidereyes` of its own has to write the
+line under whatever the fallback tree lands its eyes on. And they are drawn at **full light**, which
+the cracks over a mined block are as well: the light map coordinate the pack reads is the brightest
+one whatever the mob is standing in, and the light map image itself is one white texel, so a pack
+that multiplies by it is left where it started. Given only one of those two, an eye comes out darker
+than the game would have drawn it, and the additive blend then adds that darkness.
 
 What decides whether a family can come in at all is **the mesh the game binds for it**, not how
-interesting the family is. The door reads one vertex layout, the game's entity format, and names the
-attributes a pack expects out of its elements. A pipeline binding anything else would have every
-attribute read from the wrong offset, which is a picture and a wrong one with nothing to say so, so
-it is refused and named in the log instead. The glint is the one exception and it is a narrow one:
-it is drawn from a two-element quad the door decodes as well.
+interesting the family is. The door reads eight vertex layouts and names the attributes a pack
+expects out of the elements of each: the game's entity format, the glint's two, the block format the
+cracks over a mined block are drawn from, the lines format the block outline is drawn from, and the
+four the text is. A pipeline binding anything else would have every attribute read from the wrong
+offset, which is a picture and a wrong one with nothing to say so, so it is refused and named in the
+log instead.
 
-That layout is the game's own with **three elements appended**: the numbers a pack tells one kind of
-mob, block entity or held item apart by, then the middle of the sprite a face is mapped to and the
-direction the texture runs in over that face. The last two belong to a POLYGON rather than to a
-corner, so the four corners of a quad carry one pair and one direction between them, and they are
-what a normal map on a mob is read through. It is a format of the engine's rather than the game's
-own object lengthened, and the difference is not cosmetic: Sodium writes every cuboid of a mob at
-the game's stride and copies the run over untouched whenever the two are the same object, so
+The entity format is the game's own with **three elements appended**: the numbers a pack tells one
+kind of mob, block entity or held item apart by, then the middle of the sprite a face is mapped to
+and the direction the texture runs in over that face. The last two belong to a POLYGON rather than
+to a corner, so the four corners of a quad carry one pair and one direction between them, and they
+are what a normal map on a mob is read through. It is a format of the engine's rather than the
+game's own object lengthened, and the difference is not cosmetic: Sodium writes every cuboid of a
+mob at the game's stride and copies the run over untouched whenever the two are the same object, so
 widening the game's own leaves that copy reading twenty bytes a vertex past what was written and no
 mob is drawn at all. The engine registers the conversion between the two formats with Sodium
 instead, which is where those cuboids get their three. What the game writes vertex by vertex rather
@@ -250,12 +252,14 @@ them. The mesh only carries them while the pack is drawing the entities or the h
 switch asks the game to rebuild the world, the same door F3+A uses, and it does not ask for a
 restart.
 
-That is the whole reason the lightning bolt and the text of a sign or a name plate still come from
-the game's own shader: they bind the position-colour and glyph layouts, which nothing here reads.
-The beacon beam is with them for another reason, the block layout it binds being read since the
-cracks of a mined block are drawn through the pack: what the beam still wants is a pass of its own.
-All three reach the pack's image through the layer described below, which means they are visible but
-flat, and drawn in front of what should hide them.
+The lightning bolt and the beacon beam are what still come from the game's own shader, and the mesh
+is not the reason for either: the beam binds the block layout, which the cracks over a mined block
+are decoded through, and the bolt binds the position-colour one, which a text display's background
+is decoded through. What each still wants is a **row** of its own, with the alpha test, the fog and
+the lighting that belong to it, and neither is another family's under a new name. The text of a sign
+or a name plate was with them until the eight text pipelines took rows in the table. Both reach the
+pack's image through the layer described below, along with the one glint that is addressed away from
+the main target, which means they are visible but flat, and drawn in front of what should hide them.
 
 Which target is seeded is the first draw buffer of the pass that draws the terrain, resolved through
 the fallback tree, and it is not always target zero: one pack of the corpus serves its terrain

--- a/docs/internals/entities.md
+++ b/docs/internals/entities.md
@@ -297,13 +297,15 @@ drawn by the game in the middle of geometry the pack drew.
   chest is lit as the block it is even on a pack that ships no such file. The threshold follows the
   program and not the phase. A skull is where the program and the phase really part company, and it
   is not a corner case: it is a block entity, it draws with an entity pipeline the reference pins to
-  the entity program, so it takes the entity program and the block entity phase at once. Three rows
-  are pinned that way, and the test for them is a **list** rather than the blend, because one of the
-  three blends and still asks for the writing half's name.
+  the entity program, so it takes the entity program and the block entity phase at once. Five rows
+  are pinned that way, the three entity ones and the two boxes a text display draws behind its
+  lines, and the test for them is a **list** rather than the blend, because one of the three entity
+  rows blends and still asks for the writing half's name.
 - **The hand, twice.** Nothing about a pipeline decides which of the two hand programs answers; the
   pass does, and what separates the passes is which items go into them, settled a step earlier at the
-  submission. Every hand row discards at a tenth, the solid ones included, which is the reference's
-  answer and not an inheritance from the pipeline.
+  submission. Every hand row made from an entity row discards at a tenth, the solid ones included,
+  which is the reference's answer and not an inheritance from the pipeline; a text row's hand twin
+  discards at any alpha at all instead, which is what the reference's own glyph keys carry.
 - **The shadow map**, which the next section is about. It takes the eye tables' rows as well, and
   the one row derived nowhere is the ground oval's twin, for the reason given there.
 
@@ -312,20 +314,22 @@ exactly what would destroy that.
 
 **The eyes.** The reference reaches them by a constant that consults nothing, so an eye is an eye on
 a mob, in a chest's draw and in the hand alike, and derived into the other tables they would ask for
-the block or the water program where it asks for neither. They are also the one family drawn at
-**full light**: the light map names are answered with a constant and the sampler behind them with one
-white texel. Without it a pack whose eye program multiplies by the light map draws an enderman's eyes
-as dark as the block it stands on, and the additive blend the reference hangs on that program name is
-what would make that darkness the thing being added. The element is still declared and still bound
-either way, because the head has to declare the whole format; what changes is one line of it.
+the block or the water program where it asks for neither. They are drawn at **full light**, which
+they share with the cracks over a mined block and no other row: the light map names are answered
+with a constant and the sampler behind them with one white texel. Without it a pack whose eye program
+multiplies by the light map draws an enderman's eyes as dark as the block it stands on, and the
+additive blend the reference hangs on that program name is what would make that darkness the thing
+being added. The element is still declared and still bound either way, because the head has to
+declare the whole format; what changes is one line of it.
 
-**The glint.** It is one of the two pieces served here that are not drawn from an entity mesh, and
-the only one whose pipeline carries more than one render type's worth of answers. It is four compiled pieces
-of one program name, one per moment, because the side of the deferred stage is baked into a piece and
-the glint arrives on both: which carrier goes where is the game's sort, an enchanted book being
-submitted among the solid features foil and all, an enchanted armour piece and a trident and a shield
-among the translucent ones. It is in the opaque half's coverage mask and could not be left out: it
-blends onto the pixels the piece under it just wrote, and those pixels are the pack's target now.
+**The glint.** It is one of the four families served here that are not drawn from an entity mesh,
+and the only one whose pipeline carries more than one render type's worth of answers. It is four
+compiled pieces of one program name, one per moment, because the side of the deferred stage is baked
+into a piece and the glint arrives on both: which carrier goes where is the game's sort, an enchanted
+book being submitted among the solid features foil and all, an enchanted armour piece and a trident
+and a shield among the translucent ones. It is in the opaque half's coverage mask and could not be
+left out: it blends onto the pixels the piece under it just wrote, and those pixels are the pack's
+target now.
 
 Because those tables are keyed by pipeline and a texture is all that separates two rows, **two
 origins must not land in one draw**. There are two ways they could. The obvious one is the equality
@@ -337,16 +341,16 @@ really alternates pays each time it comes back; geometry that does not alternate
 pair in the game is known to reach it, which is not a reason to leave it open: the cost of being
 wrong is silent and the cost of the guard is one draw.
 
-**The cracks over a block being mined** are the other piece drawn from a mesh of the game's, the
-block format, and they are here rather than with the terrain because the game submits them through
-these same feature renderers. Leaving them to the game is not the neutral answer it looks like: the
-game draws them among the translucent features, which is the stretch the full-screen layer catches,
-and that layer is cleared to transparent black and composed as though every draw in it blended by
-alpha. The crumbling multiplies instead, so left there it multiplies against the clear and the
-cracks come out opaque black rather than darkening the face they lie on. Served, the multiply lands
-on the picture, which is where the game meant to put it.
+**The cracks over a block being mined** are the second of those four, drawn from a mesh of the
+game's, the block format, and they are here rather than with the terrain because the game submits
+them through these same feature renderers. Leaving them to the game is not the neutral answer it
+looks like: the game draws them among the translucent features, which is the stretch the full-screen
+layer catches, and that layer is cleared to transparent black and composed as though every draw in it
+blended by alpha. The crumbling multiplies instead, so left there it multiplies against the clear
+and the cracks come out opaque black rather than darkening the face they lie on. Served, the multiply
+lands on the picture, which is where the game meant to put it.
 
-**The block outline** is the third piece drawn from a mesh of the game's, the lines format, and it
+**The block outline** is the third of those four, drawn from the lines format of the game's, and it
 is the one the full-screen layer could not carry at all rather than carry flat. The layer is composed
 onto the first target the pack's translucent pass writes, which is the scene colour for most packs
 and, for a pack that forward-shades its translucents into a target of their own, something else
@@ -365,11 +369,16 @@ runs one position and is left alone, where Iris would normalise nought. The widt
 the game's own, carried on the vertex, and the screen size comes from the two uniforms every pack may
 read, supplied where the pack did not declare them.
 
-Three families in this window stay the game's, and are carried in flat by the full-screen layer: the
-beacon beam, the lightning, and the text of a name plate or a sign. The lightning and the text bind
-a mesh this door cannot decode. The beam binds the block format, which the door now reads, and what
-it still wants is a row of its own: the reference gives it another program, no alpha test and its
-fog per fragment, so it is not the cracks' row under another name.
+**The text** of a name plate or a sign is the fourth, and the one family here whose rows do not
+share a format: its eight pipelines bind four of the game's between them, a glyph in the world
+carrying a light map, a glyph read through a wall carrying none, and a text display's box carrying no
+texture coordinate at all.
+
+Two families in this window stay the game's, and are carried in flat by the full-screen layer: the
+beacon beam and the lightning. The lightning binds a mesh this door cannot decode. The beam binds
+the block format, which the door now reads, and what it still wants is a row of its own: the
+reference gives it another program, no alpha test and its fog per fragment, so it is not the cracks'
+row under another name.
 
 That is not taken on trust either. Every piece states the format it claims, and the
 claim is compared against what the pipeline really binds before the pack is read for it, because the
@@ -429,7 +438,7 @@ the world and nothing alive in it is the worse of the two to leave standing.
 Two culling details differ from the reference and are gaps rather than workarounds. Where a pack asks
 for a shorter reach for the casters that move, the reference rebuilds a whole second shadow frustum
 at that distance and tests a caster's bounding box against it; here the light's own frustum is kept
-and the reach alone is cut, as a box about the camera measured on the caster's position. The two
+and the reach alone is cut, as a cube about the camera asked of the caster's culling box. The two
 keep-sets are not nested, so the difference runs both ways. And the player flag is read as the
 reference reads it, which is not as a flag: where the pack allows the entities they are all extracted
 and the player is one of them, and the player directive is what is left when it refuses them. Read

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -290,7 +290,7 @@ pack's chain is.
   own go past its pipeline-layout interception untouched, which is what makes it safe to build them
   differently from its own. It is also a fact about one version of another mod, so it is worth
   re-checking whenever that one moves.
-- **Sodium scissors each region inside a pass.** Reusing that pass for the next family without
-  putting the viewport back and disabling the scissor clips those draws to the last region's
-  rectangle. The leftover half of the screen keeps the previous image, which reads as a band
+- **A scissor belongs to the draw that set it and the pass outlives it.** Reusing a pass for the
+  next family without putting the viewport back and disabling the scissor clips those draws to the
+  last rectangle. The leftover half of the screen keeps the previous image, which reads as a band
   that copies the top onto the bottom.

--- a/docs/internals/pack-loading.md
+++ b/docs/internals/pack-loading.md
@@ -137,9 +137,12 @@ The rewrite rules are asymmetric on purpose:
   undeclared where it is used, and skipping it would drop the player's choice silently.
 
 **Those last two reach a closed list of names and no others.** A `const` the reference does not
-configure is a plain constant, whatever its type, and no choice ever rewrites it. So is one the
-index refuses for a reason of its own: a `uint`, a number shipped without a list of values to
-cycle through, or a boolean nothing tests.
+configure is a plain constant, whatever its type, and no choice ever rewrites it. The list is the
+whole of the gate, though, and that matters for a listed name the option index refuses for a reason
+of its own: a `uint`, a number shipped without a list of values to cycle through, a boolean nothing
+tests. The rewriter reads one line at a time and holds no index, so a value chosen for such a name
+is applied here where the reference drops it. No screen offers the name, so a value for it can only
+have been written by hand, in the pack's own settings file or in a profile.
 
 A name the pack declares **nowhere** is not applied at all, and nothing is emitted for it in the
 unit's header. There is nowhere to apply it: the section below carries why that is the answer rather
@@ -206,11 +209,11 @@ scalars, the render stage
 constants taken straight off the engine's own enumeration so the number a pack compares against and
 the number a draw carries cannot part company, the block kinds and precipitation kinds packs read
 without declaring, and the biome and biome-category symbols, which stay empty until a caller has a
-registry to walk. Two more are posted only while they hold: the far terrain symbol while that mod
-is drawing, and the custom images capability while it is served. **A missing symbol does not fail
-loudly.** It quietly sends the pack down a
-fallback path written for a renderer from a decade ago, which is why classifying a vendor string into
-the wrong bucket is worse than not classifying it.
+registry to walk. The capability symbols of the `IRIS_FEATURE_` family are posted for every pack,
+custom images among them, each of them a promise the engine has to keep; the far terrain symbol is
+posted only while that mod is drawing. **A missing symbol does not fail loudly.** It quietly sends
+the pack down a fallback path written for a renderer from a decade ago, which is why classifying a
+vendor string into the wrong bucket is worse than not classifying it.
 
 ## The condition stack, shared on purpose
 
@@ -227,18 +230,17 @@ The same stack serves the GLSL sources and the properties files. Two implementat
 disagree about what is live, and the disagreement would appear as a program that exists in one place
 and not in the other: a defect with no visible cause.
 
-The two files that carry conditionals do not order their passes the same way, and the difference is
-deliberate rather than an oversight.
+Every reader handed a define table walks its file the same way, whichever of the four it is: **the
+conditionals first and the continuations after.** Folding first lets a value continued past the
+directive that closes a conditional swallow that directive into the middle of a value, where nothing
+recognises it; the conditional above is then never closed and the rest of the file goes dark. Packs
+write exactly that, in `block.properties` and in `shaders.properties` alike.
 
-The block, item and entity property files **read the conditionals first and join the continuations
-after.** Folding first lets a value continued past the directive that closes a conditional swallow
-that directive into the middle of a value, where nothing recognises it; the conditional above is
-then never closed and the rest of the file goes dark. Packs write exactly that.
-
-The shader properties file does the opposite: continuations are joined over the whole text before
-it is split into lines at all, and the conditionals are then evaluated on the joined lines. What
-makes that safe there is the join rule itself, which swallows only the indentation of the following
-line and never crosses a blank one, so a continued key cannot absorb the block beneath it.
+The shader properties file carries a second road, and only for what has to be read before any
+setting exists at all: the profiles, the screens and the sliders. That pass folds the continuations
+over the whole text and steps over the directives without evaluating one, since the profiles it is
+reading are themselves what a conditional would be evaluated against. Everything a setting can
+decide is left to the walk above.
 
 The expression evaluator itself is a recursive descent over C precedence, in integers rather than
 floating point, because the compiler that sees the same line later will give the C answer whatever is

--- a/docs/internals/pack-textures.md
+++ b/docs/internals/pack-textures.md
@@ -182,18 +182,21 @@ looks exactly like a noise lookup that is right: there is no observation on scre
 them.
 
 **The gutter is the part easy to leave out and impossible to see afterwards.** Each slice is laid
-out with one texel of margin on all four sides, holding the wrapped copy of the opposite edge.
-Without it, the hardware's bilinear tap at the edge of a tile reaches into the neighbouring tile,
-which is a different depth entirely, and the result still looks like noise. With it, that tap reads
-exactly what repeat addressing would have read on a real volume. Depth needs no gutter of its own:
-nothing interpolates between tiles in hardware, and the helper does that half itself.
+out with one texel of margin on all four sides, holding what the hardware would have read one texel
+past the edge of a real volume: the opposite edge for a volume that repeats, the edge itself again
+for one that clamps. Without it, the hardware's bilinear tap at the edge of a tile reaches into the
+neighbouring tile, which is a different depth entirely, and the result still looks like noise. With
+it, that tap reads exactly what the addressing the pack asked for would have read. Depth needs no
+gutter of its own: nothing interpolates between tiles in hardware, and the helper does that half
+itself, repeating or clamping the slice index as the pack asked.
 
 **The atlas needs a bound that the blob's does not give.** The blob is held under the ceiling on a
 pack file and checked against the length its declaration announces, but the atlas is what those
 texels are laid out *as*: a declared shape with one long axis and a thin one lays its slices out in
 a line, so a modest file spreads to a width no device will allocate and that nothing in the file
-said. The layout is therefore checked against a limit per side and on total texels before the volume
-is served, and one that does not fit refuses the directive by name like any other refusal.
+said. The layout is therefore checked against a limit per side and against a ceiling on the memory
+it would take, counted in bytes because a texel is four to eight of them, before the volume is
+served; one that does not fit refuses the directive by name like any other refusal.
 
 **Nothing moves unless everything can.** A name reached in any way other than the plain lookup the
 helper replaces (taken as a function parameter, reached through a macro, sampled with an extra
@@ -212,22 +215,27 @@ is answered without consulting the stage at all. Iris remains the authority on w
 means; see [the note on sources](../README.md#a-note-on-sources) for how that authority is used and
 credited.
 
-## Why a volume asked to be clamped is not laid out flat
+## Why a volume the atlas cannot lay out takes every program with it
 
-The wrapping lives in two places that cannot be undone at the sampler: the gutter holds wrapped
-copies of the far edge, and the printed helper wraps. Serving a volume the pack asked to clamp with
-those would be right everywhere except within half a texel of its border, which is the exact shape
-of a plausible wrong picture.
+The addressing a pack asked for is decided once and honoured in three places at the same time. A
+volume that clamps is laid out flat like any other: the gutter carries the edge itself rather than
+the far one, the printed helper clamps its coordinates and its slice index instead of wrapping them,
+and the atlas is bound clamped whatever the pack wrote, since its wrapping has already been done on
+coordinates that never leave the tile. Letting the sampler repeat as well would wrap the atlas,
+which is a different image, and the gutter would stop being read at all.
 
-The trap is that a raw blob is filtered and clamped by default, unless the metadata beside it says
-otherwise. That default is the format's rule rather than a taste, and a defensible one: a blob
-carries a lookup table as often as an image, and a table read past its edge or between its entries
-answers with a value that was never in it. A volume shipped without that metadata therefore lands in
-the clamped case, its declaration stays three-dimensional, and every program carrying that
+Clamping is also the common case rather than an exotic one. A raw blob is filtered and clamped
+unless the metadata beside it says otherwise, which is the format's rule rather than a taste, and a
+defensible one: a blob carries a lookup table as often as an image, and a table read past its edge
+or between its entries answers with a value that was never in it.
+
+What cannot be laid out flat is a blob of a channel type or a channel order the atlas does not
+carry, or one declaring an extent of nought. Its declaration then stays three-dimensional, and this
+backend binds nothing but two-dimensional and cube samplers, so every program carrying that
 declaration fails to build.
 
 Which is why the log says so in as many words at the moment the volume is read. The refusal that
 follows cannot say it: "this program declares a sampler the backend will not take" does not point
-at a missing metadata file, and a symptom that does not name its cause is the kind that costs
-someone a day. [Pack compatibility](../compatibility.md) collects those symptoms from the other
-end, starting from what is on screen.
+at the channel type of a blob read long before it, and a symptom that does not name its cause is the
+kind that costs someone a day. [Pack compatibility](../compatibility.md) collects those symptoms
+from the other end, starting from what is on screen.

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -55,11 +55,14 @@ this is a rename either.
 filtering is not defined. Getting this wrong is invisible on a target that is only ever sampled at
 texel centres and obvious on one that is not.
 
-Two questions the game gives no way to ask: whether the driver accepts the packed eleven-eleven-ten
-float format as a colour attachment, and whether it can filter a thirty-two bit float format
-linearly. Neither `GpuDevice` nor `DeviceInfo` exposes a format capability query, so there is no
-graceful path. The only defence is ordering: the format is named in the log **before** the
-allocation is attempted, so that when a driver dies the last line written names the culprit.
+Two questions neither `GpuDevice` nor `DeviceInfo` gives a way to ask: whether the driver accepts
+the packed eleven-eleven-ten float format as a colour attachment, and whether it can filter a
+thirty-two bit float format linearly. The backend behind them answers that kind of question, and the
+engine asks it in one place already: whether this device makes a storage image of a format, which a
+compute writing a colour target needs, is read off the physical device's format properties rather
+than off a table of our own. These two are not asked that way, and their defence is ordering: the
+format is named in the log **before** the allocation is attempted, so that when a driver dies the
+last line written names the culprit.
 
 ## Where the format directives live, and why a naive reader finds none
 

--- a/docs/internals/uniforms.md
+++ b/docs/internals/uniforms.md
@@ -97,12 +97,14 @@ clock, so it stops while the game is paused, which is what a pack driving noise 
 A handful of values are properties of the **pass** rather than of the frame: the depth convention of
 the target being drawn into, the model view the pass draws with and the projection it draws under,
 the colour it modulates by, and which stage of the frame it is. Those are set beside each block
-write and dropped rather than carried over, though not in the same place: the frame boundary drops
-the model view, the projection and the colour, and the chain drops the render stage before it
-writes its own blocks, being the only reader left that could hold a stale one. Left
-standing from the pass before, the render stage would tell every full-screen pass of the frame that
-it was drawing the moon, because that value sits in the same table a full-screen pass shares with a
-geometry one.
+write and dropped rather than carried over, in two places that are not one guard written twice. The
+frame boundary drops the model view, the projection and the colour at the head of the frame, which
+covers whatever reads before the first geometry pass. The chain drops those three again and the
+render stage with them, and says its own depth convention rather than inheriting the one the shadow
+programs flipped, before it writes its own blocks: every geometry family has run by then, so what
+would otherwise stand is whatever the last of them set. Left standing from the pass before, the
+render stage would tell every full-screen pass of the frame that it was drawing the moon, because
+that value sits in the same table a full-screen pass shares with a geometry one.
 
 Changing world drops all of it, the clock included. Nothing carried from the previous frame means
 anything once the camera has jumped a dimension's worth of coordinates, and a frame duration

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -41,7 +41,8 @@ reference: a folder called `lib` is not special, its contents are simply not ent
 What is left is then filtered twice: the directory has to be a dimension directory, and the base
 name has to be a program name. Both catch real cases: shared bodies parked in a subfolder carry
 perfectly valid program names, and shared bodies parked inside a dimension folder carry names
-outside the list. Whatever is rejected is named in the log rather than dropped silently.
+outside the list. What is rejected is counted in the log rather than dropped silently: each of the
+two lists is printed with its total and the first eight distinct names it holds, the rest elided.
 
 A program name is one of a closed list of geometry names, a numbered family where the unnumbered
 spelling means slot zero, or one of a small set of unnumbered names. One detail bites implementers:
@@ -69,12 +70,15 @@ A pack that ships a dimension folder holding two programs has **exactly two prog
 dimension. Everything else there resolves through the fallback tree *inside that folder*, not
 through the root. The reference implementation states this in as many words.
 
-Two corollaries follow. The condition is the **existence** of the directory, not its contents, so an
-empty dimension directory yields an empty program set rather than falling back to the root, because
-emptying a folder is the only way a pack has of saying "nothing here", and reading the base set
-instead would overrule it. A directory that is named and *absent* does fall back. And the base set
-is not necessarily the root: it is the directory bound to the catch-all entry of the dimension
-mapping, and in practice most packs keep no programs at the root at all.
+Two corollaries follow, and the first is this engine's own rather than the reference's. The
+condition is the **existence** of the directory, not its contents, so an empty dimension directory
+yields an empty program set rather than falling back to the root, because emptying a folder is the
+only way a pack has of saying "nothing here", and reading the base set instead would overrule it.
+The reference draws that line elsewhere: it registers a dimension only where the folder holds an
+entry point, so an empty one overrides nothing there and the base set answers for it. A directory
+that is named and *absent* does fall back under both. And the base set is not necessarily the root:
+it is the directory bound to the catch-all entry of the dimension mapping, and in practice most
+packs keep no programs at the root at all.
 
 ### The fallback tree
 
@@ -168,9 +172,10 @@ what makes a pack's misspelled key visible: correct to ignore, wrong to lose.
 and an explicit `false` is the only value that moves anything: a pack that says nothing leaves the
 stage standing on whichever shadow programs it ships, which is how the reference reads it. Written
 false, nothing is ever drawn from the light, and the six directives below decide nothing because
-there is no map for them to decide about. Like them it takes a literal boolean and nothing else, a
-value that is not one being honoured nowhere, and like them it is read through the pack's own
-conditionals, so the line may sit inside a branch of the pack's own settings.
+there is no map for them to decide about. Like them it takes a boolean written out or as `1` and
+`0`, which is the reference's own pair of spellings and one more than OptiFine's; a word that is
+neither is honoured nowhere. And like them it is read through the pack's own conditionals, so the
+line may sit inside a branch of the pack's own settings.
 
 `shadowTerrain`, `shadowTranslucent`, `shadowEntities`, `shadowPlayer`, `shadowBlockEntities` and
 `shadowLightBlockEntities` say which families a pack wants drawn into its shadow map. Four of them
@@ -259,8 +264,9 @@ throughout.
 
 The same first line also drops the sweep when the shadow program voxelises. A geometry stage on
 that program is enough, even when this engine never binds it, and so is an image load / store that
-the preprocessor left standing, which is the reference's `setUsesImages`. A name gated off does
-not count.
+the preprocessor left standing. That second half is this engine's alone: the reference has a
+`setUsesImages` for it and calls it from nowhere, so an image load / store decides nothing there.
+A name gated off does not count.
 
 ## Settings, and how a user changes them
 
@@ -309,14 +315,21 @@ right-hand side, when that constant's name is on the closed list at all. A
 boolean lands on a constant in one of two ways: on a `const bool` it is written out as `true` or
 `false`, since a constant is read as an expression rather than tested for existence and commenting
 the line out would leave the name undeclared; on a constant holding a number it is ignored and the
-line is left exactly as it was, a switch having nothing to say about a number. Indentation and the
-trailing value-list comment are preserved.
+line is left exactly as it was, a switch having nothing to say about a number. Indentation is
+preserved, and so is the trailing comment, whole on a constant where everything past the semicolon
+is copied over. On a define it survives only where the bracket follows the slashes directly, and the
+index that offered the setting is wider than that, taking the first bracket anywhere in the comment,
+so a define whose list sits behind a sentence of prose loses the sentence and the list together the
+first time a value is written into it.
 
 ### Two define tables, deliberately different
 
 The table used to preprocess `shaders.properties` carries the engine's defines, the default of
-every non-constant uncommented setting, and the variant overrides. The per-unit table carries the
-engine's defines alone: the pack's own defaults and the overrides applied to them enter as
+every non-constant uncommented declaration, and the variant overrides. Declaration and not offered
+setting: the gate deciding what a screen may offer is applied to the constants alone, so a bare
+define nothing tests and a define carrying a value with no list beside it are both in this table
+under their default, neither of them being a setting anyone can reach. The per-unit table carries
+the engine's defines alone: the pack's own defaults and the overrides applied to them enter as
 expansion walks over its define lines, like a real preprocessor.
 
 Unifying them is a mistake, and the asymmetry is the whole point: the properties table has to be
@@ -375,9 +388,16 @@ a global set.
 
 **Dead branches are not eliminated.** Conditional evaluation only decides which files to open;
 inactive lines are re-emitted as they stand, because the compiler will re-evaluate the same
-conditions on the final text anyway. One line is the exception and it has to be: an `#include` on a
-branch that is off becomes a comment naming what was not pulled in, since leaving it would open the
-file after all. The line count is preserved either way, which is what the numbering below rests on.
+conditions on the final text anyway. What is rewritten is what no compiler would take. An `#include`
+on a branch that is off becomes a comment naming what was not pulled in, since leaving it would open
+the file after all. A conditional the pack wrote loosely goes out as the decision the reference's
+preprocessor reached on it: an `#if` or an `#elif` carrying no expression becomes `#if 0` and
+`#elif 0`, an `#ifdef` carrying nothing that can name a setting becomes `#if 1`, and an `#else` or
+an `#endif` with nothing open for it becomes a comment. Each of those is named in the log. One line
+still comes out for one line, which is what the numbering below rests on, and the only thing added
+is an `#endif` at the end of the file for each rewritten group the file never closed. Only for
+those: a group the PACK left open is one the compiler may never have opened, a conditional written
+inside a block comment being a directive to this reader and nothing at all to the compiler.
 
 **A non-evaluable condition is taken as true**, and counted. The asymmetry is deliberate: including
 too much is recoverable, while a skipped include produces an avalanche of undeclared identifiers
@@ -398,11 +418,14 @@ that re-evaluates the same conditions on the emitted text.
 An include directive is replaced by the lines of the file it names, so the unit that reaches the
 compiler is one flat text and errors are numbered against that.
 
-Version and extension directives are **blanked in place rather than deleted**, which looks fussy
-and is not: later passes carry per-line information about which lines a branch actually took, and
-that information is indexed by line number. Remove a line and every index after it is wrong. The
-unit takes its version from the header the engine writes, and the directives that were blanked are
-counted, so an unexpected one shows up in the totals instead of vanishing.
+The `#version` of the entry file is kept and every later one is dropped with nothing written in its
+place, a version directive arriving from an include being an error where it lands. Both directives
+go for good later, in the translator, and there they are **blanked in place rather than deleted**,
+which looks fussy and is not: the passes that follow carry per-line information about which lines a
+branch actually took, and that information is indexed by line number. Remove a line and every index
+after it is wrong. So the version and every `#extension` are emptied where they stand, the unit
+taking its version from the header the engine writes, and it is the extensions that are counted, so
+an unexpected one shows up in the totals instead of vanishing.
 
 ## Textures a pack supplies itself
 
@@ -430,7 +453,10 @@ meaning what it meant.
 
 **A three-dimensional volume is flattened onto a two-dimensional atlas**, its declaration rewritten
 under a forged name, and each read replaced by a helper that reads two slices and interpolates.
-This works because the backend refuses the declared type, not what actually sits behind the sampler.
+What forces that is the data rather than the type: the blob is uploaded as one flat atlas of slices
+and nothing builds a three-dimensional view over a texture a pack ships. The declared type stopped
+being the obstacle the day a mixin made the bind group's walk read `SpvDim3D` as 2D, which is what a
+volume an `image` directive fills is bound through.
 The atlas keeps the blob's own channel type, an unsigned byte, an unsigned short or a half float
 a channel, and the addressing the pack asked for is baked into it: a repeating volume carries the far edge in the
 gutter of each slice and the helper wraps, a clamped one carries the edge again and the helper

--- a/docs/render-scale.md
+++ b/docs/render-scale.md
@@ -1,6 +1,6 @@
 # The render scale, and what it covers
 
-**FSR Render Scale**, under Video Settings on Vitrail's own page, draws the world at a fraction of
+**Render Scale**, under Video Settings on Vitrail's own page, draws the world at a fraction of
 the window and brings the finished picture back to full size before the interface. It is the
 setting to reach for when a pack runs but runs slowly, and it is worth knowing exactly how far it
 reaches, because a lot of a frame is not measured in pixels at all.
@@ -77,10 +77,10 @@ to 50 makes the world cheaper and leaves the upscale exactly where it was.
 ## Per-pass costs do not shrink either
 
 The scale buys fragment work and nothing else. A frame also pays for things counted per pass, per
-draw or per object, and none of them know the picture got smaller:
+draw or per object, and a smaller picture makes none of them cheaper:
 
 - the number of passes the pack runs, and the pipeline binds and barriers between them;
-- the uniforms written for each program, which are the same values whatever the viewport;
+- the uniforms written for each program, one block filled per program however few pixels it covers;
 - the geometry submitted. The world is walked, culled and drawn from the same sections at the same
   render distance, into fewer pixels.
 
@@ -92,12 +92,12 @@ most.
 
 In the order of how much they change what is drawn rather than how it is drawn:
 
-- **Max Shadow Distance** changes what is drawn at all: terrain and entities past it are not
+- **Shadow Distance** changes what is drawn at all: terrain and entities past it are not
   submitted to the light. That is geometry not walked, not culled and not rasterised.
 - **Shadow Map Scale** keeps the same geometry and rasterises it into a smaller map, and tells
   the pack that is what it got. It costs less defined shadow edges, softer or coarser depending
   on whether the pack smooths them, and a pack reload each time it moves.
-- **FSR Render Scale** keeps the whole frame and rasterises it into fewer pixels, then buys the
+- **Render Scale** keeps the whole frame and rasterises it into fewer pixels, then buys the
   sharpness back with a fixed pass at full size.
 - **The pack's own settings** are the last and often the largest: a pack's own shadow, volumetric
   and reflection quality settings are what decide how many passes there are to pay for.

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -96,8 +96,10 @@ Two things on a page do not answer to that.
   and not twenty. The handle snaps to the value that will be written rather than staying under the
   mouse. From the keyboard, Return picks the handle up and puts it down again, and the arrows move it
   one value while it is up.
-- The **profile selector** ignores shift and a click, on purpose: a profile is a whole set of values
-  rather than one of them, so there is no single value to hand back. The way back is to reset.
+- The **profile selector** has nothing to hand back, a profile being a whole set of values rather
+  than one of them, so the gesture that asks for the pack's own value is the one thing it does not
+  answer: shift and a click step the profile like an unmodified click, and control and Return leave
+  it where it is. The way back is to reset.
 
 **A pack's own words about a setting appear in a panel at the bottom** after the mouse has rested on
 it for a moment, one line per sentence. A setting whose name was too long for its cell offers the
@@ -223,10 +225,10 @@ pack to come back to. A file holding one bare word is still read the way it alwa
 holding `none` still reads as shaders off.
 
 Three more lines of that same file are not this screen's at all, and all three are written by the
-video settings: `shadowdistance=` is how far the shadow map reaches, in chunks, from the Max Shadow
+video settings: `shadowdistance=` is how far the shadow map reaches, in chunks, from the Shadow
 Distance slider, `shadowmapscale=` is how much of the map the pack asked for is actually drawn,
 from the Shadow Map Scale slider, and `renderscale=` is what fraction of the window the world
-renders at before being upscaled, from the FSR Render Scale slider. They sit there because they are
+renders at before being upscaled, from the Render Scale slider. They sit there because they are
 the same kind of thing as the other two, one number a player sets once that outlives whichever pack
 is loaded, which is where the reference keeps its own distance. Every writer reads the file before
 writing it, so none drops another's line. What each of the last two costs, and what neither of them

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -156,8 +156,9 @@ camera, and what belongs in a shadow map is mostly what the camera cannot see.
 Those pieces are drawn with one program for the lot, `shadow_entities`, whatever the camera would
 have used for them. A chest and a mob are submitted through the same pipelines, so the mark that
 buys a block entity its own program against the camera buys nothing against the light. Every row
-discards at a tenth and none of them blends: what a map wants of a translucent surface is the depth
-that surface stands at, not that depth mixed with the one behind it.
+discards at a tenth, bar the text rows at a ten thousandth, and none of them blends: what a map
+wants of a translucent surface is the depth that surface stands at, not that depth mixed with the
+one behind it.
 
 **A piece this engine has no shadow row for is dropped rather than handed back**, and that is a
 divergence. Iris binds its shadow framebuffer for the whole of its stage, so a pipeline its table
@@ -326,12 +327,16 @@ picture is where that shows.
 
 What remains open is the shape beside the cube, and it is a gap and not a workaround. Iris measures
 the movers against the same swept camera volume as the terrain, rebuilt at the shorter distance
-(`shadows/ShadowRenderer.java:536-541`); here they measure against the light's frustum. A caster
-inside the cube and the light's box but outside the sweep is kept here and dropped there, which
-costs a draw and never a pixel, the sweep being built so that nothing outside it can shadow what the
-camera sees. The other way round is empty: Iris never asks the light's box of a mover, so one outside
-it is kept there and dropped here, but outside the light's box is outside the map, and what Iris
-keeps of it draws nothing. Nothing makes Iris's shape impossible here; it has not been written yet.
+(`shadows/ShadowRenderer.java:536-541`); the planes here are the light's own frustum. But the sweep
+reaches the caster all the same, by Sodium's road: the frustum test of `shouldRender` is Sodium's
+entity culling, which answers off the occlusion tree the last walk left, and after the light's walk
+that tree holds the sections the sweep kept. So a caster inside the cube and the light's box but
+outside the sweep is dropped here and kept there. Sodium spares a box that touches a section with no
+geometry in it, and either way the difference costs a draw and never a pixel, the sweep being built
+so that nothing outside it can shadow what the camera sees. The other way round is empty: Iris never
+asks the light's box of a mover, so one outside it is kept there and dropped here, but outside the
+light's box is outside the map, and what Iris keeps of it draws nothing. Nothing makes Iris's shape
+impossible here; it has not been written yet.
 
 ### The experiment that separates the two failure modes
 
@@ -545,13 +550,16 @@ Vitrail does the same, in `render/HorizonCone.java`: an octagonal cone between t
 drawn with the pack's basic sky program inside the pass the game opens for its disc, so it inherits
 that pass's pipeline state, topology and depth convention.
 
-Two conditions come with it, and neither is optional. The cone rides in the disc's pass, so it is
-drawn only where the disc is: a pack that refuses the disc has drawn its own, and the Nether and
-the End draw no disc at all. And it is drawn only where the world's opaque geometry marks the
-pixels it wrote: the cone stands over the whole of the ground rather than over the sky, and marking
-a pixel cuts the full-screen layer there, so a cone drawn while the world still reaches the pack's
-target through that layer would cut the ground out of the picture. On the first frame of a world
-nobody has answered that question yet, and the frame goes without its cone.
+Three conditions come with it, and none is optional. The cone rides in the disc's pass, so it is
+drawn only where the game draws a disc, which the Nether and the End do not; no directive refuses
+the disc itself, a pack that draws its own sky still getting one, served by its own program. It is
+withheld where the pack wrote `sky=false`, which is the one thing that word decides in either
+engine: a pack saying it draws the sky itself is not handed geometry the game has none of. And it
+is drawn only where the world's opaque geometry marks the pixels it wrote: the cone stands over the
+whole of the ground rather than over the sky, and marking a pixel cuts the full-screen layer there,
+so a cone drawn while the world still reaches the pack's target through that layer would cut the
+ground out of the picture. On the first frame of a world nobody has answered that question yet, and
+the frame goes without its cone.
 
 ### The method lesson
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -7,10 +7,11 @@ about how the first becomes the second, and what does not survive the trip.
 
 Every GLSL unit a pack ships is rewritten before it can draw, then handed to the compiler the game
 already embeds, which produces SPIR-V and performs reflection and binding remapping itself. The
-chain's own units go at selection; the programs that draw the world and the sky are translated on
-demand, at the first frame of a place that needs them. What is translated is never *patched*
-afterwards: a setting that moves rebuilds its units from the pack's source, and so does a change of
-dimension, which rebuilds the lot.
+chain's own units go at selection, and the six families that draw the world and the sky follow on a
+worker as soon as the pack is loaded, read one after another on that one worker and compiled by a
+task each. A first draw that outruns it reads its own family, which is the fallback rather than the
+road it normally takes. What is translated is never *patched* afterwards: a setting that moves
+rebuilds its units from the pack's source, and so does a change of dimension, which rebuilds the lot.
 
 Two properties follow, and both are load-bearing:
 
@@ -54,8 +55,8 @@ each other overflow the stack.
 **Why bounding rather than catching.** Stack overflow and out-of-memory are errors, not runtime
 exceptions, so a catch around pack reading does not see them. The fix is to make sure the error is
 never reached, not to widen the catch. Otherwise a single malformed pack dropped in the folder can
-stop the client from starting, including a pack that was never selected, since reporting reads
-them all.
+stop the client from starting. It has to be the selected one: the report reads the pack about to be
+drawn and not the folder, which is what took the ones nobody chose out of every startup.
 
 Two smaller rules in the same family. A macro whose value is an expression is folded to its
 **value**, not to a truth value, or conditions built on derived settings evaluate wrongly. And
@@ -103,23 +104,23 @@ depth textures nearest and never mipmapped, the noise linear, and a colour targe
 target's own sampler, mipmapped once a program's `colortexNMipmapEnabled` turned its chain on; under
 OpenGL a filter without a mipmap in its name never selects a level, whatever level of detail the
 lookup computed or carried. Vulkan has no such filter. Every sampler selects a level, the one bound
-where no chain exists is told to stay at the base, and measured on one driver that is not what a
-lookup got: AstraLex marches a reflection ray across the opaque depth in its translucent pass,
-thirty steps with an early exit, reading the depth with `texture` at a coordinate each step
-computes, and on some steps the depth that came back was not the image's, so the ray landed where it
-never reached and every glass pane bloomed a saturated blue over its wall, on some frames and not
-others. The same read at an explicit level of nought was right on every frame. So the level is
-written into the text, which is what the reference's filter amounted to. The rewrite is by the name
-of the sampler, and a sampler a function takes as a parameter, the blind spot the depth conversion
-below describes, is read through its call sites instead: the parameter is pinned when every call
-hands it a sampler already pinned or a parameter already proven, outright in a full screen program
-that asks for no chain at all, and its lookups are counted and left otherwise, a function some macro
-calls included. The shadow map's samplers are pinned with the rest, since nothing here fills a chain
-on the map whatever mipmap directive the pack wrote, which is an older gap of the shadow bindings
-and not of this rewrite. The engine gives a chain to the program that asked for it
-and to that program alone, where the reference keeps the mipmap filter on the target for the rest
-of the frame; that is an older divergence of the bindings, and the rewrite does not change what
-those later programs read.
+where no chain exists is capped a quarter of a level above the base, which ought to come to the same
+thing, and measured on one driver it did not: AstraLex marches a reflection ray across the opaque
+depth in its translucent pass, thirty steps with an early exit, reading the depth with `texture` at
+a coordinate each step computes, and on some steps the depth that came back was not the image's, so
+the ray landed where it never reached and every glass pane bloomed a saturated blue over its wall,
+on some frames and not others. The same read at an explicit level of nought was right on every
+frame. So the level is written into the text, which is what the reference's filter amounted to. The
+rewrite is by the name of the sampler, and a sampler a function takes as a parameter, the blind spot
+the depth conversion below describes, is read through its call sites instead: the parameter is
+pinned when every call hands it a sampler already pinned or a parameter already proven, outright in
+a full screen program that asks for no chain at all, and its lookups are counted and left otherwise,
+a function some macro calls included. The shadow map's samplers are pinned with the rest, since
+nothing here fills a chain on the map whatever mipmap directive the pack wrote, which is an older
+gap of the shadow bindings and not of this rewrite. The engine gives a chain to the program that
+asked for it and to that program alone, where the reference keeps the mipmap filter on the target
+for the rest of the frame; that is an older divergence of the bindings, and the rewrite does not
+change what those later programs read.
 
 **One uniform becomes a sampler, because its value never comes back from the card.**
 `centerDepthSmooth` is the depth at the middle of the screen, faded by the pack's own half-life,
@@ -183,11 +184,12 @@ the fragment declares without the vertex emitting it is refused loudly, while th
 and shifts the locations of everything after it.
 
 The two sides are reconciled in two different ways, and it is worth not confusing them. A varying
-the *engine* names (there are two, the fog coordinate and the colour a hurt mob flashes) has to be
-declared by both stages or by neither, so it is decided once at program assembly and written into
-both headers from the one answer. The pack's own varyings are not unified that way. They are
-brought into agreement by three passes over the pair, in this order, and the order matters because
-each one changes what the next one sees:
+the *engine* names (there are five, the fog coordinate, the colour a hurt mob flashes and the three
+entity identifiers) has to be declared by both stages or by neither, so it is decided once at
+program assembly and written into both headers from the one answer. The four that ride on the
+overlay are asked of the mesh as well, so a family drawn without one declares none of them. The
+pack's own varyings are not unified that way. They are brought into agreement by three passes over
+the pair, in this order, and the order matters because each one changes what the next one sees:
 
 1. An input the later stage declares that nothing upstream writes is **struck out**, where its body
    never reads it. That is the cheapest answer, because it changes nothing else.
@@ -326,12 +328,14 @@ exists, its value is defined, and the shortfall is announced rather than left to
 memory.
 
 The announcement is split into separate buckets rather than counted, because a program can be short
-in several different ways at once and each line says which. Two of them are names the block could
-not be given: one this engine owes, and one the pack declared for itself and none of whose
-declarations survived. Underneath those sits the dangerous one, which is not a gap at all: a name
-the table answers with a **stand-in**, which counts as supplied everywhere else. A zero that
-arrived through a registered source looks exactly like a measured value, and no screenshot will
-ever show it.
+in several different ways at once and each line says which. Three of them are names the block could
+not be given: one this engine owes, one the pack declared for itself and none of whose declarations
+survived, and one no engine answers at all, which is there so that the log stops reading as a debt
+where there is none, a reader having once been sent through the whole Distant Horizons path of two
+packs by a single line about `farPlane`. Underneath those sits the dangerous one, which is not a
+gap at all: a name the table answers with a **stand-in**, which counts as supplied everywhere else.
+A zero that arrived through a registered source looks exactly like a measured value, and no
+screenshot will ever show it.
 
 Packs can also define their own uniforms as expressions over others. Those form a dependency graph
 that is validated: a cycle is refused by naming the uniforms involved, a broken uniform withdraws
@@ -348,7 +352,11 @@ for that path, three different mechanisms, and it is worth knowing which:
 
 - **Samplers are refused by name.** The compiler takes one as two-dimensional or as a cube, or as a
   texel buffer where the pipeline declared that name as a uniform rather than as a sampler, and
-  rejects every other dimensionality.
+  rejects every other dimensionality. Three dimensions are the one exception, and it is this
+  engine's doing: a mixin makes that walk read the dimension as two, so a `sampler3D` naming a
+  volume an `image` directive fills, or the image itself, is bound and never refused. What stays
+  refused is a three-dimensional shape with nothing behind it, and a volume the pack ships as a
+  file escapes by being flattened onto a flat atlas long before it reaches here.
 - **Compute has nowhere to go through the Java facade.** The game's shader-type enumeration carries
   a vertex stage and a fragment stage and nothing else, and the device exposes no way to precompile
   anything but a render pipeline. The Vulkan backend behind that facade already has a compute-capable
@@ -377,10 +385,13 @@ No amount of translation work makes a pack compute unit or a pack storage image 
 facade. Vulkan itself supports all of them. The layer above does not, and the backend below it
 does; [the game's graphics API](internals/game-graphics-api.md) says where the split sits.
 
-**Defects in the pack itself.** A conditional directive with no name is a pack bug and stays a
-failure.
+**Defects in the pack itself.** A conditional directive the pack wrote loosely no longer costs it
+the program. The group an `#ifdef` with no name opens is taken and the line goes out as `#if 1`,
+which is what the reference's preprocessor decides on it, and the log names the file and what was
+read there. It is still a pack bug, said as one rather than left to a compile error nobody can
+trace back.
 
-One class of pack defect is handed a value instead, because under the reference it has one. GLSL
+Another class of pack defect is handed a value, because under the reference it has one. GLSL
 leaves a variable declared without an initialiser undefined until it is written, and a pack that
 reads one first has a defect that shows nowhere on the platform it was written on: measured against
 Iris at the same spot on the same machine, the pack reads zero there, so the picture is right and


### PR DESCRIPTION
## What changes

Nothing the engine draws. Every page of `docs/`, the README, the contributing guide and NOTICE were read sentence by sentence against the code they describe, and what the code contradicted is rewritten: the scene seed named where the pages said the full-screen layer, the family warm-up where they said a first frame waits, the eight vertex layouts the entity door reads and the text it serves, the five pinned rows, the switched-off symbols and the four files walked one way, a clamped volume laid out flat, the atlas ceiling counted in bytes, the version directives the expander drops, the loose conditionals it rewrites, the spellings a boolean directive takes, the storage capability the engine already asks the driver, the two slider names as the language file has them, the profile widget under shift, the caster the sweep drops here and Iris keeps there, the disc no directive refuses, and the fifteen NOTICE paths the package moves had left dangling. Two lines the engine prints move with them: the load line that said the entities that blend still come from the game, where the beacon beam and the lightning are what still does, and the comments that had Iris count an image load or store as voxelisation, where Iris computes that half and reads it nowhere.

## How it differs from the reference, and for what obstacle

It does not. Where a page described Iris, the sentence was reread in Iris before it was rewritten; two divergences the reading surfaced are now named as this engine's own rather than as the reference's (an empty dimension folder overriding the base set, and an image load or store counting as voxelisation), and the second is left for a batch of its own.

## What proves it

- `gradlew build` green, which is the text gate.
- Each sentence corrected was verified in the source by the reader that found it, again by the hand that rewrote it, and the code comments touched cite the line they rest on.

## What it leaves owing

The count of corpus packs offering a render scale slider on `render-scale.md:59` stays as it was, the page naming no pack; and whether an image load or store should stop counting as voxelisation, since Iris reads no such half.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
