### PR TITLE
fix(pack): evaluate a conditional the way a driver does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ what the next one holds.
 
 ### Fixed
 
+- **A setting compared against a number with a decimal point no longer switches a pass off.** Some
+  packs write conditions like "if the motion blur is above 0.0" or "if the falloff equals 1", with
+  the setting itself holding 0.5 or 1.0. Those were read as whole numbers, so a half became nought
+  and the branch was decided the wrong way, and the line was then refused outright besides. Pegasus
+  was losing its terrain, its water, its entities and its particles to one of them, and Clarity two
+  of its passes.
+
 - **The extensions a pack asks for are no longer dropped.** A pack using half precision types
   guarded them on the extension being available and shipped a fallback for when it is not; the line
   that enables the extension was thrown away while everything around it stayed, so neither road

--- a/common/src/main/java/dev/vitrail/pack/source/ConditionStack.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ConditionStack.java
@@ -51,6 +51,15 @@ public final class ConditionStack {
 	}
 
 	/**
+	 * The same for a branch whose condition this reader wrote out itself, which is already decided
+	 * and must not be asked again: what goes into the text is the answer, so what is recorded here
+	 * has to be the same answer. An earlier branch already taken still wins, as it does below.
+	 */
+	public void rewrittenElifDirective(boolean condition) {
+		elifDirective(() -> condition);
+	}
+
+	/**
 	 * The condition is only evaluated when it can still matter, which is not an optimisation:
 	 * a later branch may well be nonsense once an earlier one has been taken.
 	 */

