### PR TITLE
fix(render): answer the player flags false without a player

### DIFF
--- a/common/src/main/java/dev/vitrail/render/FrameState.java
+++ b/common/src/main/java/dev/vitrail/render/FrameState.java
@@ -772,6 +772,8 @@ public final class FrameState implements WorldState {
 			// different animal.
 			noVehicle();
 
+			noFlags();
+
 			return;
 		}
 
@@ -816,6 +818,39 @@ public final class FrameState implements WorldState {
 		this.vehicleId = 0;
 		this.vehicleLookVector.zero();
 		this.relativeVehiclePosition.zero();
+	}
+
+	/**
+	 * What the ten flags answer while there is no player, which is false for every one of them.
+	 * <p>
+	 * Left alone they would still be the previous frame's, and a boolean is the one value stale
+	 * enough to be believed: false is what a pack reads off a player standing still, so a sprint or
+	 * a burn carried out of the world just left arrives looking measured. Iris answers each of them
+	 * false, one supplier at a time, and the ten follow those: {@code sneaking} from
+	 * {@code uniforms/CommonUniforms.java:216-222}, {@code sprinting} from {@code :224-230},
+	 * {@code hurt} from {@code :192-198}, {@code invisible} from {@code :200-206}, {@code burning}
+	 * from {@code :208-214} and {@code onGround} from {@code :188-190}; then {@code elytraFlying}
+	 * from {@code uniforms/IrisExclusiveUniforms.java:167-173}, {@code riding} from
+	 * {@code :159-165}, {@code feetInWater} from {@code :143-149} and {@code swimming} from
+	 * {@code :151-157}.
+	 * <p>
+	 * Nothing reaches this today, and it is written anyway. The game reads the player's portal
+	 * intensity before it hands the level to the renderer ({@code renderer/GameRenderer.java:548}),
+	 * so a level drawn without one never gets as far as this engine; and the neighbours here all
+	 * fall back rather than hold, {@code readStats} and {@code readHeld} both, which leaves
+	 * these ten as the only reading of a frame that would answer for a player who is not there.
+	 */
+	private void noFlags() {
+		this.sneaking = false;
+		this.sprinting = false;
+		this.hurt = false;
+		this.invisible = false;
+		this.burning = false;
+		this.onGround = false;
+		this.elytraFlying = false;
+		this.riding = false;
+		this.feetInWater = false;
+		this.swimming = false;
 	}
 
 	/**


### PR DESCRIPTION
## What changes

The ten boolean flags a pack reads about the player (`sneaking`, `sprinting`, `hurt`, `invisible`,
`burning`, `onGround`, `elytraFlying`, `riding`, `feetInWater`, `swimming`) were left at the
previous frame's values when the frame was read without a player, while every neighbouring reading
of the same frame falls back. They answer false now, which is what Iris answers on a null player for
each of them, one supplier at a time. Nothing reaches that road today: the game reads the player
before it hands the level to the renderer, so a frame without one never gets this far. The guard is
written all the same, because a stale boolean is the one value that reads as measured.

## How it differs from the reference, and for what obstacle

It does not: `uniforms/CommonUniforms.java:188-230` and `uniforms/IrisExclusiveUniforms.java:143-173`
answer false for each of the ten when there is no player, and so does this.

## What proves it

- `gradlew build` green.
- The off-game harness is not concerned: no pack input changes.
- In the game: nothing to look at, no frame takes that road; the picture does not depend on it.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
