### PR TITLE
build: raise the version to 0.10.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.10.0-beta
 
 ### Added
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.10.0-dev
+mod_version=0.10.0-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

`mod_version` in `gradle.properties` leaves `0.10.0-dev` and takes `0.10.0-beta`, and the
`Unreleased` section of the changelog takes that name. Nothing else moves: this is the commit the
tag goes on, and it lands last so that the tip of `main` at the release names the version.

## How it differs from the reference, and for what obstacle

It does not. One line of `gradle.properties` and one heading of `CHANGELOG.md`.

## What proves it

- `gradlew build` green on the commit.
- `release.ps1 -Check` accepts the tip once this has landed: the version, the changelog section
  and the subject line all agree.

## What it leaves owing

Nothing. The next request opens `0.11.0-dev` on `dev` once the tag is out.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
