### PR TITLE
ci(release): unfeature the older Modrinth versions again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,13 +276,6 @@ jobs:
           curseforge-token: ${{ steps.mirror.outputs.curseforge == 'true' && secrets.CURSEFORGE_TOKEN || '' }}
           modrinth-id: ${{ secrets.MODRINTH_ID || vars.MODRINTH_ID }}
           modrinth-token: ${{ steps.mirror.outputs.modrinth == 'true' && secrets.MODRINTH_TOKEN || '' }}
-          # Older versions stay featured. The action's default unfeatures whichever of them the new
-          # upload covers, and that is an edit of each old version, which Modrinth now routes through
-          # its v3 API and answers with a 401 unless the token carries the VERSION_WRITE scope on top of
-          # the one the upload needs. The run then ends red after GitHub, CurseForge and Modrinth have
-          # all been written to, and the red says the opposite of what happened. Nothing is given up
-          # by not asking: every version stayed featured through the runs that passed, too.
-          modrinth-unfeature-mode: none
           files: ${{ steps.jars.outputs.merged }}
           # The two loaders are named in the row's own title because the file no longer names
           # them: what ships is one merged jar, where the pair it replaced said neoforge or


### PR DESCRIPTION
## What changes

The release workflow asks mc-publish again to unfeature the older Modrinth versions once a new one
is up, which is the action's default. It had been switched off because that step edits each older
version and Modrinth refused the edit for want of the `VERSION_WRITE` scope on the token. The token
now carries that scope, so the step passes and nothing is left to work around. The branch takes the
one line and its comment back out.

## How it differs from the reference, and for what obstacle

It does not. One workflow file, no engine code.

## What proves it

- `gradlew build` green.
- The diff is the exact inverse of the commit that added the line.
- The step itself runs on the next tag push, as every release step does.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
