### PR TITLE
feat(render): give every colour target its own blend function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,6 @@ what the next one holds.
 
 ## Unreleased
 
-### Fixed
-
-- **A pack's quality profile is named again instead of reading "Custom".** A profile can list a
-  setting the pack does not actually have, and one such name was enough to stop the profile from
-  ever being recognised: the shader screen and the F3 overlay both fell back to "Custom" on a pack
-  nobody had touched, and the profile buttons could never land on a name. Photon is the pack this
-  showed on, where all four of its profiles now read as themselves.
-
 ### Added
 
 - **A pack may now blend one of a pass's targets differently from the others.** A shader pack can
@@ -110,6 +102,12 @@ what the next one holds.
   gained.
 
 ### Fixed
+
+- **A pack's quality profile is named again instead of reading "Custom".** A profile can list a
+  setting the pack does not actually have, and one such name was enough to stop the profile from
+  ever being recognised: the shader screen and the F3 overlay both fell back to "Custom" on a pack
+  nobody had touched, and the profile buttons could never land on a name. Photon is the pack this
+  showed on, where all four of its profiles now read as themselves.
 
 - **A pack reloaded while you play no longer comes back with the world drawn in one colour.** On
   Photon with its coloured lighting on, most reloads left the world with no red and no blue in it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ what the next one holds.
 
 ### Added
 
+- **A pack may now blend one of a pass's targets differently from the others.** A shader pack can
+  ask for a blend function per target rather than one for the whole program, and the engine read
+  those lines and then dropped them the moment two targets of one pass disagreed, putting the
+  program's plain function on all of them. Each line now lands on the target it names, which is
+  what decides the shape of anything drawn over something else: an overlay that should multiply, a
+  surface that should add, a second target written straight through while the first blends. The
+  shadow map is in, the same as anywhere else.
+
+  With it, `PER_BUFFER_BLENDING` is served, so that name alone no longer turns a pack away. It
+  needs a driver that lets the targets of one pass differ; where there is none the name is refused
+  as before and the whole-program function stands, which is the ground Iris refuses it on too.
+
 - **Temporal Fold, a new setting on the engine page.** A world drawn at a lower render scale loses
   the thin things first, and those are what crawls as you move: distant leaves, fences, the far
   edges of terrain. The upscale cannot put them back, because it only sees one frame. This blends

