### PR TITLE
feat(uniform): look the held item up in the pack's table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,20 @@ what the next one holds.
   that says it cannot draw without them was being refused for something it would have got. Clarity
   and Noble now load.
 
+- **The pack is told what you are holding.** A shader recognises an item by the number the pack
+  gives it in its own table, and nothing was looking your hands up in that table, so whatever you
+  carried the pack was told you carried nothing it knew. What that drives on most packs is the
+  light in your hand: on Complementary a torch, a soul lantern and a froglight all cast the same
+  generic glow instead of their own colour, and a lava bucket cast none at all; on Pegasus the
+  light was white whichever torch you held. Both hands are read. The block you are aiming at and
+  the mount you are riding go through tables of the same kind and are read with them.
+
+  **And the off hand no longer answers for the main one on a pack that asked it not to.** A pack
+  says whether the brighter of your two hands is what the main one reports, which is how it worked
+  before the off hand had a light of its own, and that was being done whatever the pack said. Seven
+  of the eleven packs tested ask for it to stop: on those, a torch in the off hand was being
+  reported in both hands at once, so the pack lit the scene from the empty one beside it as well.
+
 ### Changed
 
 - **The compiled shaders kept on disk are three times smaller.** Every one of them carried a copy

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -127,6 +127,12 @@ public final class ShaderProperties {
 	// live lines and on separateAo's rule in every respect, and answered the same way.
 	private static final Pattern BREAKS_ANISOTROPY =
 			Pattern.compile("^\\s*breaksAnisotropy\\s*=\\s*(.*)$");
+	// Whether the main hand reports the brighter of the two hands' light, which is what a pack
+	// written before the off hand had a light of its own expects. Read on the live lines and on
+	// separateAo's rule in every respect, the default alone being the other way round. Seven of the
+	// eleven packs of the corpus write it, all seven write false, and none writes true, so a flat
+	// default would have an off hand torch answering for seven main hands that asked it not to.
+	private static final Pattern OLD_HAND_LIGHT = Pattern.compile("^\\s*oldHandLight\\s*=\\s*(.*)$");
 	private static final Pattern SIZE_BUFFER = Pattern.compile("^\\s*size\\.buffer\\.([^=\\s.]+)\\s*=\\s*(.*)$");
 	private static final Pattern SKY_ELEMENT = Pattern.compile("^\\s*(sun|moon|stars|sky)\\s*=\\s*(.*)$");
 	// The fifth word of that family, kept apart because it is the one that takes neither a yes nor a
@@ -411,6 +417,12 @@ public final class ShaderProperties {
 		// On that same rule, and read for the same reason: a word this cannot read leaves the
 		// default standing rather than being stepped over.
 		if (BREAKS_ANISOTROPY.matcher(line).matches()) {
+			return;
+		}
+
+		// And on that rule too, for that reason: a word this cannot read is what puts the answer back
+		// to the default, so the line is read whether the word is one of the four or not.
+		if (OLD_HAND_LIGHT.matcher(line).matches()) {
 			return;
 		}
 
@@ -1404,6 +1416,35 @@ public final class ShaderProperties {
 		}
 
 		return Boolean.TRUE.equals(asked);
+	}
+
+	/**
+	 * Whether the main hand reports the brighter of the two hands' light, live lines only, ON unless
+	 * the pack says otherwise.
+	 * <p>
+	 * <strong>The default is the other way round from its two neighbours above, and it is Iris's</strong>
+	 * ({@code shaderpack/properties/PackDirectives.java:96}, {@code getOldHandLight().orElse(true)}).
+	 * A pack that says nothing was written when the off hand had no light of its own, so the one
+	 * name it reads has to answer for whichever hand carries the torch.
+	 * <p>
+	 * <strong>It decides a light and never an identifier.</strong> Iris builds the off hand's
+	 * supplier with the rule switched off outright ({@code uniforms/IdMapUniforms.java:29}) and
+	 * applies it inside the light alone ({@code :98-100}, after the identifier is settled at
+	 * {@code :93}), so a torch in the off hand brightens the scene without making an empty main hand
+	 * read as a torch.
+	 * <p>
+	 * Read through {@link #live} and answered like {@link #separateAo}, whose note carries why the
+	 * last live line decides even when it carries a word this cannot read.
+	 *
+	 * @param defines the pack's settings, which decide which lines of the file are alive at all
+	 */
+	public boolean oldHandLight(Map<String, String> defines) {
+		Boolean asked = null;
+		for (Matcher line : live(OLD_HAND_LIGHT, defines)) {
+			asked = truth(line.group(1).trim());
+		}
+
+		return asked == null || asked;
 	}
 
 	/** Each profile's unexpanded body, in the order the pack declares them. */

--- a/common/src/main/java/dev/vitrail/render/BlockStateIds.java
+++ b/common/src/main/java/dev/vitrail/render/BlockStateIds.java
@@ -35,6 +35,17 @@ import java.util.TreeSet;
  * packs are written against Iris: two declarations covering one state is ordinary rather than a
  * mistake, and resolving it the other way round lights the block as something else.
  * <p>
+ * <strong>A pack that ships no {@code block.properties} is named nothing here, where the reference
+ * still names a hundred blocks.</strong> Iris fills its block map from {@code LegacyIdMap} whenever
+ * that file is missing ({@code shaderpack/IdMap.java:84-88}), which is the numbering shadersmod
+ * handed out before the file existed: twenty-five numbers over a hundred block entries, stone 1,
+ * water 9, torch 50, the sixteen wools 35 ({@code shaderpack/materialmap/LegacyIdMap.java:21-78}).
+ * None of that is written here, so such a pack gets {@link #empty} and every state falls to the
+ * minus one that table defaults to: {@code currentSelectedBlockId} reads minus one on a block the
+ * reference would have numbered, and the mesh carries {@link #NONE} where it would have carried
+ * that number. What it costs is a pack old enough to be relying on the legacy numbering, and every
+ * one of the eleven packs of the corpus ships the file, so today it costs them nothing.
+ * <p>
  * Read on the chunk build threads and written on whichever thread loads a pack, so what they share
  * is one immutable map swapped whole. Nothing is ever added to a table that is being read.
  */

--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -1,6 +1,7 @@
 package dev.vitrail.render;
 
 import dev.vitrail.dh.DhDepth;
+import dev.vitrail.pack.id.NameIds;
 import dev.vitrail.pack.model.RenderStage;
 import dev.vitrail.pack.target.PackDirectives;
 import dev.vitrail.uniform.ClipSpace;
@@ -18,8 +19,11 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.AtlasIds;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.attribute.EnvironmentAttributes;
@@ -36,6 +40,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.material.FogType;
@@ -107,6 +112,13 @@ public final class FrameState implements WorldState {
 
 	/** From the pack's own properties file rather than from its GLSL, hence not a directive. */
 	private boolean endFlashShadows;
+
+	/**
+	 * The same, and on until the pack says otherwise, which is the default Iris gives it
+	 * ({@code shaderpack/properties/PackDirectives.java:96}). A pack loaded before this is set at
+	 * all is therefore read the way a pack that writes nothing is.
+	 */
+	private boolean oldHandLight = true;
 
 	/** Which world the last frame was in, by identity, so that a change of one is noticed. */
 	private Object lastLevel;
@@ -191,6 +203,7 @@ public final class FrameState implements WorldState {
 	private boolean feetInWater;
 	private boolean swimming;
 	private boolean vehicleInWater;
+	private int vehicleId;
 	private final Vector3d vehicleLookVector = new Vector3d();
 	private final Vector3d relativeVehiclePosition = new Vector3d();
 	private float playerHealth = -1.0F;
@@ -200,9 +213,12 @@ public final class FrameState implements WorldState {
 	private float playerAir = -1.0F;
 	private float playerMaxAir = -1.0F;
 	private final Vector3f selectedBlockPos = new Vector3f(NOTHING_SELECTED);
+	private int selectedBlockId;
 	private final Vector4f lightningBoltPosition = new Vector4f();
 	/** The tick the position beside this was searched for on, so a frame does not do it again. */
 	private long lightningTick = Long.MIN_VALUE;
+	private int heldItemId = NameIds.NONE;
+	private int heldItemId2 = NameIds.NONE;
 	private int heldBlockLight;
 	private int heldBlockLight2;
 
@@ -242,11 +258,16 @@ public final class FrameState implements WorldState {
 	}
 
 	/**
-	 * The one thing the pack says about itself that is not in its GLSL. Set on a pack load, next to
-	 * the directives, and for the same reason.
+	 * One of the two things the pack says about itself that are not in its GLSL. Set on a pack load,
+	 * next to the directives, and for the same reason.
 	 */
 	public void endFlashShadows(boolean endFlashShadows) {
 		this.endFlashShadows = endFlashShadows;
+	}
+
+	/** And the other, which {@link #readHeld} is the whole of what reads. */
+	public void oldHandLight(boolean oldHandLight) {
+		this.oldHandLight = oldHandLight;
 	}
 
 	/** The view geometry, which comes from a captured matrix rather than from a game object. */
@@ -659,7 +680,7 @@ public final class FrameState implements WorldState {
 		readStats(minecraft, player);
 		readSelection(minecraft, level, camera);
 		readLightning(level, pt);
-		readHeldLight(player);
+		readHeld(player);
 	}
 
 	/**
@@ -744,6 +765,13 @@ public final class FrameState implements WorldState {
 
 	private void readFlags(LocalPlayer player) {
 		if (player == null) {
+			// The mount goes back to nothing rather than standing: each of the four names it answers
+			// asks after the player before it asks after the vehicle and gives up on the first
+			// question (uniforms/IrisExclusiveUniforms.java:106, :119, :126 and :137). A number
+			// carried over is the last world's mount read against this world's table, which names a
+			// different animal.
+			noVehicle();
+
 			return;
 		}
 
@@ -761,17 +789,33 @@ public final class FrameState implements WorldState {
 		this.swimming = player.isSwimming();
 
 		Entity vehicle = player.getVehicle();
-		this.vehicleInWater = vehicle != null && vehicle.isInShallowWater();
 		if (vehicle == null) {
-			this.vehicleLookVector.zero();
-			this.relativeVehiclePosition.zero();
+			noVehicle();
 		} else {
+			this.vehicleInWater = vehicle.isInShallowWater();
+			this.vehicleId = PackNameIds.entity(vehicle.getType());
 			Vec3 forward = vehicle.getForward();
 			this.vehicleLookVector.set(forward.x, forward.y, forward.z);
 			Vec3 position = vehicle.getPosition(this.partialTick);
 			this.relativeVehiclePosition.set(this.shift.unshifted())
 					.sub(position.x, position.y, position.z);
 		}
+	}
+
+	/**
+	 * What the four names about the mount answer when there is none, which is also what they answer
+	 * when there is no player to ride one.
+	 * <p>
+	 * The number is nought and not the table's minus one, which is the difference between "riding
+	 * nothing" and "riding something the pack said nothing about". Iris answers the same nought on
+	 * the first of those ({@code uniforms/IrisExclusiveUniforms.java:106-107}) and the table's own
+	 * answer on the second ({@code :115}).
+	 */
+	private void noVehicle() {
+		this.vehicleInWater = false;
+		this.vehicleId = 0;
+		this.vehicleLookVector.zero();
+		this.relativeVehiclePosition.zero();
 	}
 
 	/**
@@ -807,27 +851,32 @@ public final class FrameState implements WorldState {
 	}
 
 	/**
-	 * Where the block the player is looking at is, but only while the game is drawing its outline.
+	 * Where the block the player is looking at is and what the pack calls it, but only while the
+	 * game is drawing its outline.
 	 * <p>
 	 * The outline test is the whole difference between this and reading the hit result, and it is
 	 * not a detail: a pack uses this to draw its own highlight, so without the test the highlight
 	 * stays on with the interface hidden, which is the one moment somebody is taking a screenshot.
 	 * Iris reads the game's own answer through a mixin; the two cases that answer differently from
 	 * the hit result are reachable without one, so they are written out here instead.
+	 * <p>
+	 * The number carries two tests the position does not, and they are the reference's own
+	 * ({@code uniforms/IrisExclusiveUniforms.java:189} against :197-205): a block outside the world
+	 * border and an air block are both aimed at and neither is named.
 	 */
 	private void readSelection(Minecraft minecraft, ClientLevel level, Camera camera) {
 		HitResult hit = minecraft.hitResult;
 		if (hit == null || hit.getType() != HitResult.Type.BLOCK
 				|| !(minecraft.getCameraEntity() instanceof Player player)
 				|| minecraft.gui.hud.isHidden()) {
-			this.selectedBlockPos.set(NOTHING_SELECTED);
+			nothingSelected();
 
 			return;
 		}
 
 		BlockPos block = ((BlockHitResult) hit).getBlockPos();
 		if (!player.getAbilities().mayBuild && !outlined(minecraft, level, player, block)) {
-			this.selectedBlockPos.set(NOTHING_SELECTED);
+			nothingSelected();
 
 			return;
 		}
@@ -836,6 +885,23 @@ public final class FrameState implements WorldState {
 		this.selectedBlockPos.set((float) (block.getX() + 0.5 - position.x),
 				(float) (block.getY() + 0.5 - position.y),
 				(float) (block.getZ() + 0.5 - position.z));
+
+		BlockState state = level.getBlockState(block);
+		this.selectedBlockId = state.isAir() || !level.getWorldBorder().isWithinBounds(block)
+				? 0
+				: BlockStateIds.id(state);
+	}
+
+	/**
+	 * Nought for the number and the far away sentinel for the position, which are not the same kind
+	 * of "nothing" and are not written as one: nought is a number the pack may hand out itself, so
+	 * what tells it apart from a block the pack named nothing about is the minus one the table
+	 * answers there. Iris ends on the same nought
+	 * ({@code uniforms/IrisExclusiveUniforms.java:194}).
+	 */
+	private void nothingSelected() {
+		this.selectedBlockPos.set(NOTHING_SELECTED);
+		this.selectedBlockId = 0;
 	}
 
 	/**
@@ -890,22 +956,72 @@ public final class FrameState implements WorldState {
 	}
 
 	/**
-	 * The {@code oldHandLight} rule, which defaults to on: the brighter of the two hands is what
-	 * the main hand reports, so a torch in the off hand still lights the scene on a pack that only
-	 * reads one of them.
+	 * What is in the two hands: the number the pack gave each item, and the light each one emits.
+	 * <p>
+	 * <strong>The pack's {@code oldHandLight} decides the main hand's light, and it decides nothing
+	 * else.</strong> Where the pack leaves it on, which is where it says nothing, the brighter of
+	 * the two hands is what the main hand reports, so a torch in the off hand still lights the scene
+	 * on a pack that reads one hand only; where the pack turns it off, the main hand answers its own
+	 * item and the second name is the whole of what carries the off hand. The reference gates it the
+	 * same way, handing the flag to the main hand's supplier and a flat false to the off hand's
+	 * ({@code uniforms/IdMapUniforms.java:28-29}, the flag itself coming from
+	 * {@code uniforms/CommonUniforms.java:134}).
+	 * <p>
+	 * <strong>It is the light and never the identifier</strong>, on either setting: the reference
+	 * applies the rule inside the light alone ({@code uniforms/IdMapUniforms.java:98-100}, after the
+	 * identifier is settled at {@code :93}), so a torch in the off hand brightens the scene without
+	 * making an empty main hand read as a torch.
 	 */
-	private void readHeldLight(LocalPlayer player) {
+	private void readHeld(LocalPlayer player) {
 		if (player == null) {
+			this.heldItemId = NameIds.NONE;
+			this.heldItemId2 = NameIds.NONE;
 			this.heldBlockLight = 0;
 			this.heldBlockLight2 = 0;
 
 			return;
 		}
 
-		int main = emission(player.getItemInHand(InteractionHand.MAIN_HAND));
-		int off = emission(player.getItemInHand(InteractionHand.OFF_HAND));
-		this.heldBlockLight = Math.max(main, off);
+		ItemStack mainHand = player.getItemInHand(InteractionHand.MAIN_HAND);
+		ItemStack offHand = player.getItemInHand(InteractionHand.OFF_HAND);
+		this.heldItemId = itemId(mainHand);
+		this.heldItemId2 = itemId(offHand);
+
+		int main = emission(mainHand);
+		int off = emission(offHand);
+		this.heldBlockLight = this.oldHandLight ? Math.max(main, off) : main;
 		this.heldBlockLight2 = off;
+	}
+
+	/**
+	 * The pack's number for what one hand holds, named by the model the item points at and by its
+	 * registry key after that, which is the order the reference takes
+	 * ({@code uniforms/IdMapUniforms.java:89-92}) and the same one the DRAWN item takes here: a
+	 * resource pack that points two items at one model then has the pack answer once for both.
+	 * <p>
+	 * <strong>An empty hand is not a case of its own, and deliberately so.</strong> It holds air,
+	 * whose components are empty, so the model is absent and the registry key is what answers;
+	 * against a pack that says nothing about air that is minus one, which is what a pack expects
+	 * from an empty hand. Against one that does name it, and Complementary names it at
+	 * {@code shaders/item.properties:9}, it is that pack's own number; against one that ships no
+	 * such file at all it is nought, for the reason {@link PackNameIds} carries. The reference asks
+	 * the same question of an empty hand rather than short circuiting on it, so both engines answer
+	 * alike.
+	 * <p>
+	 * The registry key is not weighed against null, because it cannot be one: the item registry is a
+	 * {@code DefaultedRegistry}, whose {@code getKey} answers the default key rather than nothing for
+	 * a value it does not hold, and {@code getKeyOrNull} is the other method for whoever wants the
+	 * question asked. The reference dereferences it unguarded on the same ground
+	 * ({@code uniforms/IdMapUniforms.java:93}).
+	 */
+	private static int itemId(ItemStack stack) {
+		if (stack == null) {
+			return NameIds.NONE;
+		}
+
+		Identifier name = stack.get(DataComponents.ITEM_MODEL);
+
+		return PackNameIds.item(name == null ? BuiltInRegistries.ITEM.getKey(stack.getItem()) : name);
 	}
 
 	/**
@@ -1532,10 +1648,9 @@ public final class FrameState implements WorldState {
 		return this.vehicleInWater;
 	}
 
-	/** Needs the pack's entity.properties table, which nothing reads yet. */
 	@Override
 	public int vehicleId() {
-		return 0;
+		return this.vehicleId;
 	}
 
 	@Override
@@ -1593,10 +1708,9 @@ public final class FrameState implements WorldState {
 		return this.selectedBlockPos;
 	}
 
-	/** Needs the pack's block.properties table, which nothing reads yet. */
 	@Override
 	public int selectedBlockId() {
-		return 0;
+		return this.selectedBlockId;
 	}
 
 	@Override
@@ -1604,19 +1718,14 @@ public final class FrameState implements WorldState {
 		return this.lightningBoltPosition;
 	}
 
-	/**
-	 * Needs the item the player is holding, which nothing here has. The pack's own table is read and
-	 * live, {@code PackNameIds}, and is asked about what is being DRAWN rather than about what is in
-	 * a hand; the two are different questions and this is the one still owed.
-	 */
 	@Override
 	public int heldItemId() {
-		return -1;
+		return this.heldItemId;
 	}
 
 	@Override
 	public int heldItemId2() {
-		return -1;
+		return this.heldItemId2;
 	}
 
 	@Override

--- a/common/src/main/java/dev/vitrail/render/PackNameIds.java
+++ b/common/src/main/java/dev/vitrail/render/PackNameIds.java
@@ -104,7 +104,7 @@ public final class PackNameIds {
 	 * the flame is no kind of entity and has nothing to fall back on.
 	 */
 	public static int flame() {
-		return entities.id(ENTITY_FLAME.toString());
+		return id(entities, ENTITY_FLAME);
 	}
 
 	/**
@@ -121,7 +121,7 @@ public final class PackNameIds {
 		}
 
 		Identifier key = BuiltInRegistries.ENTITY_TYPE.getKey(type);
-		int id = key == null ? NameIds.NONE : entities.id(key.toString());
+		int id = key == null ? NameIds.NONE : id(entities, key);
 		cache.put(type, id);
 
 		return id;
@@ -141,10 +141,31 @@ public final class PackNameIds {
 			return known;
 		}
 
-		int id = items.id(name.toString());
+		int id = id(items, name);
 		cache.put(name, id);
 
 		return id;
+	}
+
+	/**
+	 * One lookup in one of the two tables, and <strong>a file the pack does not ship answers nought
+	 * where a file it does ship answers {@link NameIds#NONE} for a name it leaves out.</strong>
+	 * <p>
+	 * The two are not the same question and Iris does not give them the same answer. It builds a
+	 * table per file and hands an EMPTY one over where the file is missing
+	 * ({@code shaderpack/IdMap.java:70-71} for the items and {@code :73-74} for the entities, both
+	 * {@code orElse(Object2IntMaps.emptyMap())}); fastutil's empty map answers nought, where a table
+	 * that was parsed carries the {@code defaultReturnValue(-1)} it is given at {@code :162}. So
+	 * what a pack meets is nought for a file it never wrote and minus one for a name it left out of
+	 * one it did.
+	 * <p>
+	 * Which the corpus reaches rather than being a corner: of its eleven packs four ship no
+	 * {@code item.properties} and one no {@code entity.properties}, so on those the hand and the
+	 * mount reported the minus one that says "the pack named this nothing" where there was no table
+	 * for it to be named in.
+	 */
+	private static int id(NameIds table, Identifier name) {
+		return table.present() ? table.id(name.toString()) : 0;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -132,6 +132,7 @@ public final class PackValues {
 
 		values.state.directives(PackDirectives.read(source, settings, dimension));
 		values.state.endFlashShadows(properties.endFlashShadows(settings.globalDefines(options)));
+		values.state.oldHandLight(properties.oldHandLight(settings.globalDefines(options)));
 		values.skyElements = properties.skyElements(settings.globalDefines(options));
 		values.weather = properties.weather(settings.globalDefines(options));
 		values.rainDepth = properties.rainDepth(settings.globalDefines(options));

--- a/common/src/main/java/dev/vitrail/uniform/UniformGaps.java
+++ b/common/src/main/java/dev/vitrail/uniform/UniformGaps.java
@@ -89,17 +89,7 @@ public final class UniformGaps {
 	private static Map<String, String> standIns() {
 		Map<String, String> reasons = new LinkedHashMap<>();
 
-		// The tables themselves are read and live, block.properties, item.properties and
-		// entity.properties alike; what is missing is the asking, each of these four naming a thing
-		// the frame holds rather than a thing being drawn.
-		String noTable = "nothing looks the held item, the block in front or the vehicle up in the "
-				+ "pack's own identifier table yet";
-		reasons.put("heldItemId", noTable);
-		reasons.put("heldItemId2", noTable);
-		reasons.put("currentSelectedBlockId", noTable);
-		reasons.put("vehicleId", noTable);
-
-		// And only this one of the four settings values. The other three are read off the game's
+		// Only this one of the four settings values. The other three are read off the game's
 		// own options and are as true as anything else here; listing them said a measured value was
 		// a placeholder, which is the same mistake as the reverse and costs the list its point.
 		reasons.put("currentColorSpace", "there is no settings screen to choose it from, which is "

--- a/common/src/main/java/dev/vitrail/uniform/WorldState.java
+++ b/common/src/main/java/dev/vitrail/uniform/WorldState.java
@@ -208,6 +208,7 @@ public interface WorldState extends ViewSource {
 
 	boolean vehicleInWater();
 
+	/** The pack's own number for what is being ridden, 0 for nothing and -1 for the unnamed. */
 	int vehicleId();
 
 	Vector3dc vehicleLookVector();
@@ -234,12 +235,18 @@ public interface WorldState extends ViewSource {
 	/** {@code vec3(-256)} when nothing is aimed at. */
 	Vector3fc selectedBlockPos();
 
+	/** Nought where nothing is aimed at, against -1 for a block the pack named nothing about. */
 	int selectedBlockId();
 
 	Vector4fc lightningBoltPosition();
 
+	/**
+	 * The pack's own number for the main hand's item, -1 for one it named nothing about. It is the
+	 * main hand's alone, where the light below borrows the off hand's whenever that one is brighter.
+	 */
 	int heldItemId();
 
+	/** And the off hand's. */
 	int heldItemId2();
 
 	int heldBlockLight();

--- a/docs/internals/entities.md
+++ b/docs/internals/entities.md
@@ -193,8 +193,9 @@ What is left in the uniform table for those four names is the right answer rathe
 Outside a pass drawn from this mesh, a composite or the terrain or the sky, the reference hands over
 a uniform too, and the numbers here are its numbers. Inside one, the name never reaches a table on
 either engine. So none of the four is listed among the stand-ins, which is what that list looks like
-when it works: what is still listed beside them is the held item, the block in front and the vehicle,
-whose tables are read and live and whose asking is not there.
+when it works. The held item, the block in front and the vehicle are read out of those same tables
+and are not on that list either: they are frame values rather than mesh values, asked once a frame of
+the player rather than of a draw.
 
 **What a pack still reads as a constant on this mesh is the block id**, and the reference does not
 serve it here either: an entity is not a block state and has no id to travel on. A pack branching on


### PR DESCRIPTION
## What changes

A pack ships identifier tables for items, blocks and entities, and the engine read them for the
things it draws but never asked them about the frame's own things. The four uniforms that carry
those answers, `heldItemId`, `heldItemId2`, `currentSelectedBlockId` and `vehicleId`, answered a
stand-in, so a pack was told the player held nothing it knew, aimed at nothing and rode nothing.
They are read once a frame now: both hands through the item table, the item's model first and
its registry key after; the block aimed at through the block table, behind the same gate its
position already takes, with an air block and a block outside the world border answering nought;
the mount through the entity table, nought without one and nought again when there is no player.
The pack's `oldHandLight` directive is read, so the brighter of the two hands answers the main
one only where the pack asks for that. A table the pack does not ship answers nought, a table it
ships answers minus one for a name it leaves out.

## How it differs from the reference, and for what obstacle

One divergence, written beside the block table. A pack that ships no `block.properties` is given
no block numbers here, while Iris falls back to the numbering that predates the file
(`shaderpack/IdMap.java:84-88` into `LegacyIdMap.java`). Nothing here prevents it; the table is
simply not carried yet, and every pack of the corpus ships the file, so no picture changes today.
Everything else follows `uniforms/IdMapUniforms.java` and `uniforms/IrisExclusiveUniforms.java`
value for value, the empty table's nought and the present table's minus one included.

## What proves it

- `gradlew build` green.
- The off-game harness, `Uniformes` over the corpus: the four names are answered by the engine
  wherever a pack reads them, and the stand-in reason is gone from the catalogue.
- In the game: a full sweep of the corpus on a jar carrying this and the neighbouring batches is
  still to come. Complementary's hand light, a torch against a soul lantern, is what to look at.

## What it leaves owing

The legacy block numbering for a pack without `block.properties`, as above.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
