### PR TITLE
fix(pack): drop a profile token the pack declares nowhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ what the next one holds.
 
 ## Unreleased
 
+### Fixed
+
+- **A pack's quality profile is named again instead of reading "Custom".** A profile can list a
+  setting the pack does not actually have, and one such name was enough to stop the profile from
+  ever being recognised: the shader screen and the F3 overlay both fell back to "Custom" on a pack
+  nobody had touched, and the profile buttons could never land on a name. Photon is the pack this
+  showed on, where all four of its profiles now read as themselves.
+
 ### Added
 
 - **Temporal Fold, a new setting on the engine page.** A world drawn at a lower render scale loses

--- a/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
+++ b/common/src/main/java/dev/vitrail/pack/menu/PackMenu.java
@@ -179,15 +179,36 @@ public final class PackMenu {
 
 		Map<String, Map<String, String>> profiles = new LinkedHashMap<>();
 		for (String name : properties.profiles().keySet()) {
-			profiles.put(name, expand(properties, name));
+			profiles.put(name, expand(properties, index, warnings, name));
 		}
 
 		return new PackMenu(packName, pages, options, profiles, lang, warnings);
 	}
 
-	private static Map<String, String> expand(ShaderProperties properties, String name) {
+	/**
+	 * What a profile constrains, which is not always what it writes.
+	 * <p>
+	 * A bare positive token naming a setting the pack declares nowhere is dropped, the one form the
+	 * reference checks ({@code ProfileSet.java:78-81}), because a constraint on a name that exists
+	 * nowhere can never be met and would cost the profile its whole purpose: Photon writes
+	 * {@code GTAO} in all four of its profiles and declares it in none of its shaders, so keeping it
+	 * makes every profile fail to match and the overlay read {@code Custom} on a pack nobody has
+	 * touched.
+	 */
+	private static Map<String, String> expand(ShaderProperties properties, OptionIndex index,
+			List<String> warnings, String name) {
 		Map<String, String> expanded = new LinkedHashMap<>();
-		properties.expandProfile(name).forEach((option, value) -> expanded.put(option, text(value)));
+		properties.expandProfile(name, token -> {
+			boolean toggle = index.get(token)
+					.filter(option -> option.kind() == PackOption.Kind.TOGGLE)
+					.isPresent();
+			if (!toggle) {
+				warnings.add("profile." + name + " names " + token
+						+ ", which this pack declares nowhere as a toggle, so it is not a constraint");
+			}
+
+			return toggle;
+		}).forEach((option, value) -> expanded.put(option, text(value)));
 
 		return Collections.unmodifiableMap(expanded);
 	}

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -1129,8 +1130,30 @@ public final class ShaderProperties {
 	 * chain; the later choice wins, which is what lets a profile refine the one it includes.
 	 */
 	public Map<String, OptionValue> expandProfile(String name) {
+		return expandProfile(name, _ -> true);
+	}
+
+	/**
+	 * The same, with a say over the ONE form the reference checks before it keeps it.
+	 * <p>
+	 * <strong>A bare positive token naming a setting the pack declares nowhere is not a
+	 * constraint.</strong> {@code ProfileSet.parse} looks that form up in the boolean half of its
+	 * index and drops it with a warning when it is not there
+	 * ({@code shaderpack/option/ProfileSet.java:78-81}), leaving the profile made of what remains.
+	 * The other three forms it takes go through unchecked, and so do they here.
+	 * <p>
+	 * Keeping it costs what a profile is for. Photon writes {@code GTAO} in all four of its
+	 * profiles and declares it in no shader, so a constraint on it can never be met: every profile
+	 * fails to match, the overlay reads {@code Custom (+0 options changed by user)}, which is its own
+	 * contradiction, and the selector can never land on a name. The picture is untouched either way,
+	 * both engines applying a word nowhere, which is why {@link #expandProfile(String)} keeps its
+	 * old behaviour for the paths that only apply values.
+	 *
+	 * @param known answers whether the pack declares that name as a toggle
+	 */
+	public Map<String, OptionValue> expandProfile(String name, Predicate<String> known) {
 		Map<String, OptionValue> chosen = new LinkedHashMap<>();
-		expandProfile(name, chosen, 0, new int[1]);
+		expandProfile(name, chosen, 0, new int[1], known);
 
 		return chosen;
 	}
@@ -1142,7 +1165,8 @@ public final class ShaderProperties {
 	 *               choice wins and a profile named twice is written twice on purpose, and the
 	 *               second stops only cycles, which are not what costs
 	 */
-	private void expandProfile(String name, Map<String, OptionValue> chosen, int depth, int[] budget) {
+	private void expandProfile(String name, Map<String, OptionValue> chosen, int depth, int[] budget,
+			Predicate<String> known) {
 		String body = this.profiles.get(name);
 		if (body == null || depth > MAX_PROFILE_DEPTH || ++budget[0] > MAX_PROFILE_EXPANSIONS) {
 			return;
@@ -1155,14 +1179,14 @@ public final class ShaderProperties {
 			}
 
 			if (token.startsWith("profile.")) {
-				expandProfile(token.substring("profile.".length()), chosen, depth + 1, budget);
+				expandProfile(token.substring("profile.".length()), chosen, depth + 1, budget, known);
 			} else if (token.startsWith("!")) {
 				chosen.put(token.substring(1), OptionValue.off());
 			} else {
 				int equals = token.indexOf('=');
 				if (equals >= 0) {
 					chosen.put(token.substring(0, equals), OptionValue.of(token.substring(equals + 1)));
-				} else {
+				} else if (known.test(token)) {
 					chosen.put(token, OptionValue.on());
 				}
 			}


### PR DESCRIPTION
## What changes

A pack's quality profile is named again instead of always reading "Custom".

A profile is a list of settings a pack says a quality level amounts to, and matching one is how the
shader screen and the F3 overlay name the level in effect. A bare positive token in that list became
a constraint here whatever it named, so a token naming a setting the pack never declares made a
constraint nothing could satisfy: every profile failed to match, the overlay read
`Custom (+0 options changed by user)`, which contradicts itself, and the profile buttons could never
land on a name.

Only the constraint side changes. Applying a profile still writes exactly what the pack wrote.

## How it differs from the reference, and for what obstacle

It stops differing. `ProfileSet.parse` looks a bare positive token up in the boolean half of its
index and warns `Invalid pack option` when it is not there, leaving the profile made of what remains
(`shaderpack/option/ProfileSet.java:78-81`). The three other forms it takes go through unchecked,
and so do they here. This engine checked none of the four, which is the gap.

## What proves it

- `gradlew build` green.
- In the game, Fabric bench, Photon v1.3b with its settings at their defaults: the overlay reads
  `Profile: high (+0 options changed by user)`, the same sentence the reference shows on the same
  pack, where before it read `Custom (+0 options changed by user)`.
- Photon is the pack this shows on because it writes `GTAO` in all four of its profiles and declares
  it in none of its shaders.
- The out-of-game harness was not run: nothing here touches translation, targets or chains.

## What it leaves owing

- **Two unrelated gaps sit in the same method and are untouched.** `NAME:value` falls through to the
  bare case and turns on an option whose name carries the colon, where the reference splits it; and
  `!program.NAME` turns off an option called `program.NAME` where the reference disables the program.
  No pack of the corpus writes either.
- The three unchecked forms stay unchecked, as they are in the reference, so a typo in
  `NAME=value` is still invisible on both engines.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.