### PR TITLE
fix(cache): name a development build's caches after its commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,26 +19,30 @@ plugins {
 // release exactly what gradle.properties says. `.github/workflows/release.yml` compares the tag
 // against that line and refuses a mismatch, and it checks a tag out, so its head is detached and
 // carries no branch name to append anyway. `dev` and `main` are left bare for the other half of
-// the reason: there is nothing there to tell one build from another.
+// the reason: a branch name that every build of the line shares tells no build from another. What
+// does tell them apart is the commit, and that is read below and kept out of the version.
 def effectiveVersion = project.mod_version
+def development = effectiveVersion.endsWith("-dev")
 
-if (effectiveVersion.endsWith("-dev")) {
-	def branch = null
-
+// What git says to one question, trimmed, or null when there is no git on the path, no repository
+// under this directory, or the command itself refused. A build out of a tarball is a legitimate
+// build, so every caller below answers a null rather than stopping on it.
+def gitSaid = { String... command ->
 	try {
-		def git = new ProcessBuilder("git", "rev-parse", "--abbrev-ref", "HEAD")
+		def git = new ProcessBuilder(command)
 				.directory(rootDir)
 				.redirectErrorStream(true)
 				.start()
 		def said = git.inputStream.getText("UTF-8").trim()
 
-		if (git.waitFor() == 0) {
-			branch = said
-		}
+		return git.waitFor() == 0 ? said : null
 	} catch (IOException ignored) {
-		// No git on the path, or no repository under this directory. A build out of a tarball is
-		// a legitimate build, and the bare suffix is the right answer for it rather than a stop.
+		return null
 	}
+}
+
+if (development) {
+	def branch = gitSaid("git", "rev-parse", "--abbrev-ref", "HEAD")
 
 	// "HEAD" is what a detached head answers, which is what continuous integration checks out and
 	// what a release build therefore is.
@@ -69,6 +73,40 @@ if (effectiveVersion.endsWith("-dev")) {
 // Put back on the project because both loader modules read it too, each of them naming it in the
 // metadata it expands and in the name of the jar it writes.
 ext.effectiveVersion = effectiveVersion
+
+// The commit a development build was made from, which is the one thing that tells two of them
+// apart. The number above cannot: every build between two releases declares the same one, and the
+// two disk caches name their editions after it, so a jar built today is served the units a jar
+// built last week wrote. A translator fixed without the number moving is then invisible on screen,
+// with nothing anywhere saying why.
+//
+// It stays out of the version. The version is what a player reads, what names a jar and what two
+// loaders parse, and a hash there is noise to all three. It travels as a resource the common
+// module writes instead, and the road is the branch's: read from git here, committed nowhere,
+// because the answer depends on which commit is checked out and a committed one would be wrong at
+// the next.
+//
+// A release build leaves it empty, and that is what leaves a player's caches exactly as they are:
+// they are worth keeping across every jar of one version, since nothing but a release changes what
+// those jars compile.
+def buildIdentity = ""
+
+if (development) {
+	def head = gitSaid("git", "rev-parse", "--short", "HEAD")
+
+	if (head != null && !head.isEmpty()) {
+		// A jar built over an edited tree is described by no commit, so it says so. Two such jars
+		// off one commit still share the name, which is the one case left where a build can read
+		// another's units. An unanswered question counts as edited for the same reason a silence
+		// counts against: what must not happen is a folder claiming a commit it does not hold.
+		def edits = gitSaid("git", "status", "--porcelain")
+
+		buildIdentity = edits == null || !edits.isEmpty() ? head + ".dirty" : head
+	}
+}
+
+// Read by the common module, which is where the caches that need it live.
+ext.buildIdentity = buildIdentity
 
 subprojects {
 	apply plugin: "java"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -61,3 +61,36 @@ tasks.named("processResources", ProcessResources).configure {
 		rename { "config-icon.png" }
 	}
 }
+
+// The commit this jar was built from, for the two disk caches, which cannot tell two development
+// builds of one version apart without it. Written by the build rather than kept in the tree, for
+// the reason the root build gives where the value is read, and it lands here because both caches
+// are this module's and both loader jars take this module's output whole.
+//
+// A release build has no commit to write and the file is then absent, which is the answer
+// Vitrail.buildIdentity reads as a release: its jar carries nothing this task did not exist for.
+def buildIdentity = rootProject.buildIdentity
+def buildIdentityDir = layout.buildDirectory.dir("generated/resources/build-identity")
+
+def writeBuildIdentity = tasks.register("writeBuildIdentity") {
+	description = "Writes the commit a development build was made from into the jar."
+
+	inputs.property("identity", buildIdentity)
+	outputs.dir(buildIdentityDir)
+
+	doLast {
+		def directory = buildIdentityDir.get().asFile
+		def stamp = new File(directory, "vitrail-build-identity")
+
+		directory.mkdirs()
+
+		if (buildIdentity.isEmpty()) {
+			stamp.delete()
+		} else {
+			stamp.setText(buildIdentity, "UTF-8")
+		}
+	}
+}
+
+// The task rather than its directory, so that processResources waits for it without being told.
+sourceSets.main.resources.srcDir(writeBuildIdentity)

--- a/common/src/main/java/dev/vitrail/Vitrail.java
+++ b/common/src/main/java/dev/vitrail/Vitrail.java
@@ -5,6 +5,10 @@ import dev.vitrail.platform.VitrailPlatform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
 /**
  * Entry point shared by every loader module. A loader module calls
  * {@link #initClient(VitrailPlatform)} once, as early as it can, and everything after
@@ -17,6 +21,12 @@ public final class Vitrail {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MOD_NAME);
 
+	/** Where the build writes the commit, and absent in a jar built from a release version. */
+	private static final String BUILD_STAMP = "/vitrail-build-identity";
+
+	/** Read once, because it is a fact about the jar and cannot change under a running game. */
+	private static final String BUILD_IDENTITY = readBuildIdentity();
+
 	private static VitrailPlatform platform;
 
 	private Vitrail() {
@@ -27,18 +37,17 @@ public final class Vitrail {
 	}
 
 	/**
-	 * The declared version with the branch name cut off it, which is what the two compiled stores
-	 * name their edition after and key their entries by.
+	 * The declared version with the branch name cut off it, which is the version half of what the
+	 * two compiled stores name their edition after and key their entries by.
 	 * <p>
 	 * A build made off a topic branch declares that branch in its version,
 	 * {@code 0.10.0-dev.fix.shadow-band} where {@code dev} declares {@code 0.10.0-dev}, so that a
-	 * jar, a log line and a screenshot say which branch made them. A cache edition must not follow
-	 * it there. Both stores delete every edition but their own when they open, so a bench swapping
-	 * between two branch builds would throw the other one's store away on every swap and compile
-	 * every pack from cold again: on this machine that is most of a gigabyte of work bought by a
-	 * name. What a version says in a cache key is a claim about the translator and the compiler,
-	 * and neither of them changes because a branch does, so every build between two releases goes
-	 * on sharing one folder exactly as it did before there was a suffix to share it despite.
+	 * jar, a log line and a screenshot say which branch made them. A cache edition does not follow
+	 * it there. What a version says in a cache key is a claim about the translator and the
+	 * compiler, and neither of them changes because a branch does. What does change between two
+	 * builds of one version is the commit, and {@link #buildIdentity()} is where that is named, so
+	 * a branch in the folder as well would be a second name for the same build and a longer
+	 * directory holding the same units.
 	 * <p>
 	 * The cut is at the first dot after the dash, which is where the build appends and the only
 	 * place a dot can follow: a version is three numbers and then {@code -alpha}, {@code -beta},
@@ -53,6 +62,73 @@ public final class Vitrail {
 
 		int dot = version.indexOf('.', dash);
 		return dot < 0 ? version : version.substring(0, dot);
+	}
+
+	/**
+	 * The commit this jar was built from, for a development build, and empty for a release and for
+	 * anything running outside a jar the build wrote.
+	 * <p>
+	 * Every build made between two releases declares one version number, and both disk caches name
+	 * their edition after that number: with nothing else in the name, a build is served the units
+	 * its predecessor wrote, so a translator changed without the number moving goes unseen on
+	 * screen and the build that happens to carry a new define is the only one that translates
+	 * afresh. This is what separates them, and it is a fact about the build rather than about the
+	 * version, so the build writes it into the jar and commits it nowhere.
+	 * <p>
+	 * A release leaves it empty on purpose. A player's caches are worth keeping across every jar of
+	 * one version, since nothing but a release changes what those jars compile, and a name per jar
+	 * would buy a cold load for nothing. A developer's are worth nothing across two builds.
+	 * <p>
+	 * The short hash, or the short hash and {@code .dirty} when the tree the build read carried
+	 * edits: a jar built over edits is described by no commit. Two of those off one commit still
+	 * share an edition, which is the one case left where a build reads what another wrote.
+	 */
+	public static String buildIdentity() {
+		return BUILD_IDENTITY;
+	}
+
+	/**
+	 * What every edition of this version and this game begins with, and the whole of what a RELEASE
+	 * build names its own.
+	 * <p>
+	 * It is also what the caches sweep by: an edition outside this family holds keys nothing can
+	 * ever ask for again, and one inside it belongs to another build of the same version.
+	 */
+	public static String cacheEditionFamily() {
+		return plain(cacheVersion()) + "+mc" + plain(platform().minecraftVersion());
+	}
+
+	/**
+	 * What the two disk caches name their directory after: the family, and for a development build
+	 * the commit it was built from.
+	 * <p>
+	 * One place rather than one per cache, because the two answer the same question and a folder
+	 * that disagreed with the other would be the defect all over again in half the engine.
+	 */
+	public static String cacheEdition() {
+		String build = buildIdentity();
+
+		return build.isEmpty() ? cacheEditionFamily() : cacheEditionFamily() + "+" + plain(build);
+	}
+
+	/** Whatever a directory name cannot hold, replaced so that a name is never two names. */
+	private static String plain(String text) {
+		return text.replaceAll("[^A-Za-z0-9._-]", "_");
+	}
+
+	private static String readBuildIdentity() {
+		try (InputStream stamp = Vitrail.class.getResourceAsStream(BUILD_STAMP)) {
+			if (stamp == null) {
+				return "";
+			}
+
+			return new String(stamp.readAllBytes(), StandardCharsets.UTF_8).trim();
+		} catch (IOException | RuntimeException ignored) {
+			// The release answer, which is the edition every build shared before the stamp existed:
+			// a slow launch at worst, and never a failure to start. It cannot be anything louder
+			// either, since this runs in a static initialiser and a throw here would be an Error.
+			return "";
+		}
 	}
 
 	public static VitrailPlatform platform() {

--- a/common/src/main/java/dev/vitrail/cache/ModuleCache.java
+++ b/common/src/main/java/dev/vitrail/cache/ModuleCache.java
@@ -53,12 +53,12 @@ import java.util.stream.Stream;
  * <p>
  * <strong>The key IS the input, hashed</strong>, and nothing else: the exact text handed to the
  * compiler, the stage it is compiled for, and everything that decides what that text turns into,
- * which is the mod's version, the game's, the loader with its own version, and the LWJGL build
- * whose bundled shaderc and SPIRV-Cross do the work. Nothing is keyed on a pack name, a file path
- * or the debug name the module carries, so there is no invalidation to get wrong and none is
- * written. An edited shader, a moved pack setting, a translator that emits one word differently, a
- * loader that patches the compiler: each is a different key, and the blob under the old one is
- * never asked for again.
+ * which is the mod's version and, on a development build, the commit behind it, the game's, the
+ * loader with its own version, and the LWJGL build whose bundled shaderc and SPIRV-Cross do the
+ * work. Nothing is keyed on a pack name, a file path or the debug name the module carries, so
+ * there is no invalidation to get wrong and none is written. An edited shader, a moved pack
+ * setting, a translator that emits one word differently, a loader that patches the compiler: each
+ * is a different key, and the blob under the old one is never asked for again.
  * <p>
  * <strong>The debug name stays out of the key on purpose.</strong> The game's pipeline cache is
  * keyed on the identifier and never on the text, so this engine puts the load number in that name
@@ -92,21 +92,26 @@ import java.util.stream.Stream;
  * platter, so what answers for a file after a power cut is the digest behind it and not the move.
  * <p>
  * <strong>The disk is bounded</strong>, at half a gigabyte by default, and bounded per edition:
- * the files sit under a directory named for the mod and game versions, and any directory named
- * for another edition is deleted when this one opens. Without that an update would fill a fresh
- * set of keys on top of the set it had just made unreachable, and two packs plus one update
- * would go over the ceiling with nothing in the way. The Sodium slider writes the number, and
- * a store already over it is swept at once. Past the ceiling the units nothing has asked for
- * lately go first, down to three quarters of it so that the sweep is not paid again at the
- * very next write.
+ * the files sit under a directory named for the mod and game versions, and for a development
+ * build the commit as well, and a directory named for another edition is deleted when this one
+ * opens. Without that an update would fill a fresh set of keys on top of the set it had just made
+ * unreachable, and two packs plus one update would go over the ceiling with nothing in the way. A
+ * build carrying a commit keeps one neighbour and so holds two of those ceilings rather than one,
+ * and {@link #dropOtherEditions} says which neighbour and why. The Sodium slider writes the number,
+ * and a store already over it is swept at once. Past the ceiling the units nothing has asked for
+ * lately go first, down to three quarters of it so that the sweep is not paid again at the very
+ * next write.
  * <p>
  * <strong>The folder's name is narrower than the key</strong>, and deliberately: the key also
  * carries the loader, its version and the LWJGL build, so a NeoForge or an LWJGL bump makes every
  * blob unreachable without moving the folder, and what those blobs then cost is space until a
  * sweep collects them. Naming the folder after all five would sweep the whole store on a loader
- * bump, which is the same space spent on the same day for no reading. And two builds declaring
- * one version share the folder AND the keys, which is every build made between two releases: in
- * the workshop the answer is to delete the folder, and there is nothing automatic about it.
+ * bump, which is the same space spent on the same day for no reading. What the folder does carry
+ * beyond the two versions is the commit, and only on a development build: without it, two builds
+ * declaring one version would share the folder AND the keys, which is every build made between
+ * two releases, and a translator changed since yesterday would be served yesterday's modules with
+ * nothing saying so. A release build carries no commit, because a player's store is worth keeping
+ * across every jar of one version and nothing but a release changes what those jars compile.
  * <p>
  * {@code -Dvitrail.moduleCache=false} turns the whole thing off, and the line is still printed, so
  * one jar answers the question in both directions.
@@ -173,6 +178,12 @@ public final class ModuleCache {
 	private static final String FORMAT = "vitrail-module-3";
 
 	private static final String FOLDER = "modules";
+
+	/**
+	 * What {@link Vitrail#cacheEdition()} puts between the family and the commit, and what a
+	 * neighbour of this family is therefore matched on.
+	 */
+	private static final String EDITION_SEPARATOR = "+";
 
 	/** How many of a load's rebuilt units are named on the line that counts them. */
 	private static final int NAMED_MISSES = 12;
@@ -326,6 +337,17 @@ public final class ModuleCache {
 
 		feed(digest, FORMAT);
 		feed(digest, Vitrail.cacheVersion());
+
+		// The commit, on a development build and only there. The folder already keeps two such
+		// builds apart, and this is the same claim made where the class makes every other one: the
+		// key IS the input, and on a development build the version alone does not name the
+		// translator that produced the text. A release feeds nothing extra, which is what leaves
+		// every key a player already holds exactly where it was.
+		String build = Vitrail.buildIdentity();
+		if (!build.isEmpty()) {
+			feed(digest, build);
+		}
+
 		feed(digest, Vitrail.platform().minecraftVersion());
 		feed(digest, Vitrail.platform().loaderName());
 		feed(digest, Vitrail.platform().loaderVersion());
@@ -677,7 +699,8 @@ public final class ModuleCache {
 	}
 
 	/**
-	 * Makes the edition's directory, clears out every other edition's, and measures what is left.
+	 * Makes the edition's directory, clears out what other editions left but for the one neighbour
+	 * {@link #dropOtherEditions} spares, and measures what is left.
 	 * <p>
 	 * The only moment at which a leftover neighbour can be swept up: nothing else has been handed
 	 * the directory yet, because {@link #directory} is set on the last line, so a {@code .part} seen
@@ -686,9 +709,10 @@ public final class ModuleCache {
 	private static void open() {
 		try {
 			Path root = Vitrail.platform().gameDirectory().resolve(Vitrail.MOD_ID).resolve(FOLDER);
-			Path mine = root.resolve(edition());
+			Path mine = root.resolve(Vitrail.cacheEdition());
 			Files.createDirectories(mine);
-			dropOtherEditions(root, mine);
+			touch(mine);
+			dropOtherEditions(root, mine, Vitrail.cacheEditionFamily());
 			BYTES.set(total(scan(mine, true)));
 			directory = mine;
 		} catch (IOException | RuntimeException e) {
@@ -699,31 +723,74 @@ public final class ModuleCache {
 	}
 
 	/**
-	 * What names a whole set of keys at once, and therefore what names their directory. The version
-	 * is the one {@link Vitrail#cacheVersion()} answers, so that a build off a topic branch shares
-	 * this folder with every other build between the same two releases rather than emptying it.
+	 * Deletes what another edition left, because not one of its keys can be asked for by this build
+	 * and the ceiling has to be about the blobs that are still reachable.
+	 * <p>
+	 * <strong>A build carrying a commit spares one of them</strong>, the edition of its own family
+	 * used most recently. Two builds of one version are two editions, and a developer moving between
+	 * them would otherwise have each of them empty the other's folder on the way in, which is every
+	 * pack compiled from cold at every swap and exactly what an edition exists to prevent. One is
+	 * what a swap needs, and it is also what bounds the disk: two editions under one ceiling each,
+	 * rather than a folder for every build ever made. A third build's folder goes at the launch
+	 * after it.
+	 * <p>
+	 * A build whose edition IS the family spares none, so a player's store holds the one edition it
+	 * always held. That is every RELEASE, and also a development build git could answer no question
+	 * for, which carries no commit to name a folder of its own with.
 	 */
-	private static String edition() {
-		return plain(Vitrail.cacheVersion()) + "+mc"
-				+ plain(Vitrail.platform().minecraftVersion());
-	}
+	private static void dropOtherEditions(Path root, Path mine, String family) throws IOException {
+		List<Path> entries;
+		try (Stream<Path> found = Files.list(root)) {
+			entries = found.toList();
+		}
 
-	private static String plain(String text) {
-		return text.replaceAll("[^A-Za-z0-9._-]", "_");
+		String kept = mine.getFileName().toString().equals(family)
+				? "" : newestSibling(entries, mine, family);
+
+		for (Path entry : entries) {
+			if (!entry.equals(mine) && !entry.getFileName().toString().equals(kept)) {
+				dropTree(entry);
+			}
+		}
 	}
 
 	/**
-	 * Deletes what an earlier or later edition left, because not one of its keys can ever be asked
-	 * for again and the ceiling has to be about the blobs that are still reachable.
+	 * The name of the edition of this family used most recently, or empty when this build is the
+	 * only one of its family to have run here. A directory has a name, so an empty answer matches
+	 * nothing.
 	 */
-	private static void dropOtherEditions(Path root, Path mine) throws IOException {
-		try (Stream<Path> entries = Files.list(root)) {
-			for (Path entry : entries.toList()) {
-				if (!entry.equals(mine)) {
-					dropTree(entry);
-				}
+	private static String newestSibling(List<Path> entries, Path mine, String family)
+			throws IOException {
+		String newest = "";
+		long stamp = Long.MIN_VALUE;
+
+		for (Path entry : entries) {
+			String name = entry.getFileName().toString();
+			if (entry.equals(mine) || !ofFamily(name, family)) {
+				continue;
+			}
+
+			long when = Files.getLastModifiedTime(entry).toMillis();
+			if (when > stamp) {
+				stamp = when;
+				newest = name;
 			}
 		}
+
+		return newest;
+	}
+
+	/**
+	 * Whether a directory name is an edition of this family: the family entire, or the family and
+	 * then a commit behind the separator {@link Vitrail#cacheEdition()} puts between them.
+	 * <p>
+	 * The separator is what makes this an answer and not a guess. A name beginning with the family
+	 * is not an edition of it: {@code ...+mc26.20} begins with {@code ...+mc26.2} and is another
+	 * game version altogether, whose blobs are exactly the ones nothing can ever ask for again, so a
+	 * prefix on its own would spare the folder that most needs sweeping.
+	 */
+	private static boolean ofFamily(String name, String family) {
+		return name.equals(family) || name.startsWith(family + EDITION_SEPARATOR);
 	}
 
 	private static void dropTree(Path entry) throws IOException {
@@ -750,12 +817,12 @@ public final class ModuleCache {
 	 * One piece of the key, behind its own length so that two different splits of the same
 	 * characters cannot hash alike.
 	 * <p>
-	 * <strong>The four versions are the half that is easy to leave out and expensive to leave
+	 * <strong>The versions are the half that is easy to leave out and expensive to leave
 	 * out</strong>: the text alone names none of them, and a translator that emits differently, a
 	 * game that compiles differently, a loader that patches the compiler, or an LWJGL bump that
 	 * brings a new shaderc and a new SPIRV-Cross with it are each a different answer to a question
 	 * whose text has not moved. Serving the old blob for one of those is exactly the failure this
-	 * class has to be unable to have, and none of the four announces itself any other way.
+	 * class has to be unable to have, and not one of them announces itself any other way.
 	 */
 	private static void feed(MessageDigest digest, String text) {
 		byte[] raw = text.getBytes(StandardCharsets.UTF_8);
@@ -778,6 +845,12 @@ public final class ModuleCache {
 	/**
 	 * Marks a unit as asked for, so that the sweep drops what nothing loads rather than what was
 	 * written longest ago. A stamp that cannot be set costs a worse choice later and nothing now.
+	 * <p>
+	 * The edition's own directory is stamped the same way at {@link #open}, and that is the half
+	 * that has to be written down: a file system already moves a directory's stamp when a unit is
+	 * created inside it, so a run that WROTE is stamped whether this line exists or not, while a run
+	 * that hit on everything wrote nothing and would read as abandoned by the very next build.
+	 * Between the two, the stamp is the last time the edition was used at all.
 	 */
 	private static void touch(Path file) {
 		try {

--- a/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
@@ -65,15 +65,22 @@ import java.util.zip.InflaterOutputStream;
  * Absent, unreadable, corrupt, larger than any translation is, or of a shape this build cannot
  * read: every one of them is a MISS, and a miss is the translation that would have happened anyway.
  * <p>
- * The store is bounded at a quarter of a gigabyte and bounded per edition, and it is off until
- * somebody installs it. {@code -Dvitrail.translationDir=<path>} installs it outside the game, which
- * is how the harness reaches it.
+ * The store is bounded at a quarter of a gigabyte, and bounded per edition rather than in total: a
+ * development install that keeps a neighbour holds two editions and half a gigabyte. It is off
+ * until somebody installs it. {@code -Dvitrail.translationDir=<path>} installs it outside the game,
+ * which is how the harness reaches it.
  * <p>
- * <strong>The edition is the version this build DECLARES</strong>, and that is all it can be.
- * Two builds carrying one version number share a folder and share every key, which is every
- * build made between two releases: a translator changed without the version moving is served its
- * predecessor's units, and nothing says so. What answers that in the workshop is deleting the
- * folder, or bumping {@code TranslatedProgramCodec.FORMAT} by hand, and neither is automatic.
+ * <strong>The edition is the version this build declares, and the commit it was built
+ * from.</strong> The version alone cannot hold two builds apart: every build made between two
+ * releases declares the same one, so a translator changed without the version moving would be
+ * served its predecessor's units with nothing saying so. A development build therefore translates
+ * into a folder named for its commit, which no other build has written to. A release build does
+ * not, and must not: a player's translations are worth keeping across every jar of one version,
+ * and nothing but a release changes what those jars translate. {@code Vitrail.cacheEdition} is
+ * where the two halves are put together, for this cache and for the module cache at once.
+ * <p>
+ * A build that carries a commit keeps one neighbour rather than emptying the whole folder, and
+ * {@link #dropOtherEditions} says which and why.
  */
 public final class TranslationCache {
 
@@ -83,6 +90,13 @@ public final class TranslationCache {
 	private static final String FOLDER = "translations";
 	private static final String SUFFIX = ".tr";
 	private static final String PART_SUFFIX = ".part";
+
+	/**
+	 * What stands between the family and the commit in the name of a directory here. The caller
+	 * joins the two halves with a plus, which {@link #plain} cannot hold in a directory name and
+	 * replaces, so what a neighbour is matched on is the underscore that reaches the disk.
+	 */
+	private static final String EDITION_SEPARATOR = "_";
 
 	/** SHA-256, sitting behind the blob in every file and answering for it. */
 	private static final int DIGEST_BYTES = 32;
@@ -127,7 +141,7 @@ public final class TranslationCache {
 		try {
 			String outside = System.getProperty(DIRECTORY_PROPERTY, "");
 			if (!outside.isEmpty()) {
-				open(Path.of(outside).resolve(FOLDER).resolve("outside-the-game"), false);
+				open(Path.of(outside).resolve(FOLDER).resolve("outside-the-game"), "");
 			}
 		} catch (RuntimeException e) {
 			problem = e.toString();
@@ -138,33 +152,40 @@ public final class TranslationCache {
 	}
 
 	/**
-	 * Puts the cache under a directory of the caller's choosing, and clears out every other
-	 * edition's.
+	 * Puts the cache under a directory of the caller's choosing, and clears out what another
+	 * edition left.
 	 * <p>
-	 * The edition names a whole set of keys at once: nothing under another one can ever be asked for
-	 * again, and the ceiling has to be about what is still reachable. Called once, before the first
-	 * pack is read; a failure here leaves the cache off for the run and the loads exactly as long as
-	 * they were.
+	 * The edition names a whole set of keys at once: nothing under another one can be asked for by
+	 * this build, and the ceiling has to be about what is still reachable. One neighbour is spared
+	 * for the build that owns it, and {@link #dropOtherEditions} says which and why. Called once,
+	 * before the first pack is read; a failure here leaves the cache off for the run and the loads
+	 * exactly as long as they were.
+	 *
+	 * @param edition what this build translates into, which carries the commit it was built from
+	 *                when there is one to carry and is otherwise the family entire
+	 * @param family  what every edition of this version and this game begins with, which is what
+	 *                decides whether a neighbour is another build of this version or the leavings
+	 *                of another version altogether
 	 */
-	public static void install(Path parent, String edition) {
-		open(parent.resolve(FOLDER).resolve(edition.replaceAll("[^A-Za-z0-9._-]", "_")), true);
+	public static void install(Path parent, String edition, String family) {
+		open(parent.resolve(FOLDER).resolve(plain(edition)), plain(family));
 	}
 
 	/**
 	 * Makes the directory, measures what is in it, and takes it into service.
 	 *
-	 * @param dropOthers whether every sibling edition goes with it. True for the game, where the
-	 *                   edition is the only one that can ever be asked for again and the ceiling
-	 *                   has to be about what is still reachable. False for the road the property
-	 *                   opens, which runs in a static initialiser and would therefore delete the
-	 *                   game's own edition a moment before the game installed it
+	 * @param family the sanitized family of this edition, or empty to leave every neighbour alone.
+	 *               Empty for the road the property opens, which runs in a static initialiser and
+	 *               would otherwise delete the game's own edition a moment before the game
+	 *               installed it
 	 */
-	private static void open(Path mine, boolean dropOthers) {
+	private static void open(Path mine, String family) {
 		synchronized (LOCK) {
 			try {
 				Files.createDirectories(mine);
-				if (dropOthers) {
-					dropOtherEditions(mine.getParent(), mine);
+				if (!family.isEmpty()) {
+					touch(mine);
+					dropOtherEditions(mine.getParent(), mine, family);
 				}
 
 				BYTES.set(total(scan(mine, true)));
@@ -531,7 +552,16 @@ public final class TranslationCache {
 		}
 	}
 
-	/** Marks a blob as asked for, so a sweep drops what nothing loads rather than what is oldest. */
+	/**
+	 * Marks a blob as asked for, so a sweep drops what nothing loads rather than what is oldest,
+	 * and at install the edition's own directory as opened.
+	 * <p>
+	 * The directory is stamped for the choice {@link #dropOtherEditions} makes, and stamped at
+	 * install rather than only by the blobs landing in it: a file system moves a directory's own
+	 * stamp when a blob is created inside it, so without this line a run that hit on everything and
+	 * wrote nothing would leave a folder reading as abandoned. With it, the stamp is the last time
+	 * the edition was used at all, by a launch or by a write.
+	 */
 	private static void touch(Path file) {
 		try {
 			Files.setLastModifiedTime(file, FileTime.from(Instant.now()));
@@ -540,14 +570,74 @@ public final class TranslationCache {
 		}
 	}
 
-	private static void dropOtherEditions(Path root, Path mine) throws IOException {
-		try (Stream<Path> entries = Files.list(root)) {
-			for (Path entry : entries.toList()) {
-				if (!entry.equals(mine)) {
-					dropTree(entry);
-				}
+	/**
+	 * Deletes what another edition left, sparing one neighbour when this build has a commit in its
+	 * name: the edition of this build's own family used most recently.
+	 * <p>
+	 * Two builds of one version are two editions, and a developer moving between them would
+	 * otherwise have each of them empty the other's folder on the way in, which is every pack
+	 * translated from cold at every swap. One is what a swap needs, and it is what bounds the disk
+	 * at two editions rather than at one per build ever made. A build whose edition IS the family
+	 * spares none, which is every release and also a development build no commit could be read for.
+	 */
+	private static void dropOtherEditions(Path root, Path mine, String family) throws IOException {
+		List<Path> entries;
+		try (Stream<Path> found = Files.list(root)) {
+			entries = found.toList();
+		}
+
+		String kept = mine.getFileName().toString().equals(family)
+				? "" : newestSibling(entries, mine, family);
+
+		for (Path entry : entries) {
+			if (!entry.equals(mine) && !entry.getFileName().toString().equals(kept)) {
+				dropTree(entry);
 			}
 		}
+	}
+
+	/**
+	 * The name of the edition of this family used most recently, or empty when this build is the
+	 * only one of its family to have run here. A directory has a name, so an empty answer matches
+	 * nothing.
+	 */
+	private static String newestSibling(List<Path> entries, Path mine, String family)
+			throws IOException {
+		String newest = "";
+		long stamp = Long.MIN_VALUE;
+
+		for (Path entry : entries) {
+			String name = entry.getFileName().toString();
+			if (entry.equals(mine) || !ofFamily(name, family)) {
+				continue;
+			}
+
+			long when = Files.getLastModifiedTime(entry).toMillis();
+			if (when > stamp) {
+				stamp = when;
+				newest = name;
+			}
+		}
+
+		return newest;
+	}
+
+	/**
+	 * Whether a directory name is an edition of this family: the family entire, or the family and
+	 * then a commit behind the separator.
+	 * <p>
+	 * The separator is what makes this an answer and not a guess. A name beginning with the family
+	 * is not an edition of it: {@code ...mc26.20} begins with {@code ...mc26.2} and is another game
+	 * version altogether, whose blobs are exactly the ones nothing can ever ask for again, so a
+	 * prefix on its own would spare the folder that most needs sweeping.
+	 */
+	private static boolean ofFamily(String name, String family) {
+		return name.equals(family) || name.startsWith(family + EDITION_SEPARATOR);
+	}
+
+	/** Whatever a directory name cannot hold, replaced so that a name is never two names. */
+	private static String plain(String text) {
+		return text.replaceAll("[^A-Za-z0-9._-]", "_");
 	}
 
 	private static void dropTree(Path entry) throws IOException {

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -83,11 +83,16 @@ public final class EngineStages {
 	 * The edition is the mod's version and the game's, and it names a whole set of keys at once: a
 	 * translator that emits one word differently answers differently to every key it ever held, so
 	 * a RELEASE takes its predecessor's folder away rather than filling a second one beside it.
-	 * Two builds declaring one version share the folder and every key in it, which is every build
-	 * made between two releases; what answers that in the workshop is deleting the folder by hand.
-	 * The branch a build was made on is cut out of the version first, by
-	 * {@link Vitrail#cacheVersion()}, so that a topic build is one of those two builds and not the
-	 * owner of a folder of its own.
+	 * Two builds declaring one version would share the folder and every key in it, which is every
+	 * build made between two releases, so a development build carries the commit it was built from
+	 * in its edition and translates into a folder nothing else has written to. The branch a build
+	 * was made on is cut out of the version first, by {@link Vitrail#cacheVersion()}, the commit
+	 * having already said which build this is.
+	 * <p>
+	 * The family goes over beside the edition because it is what decides the sweep at install: a
+	 * build carrying a commit keeps the neighbour of its own family used most recently, so that
+	 * moving between two builds does not empty a store on every swap.
+	 * <p>
 	 * The loader is not in the name, and does not need to be: the two loaders run the same
 	 * translator over the same text, and what does differ between them is in the key of every
 	 * entry.
@@ -95,7 +100,8 @@ public final class EngineStages {
 	private static void openTranslationCache() {
 		TranslationCache.install(
 				Vitrail.platform().gameDirectory().resolve(Vitrail.MOD_ID),
-				Vitrail.cacheVersion() + "+mc" + Vitrail.platform().minecraftVersion());
+				Vitrail.cacheEdition(),
+				Vitrail.cacheEditionFamily());
 
 		if (!TranslationCache.installed()) {
 			Vitrail.logger().warn("No translation cache this run, so every pack load translates "


### PR DESCRIPTION
## What changes

Both disk caches, the translated programs and the compiled modules, key their entries on the
version the build declares, and every build made between two releases declares the same one. A
build was therefore served the translations and the modules an earlier build of the same version
had written, so a translator change went unseen on screen until somebody deleted the folder by
hand. A development build now carries the commit it was built from, read from git beside the
branch name the build already reads and committed nowhere, and both caches fold it into their
edition: the folder of the translation cache, the folder and the key of the module cache. A jar
built over an edited tree says so. The sweep at open spares one neighbouring edition of the same
version, the one used most recently, so moving between two builds no longer has each empty the
other's store on the way in. A release build carries nothing new and behaves exactly as before,
folder names and key bytes included, so a player's caches survive every jar of one version as
they did.

## How it differs from the reference, and for what obstacle

It does not apply: Iris keeps no cache of this kind.

## What proves it

- `gradlew build` green.
- A build with `-Pmod_version=0.11.0` carries no stamp and names its folders as today; a build
  from a clean tree is stamped with its commit alone and one from an edited tree with the commit
  and the dirty mark.
- In the game: nothing to look at, the picture does not depend on it. What it removes is a
  bench reading in which a jar showed another jar's translations.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
