### PR TITLE
build: compile against Sodium 0.9.2-beta.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ fabric_loader_version=0.19.3
 moddev_version=2.0.143
 
 # Provided at runtime by the pack, never bundled.
-sodium_version=0.9.2-alpha.4+mc26.2
+sodium_version=0.9.2-beta.1+mc26.2
 
 # Provided at runtime by whichever loader is in front, never bundled either. The Mixin version is
 # the one Fabric Loader ships; NeoForge carries the same upstream 0.8.7 under its own coordinates.


### PR DESCRIPTION
## What changes

One line of `gradle.properties`: the engine compiles against Sodium `0.9.2-beta.1+mc26.2` instead
of `0.9.2-alpha.4+mc26.2`. Every bench had been running the beta since it landed while the build
still resolved the alpha, so readings were taken on an engine compiled against a version it was not
running, and `bench-check` reported the gap as a drift that had to be named on every launch.

The declared dependency does not move. It is a range, `0.9.x`, so nothing changes about what a
player has to install and 0.9.1 stays inside it. What changes is the jar the mixins are compiled
and verified against.

## How it differs from the reference, and for what obstacle

It does not. Iris tracks its own Sodium and the question does not cross between the two.

## What proves it

- `gradlew build` green, and Gradle resolves the beta.
- **Every Sodium mixin target rechecked with `javap` on the jar the build really resolves**, which
  is what a green build does not prove: mixin targets bind at run time. All ten classes under
  `mixin/sodium` declare every member their injectors name, and the seven injection points that
  name a Sodium member are all declared on the class they name.
- **Both checks carry their negative control**, because one that cannot fail proves nothing. The
  member check fails on 0.9.1, where `ArenaAggregator` does not exist as a class at all. The
  injection point check fails when a member name is altered by one letter.
- In the game on NeoForge, bench `avp 26.2 (vitrail)`, Complementary Unbound r5.8.1, world
  `frozen real`: no mixin refused, no injection error, fifteen passes drawn against `world0` and
  the chain reporting it can draw. The ten exceptions in that log are Mojang authentication over an
  offline session, a JNA platform call and a resource pack's own format declaration, none of them
  the renderer.
- On Fabric the beta has been the running version all day across three sessions and sixteen
  launches of a measurement campaign, drawing the same pack.

## What it leaves owing

- The Iris benches stay on 0.9.1 deliberately, that engine not taking the beta.
- Nothing here says the beta is faster or slower. It is an alignment, not a measurement, and no
  reading was taken to compare the two.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries no entry: the declared dependency range is unchanged, so this changes
      nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one: the machine
      constants that named the version to run and the version compiled against.
