### PR TITLE
perf(pack): keep the pack open between two loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ what the next one holds.
 
 ### Changed
 
+- **A pack read twice in one session is opened once.** Reading a pack means mounting its archive,
+  walking it for the settings it offers, parsing what it declares and pasting every shared header
+  into every file that includes one, and all of that was done again from nothing each time: at a
+  world join, at a portal, and every time you apply a setting. The engine now keeps the archive it
+  opened and reuses that reading wherever nothing it depends on has moved, which halves the work
+  the second reading of a session does. It is opened afresh the moment anything could have changed
+  it, a file edited on disk included, so a pack you are editing is still read as you left it.
+
 - **Reloading resources no longer rebuilds the pack.** Pressing F3 and T, or anything else that
   reloads the game's resources, threw away every program the pack had compiled and built them all
   again, with the world held back for about a second while it happened. A pack's programs come out

--- a/common/src/main/java/dev/vitrail/pack/option/SettingSet.java
+++ b/common/src/main/java/dev/vitrail/pack/option/SettingSet.java
@@ -73,6 +73,15 @@ public final class SettingSet {
 		shadowMapScale = percent;
 	}
 
+	/**
+	 * The percentage the NEXT reading will resolve at, which is not always the one a reading in hand
+	 * resolved at: {@link #scale()} answers for that reading, and this answers for the engine.
+	 * Comparing the two is how a caller holding a reading finds out that it has gone out of date.
+	 */
+	public static int askedShadowMapScale() {
+		return shadowMapScale;
+	}
+
 	public static SettingSet resolve(Map<String, OptionValue> profile, Map<String, OptionValue> user,
 			String variantName) {
 		Map<String, OptionValue> chosen = new LinkedHashMap<>(profile);

--- a/common/src/main/java/dev/vitrail/pack/source/KeptPack.java
+++ b/common/src/main/java/dev/vitrail/pack/source/KeptPack.java
@@ -1,0 +1,328 @@
+package dev.vitrail.pack.source;
+
+import dev.vitrail.pack.option.EngineDefines;
+import dev.vitrail.pack.option.OptionValue;
+import dev.vitrail.pack.option.SettingSet;
+import dev.vitrail.Vitrail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * One pack left open between two loads, so that the second does not mount the archive, walk it for
+ * its options, parse its properties and flatten its entry files all over again to reach the same
+ * answers.
+ * <p>
+ * <strong>What a load pays without this is not the translation.</strong> The translated programs
+ * are already kept on disk, but the key they are looked up under is the FLATTENED text, so the
+ * flattening runs before the lookup can even be attempted: the chain's forty odd units come to
+ * three tenths of a second on the thread that draws, and the mount, the option walk and the
+ * properties parse stand in front of them. All of it is a pure function of the archive's bytes and
+ * the settings, and all of it was being thrown away at {@code close}.
+ * <p>
+ * <strong>Iris is not the model here, and the difference is worth stating rather than borrowing.
+ * </strong> It keeps a parsed pack across a portal because it does not read the pack again there at
+ * all; when it does reload, it builds a whole new one. This engine reads the pack again at a portal,
+ * against a define table that has moved, so what it can keep is not a parsed pack but the reading
+ * material underneath one: the mounted archive and the memos that are functions of its bytes.
+ * <p>
+ * <strong>One opening, and only for the reader that runs on the render thread.</strong> The memos
+ * inside a {@link ShaderPackSource} belong to the single thread reading through it, so the family
+ * worker keeps opening one of its own: what is offered here is offered to the chain's reader alone,
+ * which is sequential by construction. A second pack, a settings change or a machine that answers
+ * differently replaces what is held rather than joining it.
+ * <p>
+ * <strong>What decides that two loads may share an opening is written out rather than assumed.</strong>
+ * The pack path, the settings the player chose, the profile, and the engine's whole define table,
+ * which carries the world's registries and is exactly what moves under a pack at a world join. On
+ * top of those the pack's own files are fingerprinted by size and modification time, so an archive
+ * or a directory edited on the disk is opened afresh; a directory pack being the one every workshop
+ * edits between two loads, that check is the reason this can be offered to a directory at all.
+ * <p>
+ * <strong>And what a reader worked out of an opening is NOT kept.</strong> {@link
+ * ShaderPackSource#forgetDerived} empties those at that reading's close: a plan, a texture set or a
+ * program tree is a function of more than the archive, the size of the window among it, and serving
+ * one across a load would be a picture that is credible and wrong. What is kept is the mount, the
+ * listings, the file lines and the flattened units, and each of those depends on nothing but the
+ * archive's bytes and the settings this key already compares.
+ * <p>
+ * The line is drawn where the answers are FILED and not where they could have been: a reader is free
+ * to file a pure function of the archive under {@code derived}, and one does, so that one is thrown
+ * away with the rest. Trading a little of the saving for a rule with no exceptions is the deal, and
+ * the exception is what would cost a picture.
+ * <p>
+ * <strong>What a hit does NOT save is worth having written down</strong>, so that nothing here is
+ * read as more than it is: the dimension and program enumeration, the target plan, the pack's
+ * textures, whose bytes are not memoised and are read again, the half translation that answers what
+ * a chunk program reads, and every translation and compile after that. What it saves is the mount,
+ * the listings, the file lines, the option walk, the properties parse and the flattening.
+ * <p>
+ * {@code -Dvitrail.keepPackOpen=false} closes every opening at its load's end, which is the road
+ * before this class, and the line printed at every open names the one taken either way.
+ */
+final class KeptPack {
+
+	/** Off by property rather than by rebuild, so a before and an after come out of one jar. */
+	private static final boolean ENABLED = Boolean.parseBoolean(
+			System.getProperty("vitrail.keepPackOpen", "true"));
+
+	/**
+	 * How many entries a pack may hold before it is fingerprinted at all. Far above the widest of
+	 * the corpus, and low enough that a folder somebody dropped a world into cannot turn every
+	 * pack load into a walk of it: past this the opening is simply not kept.
+	 */
+	private static final int MOST_ENTRIES = 20_000;
+
+	/**
+	 * The opening being held, with everything that decides whether it may serve, or null while
+	 * none is.
+	 * <p>
+	 * The three travel as one object behind one volatile field rather than as three fields, and
+	 * that is not decoration: the first reading of a session runs on the loader's setup thread on
+	 * NeoForge and every reading after it on the render thread. Three fields could be seen in any
+	 * mixture by the second thread, and one of those mixtures is an opening served under the key of
+	 * another.
+	 * <p>
+	 * <strong>What this field does NOT publish is the opening's own memos</strong>, and nothing here
+	 * could: they are filled by the reader after this method has returned. What publishes those is
+	 * the loader joining the executor its setup ran on, which stands between that reading and the
+	 * first frame, together with the fact that no two readings through one opening overlap. That
+	 * second half is a property of the one caller entitled to this and is enforced by nothing but
+	 * that: see {@link OpenedPack#openKept}.
+	 */
+	private static volatile Held held;
+
+	private KeptPack() {
+	}
+
+	/**
+	 * The pack opened, from the opening already held where every input it depends on still answers
+	 * the same, and freshly otherwise.
+	 */
+	static OpenedPack open(Path packPath, Map<String, OptionValue> chosen, String profile)
+			throws IOException {
+		if (!ENABLED) {
+			Vitrail.logger().info("Pack opened afresh: kept openings are off, "
+					+ "property=vitrail.keepPackOpen");
+
+			return OpenedPack.open(packPath, chosen, profile);
+		}
+
+		Key wanted = Key.of(packPath, chosen, profile);
+		String print = fingerprint(packPath);
+		Held standing = held;
+		if (standing != null && print != null && wanted.equals(standing.key())
+				&& print.equals(standing.print()) && atTheAskedScale(standing)) {
+			ShaderPackSource source = standing.pack().source();
+			Vitrail.logger().info("The pack was already open and is read again from that opening: "
+					+ "{} files and {} flattened units kept, property=vitrail.keepPackOpen",
+					source.filesRead(), source.unitsFlattened());
+
+			return standing.pack();
+		}
+
+		// Opened before the one held is let go, so that a pack that cannot be read leaves the
+		// session with the opening it had rather than with none.
+		OpenedPack opened = OpenedPack.open(packPath, chosen, profile);
+		Vitrail.logger().info("Pack opened afresh: {}, property=vitrail.keepPackOpen",
+				why(standing, print, wanted));
+		held = print == null ? null : new Held(opened, wanted, print);
+		drop(standing);
+
+		return opened;
+	}
+
+	/**
+	 * Lets the opening go, for a load that has decided there is no pack to draw.
+	 * <p>
+	 * Those roads never reach {@link #open}, so nothing there would ever replace what is held, and
+	 * a player who picks None would leave a mounted archive and a pack's worth of source strings
+	 * standing for the rest of the session with no chain that could ever use them.
+	 */
+	static void forget() {
+		Held standing = held;
+		held = null;
+		drop(standing);
+	}
+
+	/**
+	 * Whether this opening is the one being held, which is what tells {@link OpenedPack#close}
+	 * that its {@code close} is a no-op rather than the end of the archive.
+	 * <p>
+	 * By identity and not by value, and it has to be: {@link OpenedPack} is a record, so two
+	 * openings of one pack under one set of settings answer equal while owning two mounted
+	 * archives, and the wrong one would then be left open and the right one never closed.
+	 */
+	static boolean holds(OpenedPack pack) {
+		Held standing = held;
+		if (standing == null) {
+			return false;
+		}
+
+		@SuppressWarnings("ReferenceEquality")
+		boolean same = standing.pack() == pack;
+
+		return same;
+	}
+
+	/**
+	 * Whether the opening held resolved its settings at the shadow map scale the engine is asking
+	 * for now.
+	 * <p>
+	 * <strong>Asked of the reading itself and not mirrored into the key</strong>, because the scale
+	 * is the one input a {@link SettingSet} takes that is neither an argument of the reading nor
+	 * part of the define table: it is pushed onto that class as a static, so a key built beside it
+	 * would go on answering right while the two drifted. What it guards is the setting's whole
+	 * point. The scale is applied by rewriting the pack's own declaration of the shadow map size in
+	 * the flattened text, so a reading served at the old number carries the old declaration, the map
+	 * is allocated off that same text, and the slider becomes a silent no-op for the rest of the
+	 * session while the log says it moved.
+	 */
+	private static boolean atTheAskedScale(Held standing) {
+		return standing.pack().settings().scale() == SettingSet.askedShadowMapScale();
+	}
+
+	/** Why the opening held could not serve, in the words the line above prints. */
+	private static String why(Held standing, String print, Key wanted) {
+		if (standing == null) {
+			return "none was held";
+		}
+
+		if (print == null) {
+			return "this one is not fingerprinted, so it will not be held either";
+		}
+
+		if (!wanted.equals(standing.key())) {
+			return "the pack, its settings or the machine's defines have moved";
+		}
+
+		if (!atTheAskedScale(standing)) {
+			return "the shadow map scale has moved";
+		}
+
+		return "its files have moved on the disk";
+	}
+
+	private static void drop(Held standing) {
+		if (standing == null) {
+			return;
+		}
+
+		try {
+			standing.pack().source().close();
+		} catch (IOException | RuntimeException e) {
+			// Said rather than thrown: the load that provoked this has a fresh opening in hand and
+			// nothing about it is wrong, and a mounted archive that would not close is a handle
+			// held until the game is closed rather than a reason to refuse a pack.
+			Vitrail.logger().warn("Vitrail could not close the pack opening it was holding", e);
+		}
+	}
+
+	/** The opening held and the two answers it is held under. */
+	private record Held(OpenedPack pack, Key key, String print) {
+	}
+
+	/**
+	 * What the pack's files are, by their names, their sizes and when they were last written, or
+	 * null when the walk could not answer, in which case nothing is held.
+	 * <p>
+	 * Names and stamps and not content: reading a pack whole to decide whether to avoid reading it
+	 * whole answers nothing. What that misses is an edit that leaves the size and the stamp where
+	 * they were, which no editor does and which the settings screen's own reload answers anyway.
+	 * <p>
+	 * Directories go in beside the files, under their own word: a place is a DIRECTORY of a pack,
+	 * so one added or removed changes which programs a world is served even when it holds no file
+	 * of its own.
+	 */
+	private static String fingerprint(Path packPath) {
+		List<String> entries = new ArrayList<>();
+		try (Stream<Path> walk = Files.walk(packPath)) {
+			for (Path path : (Iterable<Path>) walk::iterator) {
+				if (entries.size() >= MOST_ENTRIES) {
+					return null;
+				}
+
+				// What the READER will read, which for a symlink is the target and not the link:
+				// the reading side goes through Files.readAllBytes, which follows, so a print taken
+				// off the link would stand still while the file the pack is built from moved.
+				//
+				// One entry that cannot be stat'd, a broken link among them, is written down as
+				// exactly that rather than abandoning the whole print: a single dangling link in a
+				// pack folder would otherwise make that pack unfingerprintable, and with it never
+				// kept again for the rest of the session, in silence. A target that appears later
+				// makes the read succeed, which moves the entry, which moves the print.
+				BasicFileAttributes attributes;
+				try {
+					attributes = Files.readAttributes(path, BasicFileAttributes.class);
+				} catch (IOException e) {
+					entries.add(packPath.relativize(path) + " unreadable");
+
+					continue;
+				}
+
+				if (attributes.isDirectory()) {
+					entries.add(packPath.relativize(path) + " dir");
+
+					continue;
+				}
+
+				entries.add(packPath.relativize(path) + " " + attributes.size() + " "
+						+ attributes.lastModifiedTime().toMillis());
+			}
+		} catch (IOException | RuntimeException e) {
+			return null;
+		}
+
+		// Sorted rather than taken in the walk's own order, which is the filesystem's business and
+		// not a property of the pack.
+		Collections.sort(entries);
+		MessageDigest digest = sha256();
+		for (String entry : entries) {
+			digest.update(entry.getBytes(StandardCharsets.UTF_8));
+			digest.update((byte) 0);
+		}
+
+		return HexFormat.of().formatHex(digest.digest());
+	}
+
+	private static MessageDigest sha256() {
+		try {
+			return MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 is required of every Java runtime", e);
+		}
+	}
+
+	/**
+	 * Everything outside the archive that decides what a reading of it produces.
+	 *
+	 * @param settings the chosen values written out, because {@link OptionValue} answers equality by
+	 *                 identity and two readings of one file build two objects for one value
+	 * @param defines  the engine's whole table, which is what a world join moves and what every
+	 *                 flattened unit was branched on
+	 */
+	private record Key(Path packPath, String settings, String profile, Map<String, String> defines) {
+
+		static Key of(Path packPath, Map<String, OptionValue> chosen, String profile) {
+			List<String> written = new ArrayList<>(chosen.size());
+			chosen.forEach((name, value) -> written.add(name + " " + value.isBoolean()
+					+ " " + Objects.toString(value.asText(), "")));
+			Collections.sort(written);
+
+			return new Key(packPath, String.join("\n", written), profile,
+					Map.copyOf(EngineDefines.table(EngineDefines.machine())));
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/source/OpenedPack.java
+++ b/common/src/main/java/dev/vitrail/pack/source/OpenedPack.java
@@ -33,6 +33,28 @@ public record OpenedPack(Path packPath, ShaderPackSource source, OptionIndex opt
 		ShaderProperties properties, SettingSet settings) implements AutoCloseable {
 
 	/**
+	 * The reading that runs on the thread that draws, which is the chain's, and the one reading
+	 * offered the opening a previous load left standing. {@link KeptPack} says what has to answer
+	 * the same before that offer is made, and what it empties before making it.
+	 * <p>
+	 * <strong>Nothing else may ask for it.</strong> The memos inside a {@link ShaderPackSource}
+	 * belong to one thread, and this is the only reading whose thread is known and whose readings
+	 * cannot overlap.
+	 */
+	public static OpenedPack openKept(Path packPath, Map<String, OptionValue> chosen, String profile)
+			throws IOException {
+		return KeptPack.open(packPath, chosen, profile);
+	}
+
+	/**
+	 * Lets go of whatever {@link #openKept} left standing, which a load that has decided to draw no
+	 * pack at all owes: those roads never reach the opening, so nothing else would ever replace it.
+	 */
+	public static void forgetKept() {
+		KeptPack.forget();
+	}
+
+	/**
 	 * @param chosen  settings to override, by the name the pack declares them under
 	 * @param profile a profile the pack declares, applied underneath {@code chosen} so that a single
 	 *                setting can still be overridden on top of it, or the empty string
@@ -57,8 +79,24 @@ public record OpenedPack(Path packPath, ShaderPackSource source, OptionIndex opt
 		}
 	}
 
+	/**
+	 * Gives the archive back, unless this is the opening {@link KeptPack} is holding for the next
+	 * load, in which case what a reader worked out of it goes and the archive stays.
+	 * <p>
+	 * Emptied HERE and not when the next load takes the opening: a load's conclusions have no
+	 * business outliving the load, and dropping them at the next hit would leave them alive for as
+	 * long as no hit came, which is for the rest of the session when none does. The rule above
+	 * stands as it was, and is what makes this safe: nothing taken from an opening may be used
+	 * after its {@code close}, whether or not that close reached the archive.
+	 */
 	@Override
 	public void close() throws IOException {
+		if (KeptPack.holds(this)) {
+			this.source.forgetDerived();
+
+			return;
+		}
+
 		this.source.close();
 	}
 }

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
@@ -558,6 +558,33 @@ public final class ShaderPackSource implements AutoCloseable {
 	}
 
 	/**
+	 * Empties what a READER worked out of this opening, and nothing else, so that an opening handed
+	 * to a second load carries the archive forward and no conclusion drawn from it.
+	 * <p>
+	 * The line between the two is what makes {@link KeptPack} safe. The listings, the file lines and
+	 * the flattened units are functions of the archive's bytes and the settings, and that pair is
+	 * what its key compares. What lands in {@link #derived} need not be: a plan carries the size of
+	 * the window, a texture set carries what the resource packs hold, and either of them served
+	 * across a load would be a picture that is credible and wrong. So the whole map goes, including
+	 * the entries that WOULD have been safe to keep, {@code IncludeExpander}'s logical lines among
+	 * them: the rule is about where an answer is filed rather than about what it happens to depend
+	 * on, and a rule with an exception in it is the one that costs a picture.
+	 */
+	void forgetDerived() {
+		this.derived.clear();
+	}
+
+	/** How many files this opening has read, for the line that says what a kept opening saved. */
+	int filesRead() {
+		return this.linesByFile.size();
+	}
+
+	/** And how many units it has flattened, which is the post that stands before every lookup. */
+	int unitsFlattened() {
+		return this.expandedUnits.size();
+	}
+
+	/**
 	 * Lets the two memos go as well as the archive, which is what makes an opening the bound on
 	 * what they hold: a directory pack owns no filesystem at all, so without these two lines
 	 * closing one would free nothing, and an opening a caller keeps in a field past its own use

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -218,6 +218,12 @@ public final class PackChoice {
 				// unanswered, and the folder being empty is why.
 				if (namedAPack()) {
 					packIsMissing(gameDirectory);
+					// And the opening a previous load left standing goes with it, here and on every
+					// other road out of this method that draws no pack: none of them reaches
+					// OpenedPack.openKept, so nothing would ever replace what is held, and a player
+					// who picks None would leave a mounted archive and a pack's worth of source
+					// strings standing for the rest of the session.
+					OpenedPack.forgetKept();
 
 					return;
 				}
@@ -225,6 +231,8 @@ public final class PackChoice {
 				lastError = "No shader pack in " + PackLoader.directory(gameDirectory);
 				Vitrail.logger().info("No shader pack in {}, nothing to draw",
 						PackLoader.directory(gameDirectory));
+				OpenedPack.forgetKept();
+
 				return;
 			}
 
@@ -238,6 +246,7 @@ public final class PackChoice {
 				HandDraw.wanted(false);
 				if (namedAPack()) {
 					packIsMissing(gameDirectory);
+					OpenedPack.forgetKept();
 
 					return;
 				}
@@ -248,6 +257,7 @@ public final class PackChoice {
 				Vitrail.logger().info("No pack asked for, so none of the {} in {} is read and the game "
 						+ "draws its own image. Pick one in the settings screen, or name it in {}",
 						packs.size(), PackLoader.directory(gameDirectory), packFile(gameDirectory));
+				OpenedPack.forgetKept();
 				return;
 			}
 
@@ -277,6 +287,7 @@ public final class PackChoice {
 				lastError = ShaderPackSource.nameOf(pack) + " is not drawn on the "
 						+ HostReport.backend() + " backend: set Graphics API to \"Prefer Vulkan "
 						+ "(Experimental)\" under Options, Video Settings, and restart";
+				OpenedPack.forgetKept();
 				return;
 			}
 
@@ -345,6 +356,7 @@ public final class PackChoice {
 						+ ", which this engine does not serve";
 				Vitrail.logger().error("{} requires {}, which this engine does not serve, so "
 						+ "nothing is drawn", named, names);
+				OpenedPack.forgetKept();
 				return;
 			}
 
@@ -377,7 +389,10 @@ public final class PackChoice {
 			PackDefines.install();
 			report(pack);
 
-			try (OpenedPack opened = OpenedPack.open(pack, chosen, settings.profile())) {
+			// The kept variant, and this reading is the only one in the engine entitled to it: it runs
+			// on the render thread and two of them never overlap, which is what an opening's memos
+			// require. Every other reader opens one of its own.
+			try (OpenedPack opened = OpenedPack.openKept(pack, chosen, settings.profile())) {
 				// The world decides the directory, and the pack decides which world that is: a folder
 				// may be named anything and mapped in dimension.properties, so the name is read from
 				// the pack rather than composed from the dimension.


### PR DESCRIPTION
## What changes

The translated programs of a pack are kept on disk, but the key they are looked up under is the
flattened text, so the flattening runs before the lookup can be attempted at all: mounting the
archive, walking it for its options, parsing what it declares and pasting every shared header into
every file that includes one, all of it on the thread that draws, and all of it thrown away at the
end of the reading. Every one of those is a pure function of the archive's bytes and the settings.

The chain's reading now takes the opening a previous load left standing, where the pack, the
settings, the profile, the engine's whole define table and the shadow map scale all still answer the
same and the pack's own files carry the sizes and stamps they carried. Only that one reading: the
memos inside an opening belong to a single thread, and it is the only reader whose thread is known
and whose readings cannot overlap. What a reader worked out of an opening is emptied at that
reading's close, since a plan carries the size of the window and a texture set carries what the
resource packs hold, and neither is a function of the archive alone.

The shadow map scale is asked of the reading itself rather than mirrored into the key, because it is
pushed onto the settings as a static and is applied by rewriting the pack's own declaration of the
map size: a reading served at the old number would make the slider a silent no-op.

## How it differs from the reference, and for what obstacle

It does not, and the resemblance is worth naming precisely rather than borrowing. Iris keeps a
parsed pack across a portal because it does not read the pack again there at all (`Iris.java:649`
asks the pack in memory for that dimension); when it does reload, it builds a whole new one
(`Iris.java:342`). This engine reads the pack again at a portal, against a define table that has
moved, so what it can keep is not a parsed pack but the reading material underneath one.

## What proves it

- `gradlew build` green, after the rebase.
- In the game, Fabric bench, Complementary Unbound r5.8.1, world `frozen real`, three launches per
  road out of one jar with `-Dvitrail.keepPackOpen` as the only difference. The second reading of a
  launch flattens **49 units in 470 to 601 ms with the opening kept, against 93 units in 937 to
  1274 ms without**. The worst of one road stands under the best of the other, so the difference is
  not the spread.
- The FIRST reading is the control and is identical on both roads, 897 to 1097 ms over 90 units: it
  has nothing to reuse.

## What it leaves owing

- A hit does not save the program enumeration, the target plan, the pack's textures, whose bytes
  have no memo, or any translation and compile after those.
- Nothing enforces that only one reader takes a standing opening; it is a property of the single
  call site and is stated there rather than checked.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one: what an opening's
      close does, and what its memos may and may not outlive.
