### PR TITLE
fix(glsl): keep the format a pack writes on a storage image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,12 @@ what the next one holds.
 
 ### Fixed
 
+- **A pass that writes into an image no longer goes missing.** A pack can name, in the shader
+  itself, the format of the image that shader writes to, and that word was being dropped as the
+  declaration was moved to where this backend wants it. What was left is a declaration the compiler
+  refuses, so the pass never built and the frame went on without it. Noble is the pack this showed
+  on, where nothing wrote its screen space reflections.
+
 - **A pack's quality profile is named again instead of reading "Custom".** A profile can list a
   setting the pack does not actually have, and one such name was enough to stop the profile from
   ever being recognised: the shader screen and the F3 overlay both fell back to "Custom" on a pack

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -34,7 +35,8 @@ import java.util.Set;
  */
 record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, AlphaTest alphaTest,
 		Set<String> extensions,
-		Map<String, String> engineDefines, Map<String, String> memoryQualifiers, Set<String> used,
+		Map<String, String> engineDefines, Map<String, String> memoryQualifiers,
+		Map<String, String> imageFormats, Set<String> used,
 		Set<String> declaredNames, Map<String, String> synthesized,
 		Map<String, VolumeAtlas> readVolumes, Map<Integer, Output> packOutputs,
 		int maxFragmentOutput, Map<String, String> owedOutputs, VaryingSplit splits,
