### PR TITLE
perf(mixin): carry the live pack's pipelines over a device purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ what the next one holds.
 
 ### Changed
 
+- **Reloading resources no longer rebuilds the pack.** Pressing F3 and T, or anything else that
+  reloads the game's resources, threw away every program the pack had compiled and built them all
+  again, with the world held back for about a second while it happened. A pack's programs come out
+  of its own archive, which a resource reload does not touch, so the ones being drawn with are kept
+  across it now and the reload costs the pack nothing. Programs left over from a pack that has been
+  replaced are still freed there, which is the one thing that ever frees them.
+
 - **Joining a world builds the pack once instead of twice.** The pack is read while the client
   starts up, before any world has arrived, and joining one makes it read again against what that
   world brings. That second reading used to come after the first had already built the whole

--- a/common/src/main/java/dev/vitrail/mixin/VulkanDeviceMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanDeviceMixin.java
@@ -1,13 +1,16 @@
 package dev.vitrail.mixin;
 
 import dev.vitrail.mixin.access.RenderPipelineAccessor;
+import dev.vitrail.render.PackChain;
 import dev.vitrail.render.StalePipelines;
+import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vulkan.VulkanDevice;
 import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
+import net.minecraft.resources.Identifier;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -18,6 +21,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -37,9 +41,33 @@ import org.jspecify.annotations.Nullable;
  * so no NEW draw binds it; whatever an already-recorded frame still names stays alive in
  * {@code vitrail$setAside} until {@code clearPipelineCache}, which the game only reaches after
  * quiescing rendering, frees the whole cache anyway, and now frees these with it.
