### PR TITLE
perf(render): ask whether the world moved before the level is drawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ what the next one holds.
   that says it cannot draw without them was being refused for something it would have got. Clarity
   and Noble now load.
 
+### Changed
+
+- **Joining a world builds the pack once instead of twice.** The pack is read while the client
+  starts up, before any world has arrived, and joining one makes it read again against what that
+  world brings. That second reading used to come after the first had already built the whole
+  chain, so everything was compiled and then thrown away; the question of whether the world moved
+  is asked before the building starts now. Leaving a world and joining another paid the same bill
+  in a different order, reallocating everything for the first frame and then again for the
+  reading, and it does not any more. Nothing about the picture changes, and no wait came out
+  measurably shorter on the machine this was taken on, so it says work removed rather than time
+  gained.
+
 ### Fixed
 
 - **The extensions a pack asks for are no longer dropped.** A pack using half precision types

--- a/common/src/main/java/dev/vitrail/mixin/GameRendererWarmupMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GameRendererWarmupMixin.java
@@ -11,7 +11,11 @@ import org.spongepowered.asm.mixin.injection.At;
 
 /**
  * Compiles the pack before the world is drawn, so the wait is not a two-frame-per-second
- * vanilla picture of the same work.
+ * vanilla picture of the same work, and asks first whether the world moved under it.
+ * <p>
+ * The two belong on one line because this call is the only place in the frame that stands before
+ * everything the level does: {@link PackChain#beforeLevel} says what each half of a world join was
+ * paying for that question being asked at the end of the frame instead.
  * <p>
  * Compilation itself runs here rather than after the level: that after-level path never fires
  * when the level is skipped. The HUD stays up so the action-bar line can say the pack is
@@ -26,7 +30,11 @@ public abstract class GameRendererWarmupMixin {
 							+ "Lnet/minecraft/client/DeltaTracker;)V"))
 	private void vitrail$skipLevelWhilePackWarms(GameRenderer renderer, DeltaTracker delta,
 			Operation<Void> original) {
-		if (PackChain.warming()) {
+		// Before the branch and not inside one of its arms: the question is owed whether the pack
+		// is compiling or drawing, and this is the one line both roads pass through. A frame that
+		// reads the pack again owes the level nothing, for the reason beforeLevel gives: the chunk
+		// format of this frame was settled from the pack that has just been replaced.
+		if (PackChain.beforeLevel() || PackChain.warming()) {
 			PackChain.pumpWarmup();
 			return;
 		}

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -241,7 +241,7 @@ public final class EngineStages {
 		// Nothing is drawn when no pack can be: the game's own image is a better answer than
 		// anything this mod could put over it, and the reason is already said, once in the log
 		// and again on the settings screen through PackChoice.lastError.
-		PackChain.draw(Vitrail.platform().gameDirectory());
+		PackChain.draw();
 
 		// After the chain and not before: the composites above read the map the previous frame
 		// drew, and this draws the next frame's over it. The end of the frame is the whole

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -615,14 +615,67 @@ public final class PackChain {
 	}
 
 	/**
-	 * Called from the loader module once the world has been rendered.
+	 * Asks whether the world moved under the pack, on the one road into the level and before a
+	 * single thing of the frame is drawn.
+	 * <p>
+	 * <strong>Both halves of a world join were paying for that question being asked late.</strong>
+	 * The pack is read while the client starts up, against registries no world has brought yet, so
+	 * the first world of a launch is always read against a machine that has moved. The FIRST join
+	 * compiled the whole of the title's chain here, the world held back, before {@code draw} reached
+	 * the question at the end of the frame and threw that chain away. A join after
+	 * {@link #leaveWorld} pays a different half of the same bill: the chain is still drawable there,
+	 * so the world IS drawn, and the sky, the terrain and the entities allocate everything back
+	 * before the question is reached, which then reloads and allocates it again.
+	 * <p>
+	 * Asked here, both are read once.
+	 * <p>
+	 * <strong>The frame that reloads does not draw the level, and that is the whole of what makes
+	 * this instant safe.</strong> The chunk vertex format is settled from the pack in force by
+	 * {@code TerrainMesh.settle}, which runs inside {@code GameRenderer.extract}, and that stands
+	 * BEFORE {@code GameRenderer.render} in the tick. So a frame that read a new pack here would go
+	 * on to draw a world whose format was settled from the old one, and the mesh a pipeline is
+	 * compiled for would not be the mesh it is handed. On the road where a chain is drawn that
+	 * closes itself, the reloaded chain has nothing compiled yet and {@link #warming} holds the
+	 * level back anyway; on the road where the chain is not drawn at all it does not, and the answer
+	 * is the same either way rather than one of them by luck. The caller reads what this returns and
+	 * skips the level on it.
+	 * <p>
+	 * <strong>And only where a pack is in force, which is not the same question as whether one was
+	 * read.</strong> Every road that ends a load with nothing to draw still goes through the read,
+	 * so a player who has picked None, or whose pack was refused, would have the level skipped at
+	 * every join and every portal for a reload that changed nothing they can see: the game clears
+	 * the main target at the head of the frame and only the level fills it, so what they would get
+	 * is a black world under the interface. The hazard the skip exists for cannot reach them either,
+	 * the chunk format being the game's own wherever no pack binds it.
+	 * <p>
+	 * It is NOT the only place the question is asked. The one road into a level that skips this wrap
+	 * is the panorama screenshot, which calls {@code renderLevel} itself, and the head of
+	 * {@link #draw} covers it.
 	 *
-	 * @return whether a pack was drawn, so that the caller knows to fall back to its own chain.
-	 *         The world check runs first and before the refusal below, or a pack that failed to
-	 *         compile would never be read again against the registries joining a world gives it.
+	 * @return whether the pack was read again AND one is in force, in which case the level owes this
+	 *         frame nothing
 	 */
