### PR TITLE
ci(release): leave the older Modrinth versions featured

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,6 +276,13 @@ jobs:
           curseforge-token: ${{ steps.mirror.outputs.curseforge == 'true' && secrets.CURSEFORGE_TOKEN || '' }}
           modrinth-id: ${{ secrets.MODRINTH_ID || vars.MODRINTH_ID }}
           modrinth-token: ${{ steps.mirror.outputs.modrinth == 'true' && secrets.MODRINTH_TOKEN || '' }}
+          # Older versions stay featured. The action's default unfeatures whichever of them the new
+          # upload covers, and that is an edit of each old version, which Modrinth now routes through
+          # its v3 API and answers with a 401 unless the token carries the VERSION_WRITE scope on top of
+          # the one the upload needs. The run then ends red after GitHub, CurseForge and Modrinth have
+          # all been written to, and the red says the opposite of what happened. Nothing is given up
+          # by not asking: every version stayed featured through the runs that passed, too.
+          modrinth-unfeature-mode: none
           files: ${{ steps.jars.outputs.merged }}
           # The two loaders are named in the row's own title because the file no longer names
           # them: what ships is one merged jar, where the pair it replaced said neoforge or


### PR DESCRIPTION
## What changes

The release workflow stops asking mc-publish to unfeature the older Modrinth versions once the new
one is up. That step is an edit of each older version, which Modrinth now routes through its v3 API
and refuses with a 401 unless the token carries the `VERSION_WRITE` scope on top of the one the
upload needs. The run of `v0.10.0-beta` ended red on it after the GitHub release, the CurseForge
file and the Modrinth version had all been published, so the colour of the run said the opposite of
what had happened. The step also never had a visible effect here: every version is still featured
after the runs that passed. `modrinth-unfeature-mode: none` takes it out.

## How it differs from the reference, and for what obstacle

It does not. This branch touches one workflow file and reaches no engine code.

## What proves it

- `gradlew build` green, which is what checks the file's punctuation and encoding.
- The step's own log on the red run: "Successfully published assets to CurseForge", the Modrinth
  version created, then the 401 on "Initiating unfeaturing of older Modrinth project versions".
- The next tag push is the real proof, and there is no way to run this workflow short of one:
  a dispatched run on the existing tag would offer CurseForge a file it already holds.

## What it leaves owing

Nothing. Whether the token gets the extra scope is a repository setting, not a change here.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
