### PR TITLE
fix(uniform): answer textureMatrix and the pack's own variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,26 @@ what the next one holds.
   refuses, so the pass never built and the frame went on without it. Noble is the pack this showed
   on, where nothing wrote its screen space reflections.
 
+- **The sun and the moon carry their texture again on a pack written for the core profile.** Such a
+  pack spells the matrix that places a texture under a plain name rather than the old fixed function
+  one, and nothing here answered that spelling, so every corner of the sun and of the moon was handed
+  the same texture coordinate and both came out as flat squares of a single colour. Clarity is the
+  pack this showed on, in the program that draws them.
+
+- **E-LITE's clouds follow the hour of the day again.** A pack may declare a value of its own under
+  either of two keywords, and only one of them was reaching the shaders. E-LITE writes the hour of
+  the day under the other one and its sky reads it, so it arrived as nought: the count of days was
+  all the clock the cloud cover had left, and it changed in day-sized steps instead of drifting
+  through the day. Either keyword now reaches a program that asks for the name, which is what Iris
+  does with the same pack.
+
+- **The log stops calling a value missing from this engine when nothing supplies it anywhere.** A
+  pack often reads a name no shader engine has ever answered: one left behind by the pack it grew
+  out of, one belonging to a mod that is not installed, or one it simply misspelt. Those were being
+  listed as values this engine still owes, which sends whoever reads the log looking for something
+  that was never written. They are now named for what they are, and a pack gets the same nought under
+  Iris.
+
 - **A pack's quality profile is named again instead of reading "Custom".** A profile can list a
   setting the pack does not actually have, and one such name was enough to stop the profile from
   ever being recognised: the shader screen and the F3 overlay both fell back to "Custom" on a pack

