### PR TITLE
perf(shadow): redraw what moves into the kept shadow map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,11 @@ what the next one holds.
   to fill it every frame, so the engine refuses the reuse there and says so once in the log. What
   is left is every pack that does not, and the same packs with coloured lighting off.
 
-  The price, where it applies, is on shadows of things that MOVE, a mob, a boat, your own shadow,
-  which are as many frames late as the setting keeps. One frame is what it ships at and is not
-  visible in play; the slider goes to two and stops there. Turning it off restores the previous
-  behaviour exactly.
+  What is kept is the ground alone. Everything that moves, a mob, a boat, your own shadow, is drawn
+  into the kept map afresh on every frame, so none of it is ever late. The price is on the ground
+  itself: a block you place or break casts the shadow it had for as many frames as the setting
+  keeps. One frame is what it ships at and is not visible in play; the slider goes to two and stops
+  there. Turning it off restores the previous behaviour exactly.
 
 - **A pack that ships no `final` program now draws.** Some packs end their chain on their last
   composite and expect what it wrote to be the picture; they were refused outright, with nothing on

--- a/common/src/main/java/dev/vitrail/render/ShadowAmortisation.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowAmortisation.java
@@ -34,16 +34,16 @@ import java.nio.file.Path;
  *
  * <h2>What it does not cover, and what that looks like</h2>
  *
- * <strong>Casters that move freeze with the map.</strong> A mob, a boat, a falling block or the
- * player's own shadow keep the position they had on the frame the map was drawn, and jump to the
- * new one when it is drawn again. That is the whole visible cost of this, it grows with the
- * interval, and it is why the interval is small and why this is off unless it is asked for.
+ * <strong>Only the OPAQUE world is kept.</strong> Everything that moves is drawn into the restored
+ * map on every frame, so a mob, a boat, a falling block and the player's own shadow are exact
+ * whatever the interval. What ages is the ground: a block placed or broken, or a section that
+ * finishes loading, keeps casting the shadow it had until the map is drawn again.
  * <p>