--- a/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
+++ b/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
@@ -360,6 +360,13 @@ public final class IncludeExpander {
 			state.conditionals++;
 			state.openInOutput++;
 			if (!beyondComments(iff.group(2)).isEmpty()) {
+				String written = rewritten(iff.group(2), state);
+				if (written != null) {
+					conditions.rewrittenIfDirective(written.equals("1"));
+
+					return iff.group(1) + "#if " + written;
+				}
+
 				conditions.ifDirective(() -> decide(iff.group(2), state));
 				return line;
 			}
@@ -379,6 +386,13 @@ public final class IncludeExpander {
 			}
 
 			if (!beyondComments(elif.group(2)).isEmpty()) {
+				String written = rewritten(elif.group(2), state);
+				if (written != null) {
+					conditions.rewrittenElifDirective(written.equals("1"));
+
+					return elif.group(1) + "#elif " + written;
+				}
+
 				conditions.elifDirective(() -> decide(elif.group(2), state));
 				return line;
 			}
@@ -525,6 +539,41 @@ public final class IncludeExpander {
 		}
 
 		return value.get();
+	}
+
+	/**
+	 * The verdict written out as the condition itself, on the one kind of condition the compiler
+	 * will not read, or null on every other, which keeps its own text.
+	 * <p>
+	 * The preprocessor of the language works in whole numbers and refuses a line carrying anything
+	 * else; a GL driver reduces it and answers, so packs ship them. Clarity writes
+	 * {@code #if MOTION_BLUR > 0.0} with that setting at 0.5 and Pegasus writes
+	 * {@code #if SKY_LIGHT_FALLOFF == 1} with the macro at 1.0, and the second is what its terrain,
+	 * water, entity and particle passes were refused for.
+	 * <p>
+	 * <strong>What goes out is this expander's own answer, and that is only safe because the
+	 * evaluator computes it the way a driver does.</strong> It reads a fractional value as the
+	 * number it is rather than truncating, so {@code 0.5 > 0.0} is true here as it is there. The
+	 * shape written before that was true was the same rewrite over an evaluator that truncated, and
+	 * it read Clarity's motion blur as switched off: the picture would have lost the effect with
+	 * nothing said. The two halves only work together.
+	 * <p>
+	 * An expression neither this nor a driver can settle is written as taken, which is what
+	 * {@link #decide} answers everywhere else and for the reason given there.
+	 */
+	private String rewritten(String expression, State state) {
+		PreprocessorExpression.Verdict verdict =
+				PreprocessorExpression.decide(expression, state.defines);
+		if (!verdict.fractional()) {
+			return null;
+		}
+
+		// Not counted as undecidable, unlike decide's own road, and the difference is the point:
+		// that counter says how many conditions this reader handed to the compiler without an
+		// answer, and these it answers. An `#elif` is also asked here before the stack has said
+		// whether the branch can still matter, so counting would drift by every branch an earlier
+		// one had already won.
+		return verdict.taken().orElse(true) ? "1" : "0";
 	}
 
 	private void follow(Path from, String spec, int depth, State state) throws IOException {

--- a/common/src/main/java/dev/vitrail/pack/source/PreprocessorExpression.java
+++ b/common/src/main/java/dev/vitrail/pack/source/PreprocessorExpression.java
@@ -4,16 +4,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.regex.Pattern;
 
 /**
  * Evaluates the expression of an {@code #if} or {@code #elif} well enough to decide which
  * branch of a pack is live.
  * <p>
- * Arithmetic is in integers, as the preprocessor defines it, not in floating point: a pack
- * writing {@code #if QUALITY / 2} expects the C answer, and the compiler that sees the same
- * line later will give the C answer whatever is decided here.
+ * <strong>Arithmetic follows C's rules and not the preprocessor's, which is a deliberate
+ * divergence from the language and the only one here.</strong> The preprocessor of GLSL works in
+ * integers and refuses a fractional number outright; a GL driver takes one and reduces it, so packs
+ * ship conditions the language forbids. Clarity writes {@code #if MOTION_BLUR > 0.0} with that
+ * setting at 0.5 and Pegasus writes {@code #if SKY_LIGHT_FALLOFF == 1} with the macro at 1.0.
+ * Answering those in integers alone truncates 0.5 to nought and switches an effect off in the
+ * picture, silently, which is worse than refusing the line.
+ * <p>
+ * So a value carries whether it is whole, and the promotion is C's: {@code /} and {@code %} divide
+ * in integers when both sides are whole and in floating point otherwise, so {@code 7 / 2 == 3}
+ * still holds; the shifts and the bitwise operators take whole numbers only and yield no answer on
+ * anything else, as C forbids them there; everything else widens as soon as one side is
+ * fractional. What a comparison or a logical operator hands back is whole, being nought or one.
  * <p>
  * A name stands for a value, and that value may itself be an expression naming other settings,
  * so evaluating one expression can start another. The budget for that is shared across the
@@ -58,6 +67,48 @@ public final class PreprocessorExpression {
 	/** Whether the text is not an expression at all, which no operator forgives. */
 	private boolean malformed;
 
+	/**
+	 * Whether anything the expression read was fractional, which is what the compiler refuses the
+	 * whole line for. Set wherever a value that is not whole is produced or resolved, including in
+	 * an operand a short circuit spares, because the compiler reads the text either way.
+	 */
+	private boolean fractional;
+
+	/**
+	 * One value of an expression: what it is worth, and whether it is a whole number.
+	 * <p>
+	 * The flag is not the same question as {@code number == Math.rint(number)}. What decides
+	 * whether a division is C's integer division is how the two operands were WRITTEN, so
+	 * {@code 4.0 / 2} divides in floating point and answers 2.0 while {@code 4 / 2} answers the
+	 * same 2 as a whole number, and only the second may then be shifted.
+	 * <p>
+	 * <strong>A whole number is carried as a {@code long} beside its double and read from there
+	 * whenever both sides are whole</strong>, which is the arithmetic this class did before it
+	 * learned about fractions and which a double cannot do: past two to the fifty-third a double
+	 * has no room for consecutive integers, so {@code 9007199254740993 == 9007199254740992} would
+	 * answer true and {@code 9007199254740993 & 1} would answer nought. Neither reaches a pack, and
+	 * both would be a right answer replaced by a wrong one, which is the shape this repository pays
+	 * for twice over.
+	 */
+	private record Scalar(double number, long whole, boolean integral) {
+
+		static Scalar of(long value) {
+			return new Scalar(value, value, true);
+		}
+
+		static Scalar of(boolean truth) {
+			return of(truth ? 1 : 0);
+		}
+
+		static Scalar fraction(double value) {
+			return new Scalar(value, (long) value, false);
+		}
+
+		boolean truth() {
+			return this.integral ? this.whole != 0 : this.number != 0;
+		}
+	}
+
 	private PreprocessorExpression(List<String> tokens, Map<String, String> defines, int depth) {
 		this.tokens = tokens;
 		this.defines = defines;
@@ -65,29 +116,49 @@ public final class PreprocessorExpression {
 	}
 
 	public static Optional<Boolean> evaluate(String expression, Map<String, String> defines) {
-		OptionalLong value = value(expression, defines, 0);
+		return decide(expression, defines).taken();
+	}
 
-		return value.isPresent() ? Optional.of(value.getAsLong() != 0) : Optional.empty();
+	/**
+	 * What one condition decides, and whether the compiler will take the line at all.
+	 *
+	 * @param taken      the branch this expression opens, or empty where nothing could be worked out
+	 * @param fractional whether the expression read a value that is not a whole number. The
+	 *                   preprocessor of the language refuses such a line outright, so a caller that
+	 *                   writes the text back out has to answer it here instead of passing it on
+	 */
+	public record Verdict(Optional<Boolean> taken, boolean fractional) {
+	}
+
+	/** The same as {@link #evaluate}, with what the caller needs to know about the text itself. */
+	public static Verdict decide(String expression, Map<String, String> defines) {
+		Reading read = read(expression, defines, 0);
+
+		return new Verdict(read.value().map(Scalar::truth), read.fractional());
+	}
+
+	/** One evaluation: what it came to, and whether anything fractional was read on the way. */
+	private record Reading(Optional<Scalar> value, boolean fractional) {
 	}
 
 	/** The numeric answer, which is what a name resolving to an expression needs. */
-	private static OptionalLong value(String expression, Map<String, String> defines, int depth) {
+	private static Reading read(String expression, Map<String, String> defines, int depth) {
 		if (depth > MAX_RESOLUTION_DEPTH) {
-			return OptionalLong.empty();
+			return new Reading(Optional.empty(), false);
 		}
 
 		List<String> tokens = tokenise(stripComments(expression));
 		if (tokens.isEmpty()) {
-			return OptionalLong.empty();
+			return new Reading(Optional.empty(), false);
 		}
 
 		PreprocessorExpression parser = new PreprocessorExpression(tokens, defines, depth);
-		long result = parser.logicalOr();
+		Scalar result = parser.logicalOr();
 		if (parser.failed || parser.malformed || parser.position < tokens.size()) {
-			return OptionalLong.empty();
+			return new Reading(Optional.empty(), parser.fractional);
 		}
 
-		return OptionalLong.of(result);
+		return new Reading(Optional.of(result), parser.fractional);
 	}
 
 	private static String stripComments(String expression) {
@@ -162,97 +233,128 @@ public final class PreprocessorExpression {
 	 * operand, so {@code X != 0 && 100 / X > 5} is false at zero rather than undecidable, and an
 	 * undecidable answer would have put the whole branch back in.
 	 */
-	private long logicalOr() {
-		long left = logicalAnd();
+	private Scalar logicalOr() {
+		Scalar left = logicalAnd();
 		while (accept("||")) {
 			boolean decided = this.failed;
-			long right = logicalAnd();
-			if (left != 0) {
+			Scalar right = logicalAnd();
+			if (left.truth()) {
 				this.failed = decided;
 			}
 
-			left = left != 0 || right != 0 ? 1 : 0;
+			left = Scalar.of(left.truth() || right.truth());
 		}
 
 		return left;
 	}
 
-	private long logicalAnd() {
-		long left = bitwiseOr();
+	private Scalar logicalAnd() {
+		Scalar left = bitwiseOr();
 		while (accept("&&")) {
 			boolean decided = this.failed;
-			long right = bitwiseOr();
-			if (left == 0) {
+			Scalar right = bitwiseOr();
+			if (!left.truth()) {
 				this.failed = decided;
 			}
 
-			left = left != 0 && right != 0 ? 1 : 0;
+			left = Scalar.of(left.truth() && right.truth());
 		}
 
 		return left;
 	}
 
-	private long bitwiseOr() {
-		long left = bitwiseXor();
+	private Scalar bitwiseOr() {
+		Scalar left = bitwiseXor();
 		while ("|".equals(peek())) {
 			this.position++;
-			left |= bitwiseXor();
+			left = bits(left, bitwiseXor(), "|");
 		}
 
 		return left;
 	}
 
-	private long bitwiseXor() {
-		long left = bitwiseAnd();
+	private Scalar bitwiseXor() {
+		Scalar left = bitwiseAnd();
 		while (accept("^")) {
-			left ^= bitwiseAnd();
+			left = bits(left, bitwiseAnd(), "^");
 		}
 
 		return left;
 	}
 
-	private long bitwiseAnd() {
-		long left = equality();
+	private Scalar bitwiseAnd() {
+		Scalar left = equality();
 		while ("&".equals(peek())) {
 			this.position++;
-			left &= equality();
+			left = bits(left, equality(), "&");
 		}
 
 		return left;
 	}
 
-	private long equality() {
-		long left = relational();
+	/**
+	 * The bitwise operators, which C gives whole numbers only. A fractional operand is not rounded
+	 * into one: that would answer a question the language refuses to ask, so it yields no answer.
+	 */
+	private Scalar bits(Scalar left, Scalar right, String operator) {
+		if (!left.integral() || !right.integral()) {
+			this.failed = true;
+
+			return Scalar.of(0);
+		}
+
+		long a = left.whole();
+		long b = right.whole();
+
+		return Scalar.of(switch (operator) {
+			case "|" -> a | b;
+			case "^" -> a ^ b;
+			default -> a & b;
+		});
+	}
+
+	private Scalar equality() {
+		Scalar left = relational();
 		while (true) {
 			if (accept("==")) {
-				left = left == relational() ? 1 : 0;
+				left = Scalar.of(compare(left, relational()) == 0);
 			} else if (accept("!=")) {
-				left = left != relational() ? 1 : 0;
+				left = Scalar.of(compare(left, relational()) != 0);
 			} else {
 				return left;
 			}
 		}
 	}
 
-	private long relational() {
-		long left = shift();
+	private Scalar relational() {
+		Scalar left = shift();
 		while (true) {
 			if (accept("<=")) {
-				left = left <= shift() ? 1 : 0;
+				left = Scalar.of(compare(left, shift()) <= 0);
 			} else if (accept(">=")) {
-				left = left >= shift() ? 1 : 0;
+				left = Scalar.of(compare(left, shift()) >= 0);
 			} else if (accept("<")) {
-				left = left < shift() ? 1 : 0;
+				left = Scalar.of(compare(left, shift()) < 0);
 			} else if (accept(">")) {
-				left = left > shift() ? 1 : 0;
+				left = Scalar.of(compare(left, shift()) > 0);
 			} else {
 				return left;
 			}
 		}
 	}
 
-	private long shift() {
-		long left = additive();
+	/**
+	 * Two values ordered, in whole numbers where both are whole. Comparing them as doubles instead
+	 * would call two consecutive integers equal above two to the fifty-third, where C does not.
+	 */
+	private static int compare(Scalar left, Scalar right) {
+		return left.integral() && right.integral()
+				? Long.compare(left.whole(), right.whole())
+				: Double.compare(left.number(), right.number());
+	}
+
+	private Scalar shift() {
+		Scalar left = additive();
 		while (true) {
 			if (accept("<<")) {
 				left = shiftBy(left, additive(), true);
@@ -264,34 +366,48 @@ public final class PreprocessorExpression {
 		}
 	}
 
-	/** A shift by a negative or absurd amount is undefined in C, so it is not an answer here. */
-	private long shiftBy(long left, long places, boolean up) {
-		if (places < 0 || places > 63) {
+	/**
+	 * A shift by a negative or absurd amount is undefined in C, so it is not an answer here, and
+	 * neither is a shift of or by anything that is not a whole number.
+	 */
+	private Scalar shiftBy(Scalar left, Scalar places, boolean up) {
+		if (!left.integral() || !places.integral()
+				|| places.whole() < 0 || places.whole() > 63) {
 			this.failed = true;
-			return 0;
+
+			return Scalar.of(0);
 		}
 
-		return up ? left << places : left >> places;
+		return Scalar.of(up ? left.whole() << places.whole() : left.whole() >> places.whole());
 	}
 
-	private long additive() {
-		long left = multiplicative();
+	private Scalar additive() {
+		Scalar left = multiplicative();
 		while (true) {
 			if (accept("+")) {
-				left += multiplicative();
+				Scalar right = multiplicative();
+				left = left.integral() && right.integral()
+						? Scalar.of(left.whole() + right.whole())
+						: Scalar.fraction(left.number() + right.number());
 			} else if (accept("-")) {
-				left -= multiplicative();
+				Scalar right = multiplicative();
+				left = left.integral() && right.integral()
+						? Scalar.of(left.whole() - right.whole())
+						: Scalar.fraction(left.number() - right.number());
 			} else {
 				return left;
 			}
 		}
 	}
 
-	private long multiplicative() {
-		long left = unary();
+	private Scalar multiplicative() {
+		Scalar left = unary();
 		while (true) {
 			if (accept("*")) {
-				left *= unary();
+				Scalar right = unary();
+				left = left.integral() && right.integral()
+						? Scalar.of(left.whole() * right.whole())
+						: Scalar.fraction(left.number() * right.number());
 			} else if (accept("/")) {
 				left = divide(left, unary(), false);
 			} else if (accept("%")) {
@@ -305,17 +421,40 @@ public final class PreprocessorExpression {
 	/**
 	 * Zero and the one overflowing case are treated as no answer rather than as an exception:
 	 * a pack whose condition cannot be worked out is not a reason to abandon the load.
+	 * <p>
+	 * <strong>Whole against whole divides in whole numbers</strong>, which is C's rule and what
+	 * keeps {@code 7 / 2 == 3} true. As soon as one side is fractional the division is a floating
+	 * one, and the remainder is not defined on those at all.
 	 */
-	private long divide(long left, long right, boolean remainder) {
-		if (right == 0 || (left == Long.MIN_VALUE && right == -1)) {
+	private Scalar divide(Scalar left, Scalar right, boolean remainder) {
+		if (!right.truth()) {
 			this.failed = true;
-			return 0;
+
+			return Scalar.of(0);
 		}
 
-		return remainder ? left % right : left / right;
+		if (!left.integral() || !right.integral()) {
+			if (remainder) {
+				this.failed = true;
+
+				return Scalar.of(0);
+			}
+
+			return Scalar.fraction(left.number() / right.number());
+		}
+
+		long a = left.whole();
+		long b = right.whole();
+		if (a == Long.MIN_VALUE && b == -1) {
+			this.failed = true;
+
+			return Scalar.of(0);
+		}
+
+		return Scalar.of(remainder ? a % b : a / b);
 	}
 
-	private long unary() {
+	private Scalar unary() {
 		String token = peek();
 		if (token == null || !isPrefix(token)) {
 			return primary();
@@ -324,18 +463,29 @@ public final class PreprocessorExpression {
 		this.position++;
 		if (++this.nesting > MAX_NESTING_DEPTH) {
 			this.malformed = true;
-			return 0;
+			return Scalar.of(0);
 		}
 
-		long value = unary();
+		Scalar value = unary();
 		this.nesting--;
 
-		return switch (token) {
-			case "!" -> value == 0 ? 1 : 0;
-			case "-" -> -value;
-			case "~" -> ~value;
-			default -> value;
-		};
+		switch (token) {
+			case "!":
+				return Scalar.of(!value.truth());
+			case "-":
+				return value.integral() ? Scalar.of(-value.whole())
+						: Scalar.fraction(-value.number());
+			case "~":
+				if (!value.integral()) {
+					this.failed = true;
+
+					return Scalar.of(0);
+				}
+
+				return Scalar.of(~value.whole());
+			default:
+				return value;
+		}
 	}
 
 	private static boolean isPrefix(String token) {
@@ -345,20 +495,20 @@ public final class PreprocessorExpression {
 		};
 	}
 
-	private long primary() {
+	private Scalar primary() {
 		String token = peek();
 		if (token == null) {
 			this.malformed = true;
-			return 0;
+			return Scalar.of(0);
 		}
 
 		if (accept("(")) {
 			if (++this.nesting > MAX_NESTING_DEPTH) {
 				this.malformed = true;
-				return 0;
+				return Scalar.of(0);
 			}
 
-			long value = logicalOr();
+			Scalar value = logicalOr();
 			this.nesting--;
 			if (!accept(")")) {
 				this.malformed = true;
@@ -374,33 +524,38 @@ public final class PreprocessorExpression {
 		}
 
 		if (isIdentifier(token)) {
-			return resolve(token, this.defines, this.depth + 1);
+			Reading read = resolve(token, this.defines, this.depth + 1);
+			this.fractional |= read.fractional();
+
+			return read.value().orElse(Scalar.of(0));
 		}
 
-		OptionalLong number = parseNumber(token);
+		Optional<Scalar> number = parseNumber(token);
 		if (number.isEmpty()) {
 			this.malformed = true;
-			return 0;
+			return Scalar.of(0);
 		}
 
-		return number.getAsLong();
+		this.fractional |= !number.get().integral();
+
+		return number.get();
 	}
 
-	private long definedOperator() {
+	private Scalar definedOperator() {
 		boolean parenthesised = accept("(");
 		String name = peek();
 		if (name == null || !isIdentifier(name)) {
 			this.malformed = true;
-			return 0;
+			return Scalar.of(0);
 		}
 
 		this.position++;
 		if (parenthesised && !accept(")")) {
 			this.malformed = true;
-			return 0;
+			return Scalar.of(0);
 		}
 
-		return this.defines.containsKey(name) ? 1 : 0;
+		return Scalar.of(this.defines.containsKey(name));
 	}
 
 	/**
@@ -408,21 +563,21 @@ public final class PreprocessorExpression {
 	 * identifier or a whole expression. A name nothing defines is zero, which is what the
 	 * preprocessor does and what lets a pack test a setting it never declared.
 	 */
-	public static long resolve(String name, Map<String, String> defines, int depth) {
+	private static Reading resolve(String name, Map<String, String> defines, int depth) {
 		if (depth > MAX_RESOLUTION_DEPTH) {
-			return 0;
+			return new Reading(Optional.of(Scalar.of(0)), false);
 		}
 
 		String value = defines.get(name);
 		if (value == null || value.isBlank()) {
 			// Defined but empty is the usual shape of a switch that is on.
-			return defines.containsKey(name) ? 1 : 0;
+			return new Reading(Optional.of(Scalar.of(defines.containsKey(name))), false);
 		}
 
 		String trimmed = value.trim();
-		OptionalLong number = parseNumber(trimmed);
+		Optional<Scalar> number = parseNumber(trimmed);
 		if (number.isPresent()) {
-			return number.getAsLong();
+			return new Reading(number, !number.get().integral());
 		}
 
 		if (isIdentifier(trimmed)) {
@@ -432,7 +587,9 @@ public final class PreprocessorExpression {
 		// An expression keeps its value rather than collapsing to one or zero. A pack that
 		// writes SHADOW_RES as QUALITY * 512 and then compares it against 256 is comparing
 		// sizes, and reducing that to a truth value quietly gives the wrong branch.
-		return value(trimmed, defines, depth + 1).orElse(1L);
+		Reading read = read(trimmed, defines, depth + 1);
+
+		return new Reading(Optional.of(read.value().orElse(Scalar.of(1))), read.fractional());
 	}
 
 	private static boolean isIdentifier(String token) {
@@ -443,7 +600,7 @@ public final class PreprocessorExpression {
 		return token.chars().allMatch(c -> Character.isLetterOrDigit(c) || c == '_');
 	}
 
-	private static OptionalLong parseNumber(String token) {
+	private static Optional<Scalar> parseNumber(String token) {
 		boolean hexadecimal = token.length() > 2 && (token.startsWith("0x") || token.startsWith("0X"));
 
 		// The base has to be known before a suffix can be stripped: in hexadecimal, f and F are
@@ -455,23 +612,26 @@ public final class PreprocessorExpression {
 		}
 
 		if (text.isEmpty()) {
-			return OptionalLong.empty();
+			return Optional.empty();
 		}
 
 		try {
 			if (hexadecimal) {
-				return OptionalLong.of(Long.parseLong(text.substring(2), 16));
+				return Optional.of(Scalar.of(Long.parseLong(text.substring(2), 16)));
 			}
 
-			// A pack may well write 1.0 in a condition. Truncating matches what the compiler
-			// does with the same line, which is the only thing that has to agree.
-			if (text.indexOf('.') >= 0) {
-				return OptionalLong.of((long) Double.parseDouble(text));
+			// Kept as it was written and not rounded here, which is the whole of the divergence
+			// this class carries: 0.5 is a half all the way to the comparison that reads it, and
+			// the caller is told the line held one so that it can answer for a compiler that will
+			// not. An exponent makes a number fractional as surely as a point does, 1e3 being a
+			// float in every language that has both.
+			if (text.indexOf('.') >= 0 || text.indexOf('e') >= 0 || text.indexOf('E') >= 0) {
+				return Optional.of(Scalar.fraction(Double.parseDouble(text)));
 			}
 
-			return OptionalLong.of(Long.parseLong(text));
+			return Optional.of(Scalar.of(Long.parseLong(text)));
 		} catch (NumberFormatException e) {
-			return OptionalLong.empty();
+			return Optional.empty();
 		}
 	}
 }


### PR DESCRIPTION
## What changes

The preprocessor of the language works in whole numbers and refuses a line carrying anything else.
A GL driver reduces it and answers, so packs ship conditions the language forbids: Clarity writes
`#if MOTION_BLUR > 0.0` with that setting at 0.5, Pegasus writes `#if SKY_LIGHT_FALLOFF == 1` with
the macro at 1.0.

A value in a condition now carries whether it was written whole, and the promotion is C's: division
and remainder stay in whole numbers when both sides are whole, so `7 / 2 == 3` still holds; the
shifts and the bitwise operators take whole numbers only and answer nothing on anything else;
everything else widens as soon as one side is fractional. A whole number is carried as a `long`
beside its double and read from there whenever both sides are whole, because past two to the
fifty-third a double holds no two consecutive integers. With the answer right, the expander writes
it back as the condition itself on those lines, `#if 1` or `#if 0` and the same for an `#elif`,
which is what makes the compiler take them.

**The two halves only work together, and the order matters.** The same rewrite written over the
evaluator that truncated read 0.5 as nought: it would have switched Clarity's motion blur off in the
picture with nothing said. That version was written first and thrown away for exactly that.

## How it differs from the reference, and for what obstacle

This is a divergence from the LANGUAGE and not from Iris, and it is the shape a workaround takes.
Iris hands the pack's text to the driver, which decides these lines itself and reduces a fractional
value rather than refusing it; this engine compiles through a compiler that holds the language to
its own rule, so the answer has to be worked out here and written back. What it costs the image is
nothing where a driver and this agree, which is now every row of the conditions harness.

## What proves it

- `gradlew build` green.
- The conditions harness, the gate this touches: its rows all pass, integer division among them and
  three new ones pinning exact arithmetic above two to the fifty-third; the eight rows recording
  what a float-aware evaluator owes now all pass, where five failed.
- The terrain harness over twenty-nine packs, every shaderpack of two instances merged: 660 stages
  of 660 compile, against 652 before. The translation harness goes from 5643 of 6176 to 5732, and
  its entry points from 5135 of 5427 to 5222. Pegasus goes from 168 entry points of 224 to 223, and
  Clarity from 56 of 58 to all 58.
- The negative control, the same two tools built from `dev`: 652 of 660 and five owed rows come
  back to the digit.
- In the game, on Fabric: Pegasus draws its whole chain with no pass falling back, where six of them
  did. Seven other packs loaded in turn afterwards, Clarity, I Like Vanilla, Mellow, Bliss,
  Complementary Unbound, photon and Sildur's, and none of them moved.

**The in-game reading was taken on this branch one commit earlier**, before the exact-integer
arithmetic and the `#elif` rewrite went in. Those two change nothing any pack of the corpus reaches,
which both corpus tools say to the digit: 660 of 660 and 5732 of 6176 before and after them. The
bench was taken by another session before it could be rerun.

## What it leaves owing

Nothing of this shape. An expression neither this nor a driver can settle is still written as taken,
which is what the expander answers everywhere else and for the reason given there.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
