### PR TITLE
feat(render): fold the upscaled frames together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ what the next one holds.
 
 ### Added
 
+- **Temporal Fold, a new setting on the engine page.** A world drawn at a lower render scale loses
+  the thin things first, and those are what crawls as you move: distant leaves, fences, the far
+  edges of terrain. The upscale cannot put them back, because it only sees one frame. This blends
+  each frame with the ones before it, matching every pixel to where it stood a frame ago, so the
+  detail comes from the frames themselves and a low scale settles instead of shimmering.
+
+  It is off until you turn it on, and the checkbox is greyed out at a render scale of 100 percent,
+  where there is nothing to rebuild. It costs two more passes and three more images, about 32 MiB of
+  them at 1920x1080. Things that move on their own keep a faint trail, because the match is worked
+  out from the camera and not from what each object did.
+
 - **Shadow Reuse, a new setting on the engine page.** Filling the shadow map means walking the whole
   world a second time, for the sun, and it is the most expensive thing the frame does. Between two
   frames of a player standing still nothing in that map moves, so it is now kept and reused instead

--- a/common/src/main/java/dev/vitrail/ScreenText.java
+++ b/common/src/main/java/dev/vitrail/ScreenText.java
@@ -77,6 +77,9 @@ public final class ScreenText {
 	public static final String RENDER_SCALE = "options.vitrail.render_scale";
 	public static final String RENDER_SCALE_TOOLTIP = "options.vitrail.render_scale_tooltip";
 
+	public static final String TEMPORAL_FOLD = "options.vitrail.temporal_fold";
+	public static final String TEMPORAL_FOLD_TOOLTIP = "options.vitrail.temporal_fold_tooltip";
+
 	/**
 	 * How large the compiled-shader disk store may grow. No counterpart in Iris, so both strings
 	 * are this project's own. The tooltip names the default and says the change applies at once.

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -204,6 +204,13 @@ final class ColorTargets {
 	 */
 	private final CenterDepth centerDepth = new CenterDepth();
 
+	/**
+	 * Where each pixel stood in the previous frame. Held here beside the rest, though no pack binds
+	 * it: what owns a full screen image of this engine owns it here, and a second home for one image
+	 * is how a resize comes to free some of them and not others.
+	 */
+	private final MotionVectors motionVectors = new MotionVectors();
+
 	private final Map<Integer, GpuFormat> formats = new LinkedHashMap<>();
 
 	/** The filter each carried target is sampled with, settled with its format. */
@@ -778,6 +785,14 @@ final class ColorTargets {
 		return this.centerDepth;
 	}
 
+	/**
+	 * The pass that reprojects the frame, and the image it writes. Camera only, and the class says
+	 * what that costs.
+	 */
+	MotionVectors motionVectors() {
+		return this.motionVectors;
+	}
+
 	/** Never held from one frame to the next. Null when this index was never allocated. */
 	GpuTextureView view(int index, TargetSchedule.Side side) {
 		TargetSurface surface = target(index, side);
@@ -968,6 +983,7 @@ final class ColorTargets {
 		this.shadowMap.release();
 		this.depth.release();
 		this.centerDepth.release();
+		this.motionVectors.release();
 		this.pendingClears.clear();
 
 		// Whatever is allocated next is a first allocation again, and it has to say what it costs

--- a/common/src/main/java/dev/vitrail/render/MotionVectors.java
+++ b/common/src/main/java/dev/vitrail/render/MotionVectors.java
@@ -1,0 +1,427 @@
+package dev.vitrail.render;
+
+import dev.vitrail.uniform.ClipSpace;
+import dev.vitrail.uniform.WorldState;
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.PrimitiveTopology;
+import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.buffers.Std140Builder;
+import com.mojang.blaze3d.pipeline.BindGroupLayout;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.shaders.ShaderSource;
+import com.mojang.blaze3d.shaders.ShaderType;
+import com.mojang.blaze3d.shaders.UniformType;
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.RenderPass;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import net.minecraft.client.renderer.BindGroupLayouts;
+import net.minecraft.resources.Identifier;
+import net.minecraft.client.renderer.MappableRingBuffer;
+
+import org.joml.Matrix4f;
+import org.joml.Vector3dc;
+
+import java.util.Optional;
+
+/**
+ * Where each pixel of this frame stood in the previous one, in the form a temporal upscaler takes.
+ * <p>
+ * <strong>Iris has nothing like this, and that is a carve-out rather than a drift.</strong> The
+ * directive that this engine does what Iris does was reopened on this one point, temporal
+ * upscaling, so the pass exists knowing the reference has no counterpart to be measured against.
+ * Nothing else follows from it.
+ * <p>
+ * <strong>The convention is NVIDIA's and it is written here so nobody re-derives it.</strong> The
+ * DLSS Super Resolution guide, revision 310.6.0, section 3.6: "The motion vectors map a pixel from
+ * the current frame to its position in the previous frame. That is, when the motion vector for the
+ * pixel is added to the pixel's current location, the result is the location the pixel occupied in
+ * the previous frame." Section 3.6.1 fixes the units, "the number of pixels calculated in screen
+ * space (ie the amount a pixel has moved at the render resolution)", and the axes, "[0,0] as the
+ * upper left of the screen". So the vector points AGAINST the movement, and a buffer holding the
+ * direction of travel is the whole thing negated. FSR takes the same buffer through a scale factor,
+ * which is why the pixel form is the one stored rather than a normalised one.
+ * <p>
+ * <strong>The camera moves here and nothing else does.</strong> The pass reprojects a depth sample,
+ * so it knows only what the camera did between two frames: a mob walking across a still screen gets
+ * a vector of nought, which is a lie an upscaler will smear. Per-object motion needs the previous
+ * transform of each drawn thing, which means an extra output on translated pack programs, and that
+ * is not this pass.
+ * <p>
+ * <strong>The pair of matrices is the rendered one and never the published one.</strong>
+ * {@link ViewMatrices#previousRendered} carries why at length. In one line: the volume being
+ * reconstructed from is reversed Z over 0..1, and the matrix a pack reads has been converted to the
+ * OpenGL volume, so pairing the two reconstructs a position that is wrong by more the further away
+ * it is, and the picture that comes out of it looks entirely reasonable.
+ * <p>
+ * <strong>The depth sampled is not in that volume and is put back into it here.</strong>
+ * {@link PackDepth} does not copy the device's image, it converts it: its fragment applies
+ * {@code ClipSpace.REVERSED}'s read pair, so what {@code depthtex1} holds is {@code 1 - d}, forward
+ * over 0..1, which is the window a pack reads depth in. Sampling that and dropping it into a
+ * reversed Z slot swaps near and far on every pixel. The conversion is undone from the same two
+ * constants rather than by a written out {@code 1 - d}, so that a change to the pair cannot leave
+ * one of the two sides behind. Reading the device image instead is not the alternative it looks
+ * like: that image is the one being drawn into, which is the reason {@code PackDepth} keeps a copy
+ * at all.
+ * <p>
+ * <strong>Neither matrix carries the camera's translation, so it is applied on its own.</strong>
+ * The view handed to {@link ViewMatrices#advance} is {@code viewRotationMatrix}, a pure rotation, so
+ * every position here is in player space, measured from wherever the camera of that frame stood. A
+ * point at {@code p} this frame stood at {@code p + (camera now - camera before)} in the previous
+ * frame's own space, and without that term the pass reprojects rotation alone: a player walking in a
+ * straight line writes vectors of nought and a turning one writes correct ones, which is the failure
+ * that looks most like success. The engine pays the same trap on the shadow pair and corrects it the
+ * same way, {@code ViewMatrices:465}. The two positions come from
+ * {@link dev.vitrail.uniform.WorldState#cameraPosition} and its previous, which are shifted by the
+ * same amount as each other precisely so that a difference between them survives the shift.
+ * <p>
+ * The screen coordinate comes from {@code gl_FragCoord} rather than from the quad's own
+ * interpolated UV. Vulkan puts that origin at the upper left with y increasing downwards, which is
+ * both the axis the guide asks for and the axis the depth image is stored in, so the same value
+ * serves as the sampling coordinate and as the output position, and neither depends on how the quad
+ * happens to be wound.
+ * <p>
+ * <strong>{@code ndc.xy = uv * 2 - 1} carries no flip here, and the reason is the viewport rather
+ * than the matrix.</strong> A pass is given its viewport by the game, in
+ * {@code com.mojang.blaze3d.vulkan.VulkanRenderPass}, which sets the origin at nought and takes the
+ * height from the attachment, so it is positive and the transform between clip and window
+ * coordinates is exactly {@code uv = ndc * 0.5 + 0.5} with nothing negated. That is a fact about the
+ * game and not about this engine, which is worth saying because this class has no viewport call of
+ * its own to point at: {@code VulkanCommandEncoderMixin.vitrail$viewport} exists for the mipmap
+ * chain and nothing that draws a world pass goes through it.
+ * <p>
+ * The line above is that relation read backwards, and the matrix it then inverts is the same one
+ * that projected, so the round trip closes whichever way up the projection itself is built. This is
+ * why the pass needs no separate answer to which handedness the game's Vulkan renderer uses: the
+ * question does not reach it.
+ * <p>
+ * Half floats and not full ones: the guide asks for "16-bit or 32-bit floating point values" and
+ * refuses integers, because sub-pixel movement is the point. Half precision holds a fraction of a
+ * pixel exactly where the movement is small, which is every frame that is not a whip, and the
+ * buffer is half the bandwidth of the full form.
+ */
+final class MotionVectors {
+
+	private static final Identifier VERTEX_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/motion_vectors_vertex");
+
+	private static final Identifier FRAGMENT_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/motion_vectors_fragment");
+
+	/** The depth of the opaque world, in the volume the device wrote it in. */
+	private static final String SCENE = "DepthSampler";
+
+	private static final String UNIFORM_BLOCK = "OfMotionVectors";
+
+	/** Two matrices and two pairs, which std140 lays out at 64, 64, 8 and 8. */
+	private static final int BLOCK_BYTES = 144;
+
+	/** Two triangles, the quad every full screen pass of this engine draws. */
+	private static final int VERTICES = 6;
+
+	/** Two half floats a texel, which is the form both DLSS and FSR document. */
+	private static final GpuFormat FORMAT = GpuFormat.RG16_FLOAT;
+
+	private static final String LABEL = "Vitrail motion vectors";
+
+	private static final String VERTEX = """
+			#version 460 core
+
+			in vec3 Position;
+
+			void main() {
+				gl_Position = vec4(Position.xy * 2.0 - 1.0, 0.0, 1.0);
+			}
+			""";
+
+	/**
+	 * Formatted with {@code ClipSpace.REVERSED}'s read pair, undone rather than applied: the image
+	 * being sampled has already been through {@code readA * d + readB} on its way out of the device
+	 * volume, and this pass wants the device value back.
+	 */
+	private static final String FRAGMENT = String.format("""
+			#version 460 core
+
+			uniform sampler2D DepthSampler;
+
+			layout(std140) uniform OfMotionVectors {
+				mat4 of_FromScreen;
+				mat4 of_ToPreviousClip;
+				vec2 of_Size;
+				vec2 of_InverseSize;
+			};
+
+			layout(location = 0) out vec2 ofFragData0;
+
+			void main() {
+				vec2 uv = gl_FragCoord.xy * of_InverseSize;
+				float depth = (texture(DepthSampler, uv).r - %s) / %s;
+
+				vec4 here = of_FromScreen * vec4(uv * 2.0 - 1.0, depth, 1.0);
+				vec4 before = of_ToPreviousClip * (here / here.w);
+
+				// Behind the previous camera, so there is no previous pixel to point at. Nought says
+				// the pixel did not move, which is wrong and bounded; anything else off screen would
+				// be a coordinate an upscaler would go and sample.
+				if (before.w <= 0.0) {
+					ofFragData0 = vec2(0.0);
+					return;
+				}
+
+				vec2 was = (before.xy / before.w) * 0.5 + 0.5;
+				ofFragData0 = (was - uv) * of_Size;
+			}
+			""", ClipSpace.REVERSED.w, ClipSpace.REVERSED.z);
+
+	private static final ShaderSource SOURCE = (id, type) -> {
+		if (type == ShaderType.FRAGMENT) {
+			return FRAGMENT_ID.equals(id) ? FRAGMENT : null;
+		}
+
+		return VERTEX_ID.equals(id) ? VERTEX : null;
+	};
+
+	private final Matrix4f fromScreen = new Matrix4f();
+	private final Matrix4f toPreviousClip = new Matrix4f();
+
+	private RenderPipeline pipeline;
+	private TargetSurface vectors;
+	private MappableRingBuffer block;
+
+	/**
+	 * That the allocation failed at a size, and which one. A resize is a real second chance, the
+	 * same way {@link PackDepth} treats one, since the image is the size of the screen.
+	 */
+	private boolean broken;
+	private int brokenWidth;
+	private int brokenHeight;
+
+	/** That the pipeline will not compile, which no resize lifts. */
+	private boolean refused;
+
+	/** Whether this frame drew, since a frame that did not leaves the previous frame's vectors. */
+	private boolean drawn;
+
+	/** That the image was just allocated, so the frame reaching it has no history at this size. */
+	private boolean fresh;
+
+	/**
+	 * Gives the image back on a frame nothing will read it. Separate from {@link #release} because
+	 * the caller says WHY, and because a caller that simply stops calling {@link #draw} would leave
+	 * a full screen image alive for the rest of the session.
+	 */
+	void standDown() {
+		this.drawn = false;
+		release();
+	}
+
+	/** This frame's vectors, or null while nothing has drawn them. */
+	GpuTextureView view() {
+		return this.drawn ? this.vectors.view() : null;
+	}
+
+	/**
+	 * Draws this frame's vectors. Must run on the render thread and outside any render pass.
+	 * <p>
+	 * <strong>Only called on a frame something will read them.</strong> Vectors are read by
+	 * something rebuilding one picture out of several, so on any other frame they would be a full
+	 * screen image and a pass spent on nobody. Deciding that is the caller's, and the other side of
+	 * the decision is {@link #standDown}, which gives the image back.
+	 *
+	 * @param depth the opaque world's depth as a pack reads it, forward over 0..1, which the
+	 *              fragment stage puts back into the device volume
+	 * @param view  the frame's matrices, already advanced, so its previous pair is the frame before
+	 * @param world the frame's values, for the camera of this frame and of the one before
+	 */
+	void draw(CommandEncoder encoder, GpuDevice device, GpuBuffer quad, GpuTextureView depth,
+			int width, int height, ViewMatrices view, WorldState world) {
+		this.drawn = false;
+		if (quad == null || depth == null || !ensure(width, height)) {
+			return;
+		}
+
+		// The first frame at a new size has no history at that size: the matrices still describe a
+		// camera looking through a differently shaped window, and the vectors drawn from them are
+		// that reshaping rather than any movement. Skipped outright rather than drawn and ignored,
+		// so what reads this is handed nothing and falls back for the one frame it takes.
+		if (this.fresh) {
+			this.fresh = false;
+
+			return;
+		}
+
+		RenderPipeline compiled = pipeline(device);
+		if (compiled == null) {
+			return;
+		}
+
+		// Composed and inverted here rather than in the shader: it is two multiplies and one inverse
+		// a frame against one of each per pixel, and the shader stays a line of arithmetic anybody
+		// can check against the quoted convention.
+		this.fromScreen.set(view.rendered()).mul(view.gbufferModelView()).invert();
+
+		// Post-multiplied, so the offset reaches a point BEFORE the previous frame's rotation turns
+		// it: both are distances in player space, and one applied on the far side of the rotation
+		// would be a different place in the world. The same order the shadow pair is corrected in.
+		Vector3dc now = world.cameraPosition();
+		Vector3dc before = world.previousCameraPosition();
+		this.toPreviousClip.set(view.previousRendered()).mul(view.gbufferPreviousModelView())
+				.translate((float) (now.x() - before.x()), (float) (now.y() - before.y()),
+						(float) (now.z() - before.z()));
+
+		this.block.rotate();
+		try (GpuBufferSlice.MappedView mapped = this.block.currentBuffer().map(false, true)) {
+			Std140Builder.intoBuffer(mapped.data())
+					.putMat4f(this.fromScreen)
+					.putMat4f(this.toPreviousClip)
+					.putVec2(width, height)
+					.putVec2(1.0F / width, 1.0F / height);
+		}
+
+		try (RenderPass pass = encoder.createRenderPass(() -> LABEL, this.vectors.view(),
+				Optional.empty())) {
+			pass.setPipeline(compiled);
+			RenderSystem.bindDefaultUniforms(pass);
+			pass.setUniform(UNIFORM_BLOCK, this.block.currentBuffer());
+			pass.setVertexBuffer(0, quad.slice());
+			// NEAREST, because a filtered depth between two surfaces is a position on neither of
+			// them and the vector drawn from it points at nothing.
+			pass.bindTexture(SCENE, depth,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+			pass.draw(VERTICES, 1, 0, 0);
+		}
+
+		this.drawn = true;
+	}
+
+	/** Frees the image and the buffer behind the block. */
+	void release() {
+		if (this.vectors != null) {
+			this.vectors.close();
+			this.vectors = null;
+		}
+
+		if (this.block != null) {
+			this.block.close();
+			this.block = null;
+		}
+
+		this.drawn = false;
+	}
+
+	private boolean ensure(int width, int height) {
+		// Before the latch and not after, the order PackDepth.ensure keeps and for the reason
+		// written there: a minimised window is another size, and lifting a refusal on a size nothing
+		// is ever allocated at only makes the real size pay the failure twice.
+		if (width <= 0 || height <= 0) {
+			return false;
+		}
+
+		if (this.broken && (width != this.brokenWidth || height != this.brokenHeight)) {
+			this.broken = false;
+		}
+
+		if (this.broken) {
+			return false;
+		}
+
+		if (this.block == null) {
+			try {
+				this.block = new MappableRingBuffer(() -> LABEL,
+						GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, BLOCK_BYTES);
+			} catch (RuntimeException e) {
+				this.broken = true;
+				this.brokenWidth = width;
+				this.brokenHeight = height;
+				Vitrail.logger().error("Vitrail could not allocate the uniform buffer the motion "
+						+ "vector pass writes its two matrices into, so nothing reprojects", e);
+
+				return false;
+			}
+		}
+
+		if (this.vectors != null && this.vectors.width() == width
+				&& this.vectors.height() == height) {
+			return true;
+		}
+
+		try {
+			// The old one first: a resize that allocates before freeing holds two full screen images
+			// at once, and the size that fails is the size that was already tight.
+			if (this.vectors != null) {
+				this.vectors.close();
+				this.vectors = null;
+			}
+
+			this.vectors = new TargetSurface(LABEL, FORMAT, false, width, height);
+		} catch (RuntimeException e) {
+			this.broken = true;
+			this.brokenWidth = width;
+			this.brokenHeight = height;
+			this.drawn = false;
+			Vitrail.logger().error("Vitrail could not allocate the motion vector image at {}x{}, so "
+					+ "nothing reprojects until the screen is another size", width, height, e);
+
+			return false;
+		}
+
+		this.fresh = true;
+
+		return true;
+	}
+
+	/**
+	 * The pipeline, compiled the first time it is asked for and kept.
+	 * <p>
+	 * The compiled form lives in the device cache, which the game empties at every resource reload,
+	 * so this asks the device every time rather than trusting a flag of its own: that call is a
+	 * {@code computeIfAbsent} on the device side and costs nothing once it has been made.
+	 */
+	private RenderPipeline pipeline(GpuDevice device) {
+		if (this.refused) {
+			return null;
+		}
+
+		if (this.pipeline == null) {
+			this.pipeline = build();
+		}
+
+		if (device.precompilePipeline(this.pipeline, SOURCE).isValid()) {
+			return this.pipeline;
+		}
+
+		release();
+		this.refused = true;
+		this.pipeline = null;
+		Vitrail.logger().error("The motion vector pass did not compile, so nothing reprojects for "
+				+ "the rest of this session");
+
+		return null;
+	}
+
+	private static RenderPipeline build() {
+		return RenderPipeline.builder()
+				.withLocation(Identifier.fromNamespaceAndPath(Vitrail.MOD_ID,
+						"pipeline/motion_vectors"))
+				.withVertexShader(VERTEX_ID)
+				.withFragmentShader(FRAGMENT_ID)
+				.withBindGroupLayout(BindGroupLayouts.GLOBALS)
+				.withBindGroupLayout(BindGroupLayout.builder()
+						.withUniform(UNIFORM_BLOCK, UniformType.UNIFORM_BUFFER)
+						.withSampler(SCENE)
+						.build())
+				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
+				.withColorTargetState(new ColorTargetState(Optional.empty(), FORMAT,
+						ColorTargetState.WRITE_ALL))
+				.withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
+				.withCull(false)
+				.build();
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -118,6 +118,21 @@ public final class PackChain {
 	private static volatile PackChain active;
 
 	/**
+	 * What this frame's motion vector pass wrote, or null on any frame it did not draw, which is
+	 * every frame with no pack and every frame the world is not being upscaled on.
+	 * <p>
+	 * Static because the reader is {@link RenderScale}, which stands outside the chain and outside
+	 * the pack: it owns the moment the upscale runs at, and the chain owns the image.
+	 */
+	static GpuTextureView motionVectors() {
+		PackChain chain = active;
+
+		return chain == null || chain.targets == null
+				? null
+				: chain.targets.motionVectors().view();
+	}
+
+	/**
 	 * Whether the frame has stopped drawing the pack, for a reason the load or the frame found and
 	 * {@link PackChoice#lastError} says. Lifted only by the next load.
 	 */
@@ -1784,6 +1799,21 @@ public final class PackChain {
 		// and prepares and not what this line decides, and no pack of the corpus declares the name
 		// in either family.
 		sampleCenterDepth(device);
+		// Here because the opaque depth taken above is this frame's, and because the matrices have
+		// been advanced once for this frame already, so what the pass calls the previous pair really
+		// is the frame before rather than this one. Both halves of that are the same boundary
+		// FrameState.advance draws, and moving this line either side of it would reproject a frame
+		// against itself and write a screen of noughts that looks exactly like a still camera.
+		// The gate is asked BEFORE anything is built for the call: an encoder made in the argument
+		// list is two allocations a frame for a player who never turns any of this on.
+		MotionVectors vectors = this.targets.motionVectors();
+		if (RenderScale.upscaling() && TemporalAccumulation.wanted()) {
+			vectors.draw(device.createCommandEncoder(), device, this.quad,
+					this.targets.depth().opaque(), ready.main().width, ready.main().height,
+					this.values.view(), this.values.world());
+		} else {
+			vectors.standDown();
+		}
 
 		int end = deferredEnd();
 		if (!this.split) {

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -621,6 +621,15 @@ public final class PackValues {
 	}
 
 	/**
+	 * The frame's matrices, for the engine's own passes rather than for a block. Package private and
+	 * not on {@link WorldState}, which is the pack's window onto the frame: what reads this reads
+	 * the rendered pair, and no name a pack knows is written in that volume.
+	 */
+	ViewMatrices view() {
+		return this.state.view();
+	}
+
+	/**
 	 * Moves the frame on. Called once, at a named point, before the first block of the frame is
 	 * written and never per program: the previous frame's matrices shift here, and a
 	 * {@code smooth()} in a pack's expression integrates here, so calling it twice makes every

--- a/common/src/main/java/dev/vitrail/render/RenderScale.java
+++ b/common/src/main/java/dev/vitrail/render/RenderScale.java
@@ -397,6 +397,18 @@ public final class RenderScale {
 	/** Whether the main target currently holds the scaled set, which never survives a frame. */
 	private static boolean swapped;
 
+	/**
+	 * Whether the world being drawn right now is going to be upscaled.
+	 * <p>
+	 * The one question worth asking for a pass that only earns its cost when something is going to
+	 * rebuild the image afterwards. It is the frame's answer and not the player's setting: a
+	 * hundred percent, a frame with no world, and an allocation this class refused all read false
+	 * here, which is what {@link #swapped} already means.
+	 */
+	static boolean upscaling() {
+		return swapped;
+	}
+
 	/** The window-sized set the game allocated, held only while the scaled set stands in for it. */
 	private static GpuTexture fullColor;
 	private static GpuTextureView fullColorView;
@@ -412,6 +424,12 @@ public final class RenderScale {
 	private static TargetSurface upscaled;
 
 	private static GpuBuffer quad;
+
+	/**
+	 * The temporal probe, which is nothing at all unless it was asked for on the command line. Held
+	 * here because this class owns the moment it would run at, between the upscale and the sharpen.
+	 */
+	private static final TemporalAccumulation TEMPORAL = new TemporalAccumulation();
 
 	/** Whether the entity outline target is at the scaled size and owes the window its own back. */
 	private static boolean outlineScaled;
@@ -555,8 +573,11 @@ public final class RenderScale {
 		RenderPipeline rcas = easu == null ? null : RCAS.get(device);
 		if (easu != null && rcas != null && upscaled != null) {
 			draw(encoder, device, easu, world, upscaled.view(), FilterMode.LINEAR, UPSCALE_LABEL);
-			draw(encoder, device, rcas, upscaled.view(), fullColorView(main), FilterMode.NEAREST,
-					SHARPEN_LABEL);
+			// Between the two and not after the sharpen: RCAS raises local contrast, and folding a
+			// sharpened frame into a sharpened history sharpens the same edge once per frame it
+			// survives. Sharpening last is also what AMD's own chain does.
+			draw(encoder, device, rcas, sharpenFrom(encoder, device, main), fullColorView(main),
+					FilterMode.NEAREST, SHARPEN_LABEL);
 
 			return;
 		}
@@ -633,6 +654,10 @@ public final class RenderScale {
 			upscaled.close();
 			upscaled = null;
 		}
+
+		// With them and not on its own latch: the history is the size of the window, so whatever
+		// frees the window-sized pair here has the same reason to free that one.
+		TEMPORAL.release();
 	}
 
 	/** Puts the game's own textures back into the target's fields, closing nothing. */
@@ -724,6 +749,29 @@ public final class RenderScale {
 		}
 
 		outlineScaled = scaledNow;
+	}
+
+	/**
+	 * What the sharpen reads: the upscaled frame, or the fold of it into the frames before when the
+	 * temporal probe is asked for and has everything it needs. The probe answers null for every
+	 * reason there is, a missing motion vector image included, and each of them lands back on the
+	 * plain upscale rather than on a black screen.
+	 */
+	private static GpuTextureView sharpenFrom(CommandEncoder encoder, GpuDevice device,
+			RenderTarget main) {
+		if (!TemporalAccumulation.wanted() || scaled == null) {
+			// Given back here and not left to the release below: that one is only reached when the
+			// scale stands down altogether, so a player who turns the fold off while still scaling
+			// would keep two window-sized images of half floats for the rest of the session.
+			TEMPORAL.release();
+
+			return upscaled.view();
+		}
+
+		GpuTextureView folded = TEMPORAL.fold(encoder, device, quad(device), upscaled.view(),
+				PackChain.motionVectors(), main.width, main.height, scaled.width, scaled.height);
+
+		return folded == null ? upscaled.view() : folded;
 	}
 
 	/** One full screen pass: sample one image whole, write another whole. */

--- a/common/src/main/java/dev/vitrail/render/TemporalAccumulation.java
+++ b/common/src/main/java/dev/vitrail/render/TemporalAccumulation.java
@@ -1,0 +1,451 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.PrimitiveTopology;
+import com.mojang.blaze3d.buffers.GpuBuffer;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.buffers.Std140Builder;
+import com.mojang.blaze3d.pipeline.BindGroupLayout;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.shaders.ShaderSource;
+import com.mojang.blaze3d.shaders.ShaderType;
+import com.mojang.blaze3d.shaders.UniformType;
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.RenderPass;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.FilterMode;
+import com.mojang.blaze3d.textures.GpuTextureView;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import net.minecraft.client.renderer.BindGroupLayouts;
+import net.minecraft.client.renderer.MappableRingBuffer;
+import net.minecraft.resources.Identifier;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Folds several upscaled frames into one, reprojected by {@link MotionVectors}: a checkbox on the
+ * engine page beside the render scale, off until asked for, and worth nothing at a scale of a
+ * hundred where there is nothing to rebuild.
+ * <p>
+ * <strong>What it recovers is the detail the scale stopped drawing.</strong> A world rendered small
+ * loses the thin things first, and they are exactly what shimmers as the camera moves: distant
+ * leaves, fences, the edges of far terrain. Several frames of a small world do not carry the same
+ * detail as each other, so folding them puts some of it back, and the picture at a low scale settles
+ * instead of crawling.
+ * <p>
+ * <strong>Its failure mode is also the only proof its inputs are right.</strong> None of what feeds
+ * it can be checked on a still frame, and all of it shows here within a second of walking: vectors
+ * pointing the wrong way smear the world along the direction of travel instead of holding it still,
+ * and a camera translation left out smears when the player moves and not when they turn. That is
+ * worth knowing when a report arrives about this looking wrong, because what is wrong is more likely
+ * upstream of this class than in it.
+ * <p>
+ * <strong>It deliberately does not jitter.</strong> Seven of the eight packs of the corpus already
+ * apply their own sub-pixel offset for their own temporal pass, so the low resolution frames already
+ * differ from one another and there is already something for an accumulator to recover. Arming a
+ * second jitter on top would be two of them, and would confound the one question being asked. Body
+ * Camera, which jitters nothing, is the control: if accumulation buys visibly less there than
+ * elsewhere, that is the measurement that says our own jitter is needed, and it costs nothing to
+ * take.
+ * <p>
+ * <strong>Where it sits is wrong by both vendors' contracts, and that is deliberate.</strong> NVIDIA
+ * asks for the upscale "before tone mapping", AMD splits post processing into a column that runs
+ * before and a column that runs after, with tone mapping, bloom and depth of field in the second.
+ * Here all of that belongs to the pack and this pass runs after the whole of it, on the finished
+ * picture, because that is where {@link RenderScale} already stands. So this is not FSR and not a
+ * step towards it: it is the cheapest place to learn whether the inputs are right, and what a real
+ * integration would have to buy is the cut through the pack's own chain that nothing in a pack
+ * declares.
+ * <p>
+ * The history is folded with a fixed weight rather than a variance clip, and it is held to the
+ * neighbourhood of the current frame, which is what stops a reprojection that lands on the wrong
+ * surface from dragging last frame's colour across an edge. That clamp is also what makes a defect
+ * honest: without it, wrong vectors produce a smear that a viewer reads as motion blur, and with it
+ * they produce a shimmer nobody mistakes for a feature.
+ */
+public final class TemporalAccumulation {
+
+	/** Where the answer is kept between sessions, beside the pack like the other engine settings. */
+	private static final String SETTING_FILE = "temporal-fold";
+
+	/** What a player gets without touching anything: the engine as it was, exactly. */
+	public static final boolean DEFAULT_WANTED = false;
+
+	/**
+	 * Whether the fold is asked for, or null while the file has not been read.
+	 * <p>
+	 * A checkbox on the engine page and not a command line switch: a road a session takes to measure
+	 * both sides in one jar and a road a player is handed are the same road here, and two of them
+	 * drift. The value applies at the next frame, so the two sides of a comparison are a click apart
+	 * rather than a relaunch apart.
+	 */
+	private static Boolean wanted;
+
+	private static final Identifier VERTEX_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/temporal_vertex");
+
+	private static final Identifier FRAGMENT_ID =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pack/temporal_fragment");
+
+	private static final String CURRENT = "InSampler";
+	private static final String HISTORY = "PrevSampler";
+	private static final String VECTORS = "MotionSampler";
+
+	private static final String UNIFORM_BLOCK = "OfTemporal";
+
+	/** Two pairs and a float, which std140 lays out at 8, 8 and 4, rounded up to the alignment. */
+	private static final int BLOCK_BYTES = 32;
+
+	private static final int VERTICES = 6;
+	private static final int SURFACES = 2;
+
+	/**
+	 * How much of the new frame goes in. A tenth is the usual weight for this kind of fold, and it
+	 * is the one worth starting at because it is aggressive enough that a defect in the vectors is
+	 * unmistakable rather than subtle.
+	 */
+	private static final float NEW_WEIGHT = 0.1F;
+
+	/** Half floats: an eight bit accumulator folded at a tenth quantises before it converges. */
+	private static final GpuFormat FORMAT = GpuFormat.RGBA16_FLOAT;
+
+	private static final String LABEL = "Vitrail temporal accumulation";
+
+	private static final String VERTEX = """
+			#version 460 core
+
+			in vec3 Position;
+
+			void main() {
+				gl_Position = vec4(Position.xy * 2.0 - 1.0, 0.0, 1.0);
+			}
+			""";
+
+	/**
+	 * The motion vector is read at the output pixel and is in pixels of the RENDER resolution, so it
+	 * is divided by that size and not by this pass's own: the two differ by exactly the render scale,
+	 * and dividing by the wrong one produces a reprojection that is right at a hundred percent and
+	 * wrong everywhere this is actually used.
+	 */
+	private static final String FRAGMENT = """
+			#version 460 core
+
+			uniform sampler2D InSampler;
+			uniform sampler2D PrevSampler;
+			uniform sampler2D MotionSampler;
+
+			layout(std140) uniform OfTemporal {
+				vec2 of_InverseSize;
+				vec2 of_InverseRenderSize;
+				float of_NewWeight;
+			};
+
+			layout(location = 0) out vec4 ofFragData0;
+
+			void main() {
+				vec2 uv = gl_FragCoord.xy * of_InverseSize;
+				vec4 here = texture(InSampler, uv);
+
+				vec2 motion = texture(MotionSampler, uv).rg * of_InverseRenderSize;
+				vec2 was = uv + motion;
+
+				// Off screen a frame ago, so there is no history for this pixel and the fold would
+				// be against whatever the clamp to edge hands back, which is a stripe of the border
+				// smeared inwards along every edge the camera turns towards.
+				//
+				// Written as the negation of "inside" rather than as four outside tests, because a
+				// NaN compares false against BOTH, so the four-test form lets a NaN coordinate
+				// through into the history fetch while this one rejects it.
+				if (!(was.x >= 0.0 && was.x <= 1.0 && was.y >= 0.0 && was.y <= 1.0)) {
+					ofFragData0 = here;
+
+					return;
+				}
+
+				vec3 low = here.rgb;
+				vec3 high = here.rgb;
+				for (int x = -1; x <= 1; x++) {
+					for (int y = -1; y <= 1; y++) {
+						vec3 neighbour =
+								texture(InSampler, uv + vec2(x, y) * of_InverseSize).rgb;
+						low = min(low, neighbour);
+						high = max(high, neighbour);
+					}
+				}
+
+				vec3 before = clamp(texture(PrevSampler, was).rgb, low, high);
+				ofFragData0 = vec4(mix(before, here.rgb, of_NewWeight), here.a);
+			}
+			""";
+
+	private static final ShaderSource SOURCE = (id, type) -> {
+		if (type == ShaderType.FRAGMENT) {
+			return FRAGMENT_ID.equals(id) ? FRAGMENT : null;
+		}
+
+		return VERTEX_ID.equals(id) ? VERTEX : null;
+	};
+
+	private RenderPipeline pipeline;
+	private TargetSurface[] history;
+	private MappableRingBuffer block;
+
+	private boolean refused;
+	private int current;
+
+	/** Whether the pair holds anything at all, which the first frame at a size does not. */
+	private boolean primed;
+
+	/**
+	 * Whether the road taken has been said out loud yet.
+	 * <p>
+	 * A switch that prints nothing on one of its two roads leaves every reading taken there
+	 * unattributable: a run that looks unchanged is either the fold running and changing little, or
+	 * the fold never having run, and nothing on screen tells those apart. Said once rather than per
+	 * frame, and said from the fold rather than from the flag, so what it reports is that the pass
+	 * really drew and not merely that somebody asked for it.
+	 */
+	private boolean announced;
+
+	/**
+	 * The same, for the refusal above, and a second flag rather than a shared one on purpose: one
+	 * flag would let the refusal spend it, and the fold that started working afterwards would then
+	 * go unannounced, which is the exact silence this pair exists to close.
+	 */
+	private boolean announcedMissing;
+
+	/** Whether the fold is asked for at all. Read before anything is allocated. */
+	public static boolean wanted() {
+		if (wanted == null) {
+			wanted = read();
+		}
+
+		return wanted;
+	}
+
+	/**
+	 * Takes what the settings screen chose, writes it beside the pack and keeps the live answer. It
+	 * applies at the next frame: no pack reload and no restart.
+	 */
+	public static void setWanted(boolean asked) {
+		wanted = asked;
+		try {
+			Path file = file();
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, asked + "\n");
+		} catch (IOException | RuntimeException e) {
+			// Kept live anyway: a value that cannot be stored is still the one the player asked for
+			// this session, and a checkbox that springs back says nothing at all.
+			Vitrail.logger().warn("Could not store the temporal fold, it holds for this session "
+					+ "only", e);
+		}
+	}
+
+	private static boolean read() {
+		try {
+			Path file = file();
+			if (!Files.isRegularFile(file)) {
+				return DEFAULT_WANTED;
+			}
+
+			// Anything that is not the word reads as off rather than on, which is the opposite of
+			// how the shadow interval treats a typo, and deliberately: that one answers a typo with
+			// its default because its default is a gain that would disappear silently. This one is
+			// off by default, so a typo answered with on would turn the picture over instead.
+			return Boolean.parseBoolean(Files.readString(file).trim());
+		} catch (IOException | RuntimeException ignored) {
+			return DEFAULT_WANTED;
+		}
+	}
+
+	private static Path file() {
+		return Vitrail.platform().gameDirectory().resolve("vitrail").resolve(SETTING_FILE);
+	}
+
+	/**
+	 * Folds this frame into the history and hands back what to read on, or null when it did not run,
+	 * in which case the caller carries on with the image it already had.
+	 *
+	 * @param scene   the upscaled frame, at the window's size
+	 * @param vectors what {@link MotionVectors} wrote, at the render size, or null on a frame it did
+	 *                not draw
+	 */
+	GpuTextureView fold(CommandEncoder encoder, GpuDevice device, GpuBuffer quad,
+			GpuTextureView scene, GpuTextureView vectors, int width, int height, int renderWidth,
+			int renderHeight) {
+		if (!wanted()) {
+			return null;
+		}
+
+		if (vectors == null) {
+			// The one refusal worth a line of its own, because it is the one that looks like the
+			// fold working and changing nothing: asked for, running, and handed no vectors because
+			// the chain drew none. Said once, since it is true for every frame until a pack loads.
+			if (!this.announcedMissing) {
+				this.announcedMissing = true;
+				// What it names are the reasons that can actually be true HERE. A pack and a scale
+				// under a hundred are not among them: this is only reached from inside the scaled
+				// branch, which already required both, so naming them would send a reader to check
+				// two things that cannot be the cause.
+				Vitrail.logger().warn("Temporal fold asked for but the engine wrote no motion "
+						+ "vectors this frame, so the picture is the plain upscale: either the "
+						+ "window has just changed size, or the vector pass could not allocate or "
+						+ "did not compile, both of which say so on their own line");
+			}
+
+			return null;
+		}
+
+		if (quad == null || scene == null || renderWidth <= 0 || renderHeight <= 0
+				|| !ensure(width, height)) {
+			return null;
+		}
+
+		RenderPipeline compiled = pipeline(device);
+		if (compiled == null) {
+			return null;
+		}
+
+		int into = 1 - this.current;
+		// The first frame at a size has no history, and folding against an unwritten image would
+		// hand the clamp a neighbourhood of whatever the driver left. One frame of the scene alone.
+		float weight = this.primed ? NEW_WEIGHT : 1.0F;
+
+		this.block.rotate();
+		try (GpuBufferSlice.MappedView mapped = this.block.currentBuffer().map(false, true)) {
+			Std140Builder.intoBuffer(mapped.data())
+					.putVec2(1.0F / width, 1.0F / height)
+					.putVec2(1.0F / renderWidth, 1.0F / renderHeight)
+					.putFloat(weight);
+		}
+
+		try (RenderPass pass = encoder.createRenderPass(() -> LABEL, this.history[into].view(),
+				Optional.empty())) {
+			pass.setPipeline(compiled);
+			RenderSystem.bindDefaultUniforms(pass);
+			pass.setUniform(UNIFORM_BLOCK, this.block.currentBuffer());
+			pass.setVertexBuffer(0, quad.slice());
+			pass.bindTexture(CURRENT, scene,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR));
+			// LINEAR on the history, because the reprojected coordinate lands between texels and a
+			// nearest fetch there is a quarter pixel of jitter added to every frame of the fold.
+			pass.bindTexture(HISTORY, this.history[this.current].view(),
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.LINEAR));
+			// NEAREST on the vectors: a filtered vector across a silhouette is the average of two
+			// surfaces moving differently, which points at neither of them.
+			pass.bindTexture(VECTORS, vectors,
+					RenderSystem.getSamplerCache().getClampToEdge(FilterMode.NEAREST));
+			pass.draw(VERTICES, 1, 0, 0);
+		}
+
+		this.current = into;
+		this.primed = true;
+		if (!this.announced) {
+			this.announced = true;
+			Vitrail.logger().info("Temporal fold armed: {}x{} folded from a {}x{} world, {} of each "
+					+ "new frame, reprojected by the engine's motion vectors", width, height,
+					renderWidth, renderHeight, NEW_WEIGHT);
+		}
+
+		return this.history[into].view();
+	}
+
+	void release() {
+		if (this.history != null) {
+			for (TargetSurface one : this.history) {
+				if (one != null) {
+					one.close();
+				}
+			}
+
+			this.history = null;
+		}
+
+		if (this.block != null) {
+			this.block.close();
+			this.block = null;
+		}
+
+		this.current = 0;
+		this.primed = false;
+	}
+
+	private boolean ensure(int width, int height) {
+		if (width <= 0 || height <= 0 || this.refused) {
+			return false;
+		}
+
+		if (this.history != null && this.history[0].width() == width
+				&& this.history[0].height() == height) {
+			return true;
+		}
+
+		try {
+			release();
+			this.history = new TargetSurface[SURFACES];
+			this.history[0] = new TargetSurface(LABEL, FORMAT, false, width, height);
+			this.history[1] = new TargetSurface(LABEL + ", the frame before", FORMAT, false, width,
+					height);
+			this.block = new MappableRingBuffer(() -> LABEL,
+					GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, BLOCK_BYTES);
+		} catch (RuntimeException e) {
+			release();
+			this.refused = true;
+			Vitrail.logger().error("Vitrail could not allocate the temporal fold's history at "
+					+ "{}x{}, so it stays off for this session", width, height, e);
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private RenderPipeline pipeline(GpuDevice device) {
+		if (this.refused) {
+			return null;
+		}
+
+		if (this.pipeline == null) {
+			this.pipeline = build();
+		}
+
+		if (device.precompilePipeline(this.pipeline, SOURCE).isValid()) {
+			return this.pipeline;
+		}
+
+		release();
+		this.refused = true;
+		this.pipeline = null;
+		Vitrail.logger().error("The temporal fold did not compile, so it stays off for this "
+				+ "session");
+
+		return null;
+	}
+
+	private static RenderPipeline build() {
+		return RenderPipeline.builder()
+				.withLocation(Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "pipeline/temporal"))
+				.withVertexShader(VERTEX_ID)
+				.withFragmentShader(FRAGMENT_ID)
+				.withBindGroupLayout(BindGroupLayouts.GLOBALS)
+				.withBindGroupLayout(BindGroupLayout.builder()
+						.withUniform(UNIFORM_BLOCK, UniformType.UNIFORM_BUFFER)
+						.withSampler(CURRENT)
+						.withSampler(HISTORY)
+						.withSampler(VECTORS)
+						.build())
+				.withVertexBinding(0, DefaultVertexFormat.POSITION_TEX)
+				.withColorTargetState(new ColorTargetState(Optional.empty(), FORMAT,
+						ColorTargetState.WRITE_ALL))
+				.withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
+				.withCull(false)
+				.build();
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/ViewMatrices.java
+++ b/common/src/main/java/dev/vitrail/render/ViewMatrices.java
@@ -59,6 +59,23 @@ public final class ViewMatrices implements ViewSource {
 	private final Matrix4f previousModelView = new Matrix4f();
 	private final Matrix4f previousProjection = new Matrix4f();
 
+	/**
+	 * The frame before's {@link #rendered}, which is the same camera as {@link #previousProjection}
+	 * expressed in the volume the device rasterises into rather than the one a pack reads.
+	 * <p>
+	 * <strong>The two are not interchangeable and the difference is silent.</strong>
+	 * {@code previousProjection} has been through {@link ClipSpace#toLegacyDepth}, so its z maps to
+	 * -1..1 the way an OpenGL pack expects; this one is reversed Z over 0..1, which is what the
+	 * depth image actually holds. Anything reprojecting a depth SAMPLE belongs on this side: pairing
+	 * the sampled depth with the published matrix reads a plausible position for every pixel, wrong
+	 * by an amount that grows with distance, and no picture says so.
+	 * <p>
+	 * Kept rather than derived from {@code previousProjection} by inverting the conversion. That
+	 * would be the second conversion of the same matrix, and the class already keeps every matrix
+	 * singly converted for exactly that reason.
+	 */
+	private final Matrix4f previousRendered = new Matrix4f();
+
 	private final Matrix4f shadowModelView = new Matrix4f();
 	private final Matrix4f shadowModelViewInverse = new Matrix4f();
 	private final Matrix4f shadowProjection = new Matrix4f();
@@ -227,6 +244,7 @@ public final class ViewMatrices implements ViewSource {
 		if (this.seeded) {
 			this.previousModelView.set(this.modelView);
 			this.previousProjection.set(this.projection);
+			this.previousRendered.set(this.rendered);
 		}
 
 		// Pre-multiplied and not appended: the bob is applied to the world after the camera has
@@ -245,6 +263,7 @@ public final class ViewMatrices implements ViewSource {
 			// vector in the first frame the whole screen.
 			this.previousModelView.set(this.modelView);
 			this.previousProjection.set(this.projection);
+			this.previousRendered.set(this.rendered);
 			this.seeded = true;
 		}
 
@@ -696,6 +715,27 @@ public final class ViewMatrices implements ViewSource {
 	@Override
 	public Matrix4fc gbufferPreviousProjection() {
 		return this.previousProjection;
+	}
+
+	/**
+	 * The frame's projection in the volume the device rasterises into, reversed Z over 0..1.
+	 * <p>
+	 * <strong>Not by itself what the level was drawn with, whenever the bob split holds.</strong>
+	 * It is then the clean camera, and the game drew with this times {@link #cameraBob}. The product
+	 * that matters is this one times {@link #gbufferModelView}, which is the bob back in place,
+	 * because the model view is where a pack expects the bob and where this class put it.
+	 * <p>
+	 * Engine side, and deliberately not on {@link ViewSource}: no pack names it, and handing it out
+	 * as a pack uniform would put a second convention behind a name packs read in the other one.
+	 * What it is for is the pair with {@link #previousRendered}, which reprojects a sampled depth.
+	 */
+	Matrix4fc rendered() {
+		return this.rendered;
+	}
+
+	/** The frame before's {@link #rendered}, and see that field for why it is kept apart. */
+	Matrix4fc previousRendered() {
+		return this.previousRendered;
 	}
 
 	@Override

--- a/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
+++ b/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
@@ -4,6 +4,7 @@ import dev.vitrail.cache.ModuleCache;
 import dev.vitrail.render.PackChoice;
 import dev.vitrail.render.ShadowAmortisation;
 import dev.vitrail.render.StartupGuard;
+import dev.vitrail.render.TemporalAccumulation;
 import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.screen.SettingsScreen;
 import dev.vitrail.ScreenText;
@@ -93,6 +94,10 @@ public final class ConfigEntry implements ConfigEntryPoint {
 	private static final Identifier SHADOW_AMORTISATION =
 			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "shadow_amortisation");
 
+	/** Whether the upscaled frames are folded together, directly under the scale it serves. */
+	private static final Identifier TEMPORAL_FOLD =
+			Identifier.fromNamespaceAndPath(Vitrail.MOD_ID, "temporal_fold");
+
 	/** What the selector offers while the pack draws the world, and what it offers otherwise. */
 	private static final Set<TextureFilteringMethod> WITHOUT_RGSS =
 			Set.of(TextureFilteringMethod.NONE, TextureFilteringMethod.ANISOTROPIC);
@@ -116,6 +121,7 @@ public final class ConfigEntry implements ConfigEntryPoint {
 								.addOption(shadowDistance(builder))
 								.addOption(shadowMapScale(builder))
 								.addOption(renderScale(builder))
+								.addOption(temporalFold(builder))
 								.addOption(shadowAmortisation(builder))
 								.addOption(graphicsApi(builder))
 								.addOption(moduleCacheCeiling(builder))))
@@ -250,6 +256,34 @@ public final class ConfigEntry implements ConfigEntryPoint {
 				// LATER launch starts on and costs the running frame nothing at all. Sodium's own
 				// impact labels are about the frame being drawn.
 				.setStorageHandler(() -> {});
+	}
+
+	/**
+	 * Whether the upscaled frames are folded into one another, which puts back some of the detail
+	 * the render scale above stopped drawing.
+	 * <p>
+	 * <strong>Greyed out at a scale of a hundred, because there it does nothing at all.</strong> The
+	 * fold rebuilds a large picture out of several small ones, and at full size the small ones are
+	 * the picture: there is nothing to recover and the pass would be spent for no gain. Asked of the
+	 * live state rather than read once, and declared against {@code RENDER_SCALE} so that moving that
+	 * slider greys this one in and out under the player's hand rather than at the next screen.
+	 * <p>
+	 * MEDIUM and not LOW, and the cost is worth counting properly: TWO passes, one at the render
+	 * size that writes the motion vectors and one at the window's size that folds, and THREE images,
+	 * a two-channel one at the render size and a pair of half-float ones at the window's size, since
+	 * a fold cannot read the image it writes. It is spent to make a cheaper scale look better rather
+	 * than to make the frame faster.
+	 */
+	private static OptionBuilder temporalFold(ConfigBuilder builder) {
+		return builder.createBooleanOption(TEMPORAL_FOLD)
+				.setName(Component.translatable(ScreenText.TEMPORAL_FOLD))
+				.setTooltip(_ -> Component.translatable(ScreenText.TEMPORAL_FOLD_TOOLTIP))
+				.setDefaultValue(TemporalAccumulation.DEFAULT_WANTED)
+				.setBinding(TemporalAccumulation::setWanted, TemporalAccumulation::wanted)
+				.setEnabledProvider(state -> state.readIntOption(RENDER_SCALE) < PackFile.MAX_RENDER_SCALE,
+						RENDER_SCALE)
+				.setStorageHandler(() -> {})
+				.setImpact(OptionImpact.MEDIUM);
 	}
 
 	/**

--- a/common/src/main/resources/assets/vitrail/lang/en_us.json
+++ b/common/src/main/resources/assets/vitrail/lang/en_us.json
@@ -13,6 +13,8 @@
 	"options.vitrail.shadow_map_scale_tooltip": "Share of the pack's shadow map that is actually drawn.\nLower is faster, and edges get softer or coarser. \"100%\" is what the pack asked for.\nReloads the pack.",
 	"options.vitrail.render_scale": "Render Scale",
 	"options.vitrail.render_scale_tooltip": "Resolution the world is drawn at, as a share of the window.\nLower is faster. AMD FSR 1.0 then fills the window. The interface stays sharp.\nApplies at the next frame. No pack reload.",
+	"options.vitrail.temporal_fold": "Temporal Fold",
+	"options.vitrail.temporal_fold_tooltip": "Folds several upscaled frames into one, so a lower Render Scale keeps more detail.\nDistant leaves and fences stop crawling. Things that move keep a faint trail.\nNeeds a Render Scale under 100%.\nApplies at the next frame. No pack reload.",
 	"options.vitrail.shadow_amortisation": "Shadow Reuse",
 	"options.vitrail.shadow_amortisation_tooltip": "How many frames the shadow map is kept before it is drawn again.\nHigher is faster: drawing it is the most expensive pass of the frame.\nShadows of things that MOVE are that many frames late.\nApplies at the next frame. No pack reload.",
 	"options.vitrail.shadow_amortisation_off": "Off",

--- a/common/src/main/resources/assets/vitrail/lang/fr_fr.json
+++ b/common/src/main/resources/assets/vitrail/lang/fr_fr.json
@@ -13,6 +13,8 @@
 	"options.vitrail.shadow_map_scale_tooltip": "Part de la carte d'ombres du pack vraiment dessinée.\nPlus bas, plus rapide, bords plus doux ou plus grossiers. \"100%\" est ce que le pack a demandé.\nRecharge le pack.",
 	"options.vitrail.render_scale": "Échelle de rendu",
 	"options.vitrail.render_scale_tooltip": "Résolution du monde, en part de la fenêtre.\nPlus bas, plus rapide. AMD FSR 1.0 remplit ensuite la fenêtre. L'interface reste nette.\nS'applique à la frame suivante. Pas de rechargement du pack.",
+	"options.vitrail.temporal_fold": "Fusion temporelle",
+	"options.vitrail.temporal_fold_tooltip": "Fusionne plusieurs images agrandies en une seule, pour qu'une échelle de rendu plus basse garde plus de détail.\nLes feuillages et les barrières au loin arrêtent de grouiller. Ce qui bouge laisse une légère traînée.\nDemande une échelle de rendu sous 100 %.\nS'applique à la frame suivante. Pas de rechargement du pack.",
 	"options.vitrail.shadow_amortisation": "Réutilisation des ombres",
 	"options.vitrail.shadow_amortisation_tooltip": "Combien de frames la carte d'ombre est gardée avant d'être redessinée.\nPlus haut, plus rapide : la dessiner est la passe la plus chère de la frame.\nLes ombres de ce qui BOUGE ont ce nombre de frames de retard.\nS'applique à la frame suivante. Pas de rechargement du pack.",
 	"options.vitrail.shadow_amortisation_off": "Désactivée",

--- a/docs/render-scale.md
+++ b/docs/render-scale.md
@@ -74,6 +74,32 @@ the window whatever the slider says, so what they cost does not shrink as the sc
 is a fixed addition, paid once per frame, that buys back the sharpness. Lowering the scale from 70
 to 50 makes the world cheaper and leaves the upscale exactly where it was.
 
+## Folding the frames together
+
+A world drawn small loses the thin things first, and those are exactly what crawls as the camera
+moves: distant leaves, fences, the far edges of terrain. The spatial upscale above cannot put them
+back, because it only ever sees one frame and the detail is not in it.
+
+**Temporal Fold takes it from the frames before instead.** Several small pictures of a moving scene
+do not carry the same detail as each other, so blending them recovers some of what any one of them
+dropped, and the picture at a low scale settles rather than crawling. Each pixel is matched to where
+it stood a frame ago, which the engine works out by reprojecting the depth through the two cameras,
+and the value found there is held to the range of the pixels around it before it is mixed in. That
+clamp is what keeps a match that landed on the wrong surface from dragging a colour across an edge.
+
+It is off until asked for, and the checkbox greys out at a scale of 100 percent, where there is
+nothing to rebuild and the pass would be spent for nothing.
+
+**What it costs is two more passes and three more images**, on top of the fixed cost above. One pass
+writes the match at the render size into a two-channel image, and one folds at the window's size
+into a pair of half-float images, a pair because a fold cannot read the image it is writing. At
+1920x1080 that pair alone is about 32 MiB.
+
+**What it does not carry is anything that moves on its own.** The match is worked out from the
+camera alone, so a mob walking across a still screen is matched to where its pixels were rather than
+to where it was, and it keeps a faint trail. The clamp bounds how far that can go, which is why the
+result reads as a slight softness on moving things rather than as a smear behind them.
+
 ## Per-pass costs do not shrink either
 
 The scale buys fragment work and nothing else. A frame also pays for things counted per pass, per


### PR DESCRIPTION
## What changes

A new setting on the engine page, Temporal Fold, that blends each upscaled frame with the ones
before it. A world drawn at a lower render scale loses the thin things first, and those are what
crawls as the camera moves: distant leaves, fences, the far edges of terrain. The spatial upscale
cannot put them back, because it only ever sees one frame. This matches every pixel to where it
stood a frame ago and takes the detail from the frames themselves, so a low scale settles instead
of shimmering.

The match comes from a new pass that reprojects the depth through the camera of this frame and the
camera of the last one, and writes the offset per pixel in the form a temporal upscaler takes:
pixels at render resolution, origin upper left, pointing from the current frame back to the
previous one. It runs only on a frame the fold will read.

The setting is off until asked for, and greyed out at a render scale of 100 percent, where there is
nothing to rebuild.

## How it differs from the reference, and for what obstacle

It does not diverge. Iris has no counterpart to any of this, so there is no behaviour to match and
nothing a pack expects that is served differently. What packs are handed is unchanged: no uniform is
added, no target is taken, and at a render scale of 100 with the setting off the frame is the one
that was drawn before, pass for pass.

## What proves it

- `gradlew build` green, after the rebase onto `dev`.
- In the game, Fabric bench, Complementary Unbound at a render scale of 67 percent: the fold arms
  and the engine says so on its own line with both resolutions. Walking in a straight line and
  turning on the spot both hold, which is what says the reprojection carries the camera's rotation
  and its translation rather than only the first. Distant foliage settles visibly.
- The out-of-game harness was not run: nothing here touches pack translation, targets or chains.

## What it leaves owing

- **The camera is all that moves.** The match is worked out from a depth sample, so a mob walking
  across a still screen keeps a faint trail. Per-object motion needs the previous transform of every
  drawn thing, which is an extra output on translated pack programs.
- **The placement is not where either vendor asks for one.** Both want a temporal upscale before
  tone mapping, and here tone mapping, bloom and depth of field all belong to the pack, so this runs
  after the whole of its chain. Doing it properly needs a cut through the pack's own chain that
  nothing in a pack declares.
- **No jitter of its own.** Seven of the eight packs of the corpus already offset their own frames,
  which is what gives the fold something to recover. Body Camera, which does not, gains less, and
  that is not measured.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.