-	public static boolean draw(Path gameDirectory) {
-		PackChoice.reloadIfTheWorldMoved(gameDirectory);
+	public static boolean beforeLevel() {
+		sayBeforeLevelRoad();
+
+		return RELOAD_BEFORE_LEVEL
+				&& PackChoice.reloadIfTheWorldMoved(Vitrail.platform().gameDirectory())
+				&& drawingPack();
+	}
+
+	/**
+	 * Called from the loader module once the world has been rendered.
+	 * <p>
+	 * The world check still stands on this line, and it also stands in {@link #beforeLevel} on the
+	 * frame's other side. Two askings of one idempotent question, and the second is not decoration:
+	 * the panorama screenshot calls {@code renderLevel} itself, six frames in a row, without going
+	 * through the wrap {@code beforeLevel} rides on, and this is the only line those frames reach.
+	 * Whichever of the two fires first, the other finds nothing moved.
+	 *
+	 * @return whether a pack was drawn, so that the caller knows to fall back to its own chain
+	 */
+	public static boolean draw() {
+		PackChoice.reloadIfTheWorldMoved(Vitrail.platform().gameDirectory());
 
 		PackChain chain = active;
 		if (disabled || chain == null) {
@@ -757,6 +810,9 @@ public final class PackChain {
 	 * Complementary Unbound is still not compiled all at once. Its families translate on a worker
 	 * while this thread compiles the composites and the terrain, and each family's pipelines then
 	 * compile on a small pool of the engine's own; nothing of the leftovers holds the world back.
+	 * <p>
+	 * {@link #beforeLevel} has already asked whether the world moved by the time this runs, which is
+	 * what keeps a join from compiling the pack twice.
 	 */
 	public static void pumpWarmup() {
 		PackChain chain = active;
@@ -1082,14 +1138,17 @@ public final class PackChain {
 	 * exactly what a reload frees, and everything of it is made again by the first frame of the next
 	 * world; nothing about which pack is loaded moves, so the settings screen still has one to show.
 	 * <p>
-	 * The first frame of that next world pays for it twice, and it is worth knowing where. The sky,
-	 * the terrain and the entities all open the frame while the world is being drawn, whichever of
-	 * the three comes first, so they allocate everything back
-	 * before {@code draw} reaches {@link PackChoice#reloadIfTheWorldMoved} at the end of it; a
-	 * world joined with registries this engine has not seen then reloads and makes the same work
-	 * again. One extra
-	 * allocation and one extra translation, on the frame the world appears, which is the frame
-	 * already carrying every other first cost there is.
+	 * The first frame of that next world used to pay for it twice, and where is worth knowing. The
+	 * sky, the terrain and the entities all open the frame while the world is being drawn,
+	 * whichever of the three comes first, so they allocated everything back before the end of that
+	 * frame, which is where the question of whether the world had moved was asked; a world joined
+	 * with registries this engine had not seen then reloaded and made the same work again. One
+	 * extra allocation and one extra translation, on the frame the world appears, which is the
+	 * frame already carrying every other first cost there is.
+	 * <p>
+	 * {@link #beforeLevel} asks that question at the head of the frame instead, so the reload a
+	 * join owes stands before the first allocation rather than after it, and the frame the world
+	 * appears on pays once.
 	 */
 	public static void leaveWorld() {
 		PackChain chain = active;
@@ -1985,6 +2044,34 @@ public final class PackChain {
 
 	/** Long enough for several compiles, short enough that the HUD still ticks. */
 	private static final long WARM_BUDGET_NANOS = 80_000_000L;
+
+	/**
+	 * Whether the world moving under the pack is noticed before the level rather than after it.
+	 * Turned off by {@code -Dvitrail.reloadBeforeLevel=false} rather than by a rebuild, so the join
+	 * that pays once and the join that pays twice come out of one jar. On is the default, and the
+	 * log names the road either way.
+	 */
+	private static final boolean RELOAD_BEFORE_LEVEL = Boolean.parseBoolean(
+			System.getProperty("vitrail.reloadBeforeLevel", "true"));
+
+	/** Whether the line below has been said, since it is said once a launch and not once a frame. */
+	private static boolean beforeLevelRoadSaid;
+
+	/**
+	 * Names the road at the first frame that would draw a level, and names it BOTH WAYS: a line that
+	 * only appeared on one side would leave every reading taken on the other unable to say which
+	 * road it came from, and both roads come out of the same jar here.
+	 */
+	private static void sayBeforeLevelRoad() {
+		if (beforeLevelRoadSaid) {
+			return;
+		}
+
+		beforeLevelRoadSaid = true;
+		Vitrail.logger().info("The world is asked about {} the level is drawn, "
+						+ "property=vitrail.reloadBeforeLevel",
+				RELOAD_BEFORE_LEVEL ? "before" : "after");
+	}
 
 	/**
 	 * Starts this chain's pack-load workers, once and once only: the leftover families read

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -146,10 +146,11 @@ public final class PackChoice {
 		// that cache, so emptying this between the two makes the write go in as a uniform buffer
 		// against a slot the layout already declared storage. The image half cannot do that: the
 		// write side reads StorageImages.bound, which walks an allocation of its own and never asks
-		// CustomImages, so an empty table there costs a filter mode for a frame and no more. And the
-		// road that would reach it is real: leaving a world releases the chain and does NOT replace
-		// it, so the first frame of the next world is drawn by that same chain before draw() gets to
-		// reloadIfTheWorldMoved.
+		// CustomImages, so an empty table there costs a filter mode for a frame and no more. The road
+		// that used to reach it was leaving a world, which releases the chain and does NOT replace
+		// it, so the first frame of the next world was drawn by that same chain before the question
+		// of whether the world had moved was reached at all; PackChain.beforeLevel asks it at the
+		// head of that frame now, so the reload stands in front of the drawing rather than behind it.
 		//
 		// What emptying here buys is bounded, not absolute. The pack-load worker of the chain that
 		// has just gone translates on a background thread and every program it reads reinstalls what
@@ -967,11 +968,11 @@ public final class PackChoice {
 	 * for is a second of hitch nobody asked for. The screen's pack list watches its own folder, which
 	 * is a different question: it notices a pack arriving and reads none of them.
 	 */
-	static void reloadIfTheWorldMoved(Path gameDirectory) {
+	static boolean reloadIfTheWorldMoved(Path gameDirectory) {
 		boolean stale = PackDefines.stale();
 		boolean moved = PackPlace.moved();
 		if (!stale && !moved) {
-			return;
+			return false;
 		}
 
 		if (moved) {
@@ -1000,6 +1001,8 @@ public final class PackChoice {
 		// old one, until somebody asks for a reload. Comparing content rather than a path would cost
 		// more than the report it saves.
 		readAgain(gameDirectory);
+
+		return true;
 	}
 
 	/**
@@ -1064,9 +1067,11 @@ public final class PackChoice {
 			// needs it more than that one: the load and both settle() calls stand after it, and a
 			// throw leaving here skips all three, which leaves a session drawing no pack at all with
 			// the reload still asked for. Where the throw goes then depends on which caller asked.
-			// The world moving under the pack reaches this from the first line of draw(), which
-			// stands outside its try; the settings screen, the pack key and the shadow map scale
-			// reach it from their own event, outside any frame. None of the four is under a catch.
+			// The world moving under the pack reaches this from PackChain.beforeLevel, which stands
+			// in front of the level and outside draw()'s try, and from the head of draw() on the one
+			// road that skips the level render's wrap; the settings screen, the pack key and the
+			// shadow map scale reach it from their own event, outside any frame. None is under a
+			// catch.
 			//
 			// Nothing is disabled here, where leaveWorld's catch disables: that one keeps the chain
 			// it failed to free and has to stop it being drawn, while this one has already dropped

--- a/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
+++ b/common/src/main/java/dev/vitrail/sodium/TerrainMesh.java
@@ -248,11 +248,14 @@ public final class TerrainMesh implements ChunkVertexType {
 	 * rebuild.</strong> {@code Minecraft.setLevel} reaches {@code LevelExtractor.setLevel}, which
 	 * calls {@code allChanged} itself, so the next {@code extract} invalidates the compiled geometry
 	 * and this settles before that frame's level is drawn; the pack of the new dimension is not read
-	 * until {@code PackChain.draw} reaches {@code reloadIfTheWorldMoved}, at the end of that same
-	 * frame. Nothing is bound wrongly in between, and the reason is that the reversal is complete:
-	 * the pack in force is still the previous dimension's, and its programs declare exactly the list
-	 * this settled from. When the new reading moves the list, {@code carries} asks for a rebuild of
-	 * its own and this runs again on the frame after, which is the hitch at the portal.
+	 * until {@code PackChain.beforeLevel}, which stands in {@code GameRenderer.render} and therefore
+	 * AFTER {@code GameRenderer.extract} in the same tick. Nothing is bound wrongly in between, and
+	 * the reason is that the reversal is complete: the pack in force while this settles is still the
+	 * previous dimension's, and its programs declare exactly the list this settled from. What keeps
+	 * the frame after the read out of the same question is that the frame which reads a pack again
+	 * does not draw the level at all: {@code beforeLevel} says so and the wrap it rides on obeys it.
+	 * When the new reading moves the list, {@code carries} asks for a rebuild of its own and this
+	 * runs again on the frame after, which is the hitch at the portal.
 	 * <p>
 	 * Built here rather than in a static field so that a mesh this cannot extend leaves the game
 	 * running on Sodium's own instead of failing to load a class in the middle of a world.


### PR DESCRIPTION
## What changes

A world join used to build the pack twice. The pack is read while the client starts up, against
registries no world has brought yet, so the first world of a session is always read against a
machine that has moved; the question of whether it moved was asked at the end of the frame, after
the whole chain had been compiled, and the answer threw that chain away and compiled it again. A
join after leaving a world paid the same bill in the other order: the world is drawn there, so the
sky, the terrain and the entities allocated everything back before the question was reached, which
then reloaded and allocated it again. The question is now asked in front of the level as well, on
the one line both roads pass through, and the frame that reads a pack again does not draw the level
on that frame. It stays at the head of `draw` too, for the panorama screenshot, which calls
`renderLevel` itself without passing that line.

## How it differs from the reference, and for what obstacle

It does not. Iris does not meet this: it reads its pack once and does not read it again at a world
join.

## What proves it

- `gradlew build` green, after the rebase.
- In the game, Fabric bench, Complementary Unbound r5.8.1, world `frozen real`, five launches per
  road out of one jar with `-Dvitrail.reloadBeforeLevel` as the only difference. The engine prints
  the line that says a chain is compiled and ready: **one on every launch with the question asked
  first, two whenever the join reloads with it asked last.** Four further launches per road with
  the module store switched off, so the compiler really works, say the same.
- **No wait came out measurably shorter.** First read to last compile ran 5 to 9 seconds on one
  road and 5 to 8 on the other, which is one spread inside the other: the compile that is removed
  runs behind the world load and does not show in the wall clock on this machine. What is measured
  is work removed.

## What it leaves owing

- The title reading still starts its family prefetch, about a second of background work on a pool
  thread, and the reload still throws that away. Taking it out is a separate question.
- The road where no pack is in force is covered by reading rather than by a launch: the bench
  refuses `pack.txt = none` as a bench state, so it was not tried in the game.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one: the frame order in
      `TerrainMesh`, what `leaveWorld` costs the next world, and where the world check is reached
      from in `PackChoice`.