--- a/common/src/main/java/dev/vitrail/uniform/UniformCatalog.java
+++ b/common/src/main/java/dev/vitrail/uniform/UniformCatalog.java
@@ -135,7 +135,7 @@ public final class UniformCatalog {
 	}
 
 	/**
-	 * The two names OptiFine's core profile mode gives the fixed function pair, answered from
+	 * The three names OptiFine's core profile mode gives the fixed function state, answered from
 	 * whatever that layer has just put behind the {@code gl_} spelling.
 	 * <p>
 	 * Called last in each of the three tables rather than written into the three values classes,
@@ -143,10 +143,30 @@ public final class UniformCatalog {
 	 * family at a time and over two transformers picked by the profile the unit declares; the
 	 * paths and their lines are set out in {@link dev.vitrail.glsl.LegacyGlsl#CORE_MATRICES}, and
 	 * the packs are written against them.
+	 * <p>
+	 * The third is the texture matrix, and it is unit NOUGHT rather than the array: the core
+	 * spelling names one matrix where the fixed function spelling names eight, so the alias answers
+	 * the element a bare member asks for. Iris substitutes it on the same three paths as the pair,
+	 * {@code mat4(1.0)} over a quad and over a chunk
+	 * ({@code CompositeCoreTransformer.java:27}, {@code SodiumCoreTransformer.java:47}), and the
+	 * draw's own matrix on the families the game hands over as a render type
+	 * ({@code VanillaCoreTransformer.java:85}).
+	 * <p>
+	 * <strong>That last path is a divergence, and it is the one already carried by
+	 * {@link dev.vitrail.glsl.LegacyGlsl#GAME_TEXTURE_MATRIX} rather than a new one.</strong> A
+	 * literal {@code gl_TextureMatrix[0]} is redirected in the translation on the passes that bind
+	 * the game's transforms; the core spelling arrives here instead, as a member the pack declared,
+	 * and this table has one answer per family. So a core profile program drawn from one of the six
+	 * render types that set a texture transform would read the identity here where Iris reads the
+	 * draw's matrix. Nothing of the corpus reads that difference: the one pack that names it is
+	 * Clarity, in {@code shaders/prog/generic.vsh:14}, included only by its {@code gbuffers_skybasic}
+	 * and {@code gbuffers_skytextured}, and neither of those is drawn from a render type that sets
+	 * one.
 	 */
 	private static void coreMatrices(Builder builder) {
 		builder.alias("modelViewMatrix", "of_ModelViewMatrix");
 		builder.alias("projectionMatrix", "of_ProjectionMatrix");
+		builder.alias("textureMatrix", "of_TextureMatrix");
 	}
 
 	public static Builder builder() {

--- a/common/src/main/java/dev/vitrail/uniform/UniformGaps.java
+++ b/common/src/main/java/dev/vitrail/uniform/UniformGaps.java
@@ -83,6 +83,75 @@ public final class UniformGaps {
 		reasons.put("farPlane", "no engine answers it, Iris included, so a pack reads the same "
 				+ "nought there");
 
+		// Iris does register it, in uniforms/HardcodedCustomUniforms.java:54, as the distance the
+		// camera moved between the two positions its tracker holds. That file is not wired to
+		// anything: addHardcodedCustomUniforms has no caller in the whole of the 26.2 tree, so the
+		// whole shim it belongs to is unreachable and Complementary reads the same nought there,
+		// shaders/lib/uniforms.glsl:195 on Reimagined and Unbound alike. AstraLex is the one pack
+		// of the corpus that does not, and it does not because it declares the value itself,
+		// shaders/shaders.properties:634, which is answered as any other declaration is.
+		String shimNotWired = "Iris registers it in a shim nothing in that repository calls, so it "
+				+ "is a nought there too";
+		reasons.put("velocity", shimNotWired);
+
+		// The uniforms of the Voxy mod. The mod sets the symbol a pack guards them with, and neither
+		// engine sets it: it appears nowhere in the Iris tree either, so a pack that guards both the
+		// declaration and the read never puts these names in front of an engine at all. What reaches
+		// a block is a pack that declares them whatever that symbol says, which is what raises the
+		// line: Solas, shaders/programs/deferred1.glsl:12, has them beside Distant Horizons' render
+		// distance with no guard over either.
+		String voxyMod = "it belongs to the Voxy mod, and no engine answers it with that mod absent";
+		reasons.put("vxRenderDistance", voxyMod);
+		reasons.put("vxProj", voxyMod);
+		reasons.put("vxProjInv", voxyMod);
+		reasons.put("vxProjPrev", voxyMod);
+		reasons.put("vxModelView", voxyMod);
+		reasons.put("vxModelViewInv", voxyMod);
+		reasons.put("vxModelViewPrev", voxyMod);
+
+		// Reverie's, shaders/lib/all_the_uniforms.glsl:27, beside the previousCameraPosition it
+		// really does read. Iris spells the split pair previousCameraPositionInt and
+		// previousCameraPositionFract, uniforms/CameraUniforms.java:33-34, with the camera's C in
+		// capitals; GLSL is case sensitive, so what the pack wrote reaches nothing on either engine.
+		reasons.put("previouscameraPositionFract", "the name is misspelt: Iris supplies "
+				+ "previousCameraPositionFract, with a capital C, and so does this engine");
+
+		// What is left is a pack reading a name of its own that no engine ever registered, and each
+		// one is answered with the same nought under Iris. The name is the pack's to declare and
+		// several of them nearly do: I Like Vanilla writes the declaration for rainReflectionStrength
+		// and leaves it commented out, shaders/shaders.properties:442.
+		String packsOwn = "no engine registers it, Iris included, and the pack that reads it does "
+				+ "not declare it either";
+		// BVS, shaders/world0/composite.fsh:15, and Body Camera and Cursed Fog at :13 of theirs.
+		reasons.put("playerPosition", packsOwn);
+		// Sildur's, shaders/deferred.fsh:80, in the three dimensions alike.
+		reasons.put("isNether", packsOwn);
+		// Noble, shaders/include/uniforms.glsl:73. Iris builds the family from one supplier and
+		// gives it three shapes, uniforms/MatrixUniforms.java:34-38: the matrix, its inverse and
+		// the previous frame's. There is no inverse OF the previous one, on either engine.
+		reasons.put("gbufferPreviousModelViewInverse", packsOwn);
+		// Photon, shaders/program/d3_ao.fsh:58 and d2_clouds_upscaling.fsh:66.
+		reasons.put("clouds_offset", packsOwn);
+		// Bliss, shaders/dimensions/composite11.fsh:34.
+		reasons.put("Moon_Weather_properties", packsOwn);
+		// I Like Vanilla, shaders/basics/uniforms.glsl:85, against the commented line above.
+		reasons.put("rainReflectionStrength", packsOwn);
+		// Pegasus, shaders/shaders/composite1.fsh:96 among four of its composites.
+		reasons.put("focolortex5", packsOwn);
+		// Bliss again, six of them together at shaders/dimensions/all_translucent.fsh:85-101, and
+		// the first two once more in shaders/world1/gbuffers_weather.fsh:13-14.
+		reasons.put("skyIntensity", packsOwn);
+		reasons.put("skyIntensityNight", packsOwn);
+		reasons.put("moonIntensity", packsOwn);
+		reasons.put("sunIntensity", packsOwn);
+		reasons.put("sunColor", packsOwn);
+		reasons.put("nsunColor", packsOwn);
+		// The same weather program asks for one more, shaders/world1/gbuffers_weather.fsh:9, where
+		// every other program of the pack carries that name as a flat varying it fills itself
+		// (shaders/dimensions/composite1.vsh:52). No engine registers it: the whole Iris tree has
+		// the name nowhere, uniform or otherwise.
+		reasons.put("lightCol", packsOwn);
+
 		return Map.copyOf(reasons);
 	}
 

--- a/common/src/main/java/dev/vitrail/uniform/expr/CustomUniforms.java
+++ b/common/src/main/java/dev/vitrail/uniform/expr/CustomUniforms.java
@@ -35,11 +35,21 @@ import java.util.Set;
 /**
  * The uniforms a pack declares for itself, resolved once at load and evaluated once a frame.
  * <p>
- * A {@code variable.} is an intermediate the shader never sees; a {@code uniform.} is one it
- * does. They share one namespace, they may refer to each other in any order, and they may read
+ * A {@code variable.} is written as an intermediate and a {@code uniform.} as a value the shader
+ * reads. They share one namespace, they may refer to each other in any order, and they may read
  * any value the engine catalogue answers. That is the whole feature, and it is why it is written
  * as a graph rather than as a list: BSL's {@code shadowFade} is four other declarations deep, and
  * evaluating those out of order gives a plausible number rather than an error.
+ * <p>
+ * <strong>The two keywords decide nothing at the point a program is written, and that is the
+ * reference's behaviour rather than a shortcut.</strong> Iris records the keyword on its
+ * {@code Builder.Variable} and reads it in exactly one place, a list it builds and drops on the
+ * spot ({@code uniforms/custom/CustomUniforms.java:64-67}); what actually reaches a program is
+ * {@code assignTo} ({@code :189-202}), which walks every declaration that resolved and takes a
+ * location for each one the program declares. So a pack may write {@code variable.} and still read
+ * the value as a uniform, and one pack of the corpus does: E-LITE declares
+ * {@code variable.float.hour_world} in its {@code shaders.properties} and declares
+ * {@code uniform float hour_world} in {@code shaders/lib/oscilator_utils.glsl:9}.
  * <p>
  * Three rules decide what happens when a pack gets it wrong, and all three exist so that a
  * mistake stays named instead of turning into a permanently wrong image:
@@ -70,7 +80,14 @@ public final class CustomUniforms implements FunctionContext, FrameClock {
 	private final Map<String, Input> engineInputs = new LinkedHashMap<>();
 	private final Map<String, Derived> declared = new LinkedHashMap<>();
 	private final Map<Node, List<Node>> dependsOn = new LinkedHashMap<>();
+
+	/**
+	 * The names the pack wrote as {@code uniform.} rather than as {@code variable.}. It decides
+	 * nothing about what a program may read, for the reason at the top of this class; what it still
+	 * decides is which declarations {@link #prune} walks out from.
+	 */
 	private final Set<String> exposedNames = new LinkedHashSet<>();
+
 	private final List<Node> order = new ArrayList<>();
 	private final Set<Node> live = new LinkedHashSet<>();
 
@@ -171,10 +188,10 @@ public final class CustomUniforms implements FunctionContext, FrameClock {
 		return this.deltaSeconds;
 	}
 
-	/** Null when the name is not one the pack exposes, or was dropped on the way. */
+	/** Null when the pack declares no such name, or when the declaration was dropped on the way. */
 	public UniformSource source(String name) {
 		Derived node = this.declared.get(name);
-		if (node == null || !this.exposedNames.contains(name) || !this.live.contains(node)) {
+		if (node == null || !this.live.contains(node)) {
 			return null;
 		}
 
@@ -191,10 +208,13 @@ public final class CustomUniforms implements FunctionContext, FrameClock {
 		return node == null ? null : Type.convert(node.type);
 	}
 
-	/** The names the pack exposes that survived resolution, in declaration order. */
+	/**
+	 * The names a program can read, which is every declaration that survived resolution and is
+	 * still reached, in declaration order. Both keywords, for the reason at the top of this class.
+	 */
 	public Set<String> exposed() {
 		Set<String> names = new LinkedHashSet<>();
-		for (String name : this.exposedNames) {
+		for (String name : this.declared.keySet()) {
 			if (source(name) != null) {
 				names.add(name);
 			}
@@ -236,7 +256,9 @@ public final class CustomUniforms implements FunctionContext, FrameClock {
 		/**
 		 * Takes one declaration as the properties file wrote it.
 		 *
-		 * @param exposed true for a {@code uniform.} line, false for a {@code variable.} one
+		 * @param exposed true for a {@code uniform.} line, false for a {@code variable.} one. It
+		 *                does not decide what a program may read, which is set out at the top of
+		 *                this class; it decides which declarations the graph is walked out from
 		 */
 		Builder declare(String name, String type, String expression, boolean exposed);
 
@@ -428,9 +450,21 @@ public final class CustomUniforms implements FunctionContext, FrameClock {
 	}
 
 	/**
-	 * Keeps only what an exposed uniform reaches. A pack that leaves a {@code variable.} behind
-	 * after an edit should not pay for it every frame, and neither should one whose engine inputs
-	 * are all read by declarations that were dropped.
+	 * Keeps only what a {@code uniform.} declaration reaches. A pack that leaves a {@code variable.}
+	 * behind after an edit should not pay for it every frame, and neither should one whose engine
+	 * inputs are all read by declarations that were dropped.
+	 * <p>
+	 * <strong>This is the one place the keyword still decides anything, and it leaves a
+	 * divergence.</strong> Iris keeps every declaration that resolved and drops one only in
+	 * {@code optimise} ({@code uniforms/custom/CustomUniforms.java:241}), which counts the passes
+	 * that have already claimed a location ({@code pipeline/IrisRenderingPipeline.java:477}) and so
+	 * keeps whatever one of them asked for, whichever keyword wrote it. Nothing here can do the same:
+	 * this table is built once, before a single program has been read, so it cannot tell a leftover
+	 * declaration from one a program is about to name, and keeping every one means evaluating every
+	 * one on every frame. What it costs is measured over the corpus rather than guessed: exactly one
+	 * name is written as {@code variable.} and declared as a uniform by the pack's own GLSL, E-LITE's
+	 * {@code hour_world}, and its {@code day_moment} reads it, so the walk reaches it and no pack of
+	 * the corpus loses a value here.
 	 */
 	private void prune() {
 		Deque<Node> pending = new ArrayDeque<>();

--- a/docs/internals/uniforms.md
+++ b/docs/internals/uniforms.md
@@ -187,9 +187,10 @@ world.
 
 ## Uniforms the pack defines for itself
 
-A pack can declare its own values as expressions over engine values and over each other. Some are
-intermediates the shader never sees; some are exposed to it. They share one namespace and may refer
-to each other in any order.
+A pack can declare its own values as expressions over engine values and over each other, under
+either of two keywords: one reads as an intermediate and the other as a value the shader sees,
+though which was used is not what decides whether a program can read the name (below). They share
+one namespace and may refer to each other in any order.
 
 That is why they are resolved as a graph rather than as a list. A declaration several levels deep
 (and real packs have them) evaluated out of order gives a plausible number rather than an error.
@@ -209,6 +210,15 @@ stays **named** instead of turning into a permanently wrong image:
   broke.
 - A declaration that shadows a name the engine already answers is refused, so a pack cannot quietly
   redefine what the engine means by a builtin.
+
+**Which of the two keywords a pack used does not decide what a program may read.** One is written as
+an intermediate and the other as a value the shader sees, and that is how the format documents them,
+but the reference records the keyword and never acts on it: what actually reaches a program is a walk
+over every declaration that resolved, taking a location for each name the program declares. So a pack
+may write the intermediate keyword and still read the value as a uniform, which is what E-LITE does
+with the hour of the day. Both keywords are handed over here for the same reason. The keyword still
+decides one thing, which is where the graph is walked out from when the declarations nothing reads
+are dropped, and that is a divergence written down beside the code that makes it.
 
 A cycle is refused by naming the uniforms it runs through. This is a deliberate divergence: the
 reference throws, and a pack that writes a cycle in one line should lose that line rather than the


### PR DESCRIPTION
## What changes

A pack may declare a value under `variable.<type>.<name>` in its properties and then read it from
a shader as a uniform, and this engine kept such a value as an intermediate the shaders never saw,
so the program read nought. It is pushed now, with its declared type, wherever a program names it,
as Iris pushes it. E-LITE declares its hour of the day that way and its cloud cover is driven off it,
so the cover changed in day-sized steps instead of drifting through the day. `textureMatrix` is
answered as well, by unit nought of the texture matrix array, the identity, which is what Iris
substitutes for that name; Clarity's sun and moon read it and came out flat without it.

The catalogue of what the engine answers is also made to tell the truth about the names nobody
supplies: `velocity`, the Voxy mod's `vx` names, a misspelt camera name, and a handful of names
some packs read that neither engine has ever defined were logged as this engine's own debt, and
they now log as what they are, names no engine answers. `blendFunc`, which Iris does supply, stays
on the debt list.

## How it differs from the reference, and for what obstacle

It does not. `uniforms/custom/CustomUniforms.java:64-67` records a `variable.` declaration the same
way as a `uniform.` one and `:189-202` gives every resolved declaration a location, so a shader
reading it by name gets it; this engine now does the same for the names a program declares.

## What proves it

- `gradlew build` green.
- The off-game harness, `Expressions` and `Uniformes` over the corpus: every declaration that
  resolved before still resolves, E-LITE's hour of the day comes out live and reads six at noon,
  and the catalogue's answer for each name above is what the log now prints.
- In the game: a full sweep of the corpus on a jar carrying this and the neighbouring batches is
  still to come; E-LITE's cloud cover and Clarity's sun are what to look at.

## What it leaves owing

`blendFunc`, which Iris supplies from the pass's blend state and this engine does not yet; one
pack of the corpus reads it.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
