### PR TITLE
docs(changelog): drop two entries for defects no release carried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,17 +233,6 @@ what the next one holds.
   under any other spelling that one compute did nothing at all, leaving a line in the log while
   the pass it belongs to drew on without whatever the compute was there to prepare.
 
-- **A compute pass that reads the depth runs.** A compute a pack hangs off a full screen pass
-  could read every name that pass reads except `depthtex0`, `depthtex1`, `depthtex2`, the far
-  terrain's depth and `centerDepthSmooth`: those threw on every frame, so the compute never ran,
-  with one line in the log. Reverie's cloud compute reads `depthtex1`, and without it the images
-  its sky and clouds are built from stayed empty. The compute now reads the same depth as the pass
-  after it, which is what Iris gives it.
-
-- **A compute program that reads `centerDepthSmooth` reads the smoothed centre depth.** When
-  no fullscreen pass of the pack read the name and a compute did, the compute was handed the far
-  plane on every frame. A compute hanging off a pass now arms the fold as the pass would.
-
 - **A pack's depth of field focuses past the item in your hand.** The depth the focus is taken
   from was read after the held item had been drawn into it, so whenever the item covered the
   middle of the screen the focus jumped onto it and everything behind went soft, sharpening again
@@ -256,14 +245,14 @@ what the next one holds.
   that stage read off the wrong slots. An array is now taken apart and put back together the way
   a matrix and a struct are.
 
-- **Photon's distant water is no longer red, and no longer striped.** A pack may hand a stage a
-  struct of values in one go, and Photon hands its water program its fog coefficients that way.
+- **A struct handed between a pack's stages arrives whole.** A pack may hand a stage a struct of
+  values in one go, and Photon hands its water program its fog coefficients that way.
   That struct reached the other stage wrong, so the fog Photon's reflections computed with it
   saturated on every lake past a hundred blocks. A struct handed between stages is now taken
   apart and put back together the way a matrix already was.
 
-- **Photon's shadows are lit again.** The compute programs a pack attaches to its full screen
-  passes were named in the log and skipped, so whatever they prepared for the pass after them was
+- **The compute programs a pack attaches to its full-screen passes run.** They were named in the
+  log and skipped, so whatever they prepared for the pass after them was
   never there: Photon computes its sky lighting in one, and everything in shadow, the hand first,
   was black for the lack of it. Those programs now run, right before the pass they belong to. A
   compute whose pass the pack ships no fragment program for, and one attached to a setup program,


### PR DESCRIPTION
## What changes

Two entries leave the `Unreleased` section of the changelog, and two others get a new first
sentence. The two that leave describe a compute program hanging off a full-screen pass being handed
the wrong depth, or no smoothed centre depth: no published version ever ran those computes at all,
they started running in this same section, so somebody upgrading from the last release never had
either defect and the entries would tell them about a thing they never saw. What those computes now
do is already said by the entry that makes them run.

The two reworded entries said "Photon's shadows are lit again" and "Photon's distant water is no
longer red": both are relative to a picture no release drew, since the last release refused Photon
at load. Each now opens on what the version does differently, the compute programs a pack attaches
to its full-screen passes run, and a struct handed between stages arrives whole, and keeps the rest
of its text.

## How it differs from the reference, and for what obstacle

It does not. This branch touches `CHANGELOG.md` and nothing else.

## What proves it

- `gradlew build` green, which is what checks the file's punctuation and encoding.
- The dates: the commit that first dispatches a compute before the pass it hangs off sits after the
  `v0.9.0-beta` tag, and both removed entries fix that dispatch.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