@@ -566,35 +568,46 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 	}
 
 	/**
-	 * Vulkan GLSL requires a format on a storage image, unless the image is write-only. Iris's GL
-	 * bind supplies the format at bind time, so Complementary writes
-	 * {@code writeonly uniform uimage3D voxel_img} with none, and BSL writes
-	 * {@code writeonly uniform image3D lightimg0} the same way. The format comes off the
-	 * {@code image.} directive and is written here, in the header: the body declaration has
-	 * already been lifted, so a layout qualifier inserted into the token stream would qualify a
-	 * statement that is no longer in the shader.
+	 * shaderc refuses a storage image declaration that carries no format layout qualifier, unless
+	 * the image is write-only. Iris's GL bind supplies the format at bind time, so Complementary
+	 * writes {@code writeonly uniform uimage3D voxel_img} with none, and BSL writes
+	 * {@code writeonly uniform image3D lightimg0} the same way. The format is written here, in the
+	 * header: the body declaration has already been lifted, so a layout qualifier inserted into the
+	 * token stream would qualify a statement that is no longer in the shader.
 	 * <p>
-	 * The pack's own memory qualifiers are written back for the same reason, and they are what
-	 * carries a declaration whose format we never learn: a pack switches its images off with the
-	 * setting that switches off the program reading them, and then the {@code image.} lines go
-	 * with it while the {@code writeonly} on the declaration stays. Dropping it turned a legal
-	 * declaration into one shaderc refuses.
+	 * The pack's own format comes first and the {@code image.} directive second, because the pack's
+	 * own is the text Iris hands its compiler: a pack that declares a volume one way and writes
+	 * another word in the shader is compiled on the word in the shader, and reading it back is the
+	 * only way to stay on the same side of that. It is also the only answer there is for a colour
+	 * target written as {@code colorimgN}, which no directive names.
+	 * <p>
+	 * The two words are not the same statement. The one in the shader is the format the SPIR-V
+	 * declares its loads and stores with; the {@code image.} directive is the format of the image
+	 * the chain binds under that name. A pack whose two disagree is asking for a reinterpretation
+	 * nothing promised it, and it is no better off under Iris, which binds the texture under its own
+	 * internal format and leaves the shader the word it wrote
+	 * ({@code samplers/IrisImages.java:39-41}), so the access format and the declared one part
+	 * company there as well. No pack of the corpus writes a word its own directive contradicts, so
+	 * this order is choosing between two spellings of one format rather than between two formats.
+	 * <p>
+	 * The memory qualifiers are written back for the same reason, and they are what carries a
+	 * declaration the pack left bare: a pack switches its images off with the setting that
+	 * switches off the program reading them, and then the {@code image.} lines go with it while the
+	 * {@code writeonly} on the declaration stays. Dropping it turned a legal declaration into one
+	 * shaderc refuses.
 	 */
 	private String declareOpaque(TranslatedUnit.Uniform sampler) {
 		String memory = this.memoryQualifiers.getOrDefault(sampler.name(), "");
 		String tail = (memory.isEmpty() ? "" : memory + " ") + "uniform " + sampler.declaration()
 				+ ";";
-		if (!isImageType(sampler.type())) {
+		if (!LegacyGlsl.isImageType(sampler.type())) {
 			return tail;
 		}
 
-		return CustomImages.layoutFormat(sampler.name())
+		return Optional.ofNullable(this.imageFormats.get(sampler.name()))
+				.or(() -> CustomImages.layoutFormat(sampler.name()))
 				.map(format -> "layout(" + format + ") " + tail)
 				.orElse(tail);
-	}
-
-	private static boolean isImageType(String type) {
-		return type.startsWith("image") || type.startsWith("iimage") || type.startsWith("uimage");
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -411,6 +411,13 @@ public final class GlslTranslator {
 	 */
 	private final Map<String, String> memoryQualifiers = new LinkedHashMap<>();
 
+	/**
+	 * The format a pack wrote in the {@code layout} of a storage image, by the name it declared.
+	 * Kept for the same reason as the memory qualifiers: the lifting rebuilds the declaration from
+	 * the type onwards, so a format nobody kept here is a format the shader no longer carries.
+	 */
+	private final Map<String, String> imageFormats = new LinkedHashMap<>();
+
 	/** Storage blocks this unit declares at file scope, each under the binding it was written at. */
 	private final List<TranslatedUnit.StorageBlock> storageBlocks = new ArrayList<>();
 
@@ -4066,7 +4073,7 @@ public final class GlslTranslator {
 		}
 
 		Map<String, String> found = new LinkedHashMap<>();
-		if (!readDeclarators(parts, cursor + 1, type, "", found)) {
+		if (!readDeclarators(parts, cursor + 1, type, "", "", found)) {
 			return null;
 		}
 
@@ -4229,12 +4236,38 @@ public final class GlslTranslator {
 		//
 		// Recorded for an opaque uniform alone, which is the only declaration these can be
 		// written on and the only one that reads them back out of the header.
-		if (!readDeclarators(parts, cursor + 1, type, opaque ? String.join(" ", memory) : "",
+		//
+		// The format goes the same way and for the same reason, and it is asked of a storage image
+		// alone: no other opaque type can be declared with one, and the header writes a format back
+		// in front of an image declaration and nowhere else, so read off a sampler it would sit
+		// there unread.
+		String format = opaque && LegacyGlsl.isImageType(type) ? imageFormat(parts, keywordAt) : "";
+		if (!readDeclarators(parts, cursor + 1, type, opaque ? String.join(" ", memory) : "", format,
 				opaque ? this.samplers : this.blockMembers)) {
 			return;
 		}
 
 		this.tokens.blankRange(start, end);
+	}
+
+	/**
+	 * The image format the pack wrote in front of {@code uniform}, or nothing where it wrote none.
+	 * <p>
+	 * By the vocabulary and not by the position, so that a {@code layout} carrying more than one
+	 * qualifier reads the same as one carrying a format alone: {@code binding} and {@code set} and
+	 * the numbers beside them are not format words, and neither is a name a {@code #define} stands
+	 * for, so a pack naming its format through a macro the expander did not resolve is read as
+	 * having written none rather than as having written that name.
+	 */
+	private String imageFormat(List<Integer> parts, int keywordAt) {
+		for (int part = 0; part < keywordAt; part++) {
+			Token token = this.tokens.get(parts.get(part));
+			if (token.kind() == Kind.IDENTIFIER && CustomImages.isLayoutFormat(token.text())) {
+				return token.text();
+			}
+		}
+
+		return "";
 	}
 
 	/**
@@ -4780,9 +4813,11 @@ public final class GlslTranslator {
 	 *               rather than in the declaration so that the type stays the first word of it.
 	 *               Empty for everything but an opaque uniform, which is the only declaration
 	 *               these can be written on.
+	 * @param format the image format the pack wrote, kept beside the name for the same reason.
+	 *               Empty for everything but a storage image, and for one the pack left bare.
 	 */
 	private boolean readDeclarators(List<Integer> parts, int from, String type, String memory,
-			Map<String, String> target) {
+			String format, Map<String, String> target) {
 		int cursor = from;
 		boolean any = false;
 
@@ -4798,6 +4833,10 @@ public final class GlslTranslator {
 
 			if (!memory.isEmpty()) {
 				this.memoryQualifiers.put(token.text(), memory);
+			}
+
+			if (!format.isEmpty()) {
+				this.imageFormats.put(token.text(), format);
 			}
 
 			StringBuilder declaration = new StringBuilder(type).append(' ').append(token.text());
@@ -4853,7 +4892,8 @@ public final class GlslTranslator {
 	private Emitter emitter() {
 		return new Emitter(this.stage, this.inputs, this.bound, this.alphaTest, this.extensions,
 				this.engineDefines,
-				this.memoryQualifiers, this.used, this.declaredNames, this.synthesized,
+				this.memoryQualifiers, this.imageFormats, this.used, this.declaredNames,
+				this.synthesized,
 				this.volumes.read(), this.packOutputs, this.maxFragmentOutput, this.owedOutputs,
 				this.splits, this.gameTextureMatrix,
 				this.gameModelView, this.softRewrites, this.trigCalls, this.hashCalls,

--- a/common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java
+++ b/common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java
@@ -475,6 +475,9 @@ public final class LegacyGlsl {
 			Set.of("sampler", "isampler", "usampler", "image", "iimage", "uimage",
 					"texture", "itexture", "utexture", "subpassInput", "atomic_uint");
 
+	/** The opaque prefixes that name a storage image, the one kind a format is asked of. */
+	private static final Set<String> IMAGE_PREFIXES = Set.of("image", "iimage", "uimage");
+
 	/**
 	 * Whether the pass this program is wanted for draws entities, and so reads
 	 * {@link #ENTITY_UNIFORMS} whether it declares them or not.
@@ -555,6 +558,21 @@ public final class LegacyGlsl {
 	 */
 	public static boolean isOpaqueType(String type) {
 		for (String prefix : OPAQUE_PREFIXES) {
+			if (type.startsWith(prefix)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether a uniform of this type is a storage image, which is the one opaque kind a format is
+	 * asked of: shaderc refuses an image declaration carrying no format layout qualifier unless it
+	 * is written {@code writeonly}.
+	 */
+	static boolean isImageType(String type) {
+		for (String prefix : IMAGE_PREFIXES) {
 			if (type.startsWith(prefix)) {
 				return true;
 			}

--- a/common/src/main/java/dev/vitrail/pack/texture/CustomImages.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/CustomImages.java
@@ -3,10 +3,12 @@ package dev.vitrail.pack.texture;
 import dev.vitrail.pack.model.ImageInformation;
 import dev.vitrail.pack.model.TargetFormat;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * The storage images the loaded pack declared.
@@ -17,10 +19,24 @@ import java.util.Set;
  */
 public final class CustomImages {
 
+	/**
+	 * Every word GLSL takes as an image format, which is what {@link #glslLayout} spells and so
+	 * exactly the formats a target can be given. Read to tell a format apart from the other things
+	 * a {@code layout} carries, {@code binding} and {@code set} and their values.
+	 */
+	private static final Set<String> LAYOUT_FORMATS = Arrays.stream(TargetFormat.values())
+			.map(CustomImages::glslLayout)
+			.collect(Collectors.toUnmodifiableSet());
+
 	private static volatile Map<String, ImageInformation> byName = Map.of();
 	private static volatile Set<String> names = Set.of();
 
 	private CustomImages() {
+	}
+
+	/** Whether this word names an image format, as opposed to anything else a layout carries. */
+	public static boolean isLayoutFormat(String word) {
+		return LAYOUT_FORMATS.contains(word);
 	}
 
 	/** Records the live {@code image.NAME} lines of the pack about to be translated. */


### PR DESCRIPTION
## What changes

A pack may write the format of a storage image in the shader itself, `layout (rgba16f) uniform
image2D colorimg2`, and the translator dropped that word when it lifted the declaration into the
header, rebuilding it from the type onwards. What came out, `uniform image2D colorimg2`, is a
declaration shaderc refuses for want of a format, so the whole compute unit was refused and the
pass it belongs to never ran. The format now travels beside the memory qualifiers and is written
back in front of the declaration, ahead of the format an `image.` directive declares for the same
name, and it is read by vocabulary rather than by position, so a `layout` carrying a binding beside
its format reads the same as one carrying the format alone. Noble's screen space reflections are
what this showed on, its `composite2` compute failing in all three dimensions.

## How it differs from the reference, and for what obstacle

It does not. The word in the shader is the text Iris compiles, and for a colour target addressed
as `colorimgN` it is the only word there is: Iris reads that format off the target and hands it to
the bind rather than to the shader (`samplers/IrisImages.java:39-41`), and the shader keeps what
the pack wrote.

## What proves it

- `gradlew build` green.
- The off-game harness, `Traduction` over the corpus: the units that failed for this reason on
  `dev` compile here, every other unit unchanged, and no storage image declaration comes out with
  neither a format nor `writeonly`.
- In the game: a full sweep of the corpus on a jar carrying this and the neighbouring batches is
  still to come; Noble's reflections are what it looks at.

## What it leaves owing

A declaration written `uniform layout(...) restrict image2D x`, the qualifier order Clarity and
RenderPearl use, is not lifted at all and stays in the body with its own layout, which compiles;
it takes a different road from the one this branch fixes and is unchanged by it.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
