### PR TITLE
ci: keep the push runs of the long-lived branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,14 @@ on:
 permissions:
   contents: read
 
-# A branch only needs its latest push checked. Superseded runs are cancelled rather than left to
-# finish and report on a commit nobody is looking at any more.
+# A pull request only needs its latest push checked, so a superseded run there is cancelled rather
+# than left to finish and report on a commit nobody is looking at any more. A push on one of the
+# two long-lived branches is a commit that has landed for good, and every one of those keeps its
+# own verdict: two requests merged a minute apart used to leave the first commit with a cancelled
+# run, which reads as a failure on the branch and denies that commit the check it earned.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:


### PR DESCRIPTION
## What changes

The build workflow cancelled any run that a newer push superseded, on every ref alike. On `dev`
and `main` a push is a commit that has landed for good, so two requests merged a minute apart left
the first commit with a cancelled run, which reads as a failure on the branch and denies that commit
the verdict it earned. Superseded runs are still cancelled on a pull request, where only the latest
push matters; on the two long-lived branches every push now runs to its verdict.

## How it differs from the reference, and for what obstacle

It does not apply.

## What proves it

- `gradlew build` green.
- The next two merges into `dev` landing within a minute of each other, both commits keeping a
  completed run.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
