### PR TITLE
docs(changelog): put the released version back over its own journal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ what the next one holds.
   twice, each of which cost the passes that read them: the picture kept the game's own shader there
   and the pack's effect was missing on those surfaces alone.
 
+## 0.10.0-beta
+
+### Added
+
 - **Eight shadow colour buffers for a pack that asks for them.** A pack declaring
   `HIGHER_SHADOWCOLOR` may now draw the light into `shadowcolor0` through `shadowcolor7` and read
   them back, which is what Iris gives it. Before, a shadow program naming anything above


### PR DESCRIPTION
## What changes

The section holding what 0.10.0-beta shipped was renamed to `Unreleased` instead of a new section
being opened above it, so a version that is tagged and published on both stores carried the heading
of one still to come. Its heading is back over the block it belongs to, and `Unreleased` keeps only
what has not shipped.

What it would have cost if it stayed: the next release renames `Unreleased` to its own number, so
the eight shadow colour buffers, the two capability flags, `shadowtex0HW` and the rest of
0.10.0-beta would have been published a second time, read by players who already have them.

## How it differs from the reference, and for what obstacle

It does not. Nothing here touches the engine.

## What proves it

- The block now under `## 0.10.0-beta` is identical, line for line, to what the `v0.10.0-beta` tag
  carries: `git show v0.10.0-beta:CHANGELOG.md`, same 403 lines, empty diff.
- `gradlew build` green, which is what checks the punctuation and the encoding of this file.

## What it leaves owing

Nothing. The five entries left under `Unreleased` are the ones this week's batches added and none of
them has been released.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