- * <strong>And it is judged by walking, not by capturing.</strong> The lag is counted in frames, so
- * what it looks like depends on the frame rate: three frames at two hundred a second is fifteen
- * milliseconds and reads as a bug on the player's own shadow, while the same three frames leave a
- * pinned camera's capture below the noise of two relaunches. The setting that survived a walk is
- * {@link #DEFAULT_FRAMES}, and anything above it is for a measurement rather than for playing.
+ * <strong>And it is judged by walking, not by capturing.</strong> A lag counted in frames looks
+ * like whatever the frame rate makes of it, and a pinned camera cannot see it at all: captures
+ * taken on one put the difference below the noise two relaunches make on their own. Keeping the
+ * whole finished map, which is what this did before the movers were drawn back into it, froze them
+ * too, and three frames of that reads as a bug on the player's own shadow at two hundred a second.
  * <p>
  * <strong>A pack that voxelises into its shadow pass must not be amortised at all</strong>, its
  * shadow programs writing a volume the rest of the frame reads rather than only a depth. That
@@ -67,13 +67,15 @@ public final class ShadowAmortisation {
 	 * What an empty arming file asks for: the map kept for ONE frame after the one that drew it, so
 	 * it is never more than two frames old.
 	 * <p>
-	 * Three was the first value and it is visibly wrong. Walked in game on 6 September 2026 at three
-	 * frames, the player's own shadow lags the player plainly enough to read as a bug, and a mob's
-	 * does the same. At one it is not seen. That is the whole width of the setting: the artefact
-	 * grows with it, the gain grows with it, and the eye finds the edge between them long before any
-	 * capture does. The captures of that afternoon, taken on a pinned camera where nothing moves,
-	 * put the difference BELOW the noise two relaunches make on their own and would have signed off
-	 * on three.
+	 * One is where a walk left it, and that walk was made against the map kept WHOLE, where three
+	 * frames lagged the player's own shadow plainly enough to read as a bug and one was not seen.
+	 * The movers are drawn back in now, so what that walk judged is gone and nobody has yet walked
+	 * what remains, which is the ground. The value stays where the harsher behaviour put it rather
+	 * than being widened on the strength of a lag nobody has looked at.
+	 * <p>
+	 * The captures of that walk, taken on a pinned camera where nothing moves, put the difference
+	 * BELOW the noise two relaunches make on their own and would have signed off on three. An eye
+	 * finds this edge and an instrument does not.
 	 */
 	public static final int DEFAULT_FRAMES = 1;
 
@@ -81,8 +83,9 @@ public final class ShadowAmortisation {
 	public static final int MIN_FRAMES = 0;
 
 	/**
-	 * The most frames a map may be kept for, whatever the file says. Three is where a walk finds it,
-	 * so the selector stops one short of the value that reads as a bug rather than offering it.
+	 * The most frames a map may be kept for, whatever the file says. Three is where a walk of the
+	 * map kept whole found the artefact, so the selector stops one short of it. Inherited rather
+	 * than measured against the ground alone: see {@link #DEFAULT_FRAMES}.
 	 */
 	public static final int MAX_FRAMES = 2;
 
@@ -255,7 +258,8 @@ public final class ShadowAmortisation {
 			// the map it is looking at is not this frame's.
 			if (frames > 0) {
 				Vitrail.logger().info("Shadow map kept for {} frame(s) after the one that draws it, "
-						+ "so a caster that moves is that many frames late in it", frames);
+						+ "so the ground in it is that many frames old, everything that moves being "
+						+ "drawn afresh", frames);
 			}
 		}
 

--- a/common/src/main/java/dev/vitrail/render/ShadowAmortisation.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowAmortisation.java
@@ -137,6 +137,11 @@ public final class ShadowAmortisation {
 
 	private static boolean drewSinceBegin;
 
+	private static boolean saidRefused;
+
+	private static int countedFrames;
+	private static int countedDraws;
+
 	private ShadowAmortisation() {
 	}
 
@@ -160,11 +165,34 @@ public final class ShadowAmortisation {
 		// that was never drawn.
 		drewLastFrame = drewSinceBegin;
 		drewSinceBegin = false;
+		// Counted here rather than by the stage: what the interval counts is frames since the map
+		// was last FILLED, and this is the one place that sees every frame whatever the stage did.
+		if (!drewLastFrame) {
+			sinceDraw++;
+		}
 
 		pendingCamera.set(camera);
 		pendingAngle = shadowAngle;
 
 		int asked = frames();
+		// Said once per pack, because a setting that does nothing and says nothing is worse than a
+		// setting that is not there: this pack refuses the reuse on its own account, and the player
+		// moving the slider would otherwise watch the frame rate not move.
+		if (asked > 0 && !amortisable && !saidRefused) {
+			saidRefused = true;
+			Vitrail.logger().info("This pack voxelises into its shadow pass, so the map is drawn "
+					+ "every frame whatever the reuse setting says");
+		}
+
+		// A rate and not a one-shot line: what has to be proved is how OFTEN the world is walked for
+		// the light, and a message saying it happened once says nothing about the frame after it.
+		if (asked > 0 && ++countedFrames >= 600) {
+			Vitrail.logger().info("Shadow map: the opaque world was drawn into it {} times in the "
+					+ "last {} frames", countedDraws, countedFrames);
+			countedFrames = 0;
+			countedDraws = 0;
+		}
+
 		drawThisFrame = !seeded || asked <= 0 || !amortisable
 				|| sinceDraw >= asked
 				|| anchorCamera.distance(camera) >= MOVE_BLOCKS
@@ -173,8 +201,14 @@ public final class ShadowAmortisation {
 		return drewLastFrame;
 	}
 
-	/** Whether the stage should walk the world and draw, as settled at the head of this frame. */
-	public static boolean drawThisFrame() {
+	/**
+	 * Whether the OPAQUE world is drawn into the map this frame, settled at the head of it.
+	 * <p>
+	 * Everything else in the stage runs whatever this answers: the walk, so Sodium keeps answering
+	 * visibility from the light's tree, the casters that move, and the translucent world, which
+	 * costs five per cent of what the opaque one does.
+	 */
+	public static boolean drawTerrainThisFrame() {
 		return drawThisFrame;
 	}
 
@@ -183,16 +217,12 @@ public final class ShadowAmortisation {
 	 * was set up with, not what the world looks like now: see {@link #pendingCamera}.
 	 */
 	public static void drawn() {
+		countedDraws++;
 		anchorCamera.set(pendingCamera);
 		anchorAngle = pendingAngle;
 		sinceDraw = 0;
 		seeded = true;
 		drewSinceBegin = true;
-	}
-
-	/** Counted at the close of a frame that kept the map, which is what the interval counts. */
-	public static void kept() {
-		sinceDraw++;
 	}
 
 	/**
@@ -210,6 +240,7 @@ public final class ShadowAmortisation {
 		drawThisFrame = true;
 		drewLastFrame = true;
 		drewSinceBegin = false;
+		saidRefused = false;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ShadowTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowTargets.java
@@ -159,6 +159,26 @@ final class ShadowTargets {
 	private GpuTextureView noTranslucentsView;
 
 	/**
+	 * The map as it stood once the OPAQUE world had been drawn into it and before anything that
+	 * moves was, kept so that a later frame can start from it instead of walking the world again.
+	 * <p>
+	 * That moment is the one worth keeping and the only one: measured 6 September 2026, the opaque
+	 * half of the shadow terrain costs 3.83 ms of the 4.03 ms both halves cost together, so the
+	 * water and the glass are five per cent of it and are redrawn every frame for nothing. Casters
+	 * that move are redrawn every frame too, on top of what is restored, which is what makes this
+	 * different from keeping the finished map: nothing in the picture is late.
+	 * <p>
+	 * The colours go with the depth. A pack whose shadow programs write {@code shadowcolor} would
+	 * otherwise read this frame's movers over the last frame's terrain colour, which is a picture
+	 * nobody drew.
+	 */
+	private GpuTexture keptDepth;
+	private final GpuTexture[] keptColour = new GpuTexture[MAX_COLOURS];
+	private boolean kept;
+	private boolean warnedCopy;
+	private boolean saidRestored;
+
+	/**
 	 * Whether that copy still stands for the map as it is now. Lowered by every clear, because a copy
 	 * is a moment of the map and emptying the map is the moment it stops being one: the same rule
 	 * {@link PackDepth} follows for the two depths it converts, where an image nothing has filled is
@@ -446,6 +466,127 @@ final class ShadowTargets {
 		this.copied = true;
 	}
 
+	/**
+	 * Keeps the map as it stands, which the caller invokes once the opaque world is drawn and before
+	 * anything that moves is. Must run on the render thread and outside any render pass.
+	 * <p>
+	 * Every image the stage writes goes into the store, the depth and each colour the place named,
+	 * because a frame that restores half of them draws this frame's movers over last frame's colour.
+	 */
+	void keep(CommandEncoder encoder) {
+		GpuTexture depth = this.target == null ? null : this.target.getDepthTexture();
+		if (depth == null || this.broken || !copyable(depth)) {
+			return;
+		}
+
+		if (this.keptDepth == null) {
+			this.keptDepth = store("Vitrail kept shadow depth", depth.getFormat());
+		}
+
+		encoder.copyTextureToTexture(depth, this.keptDepth, 0, 0, 0, 0, 0, this.resolution,
+				this.resolution);
+		for (int index : this.live) {
+			GpuTexture colour = colourTexture(index);
+			if (colour == null) {
+				continue;
+			}
+
+			if (this.keptColour[index] == null) {
+				this.keptColour[index] = store("Vitrail kept shadowcolor" + index,
+						colour.getFormat());
+			}
+
+			encoder.copyTextureToTexture(colour, this.keptColour[index], 0, 0, 0, 0, 0,
+					this.resolution, this.resolution);
+		}
+
+		if (!this.kept) {
+			Vitrail.logger().info("Shadow map store taken, so a later frame may put the opaque world "
+					+ "back instead of walking for it");
+		}
+
+		this.kept = true;
+	}
+
+	/**
+	 * Puts the kept map back, which a frame does instead of walking the world for the opaque half.
+	 * <p>
+	 * The copy beside it goes down with the restore: {@code shadowtex1} is a moment of this frame's
+	 * map, and the moment it names has not happened yet when this runs.
+	 *
+	 * @return whether there was anything to put back
+	 */
+	boolean restore(CommandEncoder encoder) {
+		GpuTexture depth = this.target == null ? null : this.target.getDepthTexture();
+		if (!this.kept || depth == null || this.broken || this.keptDepth == null) {
+			return false;
+		}
+
+		encoder.copyTextureToTexture(this.keptDepth, depth, 0, 0, 0, 0, 0, this.resolution,
+				this.resolution);
+		for (int index : this.live) {
+			GpuTexture colour = colourTexture(index);
+			if (colour != null && this.keptColour[index] != null) {
+				encoder.copyTextureToTexture(this.keptColour[index], colour, 0, 0, 0, 0, 0,
+						this.resolution, this.resolution);
+			}
+		}
+
+		this.copied = false;
+		if (!this.saidRestored) {
+			this.saidRestored = true;
+			Vitrail.logger().info("Shadow map put back from the store, so this frame draws only "
+					+ "what moves and the water");
+		}
+
+		return true;
+	}
+
+	/** Whether a map is in the store at all, which is what says a frame may restore rather than draw. */
+	boolean hasKept() {
+		return this.kept && !this.broken;
+	}
+
+	/** Drops the store, at a resize and wherever the images behind it stop being the map's. */
+	void forgetKept() {
+		this.kept = false;
+	}
+
+	private GpuTexture store(String name, GpuFormat format) {
+		return RenderSystem.getDevice().createTexture(() -> name,
+				GpuTexture.USAGE_COPY_DST | GpuTexture.USAGE_COPY_SRC, format,
+				this.resolution, this.resolution, 1, 1);
+	}
+
+	private GpuTexture colourTexture(int index) {
+		if (index == 0) {
+			return this.target == null ? null : this.target.getColorTexture();
+		}
+
+		TargetSurface surface = this.rest[index - 1];
+
+		return surface == null ? null : surface.texture();
+	}
+
+	/**
+	 * Whether the live image may be copied INTO, which is what a restore does and what nothing else
+	 * in this engine has ever asked of the map. Said once and not per frame: a device that refuses
+	 * it makes the whole road unavailable rather than throwing inside a frame.
+	 */
+	private boolean copyable(GpuTexture depth) {
+		if ((depth.usage() & GpuTexture.USAGE_COPY_DST) != 0) {
+			return true;
+		}
+
+		if (!this.warnedCopy) {
+			this.warnedCopy = true;
+			Vitrail.logger().warn("The shadow map cannot be copied into on this device, so it is "
+					+ "drawn every frame and the reuse setting does nothing");
+		}
+
+		return false;
+	}
+
 	/** The depth with everything in it, which the pack reads as {@code shadowtex0}. */
 	GpuTextureView depth() {
 		return this.target == null ? null : this.target.getDepthTextureView();
@@ -529,6 +670,21 @@ final class ShadowTargets {
 		if (this.noTranslucents != null) {
 			this.noTranslucents.close();
 			this.noTranslucents = null;
+		}
+
+		// The store goes with the images it was taken from: a map kept at one size is not a map at
+		// another, and the restore would be refused for a size mismatch rather than for the reason.
+		this.kept = false;
+		if (this.keptDepth != null) {
+			this.keptDepth.close();
+			this.keptDepth = null;
+		}
+
+		for (int index = 0; index < MAX_COLOURS; index++) {
+			if (this.keptColour[index] != null) {
+				this.keptColour[index].close();
+				this.keptColour[index] = null;
+			}
 		}
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -490,6 +490,25 @@ public final class TerrainDraw {
 	}
 
 	/**
+	 * Keeps the map as it stands, which the stage invokes once the opaque world is in it and before
+	 * anything that moves is. Outside any render pass, which that seam is.
+	 */
+	public static void keepShadowMap() {
+		TerrainDraw self = PackChain.terrain();
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (self != null && device != null) {
+			self.targets.shadow().keep(device.createCommandEncoder());
+		}
+	}
+
+	/** Whether a map is in the store, so the stage may put it back instead of walking the world. */
+	public static boolean shadowMapKept() {
+		TerrainDraw self = PackChain.terrain();
+
+		return self != null && self.targets.shadow().hasKept();
+	}
+
+	/**
 	 * Takes the copy the pack reads as {@code shadowtex1}. The caller invokes it between the opaque
 	 * halves of the shadow map and the translucent one, which is the only moment the two names mean
 	 * different things, and outside any render pass: the renderer closes its own before returning.
@@ -576,7 +595,14 @@ public final class TerrainDraw {
 			return false;
 		}
 
-		shadow.defer();
+		// A frame that puts the kept map back must not empty it first, and the emptying is deferred
+		// rather than encoded, so refusing it here is the whole of the refusal: the load-op the
+		// first pass would carry is what would wipe the restore, and it is armed by this line.
+		if (ShadowAmortisation.drawTerrainThisFrame() || !shadow.hasKept()) {
+			shadow.defer();
+		} else {
+			shadow.restore(device.createCommandEncoder());
+		}
 
 		// After the defer, so that a refusal below still empties the map, and before the stage is
 		// declared open, which is the whole point of the step.

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -718,24 +718,44 @@ public final class ViewMatrices implements ViewSource {
 		return this.mapShadowProjectionInverse;
 	}
 
+	/**
+	 * The pair the stage DRAWS with, which is the fresh one on a frame that fills the map and the
+	 * published one on a frame that keeps it.
+	 * <p>
+	 * <strong>That swap is what lets a kept map take this frame's movers.</strong> The terrain in a
+	 * kept map was drawn around the camera of the frame that drew it; the published pair is exactly
+	 * that matrix moved onto this frame's camera, so a mob submitted in this frame's player space
+	 * and drawn through it lands in the same texels as the ground under it. Drawn through the fresh
+	 * pair instead, the mob would sit in a space the terrain beneath it is not in, and it would slide
+	 * across the map by the camera's motion since the last fill.
+	 * <p>
+	 * On a frame that fills the map the two answers are one: {@link ShadowAmortisation#drawn} moves
+	 * the anchor to this frame, so the published pair is this frame's pair with a nought
+	 * translation. Nothing changes for a reader who never keeps a map.
+	 */
 	@Override
 	public Matrix4fc drawnShadowModelView() {
-		return this.shadowModelView;
+		return keeping() ? this.mapShadowModelView : this.shadowModelView;
 	}
 
 	@Override
 	public Matrix4fc drawnShadowModelViewInverse() {
-		return this.shadowModelViewInverse;
+		return keeping() ? this.mapShadowModelViewInverse : this.shadowModelViewInverse;
 	}
 
 	@Override
 	public Matrix4fc drawnShadowProjection() {
-		return this.shadowProjection;
+		return keeping() ? this.mapShadowProjection : this.shadowProjection;
 	}
 
 	@Override
 	public Matrix4fc drawnShadowProjectionInverse() {
-		return this.shadowProjectionInverse;
+		return keeping() ? this.mapShadowProjectionInverse : this.shadowProjectionInverse;
+	}
+
+	/** Whether this frame draws into a map it kept rather than into one it is about to fill. */
+	private boolean keeping() {
+		return this.shadowSeeded && !ShadowAmortisation.drawTerrainThisFrame();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -172,15 +172,10 @@ public final class ShadowTerrain {
 			return;
 		}
 
-		// The map on hand is still the right one, so the whole of this stage is skipped: no walk,
-		// no entities gathered, no pass opened, and above all nothing cleared. The frame's sampling
-		// passes have already been handed the matrices this map was drawn with, that decision being
-		// made at the head of the frame by the same object. Off unless armed, where this answers
-		// true every frame and the stage runs as it always did.
-		if (!ShadowAmortisation.drawThisFrame()) {
-			ShadowAmortisation.kept();
-			return;
-		}
+		// The stage itself is never skipped any more. What a kept map buys is the OPAQUE world, and
+		// that is decided inside draw below: the walk still runs, because it is what hands Sodium
+		// the light's own occlusion tree, and everything that moves is still drawn, because a
+		// caster one frame late is the only thing anybody could see.
 
 		// Ordered so that a stage that cannot open leaves the render lists untouched: the walk
 		// below hands them to the light, and from that point on the camera has to be given them
@@ -298,11 +293,11 @@ public final class ShadowTerrain {
 						walkCulling, walkKept, seen, walkDrawn, measured);
 			}
 
+			// The anchor is NOT taken here. It moves where the opaque world is really drawn, inside
+			// the call below, and a copy of that line left standing at this level is what made the
+			// whole thing do nothing: it reset the interval on every frame, so the count never
+			// elapsed and the map was filled again every time.
 			draw(renderer, minecraft, camera);
-			// Only here, past every road that leaves without a map: the anchor has to follow what
-			// was drawn and never what was planned, or the next frames would sample a map nobody
-			// wrote with the matrices of the frame that meant to write it.
-			ShadowAmortisation.drawn();
 		} finally {
 			// The flag finalizeRenderLists just lowered, back up whatever happened above: the
 			// camera's walk at the top of the next frame has to rebuild, or the world would be
@@ -343,8 +338,14 @@ public final class ShadowTerrain {
 		// shadow stage. Complementary's voxel volume is marked clear; the floodfill is not.
 		PackChain.clearCustomImages();
 
+		// The opaque world, and the one thing a kept map spares. Restored rather than drawn when the
+		// setting says so and a map is in the store, the restore itself having already been encoded
+		// where the clear would have been: the pack's own refusal still comes first, since a pack
+		// that keeps the opaque world out of its map has nothing to keep.
+		boolean drawTerrain = ShadowAmortisation.drawTerrainThisFrame() || !TerrainDraw.shadowMapKept();
+
 		// Refused by the pack rather than skipped for cheapness.
-		if (casters.terrain()) {
+		if (casters.terrain() && drawTerrain) {
 			// Distant Horizons' far terrain goes first and INSIDE this word, both of which are
 			// Iris's. DH hangs its LOD draws off the HEAD of ChunkSectionsToRender.renderGroup
 			// (neoforge/mixins/client/MixinChunkSectionsToRender.java:67-74), and the only call to
@@ -355,6 +356,14 @@ public final class ShadowTerrain {
 			DistantDraw.shadow(false, camera);
 			TerrainDraw.shadowPass(() -> renderer.drawChunkLayer(ChunkSectionLayerGroup.OPAQUE,
 					matrices, camera.x, camera.y, camera.z, sampler));
+		}
+
+		// The store is taken HERE and nowhere else: with the opaque world in the map and before the
+		// first thing that moves goes into it. A store taken later would carry a mob, and every
+		// frame restoring it would paint that mob's old place back under the new one.
+		if (drawTerrain && casters.terrain()) {
+			TerrainDraw.keepShadowMap();
+			ShadowAmortisation.drawn();
 		}
 
 		// Everything that moves, between the opaque world and the copy, which is where Iris puts it
@@ -370,7 +379,7 @@ public final class ShadowTerrain {
 		// walk above closes its last one, so a copy here is outside one.
 		TerrainDraw.copyShadowDepth();
 
-		if (casters.translucent()) {
+		if (casters.translucent() && !Boolean.getBoolean("vitrail.probeNoShadowTranslucent")) {
 			// And its water half here, after the copy and inside the word that governs the world's
 			// own translucent group, for the two reasons the opaque half is where it is: DH's hook
 			// is the head of this very call, and Iris makes it inside its own shadowTranslucent test


### PR DESCRIPTION
## What changes

Shadow Reuse kept the finished map, so everything in it was as old as the map and a caster that
moved lagged by the interval. The map is now kept at the seam where the opaque world is in it and
nothing that moves is yet, and every frame puts that back and redraws the movers and the translucent
world on top of it. The opaque half is 3.83 ms of the 4.03 ms both halves cost together, measured by
switching the translucent one off, so what is skipped is nearly all of the cost while nothing in the
picture is late.

Two pieces make it sound. The store carries the shadow colours beside the depth, or a pack writing
`shadowcolor` would read this frame's movers over last frame's terrain. And a frame that restores
draws through the PUBLISHED shadow pair rather than the fresh one: the terrain in a kept map was
drawn around another frame's camera, and the published pair is that matrix moved onto this one, so a
mob lands in the texels of the ground under it.

## How it differs from the reference, and for what obstacle

**No obstacle, and it narrows an existing divergence rather than adding one.** Iris draws its map
every frame; this engine may now keep the opaque half of it, and what that used to cost the image
was a lag on everything that moves. This branch removes that lag. A pack that voxelises into its
shadow pass is still refused the reuse outright.

## What proves it

- `gradlew build` green, after the rebase onto `dev`.
- **The engine counts what it does.** With the setting at two, it prints `the opaque world was drawn
  into it 200 times in the last 600 frames`, which is one fill in three and exactly what the setting
  asks for. That counter is what found the defect this branch was written around: an anchor call
  left at its old place reset the interval on every frame, so the map was refilled every time while
  both one-shot probes reported the mechanism working.
- **In the game.** Fabric bench, `frozen real`, eye level in open terrain, Photon v1.3b with its
  coloured lighting off, camera pinned, vsync off: 5.81 to 5.57 ms of passes, 154 to 160 frames a
  second, the shadow terrain falling from 1.347 to 1.084 ms.

## What it leaves owing

- **The gain measured here is small, and honestly so.** On that configuration the shadow terrain is
  1.35 ms of a 6.5 ms frame, so a third of it is what there is to win. The lever is worth what the
  pack's shadow terrain weighs, and this branch does not change that.
- **No image verdict.** Nothing here was judged on a capture, and the frozen station cannot judge
  what moves, which is precisely what this branch changes. A walk is what it needs.
- **The packs most people run still get nothing**, because they voxelise. Keeping that volume beside
  the map is its own branch and it is where the rest of this lever lives.
- **One machine, one pack, one scene.**

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [ ] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
      The setting's entry already describes the price this removes, and rewriting it before the
      branch is judged in play would promise an image nobody has looked at.
- [x] Every place that states a fact this branch changed now states the new one.