--- a/common/src/main/java/dev/vitrail/mixin/RenderPipelineBuilderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/RenderPipelineBuilderMixin.java
@@ -1,0 +1,54 @@
+package dev.vitrail.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.pipeline.BlendFunction;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import dev.vitrail.render.BufferBlending;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.Optional;
+
+/**
+ * Lets one pipeline carry a different blend function on each colour target it writes, where the
+ * device can really keep them apart.
+ * <p>
+ * The builder walks the active states and throws on the first two that name different functions
+ * ({@code RenderPipeline:457-468}, the throw at {@code :464}). It is right to, on both of the
+ * game's roads. OpenGL turns blending on and off per buffer but sets the function once for the
+ * whole draw, {@code _enableBlend(i)} beside an unindexed {@code _blendFuncSeparate}
+ * ({@code GlCommandEncoder:842-858}), so the last target's function would quietly stand on all of
+ * them. Vulkan fills one {@code VkPipelineColorBlendAttachmentState} per slot from that slot's own
+ * state ({@code VulkanRenderPipeline:178-191}), which is the shape wanted, but every element of
+ * that array has to be identical unless {@code independentBlend} is enabled, and the game asks for
+ * that feature nowhere.
+ * <p>
+ * So this is the second half of the permission {@link BufferBlending} describes, the device
+ * feature being the first: {@code VulkanBackendMixin} asks for the feature and answers there
+ * whether it was given, and this lifts the refusal standing in front of it.
+ * <p>
+ * <strong>The builder below is the one every pipeline of the process is built through</strong>, the
+ * game's own and every other mod's, none of which asked for anything. So the device's answer is not
+ * by itself a narrow enough condition to lift on, and {@code parting()} is the two together: a
+ * Vulkan device has to have granted {@code independentBlend}, and the build has to be one of this
+ * engine's own, which {@code GeometryProgram.part} marks on its thread for the length of the call.
+ * Everything else keeps the game's own word, the OpenGL road and a device that refused among them,
+ * and so does every builder in the process this engine is not standing in. What our own passes get
+ * where the device refused is the whole program function on every attachment
+ * ({@code GeometryProgram.state}), which no two states of one pipeline can disagree over.
+ */
+@Mixin(RenderPipeline.Builder.class)
+public abstract class RenderPipelineBuilderMixin {
+
+	/**
+	 * Two functions read as one where this engine is building and the device parts its attachments,
+	 * which is the comparison the refusal hangs off and the only thing here that moves.
+	 */
+	@WrapOperation(method = "build()Lcom/mojang/blaze3d/pipeline/RenderPipeline;", require = 1,
+			at = @At(value = "INVOKE", target = "Ljava/util/Optional;equals(Ljava/lang/Object;)Z"))
+	private boolean vitrail$blendApart(Optional<BlendFunction> current, Object last,
+			Operation<Boolean> original) {
+		return original.call(current, last) || BufferBlending.parting();
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
@@ -5,6 +5,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.vulkan.VulkanBackend;
 import com.mojang.blaze3d.vulkan.VulkanPhysicalDevice;
 import com.mojang.blaze3d.vulkan.init.VulkanFeature;
+import dev.vitrail.render.BufferBlending;
 import dev.vitrail.Vitrail;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.vulkan.VK12;
@@ -21,16 +22,23 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Turns on the storage-image features Complementary's voxel lighting needs, which the game never
- * asks for.
+ * Turns on the device features the packs need and the game never asks for.
  * <p>
- * Complementary writes {@code voxel_img} from the shadow vertex shader
+ * The storage images first. Complementary writes {@code voxel_img} from the shadow vertex shader
  * ({@code UpdateVoxelMap} under {@code SHADOW && VERTEX_SHADER}). Vulkan ignores those stores
  * unless {@code vertexPipelineStoresAndAtomics} is enabled, and {@code r16ui} / {@code rgba16f}
  * are not core storage formats unless {@code shaderStorageImageExtendedFormats} is on. The game's
  * {@code VulkanBackend} enables neither: its required set is draw-indirect, anisotropy and
  * dynamic rendering. Without this, floodfill runs on a volume that stays empty and the pack's
  * coloured lamps never light.
+ * <p>
+ * And {@code independentBlend}, which is the device's half of {@code PER_BUFFER_BLENDING}. A pass
+ * writing several targets under a {@code blend.<program>.<buffer>} directive needs each attachment
+ * to carry its own blend state, and without the feature Vulkan requires every element of
+ * {@code pAttachments} to be identical. Answered on to {@link BufferBlending}, which is what the
+ * pipeline, the refusal and the symbol all read. The other half is the game's own pipeline builder,
+ * which refuses two colour targets naming different functions whatever the device can do, and
+ * {@code RenderPipelineBuilderMixin} lifts on this same answer.
  */
 @Mixin(VulkanBackend.class)
 public abstract class VulkanBackendMixin {
@@ -55,6 +63,18 @@ public abstract class VulkanBackendMixin {
 			VulkanBackend.VK10_FEATURES_STRUCT, "shaderStorageImageWriteWithoutFormat",
 			VkPhysicalDeviceFeatures.SHADERSTORAGEIMAGEWRITEWITHOUTFORMAT);
 
+	@Unique
+	private static final VulkanFeature INDEPENDENT_BLEND = new VulkanFeature(
+			VulkanBackend.VK10_FEATURES_STRUCT, "independentBlend",
+			VkPhysicalDeviceFeatures.INDEPENDENTBLEND);
+
+	@Unique
+	private static final String VOXELS = "voxel lighting will not write";
+
+	@Unique
+	private static final String PER_BUFFER = "a pack requiring PER_BUFFER_BLENDING is refused and "
+			+ "every other one keeps a single blend function for all the targets a pass writes";
+
 	@WrapOperation(method = "createDevice(JLcom/mojang/blaze3d/shaders/ShaderSource;"
 			+ "Lcom/mojang/blaze3d/shaders/GpuDebugOptions;Ljava/lang/Runnable;)"
 			+ "Lcom/mojang/blaze3d/systems/GpuDevice;", require = 1,
@@ -62,32 +82,34 @@ public abstract class VulkanBackendMixin {
 					target = "Lcom/mojang/blaze3d/vulkan/VulkanBackend;createDevice("
 							+ "Ljava/util/Collection;Lcom/mojang/blaze3d/vulkan/VulkanPhysicalDevice;"
 							+ "Ljava/util/Set;)Lorg/lwjgl/vulkan/VkDevice;"))
-	private VkDevice vitrail$storageFeatures(Collection<String> extensions,
+	private VkDevice vitrail$deviceFeatures(Collection<String> extensions,
 			VulkanPhysicalDevice physical, Set<VulkanFeature> features,
 			Operation<VkDevice> original) {
 		List<String> enabled = new ArrayList<>();
-		enable(physical, features, VERTEX_STORES, enabled);
-		enable(physical, features, FRAGMENT_STORES, enabled);
-		enable(physical, features, EXTENDED_FORMATS, enabled);
-		enable(physical, features, WRITE_WITHOUT_FORMAT, enabled);
+		enable(physical, features, VERTEX_STORES, enabled, VOXELS);
+		enable(physical, features, FRAGMENT_STORES, enabled, VOXELS);
+		enable(physical, features, EXTENDED_FORMATS, enabled, VOXELS);
+		enable(physical, features, WRITE_WITHOUT_FORMAT, enabled, VOXELS);
+		BufferBlending.serve(enable(physical, features, INDEPENDENT_BLEND, enabled, PER_BUFFER));
 		if (!enabled.isEmpty()) {
-			Vitrail.logger().info("Vulkan storage features: {}", String.join(", ", enabled));
+			Vitrail.logger().info("Vulkan device features: {}", String.join(", ", enabled));
 		}
 
 		return original.call(extensions, physical, features);
 	}
 
 	@Unique
-	private static void enable(VulkanPhysicalDevice physical, Set<VulkanFeature> features,
-			VulkanFeature feature, List<String> enabled) {
+	private static boolean enable(VulkanPhysicalDevice physical, Set<VulkanFeature> features,
+			VulkanFeature feature, List<String> enabled, String cost) {
 		if (!supported(physical, feature)) {
-			Vitrail.logger().warn("Vulkan device does not support {}, voxel lighting will not write",
-					feature.name());
-			return;
+			Vitrail.logger().warn("Vulkan device does not support {}, so {}", feature.name(), cost);
+			return false;
 		}
 
 		features.add(feature);
 		enabled.add(feature.name());
+
+		return true;
 	}
 
 	@Unique

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -107,17 +107,20 @@ public final class EngineDefines {
 	 * @param textureFormat   what the resource pack declares its material maps are drawn in, null
 	 *                        where it declares nothing or names a convention this engine has no
 	 *                        symbol for
+	 * @param bufferBlending  whether the device lets two attachments of one pass blend differently.
+	 *                        A device answer and not an engine one, which is why it travels with
+	 *                        the vendor and the renderer rather than being read here
 	 */
 	public record Environment(int mcVersion, Os os, String vendorName, String rendererName,
 			int mipmapLevel, boolean distantHorizons, Map<String, Integer> biomes,
-			List<String> biomeCategories, TextureFormat textureFormat) {
+			List<String> biomeCategories, TextureFormat textureFormat, boolean bufferBlending) {
 
 		/** What a caller with no resource pack to ask hands over: {@link #of}, and the harness. */
 		public Environment(int mcVersion, Os os, String vendorName, String rendererName,
 				int mipmapLevel, boolean distantHorizons, Map<String, Integer> biomes,
 				List<String> biomeCategories) {
 			this(mcVersion, os, vendorName, rendererName, mipmapLevel, distantHorizons, biomes,
-					biomeCategories, null);
+					biomeCategories, null, false);
 		}
 
 		public static Environment of(int mcVersion) {
@@ -217,10 +220,24 @@ public final class EngineDefines {
 		// left to test, as with the storage blocks above.
 		defines.put("IRIS_FEATURE_COMPUTE_SHADERS", "");
 
-		// The rest of IRIS_FEATURE_ stays unposted until each capability is served, and each of the
-		// five above is posed for every pack. That is a divergence: Iris poses IRIS_FEATURE_X only
-		// where the pack itself listed X under iris.features.optional
-		// (shaderpack/ShaderPack.java:247-251), its all-usable list serving the evaluation of
+		// Per buffer blending is served where the DEVICE serves it, which is the one symbol here
+		// that is not posed for every machine: a blend.<program>.<buffer> directive is built into
+		// the attachment whose rank its target holds (render/GeometryProgram.state), and two
+		// attachments of one Vulkan pipeline carry two blend states only under independentBlend.
+		// Iris withholds its own flag where ITS api cannot part them either, the driver having to
+		// carry ARB_draw_buffers_blend or OpenGL 4.0 (features/FeatureFlags.java:15,
+		// IrisRenderSystem.supportsBufferBlending). Same rule over a different question: a Vulkan
+		// device feature and a GL extension are asked of two APIs, so the machines the two engines
+		// withhold the symbol from are not the same set.
+		if (environment.bufferBlending()) {
+			defines.put("IRIS_FEATURE_PER_BUFFER_BLENDING", "");
+		}
+
+		// The rest of IRIS_FEATURE_ stays unposted until each capability is served, and every name
+		// above but the per buffer one is posed for every pack, that one following the device as
+		// said just above. That is a divergence: Iris poses IRIS_FEATURE_X only where the pack
+		// itself listed X under iris.features.optional
+		// (shaderpack/ShaderPack.java:246-250), its all-usable list serving the evaluation of
 		// shaders.properties and nothing in the GLSL (lines 171-175). The two differ only for a
 		// pack that reads a symbol it never declared, and closing it is a lot of its own. See
 		// ShaderProperties.declares for the declaration itself, and PackChain for what a pack

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -105,12 +105,19 @@ public final class TargetPlan {
 	private final Map<String, List<Integer>> writes;
 
 	/**
-	 * What each program asks to blend with, by its bare name, the whole program form and the per
-	 * buffer form folded into one function by {@link #blendsOf}. Only the programs that say
+	 * What each program asks to blend with as a whole, by its bare name. Only the programs that say
 	 * something are in here; a program that says nothing is answered by whatever the engine would
 	 * have used anyway, which is not this plan's business.
 	 */
 	private final Map<String, BlendMode> blend;
+
+	/**
+	 * The same answer taken one attachment at a time, by the RANK the target holds among the
+	 * program's draw buffers, for the programs that carry a per buffer directive. An entry is null
+	 * where that attachment is left with the whole program answer, which is how {@link #blendsOf}
+	 * fills the ranks no directive names.
+	 */
+	private final Map<String, List<BlendMode>> blendPerTarget;
 
 	private final Set<String> inferred;
 	private final Map<String, Set<Integer>> samples;
@@ -132,6 +139,7 @@ public final class TargetPlan {
 		this.writes = Collections.unmodifiableMap(new LinkedHashMap<>(draft.effective));
 		Blends blends = blendsOf(draft);
 		this.blend = blends.byProgram();
+		this.blendPerTarget = blends.byTarget();
 		this.inferred = Collections.unmodifiableSet(new TreeSet<>(draft.inferred));
 		this.samples = Collections.unmodifiableMap(new LinkedHashMap<>(draft.samples));
 		this.geometryAt = draft.geometryAt;
@@ -783,13 +791,9 @@ public final class TargetPlan {
 		}
 
 		if (!blends.honoured().isEmpty()) {
-			notes.add("per buffer blend directives honoured, every target their program writes "
-					+ "taking the same function: " + blends.honoured());
-		}
-
-		if (!blends.shadow().isEmpty()) {
-			notes.add("per buffer blend directives on a program drawn from the light, whose passes "
-					+ "this engine builds without blending whatever the pack asks: " + blends.shadow());
+			notes.add("per buffer blend directives read onto the attachment whose rank their target "
+					+ "holds, which the pass carries where the device parts its attachments and drops "
+					+ "back to the whole program function where it does not: " + blends.honoured());
 		}
 
 		if (!blends.fullscreen().isEmpty()) {
@@ -801,12 +805,6 @@ public final class TargetPlan {
 		if (!blends.dropped().isEmpty()) {
 			notes.add("per buffer blend directives naming a target their program does not write, "
 					+ "dropped as the reference drops them: " + blends.dropped());
-		}
-
-		if (!blends.apart().isEmpty()) {
-			notes.add("per buffer blend directives that would blend two targets of one program "
-					+ "differently, which one pipeline does not carry here, so those programs keep "
-					+ "the whole program function: " + blends.apart());
 		}
 
 		if (!draft.computes.isEmpty()) {
@@ -935,22 +933,27 @@ public final class TargetPlan {
 	 * form and the per buffer form folded together the way the reference applies them: the whole
 	 * program function first, on every attachment, then each per buffer directive on the
 	 * attachment whose RANK among the program's draw buffers is the target it names, a directive
-	 * naming a target the program does not write being dropped ({@code ShaderCreator.java:142-147}
-	 * and {@code SodiumPrograms.java:145-153} resolve the rank, {@code ExtendedShader.java:225-233}
-	 * applies the two forms in that order). The reference reads the per buffer form for its
-	 * geometry programs only: a composite takes the whole program form and nothing else
-	 * ({@code CompositeRenderer.java:510-517}), the final takes neither
-	 * ({@code FinalPassRenderer.java:256-257}), so a per buffer line on one is dropped here as
-	 * well. A program drawn from the light is left out too: this engine builds every shadow
-	 * pass without blending, and the plan holds no draw buffer list for it to rank against.
+	 * naming a target the program does not write being dropped ({@code ShaderCreator.java:155-160}
+	 * resolves the rank, {@code ExtendedShader.java:244-250} applies the two forms in that order).
+	 * The reference reads the per buffer form for its geometry programs only: a composite takes the
+	 * whole program form and nothing else ({@code CompositeRenderer.java:514-522}), the final takes
+	 * neither ({@code FinalPassRenderer.java:258-259}), so a per buffer line on one is dropped here
+	 * as well.
 	 * <p>
-	 * One pipeline carries one blend function for every attachment here, so the per buffer form
-	 * is honoured exactly when every attachment of its program comes out with the same function:
-	 * a program writing one target, which is what most such directives are written for, or several
-	 * targets under directives that agree. A program whose attachments would come out apart keeps
-	 * its whole program function, and the notes name it, honouring half of such a directive being
-	 * worse than honouring none of it. A value in a form this engine cannot read is left out too,
-	 * and named the same way.
+	 * Geometry drawn from the light is in, on both forms, because the reference has it on both:
+	 * {@code createShadow} carries the whole program override into the shadow program and builds
+	 * the same rank list off that program's own draw buffers ({@code ShaderCreator.java:318}, the
+	 * block at {@code :358-363}). The rank is taken against what the shadow program DECLARED, which
+	 * this plan keeps raw because those indices name shadowcolor and none of them is allocated
+	 * here; a shadow program that declared nothing ranks against nought alone, which is how the
+	 * reference reads that silence ({@code shaderpack/properties/ProgramDirectives.java:73-76}).
+	 * <p>
+	 * The answer is kept twice over: one function for the whole program, which is what a caller
+	 * holding no attachment reads, and one function per RANK for the programs a per buffer
+	 * directive lands on. Whether two attachments of one pass may really carry two functions is not
+	 * this plan's question, and it is not the same on every device: what is said here is what the
+	 * pack asked for, and the side that builds the pipeline answers for what it can give. A value
+	 * in a form this engine cannot read is left out, and named in the notes.
 	 */
 	private static Blends blendsOf(Draft draft) {
 		Map<String, BlendMode> whole = new LinkedHashMap<>();
@@ -969,28 +972,30 @@ public final class TargetPlan {
 		}
 
 		Map<String, BlendMode> resolved = new LinkedHashMap<>(whole);
+		Map<String, List<BlendMode>> byTarget = new LinkedHashMap<>();
 		List<String> honoured = new ArrayList<>();
-		List<String> shadow = new ArrayList<>();
 		List<String> fullscreen = new ArrayList<>();
 		List<String> dropped = new ArrayList<>();
-		List<String> apart = new ArrayList<>();
 		perBuffer.forEach((program, directives) -> {
 			String family = ProgramNames.familyOf(program);
-			if (ProgramNames.shadowGeometry(family)) {
-				directives.forEach(directive -> shadow.add(spelling(directive)));
-				return;
-			}
-
 			if (!ProgramNames.geometry(family)) {
 				directives.forEach(directive -> fullscreen.add(spelling(directive)));
 				return;
 			}
 
-			// A program this place does not run has no attachment for a directive to land on.
-			List<Integer> writes = draft.effective.get(program);
-			if (writes == null) {
+			// A program this place does not run has no attachment for a directive to land on. The
+			// camera's geometry ranks against what the place effectively runs it with, the light's
+			// against the raw declaration: the two lists are kept apart because a shadow program's
+			// indices name shadowcolor and never enter what is allocated.
+			boolean fromTheLight = ProgramNames.shadowGeometry(family);
+			List<Integer> declared = fromTheLight
+					? draft.writes.get(program)
+					: draft.effective.get(program);
+			if (declared == null) {
 				return;
 			}
+
+			List<Integer> writes = fromTheLight && declared.isEmpty() ? List.of(0) : declared;
 
 			// Null stands for the engine's own choice, which is what an attachment no directive
 			// names is left with, and it is as much a function as the others when they are compared.
@@ -1022,18 +1027,22 @@ public final class TargetPlan {
 				return;
 			}
 
+			byTarget.put(program, Collections.unmodifiableList(Arrays.asList(functions)));
+			honoured.addAll(landed.values());
+
+			// The whole program answer follows only where every attachment agreed, which is what a
+			// caller holding no rank reads and what a device that cannot part two attachments falls
+			// back on. Where they disagree it stays whatever the bare directive gave, so that road
+			// answers as it did before the ranks were kept.
 			BlendMode first = functions[0];
 			if (Arrays.stream(functions).allMatch(function -> Objects.equals(function, first))) {
 				resolved.put(program, first);
-				honoured.addAll(landed.values());
-			} else {
-				apart.addAll(landed.values());
 			}
 		});
 
-		return new Blends(Collections.unmodifiableMap(resolved), List.copyOf(unreadable),
-				List.copyOf(honoured), List.copyOf(shadow), List.copyOf(fullscreen),
-				List.copyOf(dropped), List.copyOf(apart));
+		return new Blends(Collections.unmodifiableMap(resolved),
+				Collections.unmodifiableMap(byTarget), List.copyOf(unreadable),
+				List.copyOf(honoured), List.copyOf(fullscreen), List.copyOf(dropped));
 	}
 
 	/** The directive as the pack spelt its key, {@code gbuffers_water.colortex13} or bare. */
@@ -1042,21 +1051,43 @@ public final class TargetPlan {
 				: directive.program() + "." + directive.buffer();
 	}
 
-	/** What {@link #blendsOf} settled: the map the plan answers from, and the lines the notes carry. */
-	private record Blends(Map<String, BlendMode> byProgram, List<String> unreadable,
-			List<String> honoured, List<String> shadow, List<String> fullscreen, List<String> dropped,
-			List<String> apart) {
+	/** What {@link #blendsOf} settled: the maps the plan answers from, and the lines the notes carry. */
+	private record Blends(Map<String, BlendMode> byProgram, Map<String, List<BlendMode>> byTarget,
+			List<String> unreadable, List<String> honoured, List<String> fullscreen,
+			List<String> dropped) {
 	}
 
 	/**
-	 * What this program asks to blend with, or empty when it asks for nothing and the engine's own
-	 * choice stands. A per buffer directive is in the answer where every target the program writes
-	 * agreed on it, and in {@link #notes()} where they did not.
+	 * What this program asks to blend with as a whole, or empty when it asks for nothing and the
+	 * engine's own choice stands. A per buffer directive is in this answer only where every target
+	 * the program writes agreed on it; {@link #blend(String, int)} is where they are read apart.
 	 *
 	 * @param program the bare name, {@code gbuffers_water}, not the file that ends up serving it
 	 */
 	public Optional<BlendMode> blend(String program) {
 		return Optional.ofNullable(this.blend.get(TargetName.bareName(program)));
+	}
+
+	/**
+	 * The same for one attachment of that program, which is what serves {@code PER_BUFFER_BLENDING}.
+	 * <p>
+	 * A rank no directive named, and every rank of a program that carries none at all, answers the
+	 * whole program form, so a caller that walks its attachments in order gets the same picture as
+	 * the reference builds: the whole program function on every attachment, each per buffer
+	 * directive over the one whose rank its target holds.
+	 *
+	 * @param rank the attachment's place among the program's draw buffers, which is the order both
+	 *             the pipeline and the descriptor walk them in, and for a program drawn from the
+	 *             light its place among the shadowcolor buffers it declared. Out of range answers
+	 *             the whole program form, for the slots a pass carries beyond what the pack writes
+	 */
+	public Optional<BlendMode> blend(String program, int rank) {
+		List<BlendMode> perTarget = this.blendPerTarget.get(TargetName.bareName(program));
+		if (perTarget == null || rank < 0 || rank >= perTarget.size()) {
+			return blend(program);
+		}
+
+		return Optional.ofNullable(perTarget.get(rank));
 	}
 
 	private static final class Draft {

--- a/common/src/main/java/dev/vitrail/render/BufferBlending.java
+++ b/common/src/main/java/dev/vitrail/render/BufferBlending.java
@@ -1,0 +1,89 @@
+package dev.vitrail.render;
+
+/**
+ * Whether two attachments of one pass may carry two blend functions, which is what a pack's
+ * {@code blend.<program>.<buffer>} directive asks for and what it declares as
+ * {@code PER_BUFFER_BLENDING}.
+ * <p>
+ * Vulkan writes one {@code VkPipelineColorBlendAttachmentState} per attachment and the game's
+ * backend fills each of them from that slot's own {@code ColorTargetState}
+ * ({@code VulkanRenderPipeline:178-191}), so the shape is already there. What is not is the
+ * permission, and it comes in two halves.
+ * <p>
+ * The device's half. Without the {@code independentBlend} feature every element of that array has
+ * to be identical, and the game asks for the feature nowhere. {@code VulkanBackendMixin} asks for
+ * it, and answers here whether the device gave it.
+ * <p>
+ * The game's half. Its pipeline builder refuses two colour targets naming different blend functions
+ * outright ({@code RenderPipeline:457-468}), before any backend is reached, which it has to while
+ * the OpenGL road sets one function for the whole draw. {@code RenderPipelineBuilderMixin} lifts
+ * that refusal on this answer and on the build being one of ours, both at once: the builder it
+ * stands in is the one every pipeline of the process is built through, so the answer by itself
+ * would carry the lift into the game's own pipelines and every other mod's. {@link #building} is
+ * the second condition, raised on the thread for the length of one of our builds. Where the device
+ * said no the builder still refuses, ours included, and the pass is given one function for every
+ * attachment instead.
+ * <p>
+ * Iris withholds the same flag where its own API cannot part the attachments either, the driver
+ * needing {@code ARB_draw_buffers_blend} or OpenGL 4.0 ({@code features/FeatureFlags.java:15} into
+ * {@code gl/IrisRenderSystem.java:334-336}). Same rule, different question: a Vulkan device feature
+ * and a GL extension are asked of two different APIs, and a machine can be told yes by one and no
+ * by the other, so a pack refused here is not for that reason refused there.
+ * <p>
+ * Off until the device says otherwise, which is what the harness and any other caller with no
+ * device to ask gets: a pack is then refused as it was before the feature was asked for, rather
+ * than drawn with a promise nothing keeps.
+ */
+public final class BufferBlending {
+
+	/**
+	 * Whether the pipeline this thread is building is one of ours.
+	 * <p>
+	 * On the thread and not a field of the class, because our builds are not all on one: the
+	 * pack-load worker builds the six families ahead of their first draw
+	 * ({@code FamilyWarmup.start}) while the render thread builds whatever a first draw asks for
+	 * and whatever another mod's mesh makes {@code GeometryProgram} reshape. A flag raised on the
+	 * worker would lift the game's refusal under whatever the render thread happened to be building
+	 * at that moment, which is the opposite of narrowing it.
+	 */
+	private static final ThreadLocal<Boolean> BUILDING = new ThreadLocal<>();
+
+	private static volatile boolean served;
+
+	private BufferBlending() {
+	}
+
+	/**
+	 * Read where a pipeline's states are built, where a pack is refused, and where the symbol is
+	 * posed.
+	 */
+	public static boolean served() {
+		return served;
+	}
+
+	/** Set once by {@code VulkanBackendMixin}, at device creation and before any pack is read. */
+	public static void serve(boolean independentBlend) {
+		served = independentBlend;
+	}
+
+	/**
+	 * Marks this thread as inside one of our own pipeline builds, and unmarks it. Paired in a
+	 * finally by {@code GeometryProgram.part}, which is the only caller: an unmarked thread is what
+	 * every builder this engine is not standing in has to look like.
+	 */
+	static void building(boolean building) {
+		if (building) {
+			BUILDING.set(Boolean.TRUE);
+		} else {
+			BUILDING.remove();
+		}
+	}
+
+	/**
+	 * The whole of what {@code RenderPipelineBuilderMixin} lifts the game's refusal on: a device
+	 * that granted {@code independentBlend}, and a build of ours running on this thread.
+	 */
+	public static boolean parting() {
+		return served && Boolean.TRUE.equals(BUILDING.get());
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -820,6 +820,14 @@ final class ColorTargets {
 	}
 
 	/**
+	 * The same for the attachment holding that rank among the program's draw buffers, which is what
+	 * a {@code blend.<program>.<buffer>} directive lands on. Null when neither form says anything.
+	 */
+	BlendMode blend(String program, int rank) {
+		return this.plan.blend(program, rank).orElse(null);
+	}
+
+	/**
 	 * Which targets one program reads at a lod, narrowed to those that carry a chain.
 	 * <p>
 	 * Per program and not the union, because this is what decides when a chain is rebuilt. A chain

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -5,6 +5,7 @@ import dev.vitrail.glsl.PackProgram;
 import dev.vitrail.glsl.TranslatedUnit;
 import dev.vitrail.mixin.access.GpuDeviceAccessor;
 import dev.vitrail.pack.model.AlphaTest;
+import dev.vitrail.pack.model.BlendMode;
 import dev.vitrail.pack.model.ProgramStage;
 import dev.vitrail.pack.model.RenderStage;
 import dev.vitrail.pack.model.TargetName;
@@ -623,7 +624,8 @@ final class GeometryProgram {
 		// the chain does not run or the plan had no attachments to give, and then say of the water,
 		// the clouds and the weather that they are drawn before a seed they are drawn after - or
 		// before a seed that is never painted at all. Nothing tests the shadow map here because
-		// nothing needs to: every shadow pass is built with an empty blend.
+		// nothing needs to: no pass drawn from the light carries a blend of its own, whatever a
+		// pack's own directive later puts on its attachments.
 		this.demoted = owns && !this.ownsFirst && pass.blended() && !pass.afterDeferred();
 		this.extra = this.ownsFirst
 				? List.copyOf(writes)
@@ -778,30 +780,35 @@ final class GeometryProgram {
 		// form writes slot nought every time, so three calls would leave one state and a pipeline
 		// the pass refuses to bind, by name and in the middle of the world.
 		if (pass.shadow()) {
-			// One state per shadowcolor the program's own draw buffers name, in their order. The
-			// format is each buffer's own and not a constant: Mellow asks for R8 on nought, and a
-			// state naming four channels against a one channel attachment is the pipeline refusing
-			// to bind.
+			// One state per shadowcolor the program's own draw buffers name, in their order, which
+			// is also the rank a per buffer blend directive on this program lands on. The format is
+			// each buffer's own and not a constant: Mellow asks for R8 on nought, and a state naming
+			// four channels against a one channel attachment is the pipeline refusing to bind.
 			for (int slot = 0; slot < this.shadowColours.size(); slot++) {
 				builder.withColorTargetState(slot,
-						state(targets.shadowFormat(this.shadowColours.get(slot))));
+						state(slot, targets.shadowFormat(this.shadowColours.get(slot))));
 			}
 		} else {
 			for (int slot = 0; slot < this.slots.size(); slot++) {
 				Slot one = this.slots.get(slot);
 				switch (one.bound()) {
+					// Held as a null state, which the backend turns into a colour write mask of
+					// nought while every neighbour carries WRITE_ALL (VulkanRenderPipeline:182-189).
+					// So a pass that covers its outputs hands the device an attachment array whose
+					// elements already differ, blend functions or no blend functions, and has since
+					// long before any of them were read by rank.
 					case UNUSED -> builder.withUnusedColorTargetState(slot);
 					// The mask is written outright and never blended, whatever the pack asked for its
 					// own targets: what it carries is the depth the fragment left, and a depth mixed
 					// with the one behind it is the depth of nothing at all.
 					case COVERAGE -> builder.withColorTargetState(slot, new ColorTargetState(
 							Optional.empty(), one.format(), ColorTargetState.WRITE_ALL));
-					default -> builder.withColorTargetState(slot, state(one.format()));
+					default -> builder.withColorTargetState(slot, state(slot, one.format()));
 				}
 			}
 		}
 
-		this.pipeline = builder.build();
+		this.pipeline = part(builder);
 
 		// Filed against the pipeline and not the program, because the pipeline is what the
 		// descriptor walk can see when it has to answer for a name.
@@ -857,21 +864,73 @@ final class GeometryProgram {
 	}
 
 	/**
-	 * What the pack asked to blend with, falling back to what the pass wants when it asked nothing,
-	 * on every attachment alike. The per buffer form, {@code blend.<program>.<buffer>}, reaches
-	 * here folded into that one answer by the plan, where every attachment of the program comes
-	 * out with the same function; where two would come out apart the plan keeps the whole program
-	 * function and says so in its notes, one pipeline carrying one blend function for every target
-	 * it writes.
+	 * What the pack asked to blend this one attachment with, falling back to what the pass wants
+	 * when it asked nothing.
 	 * <p>
-	 * Four packs of the corpus name the translucent chunk pass here. Reverie asks for no blending
-	 * at all on its water, which is the opposite of what the pass would have chosen, and Bliss and
-	 * the two Complementary give a function whose alpha half differs from the one assumed.
+	 * The per buffer form, {@code blend.<program>.<buffer>}, is read here by the RANK the target
+	 * holds among the program's draw buffers, which is the rank this slot holds: the pipeline is
+	 * built over the pack's draw buffers in their own order, and the one slot that is not the
+	 * pack's own is draw buffer nought demoted onto the game's target, which is where that draw
+	 * buffer's colour goes. A pass drawn from the light ranks the same way over the shadowcolor
+	 * buffers its program declared. Iris resolves both the same way, the camera's at
+	 * {@code ShaderCreator.java:155-160} and the light's at {@code :358-363}, and applies the whole
+	 * program function before either ({@code ExtendedShader.java:244-250}), which is the order the
+	 * plan already folded them in.
+	 * <p>
+	 * <strong>Where the device cannot part its attachments the whole program answer stands on all
+	 * of them.</strong> Two attachments of one Vulkan pipeline may carry two blend states only
+	 * under {@code independentBlend}, so {@link BufferBlending} is asked first and the plan's
+	 * rankless answer is what a device without it gets, which is the function this pass carried
+	 * before the ranks were read at all. That function is the whole of what the fallback keeps back.
+	 * It does not hand such a device an identical array, and it never did: an unused slot is held as
+	 * a null state and the backend gives that one a colour write mask of nought beside its
+	 * neighbours' {@code WRITE_ALL} ({@code VulkanRenderPipeline:182-189}), so a pass covering its
+	 * outputs was parting its attachments there already. What the device gets back is what it had.
+	 * <p>
+	 * It is a fallback and never a refusal: the pipeline builder throws on two states that disagree,
+	 * so a pack whose directives part its targets would otherwise not be built at all, and a program
+	 * that is not built is a pass the pack does not draw.
+	 * <p>
+	 * The whole program form is what the corpus writes on the translucent chunk pass, and it is
+	 * often not what the pass would have chosen: Reverie, Noble and Photon ask for no blending at
+	 * all on their water, which is the opposite of it, and Bliss gives a function whose alpha half
+	 * differs from the one assumed.
+	 *
+	 * @param rank the slot's place among the draw buffers of the program being built, which is what
+	 *             a per buffer directive names its target by
 	 */
-	private ColorTargetState state(GpuFormat format) {
-		return new ColorTargetState(
-				BlendFunctions.of(this.targets.blend(this.loaded.path()), this.pass.blend()), format,
+	private ColorTargetState state(int rank, GpuFormat format) {
+		BlendMode asked = BufferBlending.served()
+				? this.targets.blend(this.loaded.path(), rank)
+				: this.targets.blend(this.loaded.path());
+
+		return new ColorTargetState(BlendFunctions.of(asked, this.pass.blend()), format,
 				ColorTargetState.WRITE_ALL);
+	}
+
+	/**
+	 * The build itself, with the game's refusal of two colour targets naming different blend
+	 * functions lifted for the length of it and for this thread alone.
+	 * <p>
+	 * The refusal stands in the builder every pipeline of the process is built through, so
+	 * {@code RenderPipelineBuilderMixin} cannot lift it on the device's answer alone: the wrap it
+	 * carries runs for the game's own pipelines and every other mod's, and none of those asked for
+	 * anything. The mark raised here is what the mixin reads beside that answer, which makes the
+	 * lift as wide as this engine's builds on a device that granted {@code independentBlend} and no
+	 * wider. Both of ours go through here, this class being the only place two attachments of one of
+	 * our pipelines can come out with different functions.
+	 * <p>
+	 * On the thread because the builds are not all on one: the pack-load worker builds the six
+	 * families ahead of their first draw while the render thread builds what a first draw asks for
+	 * and what {@link #reshapeAs} rebuilds inside another mod's draw.
+	 */
+	private static RenderPipeline part(RenderPipeline.Builder builder) {
+		BufferBlending.building(true);
+		try {
+			return builder.build();
+		} finally {
+			BufferBlending.building(false);
+		}
 	}
 
 	/**
@@ -1138,7 +1197,7 @@ final class GeometryProgram {
 			}
 		}
 
-		RenderPipeline built = builder.build();
+		RenderPipeline built = part(builder);
 
 		// The comparison note is keyed on the pipeline object, not read off its states, so it is
 		// the one answer a rebuild does not carry by itself. Left unfiled, the descriptor walk

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -330,7 +330,8 @@ public final class PackChoice {
 			// attribute rides in the chunk element, a pack declaring HIGHER_SHADOWCOLOR draws the
 			// light into the eight it asked for, a storage block is bound off the pack's own
 			// bufferObject, compute passes are dispatched at the head of the frame and before the
-			// pass they hang off, and custom images are served now, so a pack that cannot draw
+			// pass they hang off, a per buffer blend directive is built into the attachment whose
+			// rank its target holds, and custom images are served now, so a pack that cannot draw
 			// without one of those is simply right about what it needs. The list is the one EngineDefines poses
 			// IRIS_FEATURE_ for, and the two have to move together: a define is a promise, and a
 			// refusal is the same promise refused.
@@ -345,6 +346,15 @@ public final class PackChoice {
 			Set<String> served = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 			served.addAll(List.of("BLOCK_EMISSION_ATTRIBUTE", "COMPUTE_SHADERS", "CUSTOM_IMAGES",
 					PackDirectives.HIGHER_SHADOWCOLOR, "SSBO", "SEPARATE_HARDWARE_SAMPLERS"));
+			// The one name of the list the DEVICE answers for rather than the engine, and Iris makes
+			// the same call on the same ground: its own flag is usable only where the driver parts
+			// the blend state of one attachment from the next (features/FeatureFlags.java:15). Ours
+			// is asked for at device creation and the answer is what a pipeline can really be built
+			// with, so a machine without it refuses the pack instead of drawing it with one function
+			// where the pack wrote two.
+			if (BufferBlending.served()) {
+				served.add("PER_BUFFER_BLENDING");
+			}
 
 			required.removeIf(served::contains);
 

--- a/common/src/main/java/dev/vitrail/render/PackDefines.java
+++ b/common/src/main/java/dev/vitrail/render/PackDefines.java
@@ -156,7 +156,8 @@ public final class PackDefines {
 		// same answer the reduction and the sampler already run on: a pack told one thing and a
 		// specular map reduced under another would be two conventions in one picture.
 		return new EngineDefines.Environment(EngineDefines.DEFAULT_MC_VERSION, os(), vendor,
-				renderer, mipmap, DhDepth.present(), biomeIds(), categories(), PbrAtlases.format());
+				renderer, mipmap, DhDepth.present(), biomeIds(), categories(), PbrAtlases.format(),
+				BufferBlending.served());
 	}
 
 	private static Map<String, Integer> biomeIds() {

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -58,6 +58,7 @@
 		"QuadParticleFeatureRendererMixin",
 		"RenderPassMixin",
 		"access.RenderPipelineAccessor",
+		"RenderPipelineBuilderMixin",
 		"RenderPipelineMixin",
 		"sodium.MixinRenderRegion",
 		"access.RenderSectionManagerAccessor",

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -62,12 +62,22 @@ line is read before any of its programs is translated, so a refusal names what t
 and did not get, the log listing them, rather than the symptom that would have come later. Every
 name Reverie declares is served now, so it is no longer refused there.
 
-**Any name this engine has not built refuses the declaration.** Five names are built and served
-today, `BLOCK_EMISSION_ATTRIBUTE`, `CUSTOM_IMAGES`, `HIGHER_SHADOWCOLOR`,
-`SEPARATE_HARDWARE_SAMPLERS` and `SSBO`, so a pack that requires those alone loads, and every
-other name still refuses the pack, with the list in the log. The served flags are also the only
-`IRIS_FEATURE_` defines a pack finds: a capability define is a promise, so each appears the day
-its feature is served and not before, and the optional declarations keep reading the truth.
+**Any name this engine has not built refuses the declaration.** The names built and served today
+are `BLOCK_EMISSION_ATTRIBUTE`, `COMPUTE_SHADERS`, `CUSTOM_IMAGES`, `HIGHER_SHADOWCOLOR`,
+`PER_BUFFER_BLENDING`, `SEPARATE_HARDWARE_SAMPLERS` and `SSBO`, so a pack that requires those
+alone loads, and every other name still refuses the pack, with the list in the log. The served
+flags are also the only `IRIS_FEATURE_` defines a pack finds: a capability define is a promise, so
+each appears the day its feature is served and not before, and the optional declarations keep
+reading the truth.
+
+One of those names is the device's answer rather than the engine's. `PER_BUFFER_BLENDING` lets a
+pack give one of the targets a pass writes a different blend function from the others, and Vulkan
+allows two attachments of one pass to differ only where the driver has `independentBlend`. Where it
+has not, the name is refused and the whole-program function stands on every target the pass writes.
+Iris withholds the name where its own API cannot part the targets either, its driver needing
+`ARB_draw_buffers_blend` or OpenGL 4.0. Same rule, asked of a different API: one is a Vulkan device
+feature and the other a GL extension, and a machine can be told yes by one and no by the other, so
+a pack refused here is not for that reason refused there.
 
 Iris refuses a required flag only when the name is unknown to it or the hardware cannot serve
 it, and it has built every one of the ones Reverie asks for: some outright, some wherever the
@@ -102,12 +112,14 @@ message is one of its passes, and it is drawn because a capability test in its c
 
 The test reads capability defines. This engine announces itself the way Iris does, but a capability
 define is a promise, so it defines only what the backend actually serves, which today is
-`IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE`, `IRIS_FEATURE_CUSTOM_IMAGES`,
-`IRIS_FEATURE_HIGHER_SHADOWCOLOR`, `IRIS_FEATURE_SEPARATE_HARDWARE_SAMPLERS` and
-`IRIS_FEATURE_SSBO` and nothing else. The section above says why the features behind the other
-names are closed. A pack that finds the announcement without the capability it wants concludes it
-is running on OptiFine, the only renderer in that position when the pack was written, and words
-its message for it. Read "OptiFine" as "not Iris" and the message is accurate.
+`IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE`, `IRIS_FEATURE_COMPUTE_SHADERS`,
+`IRIS_FEATURE_CUSTOM_IMAGES`, `IRIS_FEATURE_HIGHER_SHADOWCOLOR`,
+`IRIS_FEATURE_SEPARATE_HARDWARE_SAMPLERS`, `IRIS_FEATURE_SSBO` and, where the driver parts the
+blend state of one attachment from the next, `IRIS_FEATURE_PER_BUFFER_BLENDING`, and nothing else.
+The section above says why the features behind the other names are closed. A pack that finds the
+announcement without the capability it wants concludes it is running on OptiFine, the only
+renderer in that position when the pack was written, and words its message for it. Read "OptiFine"
+as "not Iris" and the message is accurate.
 
 Complementary was the pack of the test set that did this, and it is why the define exists. Its
 colored lighting, which its two top profiles Very High and Ultra turn on, is voxel lighting:


### PR DESCRIPTION
## What changes

A pack may ask for a blend function per draw buffer, `blend.<program>.<buffer>`, and the engine
read those lines and then dropped them the moment two targets of one program disagreed, leaving
the whole-program function on all of them. The plan now keeps the answer by rank as well as whole,
and each directive is built into the attachment whose rank its target holds, on the camera's
geometry, on the geometry drawn from the light and on the far terrain alike. Two permissions make
that real on Vulkan: the `independentBlend` device feature, asked for at device creation beside the
storage features, and a lift of the game's own pipeline builder check, which refuses two attachments
with two functions and has to on its OpenGL road. The lift applies only to this engine's own builds
on a device that granted the feature; everything else in the process keeps the game's word.
`PER_BUFFER_BLENDING` is served where the device says yes, so a pack that requires it is no longer
turned away for that name, and a pack whose targets disagree is drawn either way: with its functions
where the device parts its attachments, with the whole-program function where it does not.

Also files the unreleased changelog fixes under one heading, in the order Added, Changed, Fixed.

## How it differs from the reference, and for what obstacle

It does not, on the directives: the whole-program form is applied first on every attachment and
each per-buffer line over the attachment its target ranks at, as `ExtendedShader.java:244-250`
applies them, the rank taken off the program's own draw buffers as `ShaderCreator.java:155-160`
and, for shadow programs, `:358-363` take it. The gate is each engine's own: Iris withholds the
flag where the driver lacks `ARB_draw_buffers_blend` or OpenGL 4.0 (`IrisRenderSystem.java:334-336`),
this engine where the device refuses `independentBlend`, and the two sets of machines are not
claimed to coincide.

## What proves it

- `gradlew build` green.
- The off-game harness over the corpus, `Chaine` and the plan's own notes: the per-buffer
  directives of every pack land on the rank their target holds, none on a target its program does
  not write; a bare `blend.shadow` reaches the shadow pipeline as it did before.
- In the game: a full sweep of the corpus on a jar carrying this and the neighbouring batches is
  still to come. Noble's far terrain programs are the ones that died on the game's builder check
  with the first form of this change, and they are what that sweep looks at first.

## What it leaves owing

The off-game harness never poses `IRIS_FEATURE_PER_BUFFER_BLENDING`, so what it translates is the
branch a pack compiles on a device without the feature.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