+ * <p>
+ * <strong>And the live pack's own pipelines are carried over that emptying.</strong> A resource
+ * reload, F3+T included, empties the whole cache, and a pack's programs come from a shader archive
+ * no resource reload touches: their pipelines were destroyed and compiled again from nothing, with
+ * the world held back while it happened. Iris never meets the question, its pack programs never
+ * entering this map at all. They are taken out at the head of the purge and put back at its tail,
+ * so the emptying never sees them.
+ * <p>
+ * <strong>What this does NOT keep is what nothing should keep.</strong> Every load numbers its own
+ * programs, so the pipelines of a load that has been replaced fail the test, stay in the map and are
+ * freed here exactly as before, which is the only thing that ever frees them. A chain the engine
+ * stopped drawing counts as replaced, and {@link PackChain#liveLoad} is the narrower question that
+ * says so. And the purge inside {@code close} carries nothing whatever: the device is destroyed the
+ * moment it returns, so a pipeline that left the map there would outlive its own device.
  */
 @Mixin(VulkanDevice.class)
 public abstract class VulkanDeviceMixin implements StalePipelines {
+
+	/**
+	 * Whether the live pack's pipelines cross a resource reload rather than being compiled again
+	 * behind a held-back world. Turned off by {@code -Dvitrail.keepPackAcrossReload=false} rather
+	 * than by a rebuild, so both roads come out of one jar, and the line at every purge names the
+	 * one taken and counts what it did either way.
+	 */
+	@Unique
+	private static final boolean VITRAIL$KEEP_ACROSS_RELOAD = Boolean.parseBoolean(
+			System.getProperty("vitrail.keepPackAcrossReload", "true"));
 
 	@Shadow
 	@Final
@@ -58,6 +86,18 @@ public abstract class VulkanDeviceMixin implements StalePipelines {
 	 */
 	@Unique
 	private final List<VulkanRenderPipeline> vitrail$setAside = new ArrayList<>();
+
+	/**
+	 * The live pack's compiled pipelines while the purge runs, and empty at every other instant:
+	 * they leave the map before the emptying reaches it and are put back the moment it is done.
+	 */
+	@Unique
+	private final Map<RenderPipeline, VulkanRenderPipeline> vitrail$carriedOver =
+			new LinkedHashMap<>();
+
+	/** Whether the device is being destroyed, which is what makes its last purge final. */
+	@Unique
+	private boolean vitrail$closing;
 
 	@Override
 	public List<RenderPipeline> vitrail$dropEntityPipelines() {
@@ -103,9 +143,93 @@ public abstract class VulkanDeviceMixin implements StalePipelines {
 		return this.pipelineCache.putIfAbsent(pipeline, compiled) == null;
 	}
 
+	/**
+	 * Takes the live pack's pipelines out of the map before the emptying walks it, and counts them
+	 * whether or not it takes them: a line that appeared on one road only would leave every reading
+	 * taken on the other unable to say what the purge really carried.
+	 * <p>
+	 * Nothing is carried over the LAST purge of the session, the one {@code close} runs before it
+	 * destroys the device: what leaves the map there is never looked up again, and a pipeline still
+	 * alive at {@code vkDestroyDevice} is a child outliving its parent.
+	 */
+	@Inject(method = "clearPipelineCache", at = @At("HEAD"), require = 1)
+	private void vitrail$carryTheLivePackOver(CallbackInfo callback) {
+		// Anything a purge that threw before its tail left standing is DESTROYED with this purge
+		// rather than put back, and the difference is the whole of it. Those keys left the map and
+		// were never returned, so the chain missed on them the very next frame, compiled fresh ones
+		// and filled the map with those; putting the old values back would overwrite live entries
+		// with dead ones, leak the fresh pipelines the chain is still binding, and leave the two
+		// disagreeing for the rest of the session. They join the set aside instead, which the tail
+		// frees after the wait this purge already pays for.
+		this.vitrail$setAside.addAll(this.vitrail$carriedOver.values());
+		this.vitrail$carriedOver.clear();
+
+		boolean carry = VITRAIL$KEEP_ACROSS_RELOAD && !this.vitrail$closing;
+		int load = PackChain.liveLoad();
+		String live = load == 0 ? null : "pipeline/pack/" + load + "/";
+		int ofThePack = 0;
+		int carried = 0;
+		Iterator<Map.Entry<RenderPipeline, VulkanRenderPipeline>> held =
+				this.pipelineCache.entrySet().iterator();
+		while (held.hasNext()) {
+			Map.Entry<RenderPipeline, VulkanRenderPipeline> entry = held.next();
+			// Counted for every load of the pack and not only the live one, or a session whose pack
+			// was stopped would read "0 pipelines of the pack" off a purge destroying its whole set.
+			if (!ofAPack(entry.getKey())) {
+				continue;
+			}
+
+			ofThePack++;
+			if (!carry || live == null || !entry.getKey().getLocation().getPath().startsWith(live)) {
+				continue;
+			}
+
+			carried++;
+			this.vitrail$carriedOver.put(entry.getKey(), entry.getValue());
+			held.remove();
+		}
+
+		Vitrail.logger().info("Device purge: {} pipelines of the pack in the cache, {} carried over "
+				+ "it{}, property=vitrail.keepPackAcrossReload", ofThePack, carried,
+				this.vitrail$closing ? ", the device is closing" : "");
+	}
+
+	/**
+	 * Latched at the head of {@code close}, which is the one purge nothing may survive: the device
+	 * is destroyed the moment it returns.
+	 */
+	@Inject(method = "close", at = @At("HEAD"), require = 1)
+	private void vitrail$deviceClosing(CallbackInfo callback) {
+		this.vitrail$closing = true;
+	}
+
+	/**
+	 * Whether this pipeline was built for a pack, whichever load it came from, read off the name it
+	 * was built under: {@code PackPass} and {@code GeometryProgram} both number their stem with the
+	 * load, so the name answers whose the pipeline is, and the load in it answers which reading made
+	 * it.
+	 * <p>
+	 * It answers no for the engine's own, the depth window, the scene seed, the feature layer, the
+	 * render scale and the far terrain's occlusion among them: none carries a load, all of them die
+	 * at every purge as they always did, and each asks for its compile again on the next frame that
+	 * wants it.
+	 */
+	@Unique
+	private static boolean ofAPack(RenderPipeline pipeline) {
+		Identifier location = pipeline.getLocation();
+		String namespace = location.getNamespace();
+
+		return (namespace.equals(Vitrail.MOD_ID) || namespace.startsWith(Vitrail.MOD_ID + "_"))
+				&& location.getPath().startsWith("pipeline/pack/");
+	}
+
 	@Inject(method = "clearPipelineCache", at = @At("TAIL"), require = 1)
-	private void vitrail$destroySetAside(CallbackInfo callback) {
+	private void vitrail$closeThePurge(CallbackInfo callback) {
 		this.vitrail$setAside.forEach(VulkanRenderPipeline::destroy);
 		this.vitrail$setAside.clear();
+		// Put back into a map the emptying has just cleared, so nothing here can land on a key the
+		// purge left standing.
+		this.pipelineCache.putAll(this.vitrail$carriedOver);
+		this.vitrail$carriedOver.clear();
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/LegacyTerrainFilter.java
+++ b/common/src/main/java/dev/vitrail/render/LegacyTerrainFilter.java
@@ -17,8 +17,9 @@ import java.nio.file.Path;
  * <p>
  * A file {@code vitrail/legacy-terrain-filter} in the game directory, or
  * {@code -Dvitrail.legacyTerrainFilter=true}. Read again at every pack load, so the Reload Shaders
- * key is the whole gesture. F3 and T is not one: a resource reload rebuilds the pipelines and does
- * not read the pack again, so it leaves the state where it was. The state is written to the log
+ * key is the whole gesture. F3 and T is not one: a resource reload does not read the pack again, so
+ * it leaves the state where it was, whether or not it rebuilds the pipelines the pack draws with.
+ * The state is written to the log
  * BOTH WAYS, once per pack load at the first terrain the pack draws, so a reading taken afterwards
  * can always say which of the two it belongs to.
  * <p>

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -803,6 +803,23 @@ public final class PackChain {
 	}
 
 	/**
+	 * The number of the load that will still draw, nought when none will, which is a narrower
+	 * question than {@link #loadNumber} and the only one worth asking about what to KEEP.
+	 * <p>
+	 * The two part company wherever the engine stops drawing a chain without replacing it: every
+	 * road that sets {@code disabled} leaves the chain standing so that the settings screen has one
+	 * to name and the frame has one to close, and {@code loadNumber} goes on answering for it.
+	 * Whatever that chain still holds in the device is owed a purge, not a carry, and this is what
+	 * says so. Leaving a world is NOT one of those roads: the chain there is released and will draw
+	 * again when a world is joined.
+	 */
+	public static int liveLoad() {
+		PackChain chain = active;
+
+		return disabled || chain == null ? 0 : chain.load;
+	}
+
+	/**
 	 * Compiles as many programs as a short budget on this frame will take, then returns. One
 	 * program a frame was the wait the player sat through at two frames per second; several a
 	 * frame, with the world not drawn, is the same work without that picture.
@@ -1113,7 +1130,11 @@ public final class PackChain {
 
 	/** Called when the client shuts down, while the device is still alive. */
 	public static void close() {
-		PackChain chain = active;
+		// Taken down before it is released, and not merely released: after this nothing draws again,
+		// so a chain still answering as the live one would have the release announce that the next
+		// device purge carries its pipelines, when the next purge is the one inside the device's own
+		// close and that one carries nothing at all.
+		PackChain chain = takeDown();
 		if (chain != null) {
 			chain.release();
 		}
@@ -2500,12 +2521,20 @@ public final class PackChain {
 		// waits for the queue to go idle and destroys the game's own pipelines with ours. Doing
 		// that from here would do it in the middle of a frame whose commands are already recorded
 		// against them. The reload's cost is therefore named and left: it is a few hundred
-		// kilobytes of SPIR-V a reload, against the hundred megabytes of targets freed above, and
-		// the next resource reload clears it.
+		// kilobytes of SPIR-V a reload, against the hundred megabytes of targets freed above.
+		//
+		// What frees them afterwards is not one answer any more, and the line says which it is. A
+		// release on the way out of a world leaves this chain live, because it draws again the
+		// moment one is joined, and the next device purge carries its pipelines over itself
+		// (VulkanDeviceMixin). A release because the chain is being replaced or has been stopped
+		// leaves it neither, and there the purge frees them as it always did.
 		if (this.programs != null && !this.programs.isEmpty()) {
+			boolean stillLive = active == this && !disabled;
 			Vitrail.logger().info("{} pipelines and {} shader modules of load {} stay in the device "
-					+ "cache until the next resource reload", this.programs.size(),
-					2 * this.programs.size(), this.load);
+					+ "cache, and the next purge {}", this.programs.size(),
+					2 * this.programs.size(), this.load,
+					stillLive ? "carries them, this chain being the one that draws again"
+							: "frees them");
 		}
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -1091,8 +1091,9 @@ public final class PackChoice {
 				// unreachable by the time this is caught, so nothing frees the rest of it later and
 				// no other line would ever name what it still holds. What it holds is buffers and
 				// images; the pipelines and shader modules of that load are not part of it, since
-				// the next resource reload empties the device cache whether a release reached them
-				// or not.
+				// the next device purge frees them whether a release reached them or not. That
+				// purge carries the LIVE load over itself now (VulkanDeviceMixin), and the load
+				// being replaced here is not the live one by the time it runs.
 				Vitrail.logger().error("Vitrail could not hand back everything the pack being "
 						+ "replaced held, so the buffers and images its release had not reached "
 						+ "stay allocated until the game is closed", e);

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -264,16 +264,26 @@ exactly what a reload that changes a target's format needs. The price is that th
 stay resident until the cache is cleared, so each reload leaves pipelines behind.
 
 Clearing that cache waits for the queue to drain, destroys the pipelines and empties the module
-cache with them. That gives the one usable signal there is: after a clear, asking for a pipeline
-returns a **new instance**, so comparing the instance handed back for the frame's first program
-against the previous frame's is how the engine notices that a resource reload happened, without
-re-requesting every pipeline every frame.
+cache with them. That gives the one usable signal there is: asking for a pipeline that has been
+destroyed returns a **new instance**, so comparing the instance handed back for the frame's first
+program against the previous frame's is how the engine notices that its pipelines are gone, without
+re-requesting every one of them every frame.
+
+**The pack being drawn is carried over that clear**, because its programs come from a shader archive
+that no resource reload touches, and rebuilding them there means the world held back for a second or
+three at every F3+T. Its pipelines leave the map before the clear walks it and go back once the clear
+is done, so the signal above correctly does not fire: nothing of the pack was destroyed. What is
+carried is the live load and nothing else. Every load numbers its own programs in the identifier they
+are built under, so a load that has been replaced, or one the engine stopped drawing, fails that test
+and is destroyed by the clear exactly as before. The clear that stands inside the device's own
+`close` carries nothing at all.
 
 The corollary is unpleasant and worth knowing before designing around it: **the pipelines of a pack
 being unloaded cannot be handed back.** The cache is indexed by object and the only way to remove
 one entry is to empty the whole cache, which would destroy the game's own pipelines while the
 current frame's command buffer still references them. Targets, buffers and geometry are released;
-pipelines and modules wait for the next resource reload.
+pipelines and modules wait for the next clear, which is the resource reload after the pack stopped
+being the live one.
 
 ## See also
 


### PR DESCRIPTION
## What changes

A resource reload, F3 and T among them, empties the device's whole pipeline cache. A pack's
programs come out of a shader archive that no resource reload touches, so every one of its
pipelines was being destroyed there and compiled again from nothing, with the world held back while
it happened. The live pack's pipelines now leave the cache at the head of that emptying and go back
at its tail, so it never reaches them, and the engine's own signal for a purge, a pipeline handed
back as a new instance, correctly stops firing: nothing of the pack was destroyed.

Only the live load's. Every load numbers its own programs in the identifier they are built under,
so a load that has been replaced is destroyed by the purge exactly as before, which is the only
thing that ever frees one; a chain the engine stopped drawing counts as replaced, since it is left
standing for the settings screen to name. The purge inside the device's own `close` carries nothing,
the device being destroyed the moment it returns.

## How it differs from the reference, and for what obstacle

It does not. Iris never meets the question: its pack programs never enter that cache at all, being
cancelled at `getOrCompilePipeline` (`mixin/MixinShaderManager_Overrides`), where this engine hands
them to the device like any other pipeline.

## What proves it

- `gradlew build` green, after the rebase.
- In the game, Fabric bench, Complementary Unbound r5.8.1, world `frozen real`, two resource reloads
  per road out of one jar with `-Dvitrail.keepPackAcrossReload` as the only difference. Kept: **25
  of the pack's pipelines carried over each reload and no rebuild at all.** Not kept: the same
  reloads destroy them and the engine compiles the chain again each time, one second of held-back
  world apiece, which the log shows as a fresh "the chain can draw" per reload.
- The first purge of a launch sees 39 of the pack's pipelines and carries 25: the other 14 belong to
  the reading the world join replaced, and they die there as before.

## What it leaves owing

- The engine's own handful that carry no load, the depth window, the scene seed, the feature layer,
  the render scale and the far terrain's occlusion, still die at every purge and ask for their
  compile again on the next frame that wants one.
- What a reload costs on a cold module store is not measured; the readings were taken warm.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one:
      `docs/internals/render-targets.md` on what a clear destroys and what survives it, and the
      javadoc that told a reader a reload rebuilds the pack's pipelines.
