### PR TITLE
feat(render): bring more shaderpacks to the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,36 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## 0.10.0-beta
+## Unreleased
 
 ### Added
+
+- **A pack that ships no `final` program now draws.** Some packs end their chain on their last
+  composite and expect what it wrote to be the picture; they were refused outright, with nothing on
+  screen. What the chain leaves in `colortex0` is now brought to the screen, which is what Iris
+  does with the same packs. I Like Vanilla and Pegasus were both refused for this alone.
+
+- **Compute passes are announced as a capability.** They have been running for a while, so a pack
+  that says it cannot draw without them was being refused for something it would have got. Clarity
+  and Noble now load.
+
+### Fixed
+
+- **The extensions a pack asks for are no longer dropped.** A pack using half precision types
+  guarded them on the extension being available and shipped a fallback for when it is not; the line
+  that enables the extension was thrown away while everything around it stayed, so neither road
+  worked and every one of that pack's programs failed on a type the compiler had never been told
+  about. RenderPearl went from nothing at all to most of its programs.
+
+- **A pack defining the same setting twice no longer loses every program.** Drivers take the later
+  definition and warn; this refused the whole file. Where the two cannot be told apart the later one
+  now stands, and where a use sits between them the pack is left exactly as it wrote it. Pegasus was
+  losing all of its programs to one duplicated line.
+
+- **RedHat's shadows, E-LITE's entities and hand, and the vertex stages of core-profile packs.**
+  Three separate names a pack may write that this engine either had no answer for or answered
+  twice, each of which cost the passes that read them: the picture kept the game's own shader there
+  and the pack's effect was missing on those surfaces alone.
 
 - **Eight shadow colour buffers for a pack that asks for them.** A pack declaring
   `HIGHER_SHADOWCOLOR` may now draw the light into `shadowcolor0` through `shadowcolor7` and read

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -33,6 +33,7 @@ import java.util.Set;
  * moment any of them is written, and it is read in the one expression that builds it.
  */
 record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, AlphaTest alphaTest,
+		Set<String> extensions,
 		Map<String, String> engineDefines, Map<String, String> memoryQualifiers, Set<String> used,
 		Set<String> declaredNames, Map<String, String> synthesized,
 		Map<String, VolumeAtlas> readVolumes, Map<Integer, Output> packOutputs,
