### PR TITLE
perf(mixin): compile modules without shaderc's debug info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ what the next one holds.
 
 ### Changed
 
+- **The compiled shaders kept on disk are three times smaller.** Every one of them carried a copy
+  of the whole shader text and a marker in front of nearly every instruction, which is what a
+  driver would need to name a line inside a shader and which nothing else reads. Measured on
+  Complementary Unbound, one pack's compiled programs came to eighteen megabytes and now come to
+  six. What is stored is what is read back at every load, so there is less of everything to read,
+  check and hand to the driver, though no load came out measurably shorter on the machine this was
+  taken on. A compile error still names its line exactly as before.
+
 - **A pack read twice in one session is opened once.** Reading a pack means mounting its archive,
   walking it for the settings it offers, parsing what it declares and pasting every shared header
   into every file that includes one, and all of that was done again from nothing each time: at a

--- a/common/src/main/java/dev/vitrail/cache/ModuleCache.java
+++ b/common/src/main/java/dev/vitrail/cache/ModuleCache.java
@@ -5,6 +5,7 @@ import dev.vitrail.glsl.LocalZeroes;
 import dev.vitrail.mixin.access.IntermediaryShaderModuleAccessor;
 import dev.vitrail.render.PackChain;
 import dev.vitrail.render.RawLocals;
+import dev.vitrail.render.ShaderDebugInfo;
 import dev.vitrail.Vitrail;
 
 import org.jspecify.annotations.Nullable;