@@ -79,6 +80,11 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 			Set<String> varyings, Set<String> shadowed) {
 		List<String> lines = new ArrayList<>();
 		lines.add(VERSION);
+
+		// Straight after the version, which is the only place the language takes them, and as
+		// enable rather than require. GlslTranslator.dropVersionAndExtensions carries why they are
+		// hoisted here instead of staying where the pack wrote them, and what a lost one costs.
+		this.extensions.forEach(extension -> lines.add("#extension " + extension + " : enable"));
 
 		for (Map.Entry<String, String> define : this.engineDefines.entrySet()) {
 			lines.add(define.getValue().isEmpty()

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -393,9 +393,13 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 		// writes back. It has to be the ascending function that gets there first, so this goes last.
 		// The pack's body is concatenated after the header, so its own main is only a name here and
 		// has to be declared before it can be called.
-		if (this.depthEpilogue || this.terrainPrologue || this.distantPrologue || this.entityWrapped
-				|| this.linesWrapped || wrapsFragment() || owesInitialisers()
-				|| this.splits.any()) {
+		// Asked of the one thing that decides it, which is whether the pack's own main was renamed.
+		// Every reason to wrap sets that flag as it renames, so this is the list of reasons said
+		// once instead of twice, and it cannot fall out of step with them. It used to be the list
+		// itself, and a split taken back out by dropUnprovidedSplits after the rename then left a
+		// stage whose main was called ofPackMain and whose wrapper nobody wrote: no entry point,
+		// which is the fragment stage of Sildur's gbuffers_textured.
+		if (this.mainWrapped) {
 			lines.add("void " + GlslTranslator.PACK_MAIN + "();");
 			// The lines mesh runs the pack's main twice, the far end of the edge first and the
 			// vertex itself second, so that every varying holds the vertex's own value when the

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -250,6 +250,13 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 					+ GlslTranslator.FOG_COORD + ";");
 		}
 
+		// A global and not a varying, which is why it is asked of this stage's own names rather than
+		// of the union: the fragment stage never sees it, so there is no other side to agree with.
+		// GlslTranslator.FRONT_COLOUR says what it is and why writing it is enough.
+		if (this.stage == ProgramStage.VERTEX && this.used.contains(GlslTranslator.FRONT_COLOUR)) {
+			lines.add("vec4 " + GlslTranslator.FRONT_COLOUR + ";");
+		}
+
 		// The same rule for the overlay colour, and it arrives here by the same road: the union says
 		// yes, so both sides declare it whichever of them reads it. No interpolation qualifier, which
 		// is Iris's answer too: every vertex of one model part carries the same overlay coordinate,

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -746,6 +746,7 @@ public final class GlslTranslator {
 		synthesizeAttributes();
 		dropVersionAndExtensions();
 		settleRedefinedMacros();
+		dropRedeclaredVertexBlock();
 		rewriteIdentifiers();
 		// After the identifiers, because the goldberg idiom's sine has become ofReducedSin by then
 		// and that is one of the two names the site is recognised under, the other being the plain
@@ -1479,6 +1480,57 @@ public final class GlslTranslator {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Takes out a vertex stage's own redeclaration of {@code gl_PerVertex}.
+	 * <p>
+	 * A core profile pack narrows the built-in block to the members it writes, which is legal and
+	 * which the language allows in ONE place only: before any use of the block. Splicing the
+	 * includes in moves it, exactly as it moves an {@code #extension} line, and there it is
+	 * refused. RenderPearl writes {@code out gl_PerVertex { vec4 gl_Position; };} in its shared
+	 * vertex prelude and loses every vertex stage to it, ninety nine of them.
+	 * <p>
+	 * Dropping it rather than hoisting it, and the two are not the same trade here. What the
+	 * declaration DOES is take members away, so the block left standing is the predeclared one,
+	 * which holds the narrowed one and everything else the pack did not ask for. Nothing the pack
+	 * writes can miss, where a member it writes and did not declare would have been an error under
+	 * its own narrowing; the cost is a shader interface one member wider than the pack asked for,
+	 * which no stage of this corpus reads.
+	 */
+	private void dropRedeclaredVertexBlock() {
+		if (this.stage != ProgramStage.VERTEX) {
+			return;
+		}
+
+		int[] lines = this.tokens.lineNumbers();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.directive() != null || !token.identifier("gl_PerVertex")
+					|| !this.unit.isLive(lines[index])) {
+				continue;
+			}
+
+			int keyword = this.tokens.significantBefore(index);
+			if (keyword < 0 || !this.tokens.get(keyword).identifier("out")) {
+				continue;
+			}
+
+			int brace = this.tokens.significantAfter(index);
+			if (brace < 0 || !this.tokens.get(brace).operator("{")) {
+				continue;
+			}
+
+			int close = this.tokens.matchingBracket(brace);
+			int end = close < 0 ? -1 : this.tokens.significantAfter(close);
+			while (end >= 0 && !this.tokens.get(end).operator(";")) {
+				end = this.tokens.significantAfter(end);
+			}
+
+			if (end >= 0) {
+				this.tokens.blankRange(keyword, end);
+			}
+		}
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -520,6 +520,12 @@ public final class GlslTranslator {
 	private int gameModelView;
 
 	private int strippedExtensions;
+
+	/**
+	 * The extensions this unit named, in the order it named them, to be re-emitted by the header.
+	 * See {@link #dropVersionAndExtensions} for why they cannot stay where the pack wrote them.
+	 */
+	private final Set<String> extensions = new LinkedHashSet<>();
 	private boolean depthEpilogue;
 	private boolean terrainPrologue;
 
@@ -1346,11 +1352,33 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Both directives go. The version is replaced by ours, and every extension the corpus uses is
-	 * core in 4.60, so keeping them would at best say nothing. It would also often be an error:
-	 * once includes are spliced in, an {@code #extension} line can land well past the first real
-	 * token, and there it is rejected. They are counted so that an unexpected one shows up in the
-	 * totals rather than vanishing.
+	 * Takes both directives out of the body, and remembers which extensions the unit named.
+	 * <p>
+	 * The version is replaced by ours and never comes back. The extensions cannot stay WHERE they
+	 * are, which is the half of the old reason that still holds: once includes are spliced in an
+	 * {@code #extension} line lands well past the first real token, and the language allows none
+	 * there. The other half, that every extension the corpus used was core in 4.60, is what the
+	 * wider corpus refuted. RenderPearl asks for the explicit arithmetic types, and the shape of
+	 * what it costs is worth writing down because nothing about it looks like an extension
+	 * problem: the pack guards its use on
+	 * {@code defined GL_EXT_shader_explicit_arithmetic_types_float16} and ships a fallback that
+	 * redefines {@code float16_t} to {@code float} when the macro is absent. The compiler defines
+	 * that macro for every extension it KNOWS, enabled or not, so the guarded branch is taken, the
+	 * fallback is skipped, and the {@code #extension} line that would have made the type real is
+	 * the one thing missing. Every one of the pack's 302 units died on {@code float16_t}, reported
+	 * as a syntax error hundreds of lines away from anything to do with extensions.
+	 * <p>
+	 * So they are hoisted instead: the header re-emits them straight after the version, where the
+	 * language wants them, and {@link #extensions} is what carries them there.
+	 * <p>
+	 * <strong>All of them, and as {@code enable} rather than as the {@code require} the pack
+	 * wrote.</strong> Both halves are deliberate. A pack gates its extensions on macros this
+	 * engine's own {@code #if} evaluation cannot answer, since what defines them is the compiler
+	 * further down the road, so keeping only the live ones would keep none of the ones that
+	 * matter; and a name the compiler does not know is a warning under {@code enable} where
+	 * {@code require} is an error, which turns a pack asking for a vendor extension it will not
+	 * get into a pack that still compiles. What decides whether the pack's code USES an extension
+	 * is unchanged either way: its own macro test, answered by the compiler and not by us.
 	 */
 	private void dropVersionAndExtensions() {
 		for (int index = 0; index < this.tokens.size(); index++) {
@@ -1361,12 +1389,38 @@ public final class GlslTranslator {
 
 			if (token.directive().equals("extension")) {
 				this.strippedExtensions++;
+				String named = extensionNamed(index);
+				if (named != null) {
+					this.extensions.add(named);
+				}
 			} else if (!token.directive().equals("version")) {
 				continue;
 			}
 
 			this.tokens.blankDirective(index);
 		}
+	}
+
+	/**
+	 * The extension one {@code #extension} directive names, or null for {@code all}, which is the
+	 * one name that is a state and not an extension: hoisting it would turn every extension the
+	 * compiler knows on at once.
+	 */
+	private String extensionNamed(int directive) {
+		for (int index = directive + 1; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.kind() == Kind.NEWLINE) {
+				return null;
+			}
+
+			// The directive's own keyword is a token of the line like any other, so the name is the
+			// first identifier that is not it.
+			if (token.kind() == Kind.IDENTIFIER && !token.text().equals("extension")) {
+				return token.text().equals("all") ? null : token.text();
+			}
+		}
+
+		return null;
 	}
 
 	private void rewriteIdentifiers() {
@@ -4523,7 +4577,8 @@ public final class GlslTranslator {
 	 * written back, which is why {@link Emitter} is handed these rather than this object.
 	 */
 	private Emitter emitter() {
-		return new Emitter(this.stage, this.inputs, this.bound, this.alphaTest, this.engineDefines,
+		return new Emitter(this.stage, this.inputs, this.bound, this.alphaTest, this.extensions,
+				this.engineDefines,
 				this.memoryQualifiers, this.used, this.declaredNames, this.synthesized,
 				this.volumes.read(), this.packOutputs, this.maxFragmentOutput, this.owedOutputs,
 				this.splits, this.gameTextureMatrix,

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -933,7 +933,13 @@ public final class GlslTranslator {
 
 		/** The varyings this stage hands on, which is what says whether the next one is provided. */
 		public Set<String> provides() {
-			return Set.copyOf(this.translator.declaredOutputs);
+			Set<String> names = new LinkedHashSet<>(this.translator.declaredOutputs);
+			// The columns of a split are handed on as surely as a plain out, and a walk of the text
+			// finds none of them: the declaration left the body when it was split and the header
+			// writes the columns. VaryingSplit.interfaceNames says what that hid.
+			names.addAll(this.translator.splits.interfaceNames(false));
+
+			return Set.copyOf(names);
 		}
 
 		/**
@@ -946,6 +952,8 @@ public final class GlslTranslator {
 		public Set<String> requires() {
 			Set<String> names = new LinkedHashSet<>();
 			this.translator.declaredInputs.forEach(declared -> names.addAll(declared.names()));
+			// The other half of what provides() adds, and for the same reason.
+			names.addAll(this.translator.splits.interfaceNames(true));
 			names.removeAll(this.translator.droppedInputs);
 
 			return Set.copyOf(names);
@@ -3633,6 +3641,11 @@ public final class GlslTranslator {
 	 * @param provided every name a stage before this one declares as an output
 	 */
 	private void dropUnprovidedInputs(Set<String> provided) {
+		// First, and above the return below rather than under it: a stage whose plain inputs are all
+		// provided still has splits to answer for, and Sildur's gbuffers_textured is exactly that
+		// stage. Under the return it ran on the stages that did not need it and on none that did.
+		dropUnprovidedSplits(provided);
+
 		List<FileScope> unprovided = this.declaredInputs.stream()
 				.filter(declared -> declared.names().stream().noneMatch(provided::contains))
 				.toList();
@@ -3683,6 +3696,35 @@ public final class GlslTranslator {
 		if (dropped) {
 			this.used = usedNames();
 			this.declaredAfter = declaredUnderAType();
+		}
+	}
+
+	/**
+	 * The same for a varying this stage reads through a split, which the walk above cannot see.
+	 * <p>
+	 * A split takes the pack's declaration out of the body, so it is in none of the lists that walk
+	 * offers, and a matrix the stage before never wrote would stay declared through its columns
+	 * with nobody able to take it back out. Sildur's {@code gbuffers_textured} is that shape: the
+	 * fragment stage declares {@code varying mat3 tbnMatrix} outside any condition and reads it
+	 * only under {@code #if nMap >= 1}, which is off by default, while the vertex stage declares
+	 * AND writes it inside that same condition. Three columns nothing writes, and the game refuses
+	 * the pipeline by their names, which cost the pack its solid, cutout, particle and hand passes.
+	 * <p>
+	 * The condition is the walk's own and it earns its place the same way: the columns have to be
+	 * unwritten by the stage before, and the pack's own name has to be read nowhere in the body. A
+	 * split whose name the body still reads stays, and the stage keeps the refusal it has, because
+	 * taking it out would turn that into an undeclared identifier.
+	 */
+	private void dropUnprovidedSplits(Set<String> provided) {
+		for (String name : this.splits.splitInputs()) {
+			if (this.splits.interfaceNamesOf(name).stream().anyMatch(provided::contains)
+					|| !readNames(Set.of(name)).isEmpty()) {
+				continue;
+			}
+
+			if (this.splits.forgetInput(name)) {
+				this.droppedInputs.add(name);
+			}
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -96,6 +96,25 @@ public final class GlslTranslator {
 	static final String FOG_COORD = "of_FogFragCoord";
 
 	/**
+	 * The fixed function front colour, kept as a name to write into and read by nothing.
+	 * <p>
+	 * A vertex stage of GLSL 1.20 wrote its colour there and the fragment stage read it back as
+	 * {@code gl_Color}. Neither survived the core profile, and a pack that still writes the one
+	 * without reading the other only needs somewhere for the value to land: RedHat's three shadow
+	 * vertex stages are the whole of it on this corpus, and the pass was lost outright for a name
+	 * the body never reads again. Iris answers it the same way and says as much,
+	 * {@code pipeline/transform/transformer/CommonTransformer.java:172-180} declaring
+	 * {@code vec4 iris_FrontColor;} and renaming onto it, its own comment calling that the bare
+	 * minimum and resting on the packs not reading it back.
+	 * <p>
+	 * A plain global and not an {@code out}, which is what makes it cost nothing: an output would
+	 * take a location the fragment stage never declares, and the two sides would part company over
+	 * a value neither of them uses. VERTEX only, for the same reason Iris stops there, a fragment
+	 * stage naming it having nowhere to have read it from.
+	 */
+	static final String FRONT_COLOUR = "of_FrontColor";
+
+	/**
 	 * The hit flash and the damage tint, which is a varying wherever the mesh carries the overlay and
 	 * a uniform everywhere else.
 	 * <p>
@@ -1390,6 +1409,13 @@ public final class GlslTranslator {
 			}
 
 			if (LegacyGlsl.readsDrawModelView(this.program) && rewriteGameModelView(index, name)) {
+				continue;
+			}
+
+			// Before the table, which carries no entry for it: the name is not a member of the block
+			// and not a varying either, and what it becomes is a global the header declares.
+			if (name.equals("gl_FrontColor") && this.stage == ProgramStage.VERTEX) {
+				this.tokens.replace(index, FRONT_COLOUR);
 				continue;
 			}
 

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -745,6 +745,7 @@ public final class GlslTranslator {
 		collectDrawBuffers();
 		synthesizeAttributes();
 		dropVersionAndExtensions();
+		settleRedefinedMacros();
 		rewriteIdentifiers();
 		// After the identifiers, because the goldberg idiom's sine has become ofReducedSin by then
 		// and that is one of the two names the site is recognised under, the other being the plain
@@ -1399,6 +1400,105 @@ public final class GlslTranslator {
 
 			this.tokens.blankDirective(index);
 		}
+	}
+
+	/**
+	 * Leaves one definition standing where a unit defines the same macro twice under two different
+	 * bodies, which is the last of them.
+	 * <p>
+	 * The language calls that an error and the compiler here holds it to that. A GL driver does
+	 * not: it warns and takes the newer definition from that point on, which is why packs ship it
+	 * and why it reaches nobody's bug tracker. Pegasus declares {@code ROUGH_FRESNEL} twice in
+	 * {@code settings.glsl}, at 0.7 and again at 0.2 six hundred lines further down, and every one
+	 * of its 178 compilable units died on the pair.
+	 * <p>
+	 * <strong>The last and not the first, and it is only done where the two cannot be told
+	 * apart.</strong> A driver answers a use standing BETWEEN two definitions with the first body,
+	 * and this would answer it with the last, which is a wrong number rather than a lost pass. So a
+	 * name used anywhere between its first definition and its last is left exactly as the pack
+	 * wrote it, and the unit keeps the refusal it has today. That guard is not theory: I Like
+	 * Vanilla redefines four of its own settings around uses of them and Pegasus redefines
+	 * {@code texture} around a hundred, and taking the earlier definition out cost those two packs
+	 * a hundred and thirty units and fifty five between them, measured. What is left is the shape
+	 * the guard is for, a settings file declaring the same option twice with nothing between the
+	 * two but more declarations.
+	 * <p>
+	 * Only bodies that DIFFER. Repeating a definition word for word is legal, several packs do it
+	 * through an include reached twice, and taking one of those out would say something where the
+	 * language says nothing. Only live lines, for the same reason the rest of this class reads
+	 * liveness: two definitions in two branches of one conditional are one definition.
+	 */
+	private void settleRedefinedMacros() {
+		Map<String, List<Integer>> sites = new LinkedHashMap<>();
+		Map<String, List<String>> bodies = new LinkedHashMap<>();
+
+		int[] lines = this.tokens.lineNumbers();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.kind() != Kind.HASH || !"define".equals(token.directive())
+					|| !this.unit.isLive(lines[index])) {
+				continue;
+			}
+
+			int name = this.tokens.macroNameAfter(index);
+			if (name < 0) {
+				continue;
+			}
+
+			String named = this.tokens.get(name).text();
+			sites.computeIfAbsent(named, ignored -> new ArrayList<>()).add(index);
+			bodies.computeIfAbsent(named, ignored -> new ArrayList<>()).add(macroBody(name));
+		}
+
+		sites.forEach((named, at) -> {
+			List<String> written = bodies.get(named);
+			if (at.size() < 2 || written.stream().allMatch(written.get(0)::equals)
+					|| usedBetween(named, at.get(0), at.get(at.size() - 1))) {
+				return;
+			}
+
+			for (int which = 0; which < at.size() - 1; which++) {
+				this.tokens.blankDirective(at.get(which));
+			}
+		});
+	}
+
+	/**
+	 * Whether anything between two definitions of a macro reads it, which is what decides whether
+	 * the two can be settled into one. The name a {@code #define} gives is not a read of it, and
+	 * neither is a line nobody takes.
+	 */
+	private boolean usedBetween(String named, int first, int last) {
+		int[] lines = this.tokens.lineNumbers();
+		for (int index = first + 1; index < last; index++) {
+			Token token = this.tokens.get(index);
+			if (token.kind() == Kind.IDENTIFIER && !token.macroName() && named.equals(token.text())
+					&& this.unit.isLive(lines[index])) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * What one {@code #define} substitutes, as the compiler compares it: the tokens after the name
+	 * with the spacing and the comments left out, since neither is part of a substitution.
+	 */
+	private String macroBody(int name) {
+		StringBuilder body = new StringBuilder();
+		for (int index = name + 1; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.kind() == Kind.NEWLINE) {
+				break;
+			}
+
+			if (!token.trivia()) {
+				body.append(token.text());
+			}
+		}
+
+		return body.toString();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -3345,8 +3345,27 @@ public final class GlslTranslator {
 			return;
 		}
 
-		declared.names().forEach(name -> this.synthesized.putIfAbsent(name, declared.type()));
+		// The declaration goes whatever happens; what it leaves behind does not. Where the mesh
+		// carries the overlay, the header already declares the overlay colour and the three
+		// identifiers as varyings, so a global of the same name is that name declared twice and the
+		// stage is refused for a redefinition. E-LITE writes attribute int blockEntityId in a
+		// shared vertex body and lost its entities, its hand and its blocks in three places, twenty
+		// four stages, to exactly that. Leaving the name out here is what hands its reads to the
+		// varying, which carries the value the mesh really has rather than the zero a synthesised
+		// global would hold. Iris arrives at the same place from the other side, deleting the
+		// declaration and putting iris_entityInfo in the place of every read
+		// (pipeline/transform/transformer/EntityPatcher.java:129-152).
+		declared.names().forEach(name -> {
+			if (!headerDeclares(name)) {
+				this.synthesized.putIfAbsent(name, declared.type());
+			}
+		});
 		this.tokens.blankRange(declared.start(), declared.end());
+	}
+
+	/** Whether the header names this itself on this mesh, so that a global of it would redeclare it. */
+	private boolean headerDeclares(String name) {
+		return this.inputs.overlay() && (ENTITY_COLOR.equals(name) || ENTITY_IDS.contains(name));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -1373,10 +1373,21 @@ public final class PackProgram {
 		TargetPlan targets = TargetPlan.build(source, options, settings, properties, dimension, filter);
 		String place = targets.place();
 
-		// Asked before anything is expanded. A place that serves no final draws nothing at all,
-		// and finding that out after nine programs have been read is nine wasted seconds.
-		if (!targets.running().contains(FINAL) || !serves(source, pathOf(place, FINAL))) {
-			return Optional.empty();
+		// Asked before anything is expanded, as the refusal it used to be was: a place with no
+		// final is settled here rather than nine programs later.
+		//
+		// It is no longer a refusal. A pack that ships no final still draws: what its chain left in
+		// colortex0 is brought to the screen as it stands, which is what Iris does with the same
+		// case (pipeline/FinalPassRenderer.java:113 makes the pass optional, :268-277 copies the
+		// target into the game's own), and ChainPlan.present carries the half. I Like Vanilla ends
+		// on composite99 and Pegasus on composite11, and both were refused whole for it.
+		//
+		// The name is taken OUT of the plan rather than left in it, because the loop below throws
+		// on a program that is meant to run and does not serve both of its stages.
+		if (targets.running().contains(FINAL) && !serves(source, pathOf(place, FINAL))) {
+			targets = TargetPlan.build(source, options, settings, properties, dimension,
+					filter.without(Set.of(FINAL)));
+			place = targets.place();
 		}
 
 		PackTextures textures = textures(source, properties, options, settings);

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -1315,7 +1315,7 @@ public final class PackProgram {
 	 * The same chain for a caller with no {@code options.txt} to read, which is the harness and the
 	 * corpus measurements. See {@link ChainPlan.Families#DEFAULT}.
 	 */
-	public static Optional<Chain> loadChain(Path packPath, String dimension,
+	public static Chain loadChain(Path packPath, String dimension,
 			Map<String, OptionValue> chosen, String profile, ChainFilter filter) throws IOException {
 		return loadChain(packPath, dimension, chosen, profile, filter, ChainPlan.Families.DEFAULT);
 	}
@@ -1347,9 +1347,8 @@ public final class PackProgram {
 	 * @param families  which of the families the plan's verdicts may count are really drawn, which
 	 *                  is what keeps those lines from claiming a target is filled by a family
 	 *                  somebody switched off
-	 * @return empty when the pack serves no final with both stages in that place
 	 */
-	public static Optional<Chain> loadChain(Path packPath, String dimension,
+	public static Chain loadChain(Path packPath, String dimension,
 			Map<String, OptionValue> chosen, String profile, ChainFilter filter,
 			ChainPlan.Families families) throws IOException {
 		try (OpenedPack pack = OpenedPack.open(packPath, chosen, profile)) {
@@ -1362,7 +1361,7 @@ public final class PackProgram {
 	 * the chain, the chunk programs and the shadow computes are all read at the load and share one
 	 * reading of the archive between them.
 	 */
-	public static Optional<Chain> loadChain(OpenedPack pack, String dimension, ChainFilter filter,
+	public static Chain loadChain(OpenedPack pack, String dimension, ChainFilter filter,
 			ChainPlan.Families families) throws IOException {
 		ShaderPackSource source = pack.source();
 		OptionIndex options = pack.options();
@@ -1443,8 +1442,7 @@ public final class PackProgram {
 					AlphaTest.OFF, textures));
 		}
 
-		return Optional.of(
-				new Chain(source.packName(), place, targets, chain, loaded, refused, mentions));
+		return new Chain(source.packName(), place, targets, chain, loaded, refused, mentions);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/VaryingSplit.java
+++ b/common/src/main/java/dev/vitrail/glsl/VaryingSplit.java
@@ -132,6 +132,116 @@ final class VaryingSplit {
 	}
 
 	/**
+	 * The names one side of this stage's splits really puts in the interface, which is what the
+	 * stage before it has to write or the stage after it has to declare.
+	 * <p>
+	 * A split takes the pack's declaration out of the body and the header writes the columns in its
+	 * place, so a walk of the text finds neither. Both sides of one program splitting the same
+	 * varying agree without anybody asking, which is why nothing needed this until a pack declared
+	 * a matrix on one side alone: Sildur's declares {@code varying mat3 tbnMatrix} in its
+	 * {@code gbuffers_textured} fragment stage with no condition, and in its vertex stage under
+	 * {@code #if nMap >= 1} with {@code nMap} off by default. The fragment then asked for three
+	 * columns nothing wrote and the game refused the pipeline by their names.
+	 *
+	 * @param input true for the names this stage reads, false for the ones it hands on
+	 */
+	List<String> interfaceNames(boolean input) {
+		List<String> names = new ArrayList<>();
+		for (SplitMatrix split : this.matrices) {
+			if (split.input() == input) {
+				for (int column = 0; column < split.columns(); column++) {
+					names.add(matrixColumnName(split.name(), column));
+				}
+			}
+		}
+
+		for (SplitStruct split : this.structs) {
+			if (split.input() == input) {
+				split.members().forEach(member ->
+						names.add(structMemberName(split.name(), member.name())));
+			}
+		}
+
+		for (SplitArray split : this.arrays) {
+			if (split.input() == input) {
+				for (int element = 0; element < split.size(); element++) {
+					names.add(arrayElementName(split.name(), element));
+				}
+			}
+		}
+
+		return List.copyOf(names);
+	}
+
+	/** The interface names one split of this stage stands for, by the name the pack gave it. */
+	List<String> interfaceNamesOf(String name) {
+		List<String> names = new ArrayList<>();
+		for (SplitMatrix split : this.matrices) {
+			if (split.name().equals(name)) {
+				for (int column = 0; column < split.columns(); column++) {
+					names.add(matrixColumnName(name, column));
+				}
+			}
+		}
+
+		for (SplitStruct split : this.structs) {
+			if (split.name().equals(name)) {
+				split.members().forEach(member ->
+						names.add(structMemberName(name, member.name())));
+			}
+		}
+
+		for (SplitArray split : this.arrays) {
+			if (split.name().equals(name)) {
+				for (int element = 0; element < split.size(); element++) {
+					names.add(arrayElementName(name, element));
+				}
+			}
+		}
+
+		return List.copyOf(names);
+	}
+
+	/** Every varying this stage reads through a split, by the name the pack gave it. */
+	List<String> splitInputs() {
+		List<String> names = new ArrayList<>();
+		this.matrices.forEach(split -> {
+			if (split.input()) {
+				names.add(split.name());
+			}
+		});
+		this.structs.forEach(split -> {
+			if (split.input()) {
+				names.add(split.name());
+			}
+		});
+		this.arrays.forEach(split -> {
+			if (split.input()) {
+				names.add(split.name());
+			}
+		});
+
+		return List.copyOf(names);
+	}
+
+	/**
+	 * Forgets one split this stage reads, which takes its columns out of the interface and its
+	 * rebuild out of the wrapper, so that nothing of it is declared at all.
+	 * <p>
+	 * Only ever called for a name the body no longer mentions, which is what makes it safe: the
+	 * rebuild the wrapper owed was to a local nobody reads.
+	 *
+	 * @return whether anything was forgotten
+	 */
+	boolean forgetInput(String name) {
+		boolean any = this.matrices.removeIf(split -> split.input() && split.name().equals(name));
+		any |= this.structs.removeIf(split -> split.input() && split.name().equals(name));
+		any |= this.arrays.removeIf(split -> split.input() && split.name().equals(name));
+
+		return any;
+	}
+
+	/**
 	 * One matrix varying rewritten as one vector per column.
 	 *
 	 * @param input true when this stage reads the matrix ({@code in}), false when it writes it

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -208,6 +208,15 @@ public final class EngineDefines {
 		// left to test.
 		defines.put("IRIS_FEATURE_SSBO", "");
 
+		// Compute passes are served: a shadow compute is dispatched at the head of the frame and a
+		// compute hanging off a full screen pass right before that pass, both reading and storing
+		// the colour targets on the halves the pass reads (render/PackCompute). Complementary's
+		// floodfill and Photon's sky lighting are both that road and both run. Iris holds the flag
+		// usable where the driver has compute (features/FeatureFlags.java:14,
+		// IrisRenderSystem.supportsCompute); Vulkan has it everywhere, so the condition has nothing
+		// left to test, as with the storage blocks above.
+		defines.put("IRIS_FEATURE_COMPUTE_SHADERS", "");
+
 		// The rest of IRIS_FEATURE_ stays unposted until each capability is served, and each of the
 		// five above is posed for every pack. That is a divergence: Iris poses IRIS_FEATURE_X only
 		// where the pack itself listed X under iris.features.optional

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -270,6 +270,10 @@ public final class ChainPlan {
 	private final List<Pass> passes;
 	private final int deferredEnd;
 	private final Pass last;
+
+	/** What reaches the screen where {@link #last} is null. See {@link #present()}. */
+	private final Attachment present;
+
 	private final Seed seed;
 
 	/**
@@ -325,7 +329,7 @@ public final class ChainPlan {
 	private final List<String> notes;
 	private final List<String> history;
 
-	private ChainPlan(String place, List<Pass> passes, Pass last, Seed seed,
+	private ChainPlan(String place, List<Pass> passes, Pass last, Attachment present, Seed seed,
 			Map<Key, Pass> attachments, Map<TerrainPass, Key> terrainKeys, Map<String, Key> skyKeys,
 			List<Integer> swapBack, List<String> refusals, List<String> notes,
 			List<String> history) {
@@ -333,6 +337,7 @@ public final class ChainPlan {
 		this.passes = List.copyOf(passes);
 		this.deferredEnd = pastDeferred(this.passes);
 		this.last = last;
+		this.present = present;
 		this.seed = seed;
 		this.attachments = Map.copyOf(attachments);
 		this.terrainKeys = Map.copyOf(terrainKeys);
@@ -502,10 +507,15 @@ public final class ChainPlan {
 			}
 		}
 
-		if (last == null) {
-			// Not a refusal: whoever loaded the chain has already decided whether a place without
-			// a final is worth drawing, and every pass here still writes what it says it writes.
-			notes.add("this place runs no final, so nothing the chain writes reaches the screen");
+		// colortex0 on the half the frame ends on, which is what stands in for the final where the
+		// pack ships none. present() carries what Iris does with the same case and where.
+		Attachment present = last != null ? null : new Attachment(0,
+				plan.schedule().flippedAtEnd().contains(0)
+						? TargetSchedule.Side.ALT
+						: TargetSchedule.Side.MAIN);
+		if (present != null) {
+			notes.add("this place runs no final, so " + TargetName.canonical(present.target())
+					+ " is brought to the screen as it stands, which is what Iris does");
 		}
 
 		// Worked out before the verdicts rather than in the return, so that they are handed the
@@ -652,7 +662,7 @@ public final class ChainPlan {
 			}
 		});
 
-		return new ChainPlan(plan.place(), passes, last, seed, answered, terrainKeys, skyKeys,
+		return new ChainPlan(plan.place(), passes, last, present, seed, answered, terrainKeys, skyKeys,
 				List.copyOf(back), refusals, notes, history);
 	}
 
@@ -1152,6 +1162,25 @@ public final class ChainPlan {
 	/** The final. Its attachments are always empty: it writes the game's own target. */
 	public Optional<Pass> last() {
 		return Optional.ofNullable(this.last);
+	}
+
+	/**
+	 * What has to be brought to the screen when the place runs no {@code final}, which is
+	 * {@code colortex0} on the half the chain leaves it, and empty on every place that runs one.
+	 * <p>
+	 * A pack shipping no final is not a pack that draws nothing: Iris copies {@code colortex0}
+	 * into the game's own target and says so in as many words, {@code pipeline/FinalPassRenderer.java:113}
+	 * making the pass optional and {@code :268-277} doing the copy under a comment naming the
+	 * transfer. Two packs of this corpus ship none, I Like Vanilla ending its chain on
+	 * {@code composite99} and Pegasus on {@code composite11}.
+	 * <p>
+	 * The half is the one the schedule ends the frame on, which is the same question Iris asks its
+	 * flip state when it builds that copy's framebuffer ({@code :131}). A chain whose last write
+	 * landed on the far half and which was read from the near one would otherwise show the frame
+	 * before this one.
+	 */
+	public Optional<Attachment> present() {
+		return Optional.ofNullable(this.present);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ChainPresent.java
+++ b/common/src/main/java/dev/vitrail/render/ChainPresent.java
@@ -1,0 +1,176 @@
+package dev.vitrail.render;
+
+import dev.vitrail.pack.model.TargetName;
+import dev.vitrail.pack.target.ChainPlan;
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.PrimitiveTopology;
+import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.pipeline.BindGroupLayout;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.shaders.ShaderSource;
+import com.mojang.blaze3d.shaders.ShaderType;
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.RenderPass;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import net.minecraft.client.renderer.BindGroupLayouts;
+import net.minecraft.resources.Identifier;
+
+import java.util.Optional;
+
+/**
+ * Brings the chain's own colour to the game's target on a pack that ships no {@code final}.
+ * <p>
+ * <strong>What it stands in for.</strong> A pack's {@code final} is the one program that writes the
+ * game's target rather than a colour target of the pack's, and most packs use it for their tone
+ * mapping. A pack without one has simply finished in {@code colortex0} and expects what is there to
+ * be the picture. Iris answers that by copying the target into the main framebuffer and says so in
+ * as many words, {@code pipeline/FinalPassRenderer.java:113} making the pass optional and
+ * {@code :268-277} doing the copy. Refusing such a pack, which is what this engine did until this
+ * class existed, cost I Like Vanilla and Pegasus their whole picture.
+ * <p>
+ * <strong>A draw and not a copy, for {@link SceneSeed}'s reason and it is the same one.</strong>
+ * {@code copyTextureToTexture} reaches {@code vkCmdCopyImage}, which reinterprets bits rather than
+ * converting them, and the two formats here are not the same: the game's target is RGBA8_UNORM and
+ * a pack's {@code colortex0} is commonly RG11B10_FLOAT. Both are thirty two bits wide, so a copy
+ * passes every check the Java side makes and hands back nonsense. Iris can copy because both sides
+ * of its transfer are GL textures under a conversion its own call performs; here the conversion has
+ * to be a sample and a write.
+ * <p>
+ * <strong>Loaded and never cleared</strong>, as the final it stands in for is: a chain that does not
+ * cover every pixel leaves the world showing underneath, which is Iris's behaviour and the one a
+ * pack with a partial chain is written against.
+ */
+final class ChainPresent {
+
+	private static final Identifier VERTEX_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/present_vertex");
+	private static final Identifier FRAGMENT_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/present_fragment");
+
+	private static final String SAMPLER = "InSampler";
+
+	private static final String LABEL = "Vitrail chain present";
+
+	/** The game's own colour target, the one format this ever writes into. */
+	private static final GpuFormat SCREEN_FORMAT = GpuFormat.RGBA8_UNORM;
+
+	/** Two triangles over the whole screen, the quad every full screen pass of the chain draws. */
+	private static final int VERTICES = 6;
+
+	private static final String VERTEX = """
+			#version 460 core
+
+			in vec3 Position;
+			in vec2 UV0;
+
+			out vec2 ofTexCoord;
+
+			void main() {
+				ofTexCoord = UV0;
+				gl_Position = vec4(Position.xy * 2.0 - 1.0, 0.0, 1.0);
+			}
+			""";
+
+	/**
+	 * The alpha is written as one and not as the target's, which is the same choice the final's own
+	 * pipeline makes one line further down in {@link PackPass}: the interface is drawn over this
+	 * afterwards and reads that channel.
+	 */
+	private static final String FRAGMENT = """
+			#version 460 core
+
+			uniform sampler2D InSampler;
+
+			in vec2 ofTexCoord;
+
+			layout(location = 0) out vec4 ofFragData0;
+
+			void main() {
+				ofFragData0 = vec4(texture(InSampler, ofTexCoord).rgb, 1.0);
+			}
+			""";
+
+	private final ChainPlan.Attachment from;
+	private final RenderPipeline pipeline;
+	private final ShaderSource source;
+
+	private boolean reported;
+
+	ChainPresent(ChainPlan.Attachment from) {
+		this.from = from;
+		this.source = (id, type) -> {
+			if (type == ShaderType.FRAGMENT) {
+				return FRAGMENT_ID.equals(id) ? FRAGMENT : null;
+			}
+
+			return VERTEX_ID.equals(id) ? VERTEX : null;
+		};
+
+		this.pipeline = RenderPipeline.builder()
+				.withLocation(Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pipeline/chain_present"))
+				.withVertexShader(VERTEX_ID)
+				.withFragmentShader(FRAGMENT_ID)
+				.withBindGroupLayout(BindGroupLayouts.GLOBALS)
+				.withBindGroupLayout(BindGroupLayout.builder()
+						.withSampler(SAMPLER)
+						.build())
+				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
+				.withColorTargetState(new ColorTargetState(Optional.empty(), SCREEN_FORMAT,
+						ColorTargetState.WRITE_COLOR))
+				.withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
+				.withCull(false)
+				.build();
+	}
+
+	/** Called every frame: a resource reload empties the pipeline cache. */
+	boolean prepare(GpuDevice device) {
+		if (device.precompilePipeline(this.pipeline, this.source).isValid()) {
+			return true;
+		}
+
+		if (!this.reported) {
+			this.reported = true;
+			Vitrail.logger().error("The pass that brings {} to the screen did not compile, and this "
+					+ "pack serves no final, so nothing the chain wrote is shown",
+					TargetName.canonical(this.from.target()));
+		}
+
+		return false;
+	}
+
+	/**
+	 * Draws the target the plan named over the game's own, everywhere.
+	 *
+	 * @param into    the game's colour target for this frame
+	 * @param targets where the colour target is looked up, every frame and never held: a resize
+	 *                replaces the images and one kept across it draws from a texture that is closed
+	 * @return false when the target or the quad is missing, which is a frame in the middle of a
+	 *         resize. The screen then keeps the world the game drew under the chain
+	 */
+	boolean draw(CommandEncoder encoder, GpuBuffer quad, GpuTextureView into, ColorTargets targets) {
+		GpuTextureView view = targets.view(this.from.target(), this.from.side());
+		if (quad == null || into == null || view == null) {
+			return false;
+		}
+
+		try (RenderPass pass = encoder.createRenderPass(() -> LABEL, into, Optional.empty())) {
+			pass.setPipeline(this.pipeline);
+			RenderSystem.bindDefaultUniforms(pass);
+			pass.setVertexBuffer(0, quad.slice());
+			// NEAREST, the target being the size of the screen: one texel is one pixel and the
+			// value wanted is the one the chain wrote, not a blend of it with its neighbour.
+			pass.bindTexture(SAMPLER, view,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+			pass.draw(VERTICES, 1, 0, 0);
+		}
+
+		return true;
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -270,6 +270,12 @@ public final class PackChain {
 	private final Vector4f fogClear = new Vector4f(0.0F, 0.0F, 0.0F, 1.0F);
 
 	private final SceneSeed seed;
+
+	/**
+	 * What brings the chain's colour to the screen on a pack that ships no {@code final}, or null
+	 * where the pack ships one and its own program does it. See {@link ChainPresent}.
+	 */
+	private final ChainPresent present;
 	private final boolean seedEnabled;
 
 	/** The game's translucent features, caught and composed onto the pack's image. Null when the
@@ -359,6 +365,13 @@ public final class PackChain {
 				.filter(where -> this.targets.has(where.target()))
 				.map(where -> new SceneSeed(where, this.targets.format(where.target()),
 						seedExtras(chain, where)))
+				.orElse(null);
+		// Null on every pack that ships a final, which is every pack but two of this corpus. The
+		// target has to exist for the same reason the seed's does: a plan naming one the targets do
+		// not hold is a frame drawn from a texture nobody allocated.
+		this.present = chain.chain().present()
+				.filter(where -> this.targets.has(where.target()))
+				.map(ChainPresent::new)
 				.orElse(null);
 		// Composed where the world's own translucents are about to blend, so it needs that pass to
 		// exist: a pack serving no translucent geometry gets no layer, and the game's features stay
@@ -1757,6 +1770,13 @@ public final class PackChain {
 		drawRange(device, ready, deferredEnd(), this.programs.size(), this.targets.depth().scene(),
 				this.targets.depth().distantScene());
 
+		// After the whole chain and before the halves swap back, which is where a final would have
+		// drawn. Only on a pack that ships none; ChainPresent says what it stands in for.
+		if (this.present != null && this.present.prepare(device)) {
+			this.present.draw(device.createCommandEncoder(), this.quad, ready.mainView(),
+					this.targets);
+		}
+
 		// Outside any pass, and after the last one. Only the targets the pack keeps between frames
 		// and that the chain left on the far half swap names: the next frame walks from an empty
 		// flipped set and would otherwise be handed what was written two frames ago.
@@ -1866,7 +1886,11 @@ public final class PackChain {
 		}
 
 		this.programs = List.copyOf(built);
-		this.last = built.isEmpty() ? null : built.get(built.size() - 1);
+		// Asked of the plan and not of the list: ordered() puts the final at the end when there is
+		// one, and where there is none the last of the list is an ordinary composite that writes
+		// its own targets. Drawing that one onto the game's target would be the chain's middle
+		// painted over the screen.
+		this.last = plan.last().isEmpty() || built.isEmpty() ? null : built.get(built.size() - 1);
 		// Or a compute hanging off a pass: it is handed the same texel, so it arms the same fold.
 		this.centerDepthRead = built.stream().anyMatch(PackPass::readsCenterDepth)
 				|| this.compute.readsCenterDepth();

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -392,18 +392,8 @@ public final class PackChoice {
 				TerrainSampler.breaksAnisotropy(values.breaksAnisotropy());
 
 				long began = System.nanoTime();
-				Optional<PackProgram.Chain> read =
+				PackProgram.Chain chain =
 						PackProgram.loadChain(opened, place, engine.passes(), engine.families());
-				if (read.isEmpty()) {
-					String where = place.isEmpty() ? "at its root" : "in " + place + " or at its root";
-					String named = ShaderPackSource.nameOf(pack);
-					lastError = named + " serves no final with both stages " + where;
-					Vitrail.logger().warn("{} serves no final with both stages {}, nothing to draw",
-							named, where);
-					return;
-				}
-
-				PackProgram.Chain chain = read.get();
 				Vitrail.logger().info("Read {} programs of {} in {} ms", chain.programs().size(),
 						chain.packName(), (System.nanoTime() - began) / 1_000_000L);
 

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -317,8 +317,9 @@ public final class PackChoice {
 			// Only the names this engine has not built refuse the pack: the block emission
 			// attribute rides in the chunk element, a pack declaring HIGHER_SHADOWCOLOR draws the
 			// light into the eight it asked for, a storage block is bound off the pack's own
-			// bufferObject, and custom images are served now, so a pack that cannot draw without one
-			// of those is simply right about what it needs. The list is the one EngineDefines poses
+			// bufferObject, compute passes are dispatched at the head of the frame and before the
+			// pass they hang off, and custom images are served now, so a pack that cannot draw
+			// without one of those is simply right about what it needs. The list is the one EngineDefines poses
 			// IRIS_FEATURE_ for, and the two have to move together: a define is a promise, and a
 			// refusal is the same promise refused.
 			//
@@ -330,7 +331,7 @@ public final class PackChoice {
 			// that wrote what that message told it to would be refused here on a name this engine
 			// serves. ShaderProperties.declares already reads the same lists that way.
 			Set<String> served = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-			served.addAll(List.of("BLOCK_EMISSION_ATTRIBUTE", "CUSTOM_IMAGES",
+			served.addAll(List.of("BLOCK_EMISSION_ATTRIBUTE", "COMPUTE_SHADERS", "CUSTOM_IMAGES",
 					PackDirectives.HIGHER_SHADOWCOLOR, "SSBO", "SEPARATE_HARDWARE_SAMPLERS"));
 
 			required.removeIf(served::contains);


### PR DESCRIPTION
## What changes

More shaderpacks load, and more of the ones that loaded now draw every pass instead of leaving
some to the game's own shader. Two roads did it. A pack that ships no `final` program is no longer
refused: what its chain left in `colortex0` reaches the screen, which is what such a pack expects.
And compute passes, which this engine has run for a while, are announced as a capability, so a
pack that says it cannot draw without them is no longer turned away for something it would have
got. Beside those, four names a pack may write were either unanswered or answered twice, each one
costing whole programs: the extensions a pack asks for were dropped while the code guarded on them
stayed, a settings file defining the same name twice lost every program that included it, a vertex
stage narrowing `gl_PerVertex` lost every vertex stage, `gl_FrontColor` had no answer at all, and a
pack declaring an entity identifier the mesh already carries had it declared twice.

## How it differs from the reference, and for what obstacle

It does not. Each change moves toward Iris rather than away: the optional final is
`pipeline/FinalPassRenderer.java:113` and `:268-277` there, `gl_FrontColor` is
`transform/transformer/CommonTransformer.java:172-180`, the entity identifiers are
`transform/transformer/EntityPatcher.java:129-152`. Two are workarounds for a difference in the
compiler rather than in Iris: an `#extension` line and a `gl_PerVertex` redeclaration both have to
stand before the first real token, and splicing a pack's includes in moves them past it, so the
first is re-emitted by the header and the second is dropped, the block left standing being wider
than the one the pack asked for.

## What proves it

- `gradlew build` green.
- The off-game harness over twenty-nine packs, every shaderpack of two instances merged. Translated
  and compiled units go from 5264 to 5643 out of 6176; no pack loses a unit. The varyings tool goes
  from three refused stage pairs to none.
- In the game, on Fabric, each of the twenty-nine loaded in turn and its log read. Twenty-six draw,
  against twenty-one before. Clarity, Noble, I Like Vanilla and Pegasus were drawing nothing at all;
  RedHat's three shadow passes, E-LITE's entities and hand, and Mellow's whole picture were falling
  back on the game's own shaders.

## What it leaves owing

RenderPearl is still refused, and rightly: it requires translucent entity programs and per-buffer
blending, neither of which is built. Pegasus draws but six of its passes still fall back. Sildur's
loses four passes of `gbuffers_textured` to a matrix varying its fragment stage declares outside
the condition its vertex stage writes it under; the handshake that should take such a varying back
out now sees it, but the geometry families build their pipelines by another road it does not reach.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