@@ -329,10 +330,11 @@ public final class ModuleCache {
 		feed(digest, Vitrail.platform().loaderName());
 		feed(digest, Vitrail.platform().loaderVersion());
 		feed(digest, Version.getVersion());
-		// The one switch that changes the bytes a compile produces without changing its text: the
-		// two states keep two sets of blobs, and a reading taken under one never draws the other's.
+		// The two switches that change the bytes a compile produces without changing its text: each
+		// state keeps its own set of blobs, and a reading taken under one never draws another's.
 		feed(digest, RawLocals.cacheWord());
 		feed(digest, LocalZeroes.VERSION);
+		feed(digest, ShaderDebugInfo.cacheWord());
 		feed(digest, stage);
 		feed(digest, source);
 

--- a/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
 import dev.vitrail.cache.ModuleCache;
 import dev.vitrail.glsl.LoadClock;
 import dev.vitrail.render.RawLocals;
+import dev.vitrail.render.ShaderDebugInfo;
 import dev.vitrail.render.storage.StorageImages;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -20,6 +21,10 @@ import java.nio.ByteBuffer;
  * Lets a sampled or stored 3D image through the bind-group walk, gives the compiler's output its
  * zeroes before the reflection reads it, and puts {@link ModuleCache} around the one call that
  * turns a pack's GLSL into a module, which is also where {@link LoadClock} counts what that costs.
+ * <p>
+ * It also decides, at the compiler's own constructor, whether shaderc writes debug information
+ * into every module of the session: {@link ShaderDebugInfo} says what that costs and why the
+ * constructor is the only place the question can be answered.
  * <p>
  * {@code addToBindGroup} refuses anything whose SPIR-V dimension is not 2D or Cube. SpvDim3D is 2.
  * Pretending it is 2D is enough for the check; the view that is actually bound is the 3D one
@@ -44,6 +49,24 @@ import java.nio.ByteBuffer;
  */
 @Mixin(GlslCompiler.class)
 public abstract class GlslCompilerMixin {
+
+	/**
+	 * Skips the one call that asks shaderc for debug information, unless somebody asked for it
+	 * back. {@link ShaderDebugInfo} carries the switch, what it costs and why the decision can only
+	 * be taken here: shaderc turns the option on and has no call that turns it off, so the
+	 * constructor is the only place, and the compiler it builds is the one every unit of the
+	 * session goes through.
+	 */
+	@WrapOperation(method = "<init>", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/util/shaderc/Shaderc;"
+							+ "shaderc_compile_options_set_generate_debug_info(J)V"))
+	private void vitrail$skipDebugInfo(long options, Operation<Void> original) {
+		ShaderDebugInfo.announce();
+		if (ShaderDebugInfo.asked()) {
+			original.call(options);
+		}
+	}
 
 	@WrapOperation(method = "addToBindGroup", require = 1,
 			at = @At(value = "INVOKE",

--- a/common/src/main/java/dev/vitrail/render/ShaderDebugInfo.java
+++ b/common/src/main/java/dev/vitrail/render/ShaderDebugInfo.java
@@ -1,0 +1,76 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Whether shaderc is asked to write debug information into every module it compiles.
+ * <p>
+ * The game asks for it in the compiler's constructor, once for the session. What it costs is in
+ * every module: the whole GLSL text is carried in {@code OpSource} and an {@code OpLine} stands in
+ * front of nearly every instruction, which on the corpus is a module two to three times the size it
+ * needs to be. That size is paid again at every warm load, in bytes read off the store, in the
+ * digest that answers for them, and in what the driver walks at {@code vkCreateShaderModule}.
+ * <p>
+ * <strong>What it buys is line information INSIDE the module</strong>, which is what a validation
+ * layer or a driver message points at when it names a place in a shader. A compile error is not
+ * that: shaderc's own message comes from the frontend that read the text and carries its line
+ * whatever this is set to, so a pack whose GLSL will not compile is named as precisely either way.
+ * <p>
+ * <strong>It is off by default, and it cannot be scoped to a pack's own units.</strong> shaderc
+ * has a call that turns the option on and none that turns it off again, so the only place to
+ * decide is the constructor, and the compiler there is the one the game, Sodium and this engine
+ * all compile through.
+ * <p>
+ * {@code -Dvitrail.shaderDebugInfo=true} asks for it back, and the two states keep two sets of
+ * blobs: the switch changes the bytes a compile produces without changing the text it was handed,
+ * so it goes into the module cache's key exactly as {@link RawLocals} does. Read once at start,
+ * because the option it decides is set once at start.
+ */
+public final class ShaderDebugInfo {
+
+	private static final boolean ASKED = Boolean.getBoolean("vitrail.shaderDebugInfo");
+
+	/**
+	 * Whether the line has been said. An atomic and not a plain field: a compiler is built per
+	 * pack-load worker and the pool holds three, so the announcement below is reached from several
+	 * threads at once, and two of them reading a plain false would each print it.
+	 */
+	private static final AtomicBoolean ANNOUNCED = new AtomicBoolean();
+
+	private ShaderDebugInfo() {
+	}
+
+	/** Whether the compiler is to be told to write it. */
+	public static boolean asked() {
+		return ASKED;
+	}
+
+	/** The word the module cache's key carries for the state, since the state decides the bytes. */
+	public static String cacheWord() {
+		return ASKED ? "debug-info" : "no-debug-info";
+	}
+
+	/**
+	 * Said once, at the compiler this decides, and said BOTH WAYS: a line that only appeared on one
+	 * road would leave every reading taken on the other unable to name the jar it came from, and
+	 * both roads come out of the same jar.
+	 */
+	public static void announce() {
+		if (!ANNOUNCED.compareAndSet(false, true)) {
+			return;
+		}
+
+		if (ASKED) {
+			Vitrail.logger().warn("Modules compiled WITH debug info, asked for by "
+					+ "vitrail.shaderDebugInfo: two to three times the bytes, and a place a "
+					+ "validation layer can name inside a shader");
+
+			return;
+		}
+
+		Vitrail.logger().info("Modules compiled without debug info, property="
+				+ "vitrail.shaderDebugInfo");
+	}
+}


### PR DESCRIPTION
## What changes

The game asks shaderc for debug information in the compiler's constructor, so every compiled module
of the session carries the whole GLSL text in `OpSource` with an `OpLine` in front of nearly every
instruction. That is paid again at every warm load, in bytes read off the store, in the digest that
answers for them, and in what the driver walks at `vkCreateShaderModule`. The call is skipped.

It cannot be scoped to a pack's own units: shaderc has a call that turns the option on and none that
turns it off, so the constructor is the only place to decide and the compiler it builds is the one
the game, Sodium and this engine all compile through. What is lost is line information inside the
module, which is what a validation layer points at when it names a place in a shader. A compile
error keeps its own line either way, coming from the frontend that read the text rather than from
the module.

The state goes into the module store's key beside the raw-locals switch, since it changes the bytes
a compile produces without changing the text handed to it: the two states keep two sets of blobs and
neither is ever served for the other.

## How it differs from the reference, and for what obstacle

It does not. Iris compiles through its own backend and never meets this option.

## What proves it

- `gradlew build` green, after the rebase.
- In the game, Fabric bench, Complementary Unbound r5.8.1, world `frozen real`, out of one jar with
  `-Dvitrail.shaderDebugInfo` as the only difference. The module store grew by **6.0 MB without the
  debug information and by 17.8 MB with it**, a factor of three, which is what the claim rests on.
  A second launch on each road added nothing to the store, which is the control that says the store
  was complete after the first.
- **No load came out measurably shorter.** The module post of a warm load ran 950 to 1719 ms on one
  road and 1051 to 1639 ms on the other, one spread inside the other. What is measured is the size,
  not a time.
- The reflection binds by name and still does: names are not debug information, and a pack that
  draws before the change draws after it.

## What it leaves owing

- The game's own shaders and Sodium's lose the same line information, since the option belongs to
  the one compiler they all share. `-Dvitrail.shaderDebugInfo=true` puts it back for a session that
  needs a validation layer to name a line.
- A store filled by an older build keeps its larger blobs until the sweep collects them; they are
  unreachable, not served.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one: what the module
      store's key carries, and what the compiler is asked for.
