### PR TITLE
fix(render): run a compute whose program draws nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,18 @@ what the next one holds.
 
 ### Fixed
 
+- **A compute a pack ships for a step of the chain that draws nothing now runs.** It was left out
+  on the grounds that there was no pass to run it before; it is now dispatched on its own, at the
+  moment the program it hangs off would have run at, which is what Iris does with it: its family
+  says whether that falls before the world's translucents or after them, and its name says where it
+  lands among the passes drawn there. A pack reaches that state by shipping the compute and no
+  drawing program for the step, or by shipping one and switching it off itself, its switch never
+  naming the compute file. A pack may go further and build every one of its worlds out of such
+  computes with no full screen pass at all, which used to stop its chain before the first frame:
+  RenderPearl is written that way. Noble computes the sun's illuminance and the sky's coefficients
+  in one and everything that lights its world reads what that leaves behind, so its diffuse
+  lighting, its shadows, its gbuffers and its fog all went dark at once.
+
 - **A pass that writes into an image no longer goes missing.** A pack can name, in the shader
   itself, the format of the image that shader writes to, and that word was being dropped as the
   declaration was moved to where this backend wants it. What was left is a declaration the compiler

--- a/common/src/main/java/dev/vitrail/pack/model/ProgramNames.java
+++ b/common/src/main/java/dev/vitrail/pack/model/ProgramNames.java
@@ -1,5 +1,6 @@
 package dev.vitrail.pack.model;
 
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -79,6 +80,27 @@ public final class ProgramNames {
 			case "composite" -> 5;
 			default -> 6;
 		};
+	}
+
+	/**
+	 * The order the frame runs two BARE program names in: the rank of their families first, and
+	 * then the slot inside the family, so that {@code composite2} comes before {@code composite10}
+	 * and {@code prepare} before {@code prepare1}. A name that parses as no program at all sorts
+	 * after every one that does.
+	 * <p>
+	 * This is the order {@code ProgramSet.sorted} lays the entries out in and the order Iris fills
+	 * the array of a stage, which is what makes it the order of the frame. Kept here for the reason
+	 * {@link #frameRank} is kept here, and with more readers to disagree: the plan, the schedule and
+	 * the chain each have to place a compute whose program draws nothing, and two of them answering
+	 * differently produces no error at all, only a dispatch at the wrong moment reading the half
+	 * that nothing has written yet.
+	 */
+	public static Comparator<String> frameOrder() {
+		return Comparator
+				.comparingInt((String program) -> frameRank(familyOf(program)))
+				.thenComparingInt(program -> parse(program)
+						.map(ProgramName::slot)
+						.orElse(Integer.MAX_VALUE));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -609,7 +609,7 @@ public final class ShaderProperties {
 	 * what serves the name is whatever the fallback tree offers next, and only a name whose whole
 	 * chain is switched off or absent ends up served by nothing. That is the reference's
 	 * behaviour and not an interpretation of it: a disabled name gets no source there
-	 * ({@code ShaderPack.java:290-294}), {@code ProgramSet.get} then answers empty
+	 * ({@code ShaderPack.java:292-295}), {@code ProgramSet.get} then answers empty
 	 * ({@code programs/ProgramSet.java:279-285}), and the resolver walks to the parent
 	 * ({@code programs/ProgramFallbackResolver.java:27-42}).
 	 */

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -1169,13 +1169,13 @@ public final class ChainPlan {
 	 * {@code colortex0} on the half the chain leaves it, and empty on every place that runs one.
 	 * <p>
 	 * A pack shipping no final is not a pack that draws nothing: Iris copies {@code colortex0}
-	 * into the game's own target and says so in as many words, {@code pipeline/FinalPassRenderer.java:113}
-	 * making the pass optional and {@code :268-277} doing the copy under a comment naming the
+	 * into the game's own target and says so in as many words, {@code pipeline/FinalPassRenderer.java:115}
+	 * making the pass optional and {@code :268-280} doing the copy under a comment naming the
 	 * transfer. Two packs of this corpus ship none, I Like Vanilla ending its chain on
 	 * {@code composite99} and Pegasus on {@code composite11}.
 	 * <p>
 	 * The half is the one the schedule ends the frame on, which is the same question Iris asks its
-	 * flip state when it builds that copy's framebuffer ({@code :131}). A chain whose last write
+	 * flip state when it builds that copy's framebuffer ({@code :133}). A chain whose last write
 	 * landed on the far half and which was read from the near one would otherwise show the frame
 	 * before this one.
 	 */

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -123,6 +123,7 @@ public final class TargetPlan {
 	private final Map<String, Set<Integer>> samples;
 	private final int geometryAt;
 	private final List<String> computes;
+	private final List<String> passing;
 	private final List<String> unreadable;
 	private final List<String> notes;
 	private final int programsRead;
@@ -144,6 +145,7 @@ public final class TargetPlan {
 		this.samples = Collections.unmodifiableMap(new LinkedHashMap<>(draft.samples));
 		this.geometryAt = draft.geometryAt;
 		this.computes = List.copyOf(draft.computes);
+		this.passing = List.copyOf(draft.passing);
 		this.written = Collections.unmodifiableSet(new TreeSet<>(draft.written));
 		this.sampled = Collections.unmodifiableSet(new TreeSet<>(draft.sampled));
 
@@ -212,8 +214,11 @@ public final class TargetPlan {
 		Map<String, String> defines = settings.globalDefines(options);
 		draft.blend = properties.blend(defines);
 		read(source, options, settings, properties, entries, draft);
-		walk(properties, options, defines, entries, filter, draft);
+		// Ahead of the walk and it used to follow it: the walk owes a moment in the frame to every
+		// program a compute hangs off, and it cannot know which those are before this has said so.
+		// Nothing here reads what the walk writes, so the two only ever ran in this order by habit.
 		computes(properties, options, defines, programs, draft);
+		walk(properties, options, defines, programs, entries, filter, draft);
 
 		return new TargetPlan(draft);
 	}
@@ -223,7 +228,7 @@ public final class TargetPlan {
 	 * <p>
 	 * Iris refuses a disabled program at the source: its provider hands back nothing for the name,
 	 * so no family is read and none is compiled, computes included
-	 * ({@code ShaderPack.java:261-265} fills the list, {@code :290-294} refuses on it). Here the
+	 * ({@code ShaderPack.java:261-265} fills the list, {@code :292-295} refuses on it). Here the
 	 * toggles are applied where each list is built, and this one was left out while nothing ran
 	 * it. BSL conditions its three {@code shadowcomp} programs on
 	 * {@code MULTICOLORED_BLOCKLIGHT}, and the setting takes with it both the {@code image.}
@@ -246,7 +251,8 @@ public final class TargetPlan {
 			// up, and NOT the base name. A compute hangs off a composite by a letter, so
 			// world0/composite21_a is a name of its own and a pack switching off
 			// world0/composite21 has said nothing about it. Iris keeps those computes and runs
-			// them with no fragment stage at all, CompositeRenderer.java:135-141.
+			// them as a pass with no fragment stage at all (CompositeRenderer.java:137-145), and
+			// so does the chain here: passingOf below names that program.
 			String file = key.file();
 			int dot = file.lastIndexOf('.');
 			String path = dot < 0 ? file : file.substring(0, dot);
@@ -300,8 +306,8 @@ public final class TargetPlan {
 	 * reads its answer and none of it works the answer out again.
 	 */
 	private static void walk(ShaderProperties properties, OptionIndex options,
-			Map<String, String> defines, List<ProgramSet.ProgramKey> entries, ChainFilter filter,
-			Draft draft) {
+			Map<String, String> defines, ProgramSet programs, List<ProgramSet.ProgramKey> entries,
+			ChainFilter filter, Draft draft) {
 		Map<String, Boolean> toggles = properties.programToggles(defines, options);
 		Map<String, String> conditions = properties.programConditions(defines);
 		List<TargetSchedule.Step> steps = new ArrayList<>();
@@ -376,7 +382,90 @@ public final class TargetPlan {
 			draft.geometryAt = draft.running.size();
 		}
 
-		draft.schedule = TargetSchedule.of(steps, properties.flips(defines));
+		draft.passing = passingOf(programs, toggles, draft);
+		draft.schedule = TargetSchedule.of(steps, properties.flips(defines), draft.passing);
+	}
+
+	/**
+	 * The programs a compute hangs off that this place draws no pass for, in frame order.
+	 * <p>
+	 * This is Iris's {@code source == null || !source.isValid()} and nothing wider: a pass of the
+	 * computes alone is built there and only there
+	 * ({@code pipeline/CompositeRenderer.java:137-145}). A pack reaches it three ways and only the
+	 * first reads as obvious. It ships neither half of the program, having written the
+	 * {@code .csh} and nothing else. Or it ships both halves and turns the program off with its
+	 * own switch, which makes the source provider hand back nothing for that name
+	 * ({@code shaderpack/ShaderPack.java:292-295}) while the computes are read under their own
+	 * file names, which the switch never mentioned
+	 * ({@code shaderpack/programs/ProgramSet.java:190-210}): {@code composite3_a} outlives
+	 * {@code composite3} and runs without it. Or it ships one half only, which is
+	 * {@code !isValid()} and takes the very same road
+	 * ({@code shaderpack/programs/ProgramSource.java:81-83}).
+	 * <p>
+	 * <strong>A program THIS ENGINE'S pass filter cuts is not one of them</strong>, and that is a
+	 * rule of ours rather than a reading of Iris, which has no such filter. {@code passes=N} and
+	 * the named form both exist to say that a part of the frame must not happen, so a compute of a
+	 * cut program running anyway would put a piece of it back and the knob would stop cutting the
+	 * chain where it says it does. What it costs is the parity of a bisected chain against Iris,
+	 * which is a chain nobody plays on and that is measured against itself.
+	 * <p>
+	 * Shadow composites are not in it either, {@link ProgramNames#computeBase} answering empty for
+	 * them: their moment is the shadow stage rather than this walk, and the shadow list is what
+	 * carries them.
+	 * <p>
+	 * <strong>Nor is the final</strong>, and that one is a reading of Iris rather than a rule of
+	 * ours. The final is not built by the walk above at all: its computes are made inside the
+	 * {@code map} over the final source and nowhere else
+	 * ({@code pipeline/FinalPassRenderer.java:115-125}), so a pack shipping {@code final_a.csh} and
+	 * no {@code final.fsh} gets nothing built for it there, no compute-only pass and no dispatch.
+	 * The rest of the road treats it like any other family, {@code ProgramNames.computeBase}
+	 * answering {@code final} for the file, which is why it has to be taken out here.
+	 * <p>
+	 * A program shipped with its fragment half and not its vertex one is the one name that lands
+	 * here and in {@link #running()} at once, the walk reading the fragments and so keeping it. It
+	 * draws nothing either way: a place whose running program does not serve both stages is
+	 * refused whole ({@code glsl/PackProgram.java:1398-1404}), so no frame is ever drawn off that
+	 * plan.
+	 * <p>
+	 * Deduplicated on the base name: {@code prepare}, {@code prepare_a} and {@code prepare_b} are
+	 * three computes of one program and there is one moment in the frame for the three of them.
+	 */
+	private static List<String> passingOf(ProgramSet programs, Map<String, Boolean> toggles,
+			Draft draft) {
+		Set<String> fragments = new HashSet<>();
+		Set<String> vertices = new HashSet<>();
+		for (ProgramSet.ProgramKey key : programs.keys()) {
+			if (!key.dimension().equals(draft.place)) {
+				continue;
+			}
+
+			if (key.stage() == ProgramStage.FRAGMENT) {
+				fragments.add(key.name().baseName());
+			} else if (key.stage() == ProgramStage.VERTEX) {
+				vertices.add(key.name().baseName());
+			}
+		}
+
+		return draft.computes.stream()
+				.map(ProgramNames::computeBase)
+				.flatMap(Optional::stream)
+				.filter(base -> !base.equals(FINAL))
+				.filter(base -> !sourced(base, fragments, vertices, toggles, draft))
+				.distinct()
+				.sorted(ProgramNames.frameOrder())
+				.toList();
+	}
+
+	/**
+	 * Whether this place hands out a source Iris would build a drawing pass from: both halves
+	 * shipped, and the pack's own switch left alone. Asked of the key the walk asks the switch
+	 * under, the path exactly as the pack wrote it, for the reason given there.
+	 */
+	private static boolean sourced(String base, Set<String> fragments, Set<String> vertices,
+			Map<String, Boolean> toggles, Draft draft) {
+		String path = draft.place.isEmpty() ? base : draft.place + "/" + base;
+		return fragments.contains(base) && vertices.contains(base)
+				&& !Boolean.FALSE.equals(toggles.get(path));
 	}
 
 	/**
@@ -657,11 +746,26 @@ public final class TargetPlan {
 	}
 
 	/**
+	 * The programs that the computes of {@link #computes()} hang off and that this place draws no
+	 * pass for, in frame order, one entry per program however many computes it carries. Either the
+	 * pack ships less than both halves of the program or it switched the program off itself; a
+	 * program this engine's filter cut is never one of them, and passingOf says why.
+	 * <p>
+	 * They draw nothing, they are in no step of the {@link #schedule} and they are in no count taken
+	 * off it. What they are is a moment in the frame: their computes run there, which is what the
+	 * reference does with a stage entry it has computes for and no valid source
+	 * ({@code pipeline/CompositeRenderer.java:137-145}).
+	 */
+	public List<String> passing() {
+		return this.passing;
+	}
+
+	/**
 	 * Compute entry points this place ships and keeps on, by file name without the extension,
 	 * letter included: {@code deferred4_a} and {@code deferred4} are two of them. Shadowcomp is
 	 * dispatched at the head of the frame, a compute hanging off a begin, prepare, deferred,
-	 * composite or final pass right before that pass, and the rest are named in {@link #notes()}
-	 * until a stage exists for them.
+	 * composite or final pass right before that pass, one hanging off a program of
+	 * {@link #passing()} at that program's own moment, and the rest are named in {@link #notes()}.
 	 */
 	public List<String> computes() {
 		return this.computes;
@@ -811,20 +915,40 @@ public final class TargetPlan {
 			List<String> shadow = draft.computes.stream()
 					.filter(name -> ProgramNames.shadowComposite(ProgramNames.familyOf(name)))
 					.toList();
-			// Hanging off a pass this place draws: the chain dispatches them before it. Iris also
-			// runs a compute whose pass has no fragment program, as a pass of its own
-			// (CompositeRenderer.java:135-141), and the chain has no step for that yet.
+			// Hanging off a program this place draws no pass for, so there is nothing to run them
+			// before and they are run at that program's own moment in the frame instead, which is
+			// what the reference does with them (CompositeRenderer.java:137-145). Asked BEFORE the
+			// chained list and in the order PackCompute.load asks it: a program shipped with its
+			// fragment half and not its vertex one is in running() and in passing() at once, and
+			// the two lists reading it in opposite orders would name it one thing and dispatch it
+			// the other.
+			List<String> alone = draft.computes.stream()
+					.filter(name -> !shadow.contains(name))
+					.filter(name -> ProgramNames.computeBase(name)
+							.filter(draft.passing::contains).isPresent())
+					.toList();
+			// Hanging off a pass this place draws: the chain dispatches them before it.
 			List<String> chained = draft.computes.stream()
-					.filter(name -> !ProgramNames.shadowComposite(ProgramNames.familyOf(name)))
+					.filter(name -> !shadow.contains(name) && !alone.contains(name))
 					.filter(name -> ProgramNames.computeBase(name)
 							.filter(draft.running::contains).isPresent())
 					.toList();
+			// The final's computes are built inside the reference's map over the final source and
+			// nowhere else (FinalPassRenderer.java:115-125), so a final nothing draws carries none.
+			List<String> finals = draft.computes.stream()
+					.filter(name -> !shadow.contains(name) && !alone.contains(name)
+							&& !chained.contains(name))
+					.filter(name -> ProgramNames.computeBase(name)
+							.filter(FINAL::equals).isPresent())
+					.toList();
 			List<String> orphaned = draft.computes.stream()
-					.filter(name -> !shadow.contains(name) && !chained.contains(name))
+					.filter(name -> !shadow.contains(name) && !alone.contains(name)
+							&& !chained.contains(name) && !finals.contains(name))
 					.filter(name -> ProgramNames.computeBase(name).isPresent())
 					.toList();
 			List<String> other = draft.computes.stream()
-					.filter(name -> !shadow.contains(name) && !chained.contains(name)
+					.filter(name -> !shadow.contains(name) && !alone.contains(name)
+							&& !chained.contains(name) && !finals.contains(name)
 							&& !orphaned.contains(name))
 					.toList();
 			if (!shadow.isEmpty()) {
@@ -835,9 +959,21 @@ public final class TargetPlan {
 				notes.add("compute programs dispatched before the pass they hang off: " + chained);
 			}
 
+			if (!alone.isEmpty()) {
+				notes.add("compute programs dispatched at the moment of the program they hang off, "
+						+ "which this place draws no pass for: " + alone);
+			}
+
+			if (!finals.isEmpty()) {
+				notes.add("compute programs skipped, they hang off a final this place does not "
+						+ "draw and the reference builds a final's computes with the final alone: "
+						+ finals);
+			}
+
 			if (!orphaned.isEmpty()) {
-				notes.add("compute programs skipped, the pass they hang off does not run here and "
-						+ "the reference runs them as a pass of their own: " + orphaned);
+				notes.add("compute programs skipped, the pass filter took the program they hang "
+						+ "off out of the chain, at the user's ask or because a sampler of it is "
+						+ "one this backend cannot bind: " + orphaned);
 			}
 
 			if (!other.isEmpty()) {
@@ -1128,6 +1264,7 @@ public final class TargetPlan {
 		private TargetDirectives directives;
 		private TargetSchedule schedule;
 		private List<String> computes = List.of();
+		private List<String> passing = List.of();
 		private int programsRead;
 		private long expandMillis;
 	}

--- a/common/src/main/java/dev/vitrail/pack/target/TargetSchedule.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetSchedule.java
@@ -6,6 +6,7 @@ import dev.vitrail.pack.source.ShaderProperties;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -53,9 +54,11 @@ public final class TargetSchedule {
 	private final Set<Integer> flippedAtEnd;
 	private final Set<Integer> afterDeferred;
 	private final Map<String, Map<Integer, Boolean>> forced;
+	private final Map<String, Set<Integer>> passingHalves;
 
 	private TargetSchedule(List<Bound> steps, Set<Integer> doubled, Set<Integer> flippedAtEnd,
-			Set<Integer> afterDeferred, Map<String, Map<Integer, Boolean>> forced) {
+			Set<Integer> afterDeferred, Map<String, Map<Integer, Boolean>> forced,
+			Map<String, Set<Integer>> passingHalves) {
 		this.steps = List.copyOf(steps);
 		// Sorted rather than Set.copyOf: these end up in a log, and an index that moves about
 		// between two runs of the same pack reads as a difference that is not one.
@@ -66,6 +69,10 @@ public final class TargetSchedule {
 		Map<String, Map<Integer, Boolean>> copied = new LinkedHashMap<>();
 		forced.forEach((program, indices) -> copied.put(program, Map.copyOf(indices)));
 		this.forced = Map.copyOf(copied);
+
+		Map<String, Set<Integer>> halves = new LinkedHashMap<>();
+		passingHalves.forEach((program, indices) -> halves.put(program, sortedCopy(indices)));
+		this.passingHalves = Map.copyOf(halves);
 	}
 
 	public enum Side { MAIN, ALT }
@@ -97,17 +104,36 @@ public final class TargetSchedule {
 	 * @param steps in render order, not in directive order
 	 */
 	public static TargetSchedule of(List<Step> steps, List<ShaderProperties.FlipDirective> explicit) {
+		return of(steps, explicit, List.of());
+	}
+
+	/**
+	 * The same walk, also answering for the programs of {@code passing}, which the place draws no
+	 * pass for and which the walk therefore stops at without binding anything.
+	 *
+	 * @param steps   in render order, not in directive order
+	 * @param passing the programs a compute hangs off that this place draws no pass for, in the
+	 *                same order. They enter no step: nothing of them is drawn, they write no target
+	 *                and they turn none over, so every count taken off {@link #steps()} is the same
+	 *                with them and without. What the walk owes them is the one thing Iris gives its
+	 *                own compute-only pass and nothing else, the halves standing at that point of
+	 *                the frame ({@code pipeline/CompositeRenderer.java:134} takes the snapshot,
+	 *                {@code :137-145} builds the pass and flips nothing after it)
+	 */
+	public static TargetSchedule of(List<Step> steps, List<ShaderProperties.FlipDirective> explicit,
+			List<String> passing) {
 		Map<String, Map<Integer, Boolean>> forced = byProgram(explicit);
 		Set<Integer> flipped = new LinkedHashSet<>();
 		Set<Integer> doubled = new TreeSet<>();
 		List<Bound> bound = new ArrayList<>();
+		Map<String, Set<Integer>> halves = new LinkedHashMap<>();
 		Set<Integer> afterDeferred = null;
 		int deferredRank = ProgramNames.frameRank("deferred");
 		int opened = 0;
 
-		for (Step step : steps) {
+		for (Item item : merge(steps, passing)) {
 			int reached =
-					ProgramNames.frameRank(ProgramNames.familyOf(TargetName.bareName(step.program())));
+					ProgramNames.frameRank(ProgramNames.familyOf(TargetName.bareName(item.program())));
 
 			// The snapshot is taken between the last deferred and the first thing after it, with
 			// the deferred stage opened and the composite one not. That is the moment Iris takes
@@ -120,6 +146,15 @@ public final class TargetSchedule {
 
 			opened = openStages(opened, reached, forced, flipped, doubled);
 
+			// Its stage is open and no pass of it has run, which is where Iris takes the snapshot
+			// it hands a compute whose program has no valid source. Recorded and not bound: a step
+			// here would say a pass runs, and none does.
+			if (item.step() == null) {
+				halves.put(TargetName.bareName(item.program()), sortedCopy(flipped));
+				continue;
+			}
+
+			Step step = item.step();
 			Set<Integer> readsAlt = sortedCopy(flipped);
 			Set<Integer> writesAlt = new TreeSet<>();
 
@@ -170,7 +205,49 @@ public final class TargetSchedule {
 
 		openStages(opened, Integer.MAX_VALUE, forced, flipped, doubled);
 
-		return new TargetSchedule(bound, doubled, flipped, afterDeferred, forced);
+		return new TargetSchedule(bound, doubled, flipped, afterDeferred, forced, halves);
+	}
+
+	/** One thing the walk stops at: a pass the place draws, or a program it only ships a compute for. */
+	private record Item(String program, Step step) {
+	}
+
+	/**
+	 * The two lists laid end to end in frame order, each program of {@code passing} put where its
+	 * own name would have put a pass of it.
+	 * <p>
+	 * Both lists arrive in {@link ProgramNames#frameOrder}, which is the order the steps were built
+	 * in and the order Iris fills the array a stage walks, so this is a merge and not a sort.
+	 * <p>
+	 * They meet on one name and one only, a program shipped with its fragment half and not its
+	 * vertex one: the plan's walk reads the fragments, so it made a step of it, and the plan calls
+	 * it passing all the same because half a source draws nothing. Such a place is refused whole
+	 * before a frame is drawn from it, so the compute landing after that step rather than in its
+	 * place is a plan nobody reads.
+	 */
+	private static List<Item> merge(List<Step> steps, List<String> passing) {
+		if (passing.isEmpty()) {
+			return steps.stream().map(step -> new Item(step.program(), step)).toList();
+		}
+
+		Comparator<String> order = ProgramNames.frameOrder();
+		List<Item> items = new ArrayList<>();
+		int next = 0;
+		for (Step step : steps) {
+			String against = TargetName.bareName(step.program());
+			while (next < passing.size()
+					&& order.compare(TargetName.bareName(passing.get(next)), against) < 0) {
+				items.add(new Item(passing.get(next++), null));
+			}
+
+			items.add(new Item(step.program(), step));
+		}
+
+		while (next < passing.size()) {
+			items.add(new Item(passing.get(next++), null));
+		}
+
+		return List.copyOf(items);
 	}
 
 	/**
@@ -215,6 +292,25 @@ public final class TargetSchedule {
 
 		return this.steps.stream().filter(step -> TargetName.bareName(step.program()).equals(wanted))
 				.findFirst();
+	}
+
+	/**
+	 * The halves a program this place draws no pass for stands on, for the computes that hang off
+	 * it and that run whether it is there or not.
+	 * <p>
+	 * It writes nothing and turns nothing over, so only the read side of the answer means anything:
+	 * a compute of it samples {@code colortexN} and stores into {@code colorimgN} on the one half
+	 * Iris binds for both ({@code pipeline/CompositeRenderer.java:454} hands the samplers that
+	 * snapshot and {@code :458} hands the images the same one), which is the half the next pass of
+	 * the chain reads.
+	 * <p>
+	 * Empty for every program that is not one of these, which is every program that draws: ask
+	 * {@link #step} for those. Both answers are filled for one name only, the name the merge above
+	 * describes, and no frame is drawn off a plan holding it.
+	 */
+	public Optional<Bound> passing(String program) {
+		return Optional.ofNullable(this.passingHalves.get(TargetName.bareName(program)))
+				.map(readsAlt -> new Bound(program, List.of(), true, readsAlt, Set.of()));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ChainPresent.java
+++ b/common/src/main/java/dev/vitrail/render/ChainPresent.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.pipeline.BindGroupLayout;
 import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.CompiledRenderPipeline;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.shaders.ShaderSource;
 import com.mojang.blaze3d.shaders.ShaderType;
@@ -31,8 +32,8 @@ import java.util.Optional;
  * game's target rather than a colour target of the pack's, and most packs use it for their tone
  * mapping. A pack without one has simply finished in {@code colortex0} and expects what is there to
  * be the picture. Iris answers that by copying the target into the main framebuffer and says so in
- * as many words, {@code pipeline/FinalPassRenderer.java:113} making the pass optional and
- * {@code :268-277} doing the copy. Refusing such a pack, which is what this engine did until this
+ * as many words, {@code pipeline/FinalPassRenderer.java:115} making the pass optional and
+ * {@code :268-280} doing the copy. Refusing such a pack, which is what this engine did until this
  * class existed, cost I Like Vanilla and Pegasus their whole picture.
  * <p>
  * <strong>A draw and not a copy, for {@link SceneSeed}'s reason and it is the same one.</strong>
@@ -129,9 +130,21 @@ final class ChainPresent {
 				.build();
 	}
 
+	/**
+	 * The compiled form of this pass, which is what the device's cache holds for it now.
+	 * <p>
+	 * Handed back rather than a yes or no, because comparing it with the instance of the frame
+	 * before is the one way to notice that the cache was emptied, and a place that draws no full
+	 * screen pass has no other pipeline of its own to ask. This one is the engine's and carries no
+	 * load in its name, so no purge ever carries it over: it comes back new every time.
+	 */
+	CompiledRenderPipeline compiled(GpuDevice device) {
+		return device.precompilePipeline(this.pipeline, this.source);
+	}
+
 	/** Called every frame: a resource reload empties the pipeline cache. */
 	boolean prepare(GpuDevice device) {
-		if (device.precompilePipeline(this.pipeline, this.source).isValid()) {
+		if (compiled(device).isValid()) {
 			return true;
 		}
 

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2,6 +2,7 @@ package dev.vitrail.render;
 
 import dev.vitrail.dh.DhLods;
 import dev.vitrail.glsl.PackProgram;
+import dev.vitrail.pack.model.ProgramNames;
 import dev.vitrail.pack.model.RenderStage;
 import dev.vitrail.pack.model.TargetName;
 import dev.vitrail.pack.option.OptionValue;
@@ -11,6 +12,7 @@ import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.target.TargetDirectives;
 import dev.vitrail.pack.target.TargetPlan;
+import dev.vitrail.pack.target.TargetSchedule;
 import dev.vitrail.pack.texture.CustomImages;
 import dev.vitrail.render.storage.StorageImages;
 import dev.vitrail.render.timing.PassTimings;
@@ -42,6 +44,7 @@ import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -320,6 +323,13 @@ public final class PackChain {
 	private List<PackPass> programs;
 	private PackPass last;
 
+	/**
+	 * The computes of a program this place draws no pass for, in frame order, each with the cut of
+	 * the frame it belongs to and the point of that cut's walk it is dispatched at. Empty for every
+	 * place that ships both halves of every program it writes a compute for, which is most of them.
+	 */
+	private List<Standalone> standalone = List.of();
+
 	/** Whether any program of this chain reads centerDepthSmooth, settled once the passes are built. */
 	private boolean centerDepthRead;
 
@@ -460,7 +470,8 @@ public final class PackChain {
 		this.compute = PackCompute.load(opened, chain.place(), chain.targets().computes(), this.load,
 				values.shadowGeometryCatalog(), values.catalog(),
 				ordered(chain.chain()).stream().map(ChainPlan.Pass::program)
-						.collect(Collectors.toSet()));
+						.collect(Collectors.toSet()),
+				Set.copyOf(chain.targets().passing()));
 		// Before the first frame allocates a target: the usage a compute needs is baked into the
 		// image at creation, and nothing can add it afterwards.
 		this.targets.storageTargets(this.compute.storageTargets());
@@ -745,9 +756,10 @@ public final class PackChain {
 			return false;
 		}
 
-		// An empty composite list will never become drawable. Skipping the world for it would
-		// leave the player in a black pause with nothing left to compile.
-		if (chain.programs != null && chain.programs.isEmpty()) {
+		// An empty composite list will never become drawable, unless computes stand alone in it and
+		// give the frame something to run. Skipping the world for one that will not would leave the
+		// player in a black pause with nothing left to compile.
+		if (chain.programs != null && chain.programs.isEmpty() && chain.standalone.isEmpty()) {
 			return false;
 		}
 
@@ -1295,9 +1307,13 @@ public final class PackChain {
 	 * @param distant what they read as {@code dhDepthTex0}, on the same split: the far terrain
 	 *                before its water and with it after, or null for the far plane on the frames the
 	 *                pack drew no far terrain
+	 * @param cut     which cut of the frame this range is, which is what says whose standalone
+	 *                computes belong to it. Said rather than read off the bounds: where the whole
+	 *                chain runs before the world the two cuts have the same bounds, and a compute
+	 *                placed by those would run in both of them or in neither
 	 */
 	private void drawRange(GpuDevice device, Ready ready, int from, int to, GpuTextureView depth,
-			GpuTextureView distant) {
+			GpuTextureView distant, Cut cut) {
 		// Clamped to the list, so that the rank of a chain whose every pass runs before the world is
 		// one the walk below can reach rather than one nothing ever equals.
 		int seedAt = ready.seeding()
@@ -1317,6 +1333,13 @@ public final class PackChain {
 		// list, and the deferred emptying inside a draw clears every target still owed one.
 		this.currentChains.clear();
 		for (int at = from; at < to; at++) {
+			// The standalones standing on this index are taken in two goes around the seed, as the
+			// end of the range is below: a prepare compute with no prepare pass stands on the first
+			// deferred pass, which is the index the seed is painted at, and its family says it runs
+			// before the world. Noble's world0 is written that way, and taken in one go after the
+			// seed its illuminance was computed over a world already lit by the frame before.
+			dispatchStandalone(cut, at, Reach.AT_INDEX_BEFORE_SEED, encoder, device, ready, depth,
+					distant, this.targets.hasPendingClears());
 			if (!this.seeded && at == seedAt) {
 				paintSeed(encoder, ready);
 				this.currentChains.clear();
@@ -1325,6 +1348,8 @@ public final class PackChain {
 			PackPass pass = this.programs.get(at);
 
 			boolean emptying = this.targets.hasPendingClears();
+			dispatchStandalone(cut, at, Reach.AT_INDEX_AFTER_SEED, encoder, device, ready, depth,
+					distant, emptying);
 			if (this.compute.hangsOff(pass.program())) {
 				// The frame's clears are paid before the computes and not inside the draw after
 				// them, where the first pass of the frame pays them: a compute storing into a
@@ -1336,7 +1361,7 @@ public final class PackChain {
 
 				// The computes hanging off this pass run right before it, on the halves it reads,
 				// as Iris does, and before the chains below are filled, as Iris fills them after
-				// its dispatch (CompositeRenderer.java:287-313): a compute storing into a target
+				// its dispatch (CompositeRenderer.java:289-300): a compute storing into a target
 				// the pass reads at a lod is what the chain has to be built from. Outside any
 				// render pass: a dispatch is a command of its own, and the barriers around it are
 				// what let the pass sample what the compute stored.
@@ -1379,6 +1404,19 @@ public final class PackChain {
 			}
 		}
 
+		// The end of this cut, where the ones no pass of it follows are dispatched: the loop stops
+		// before that index, so without the two calls below the compute of a cut that draws no pass
+		// after it would never run at all. It is where the frame really leaves this part of itself,
+		// and a compute of a family the cut carries has nowhere later to go.
+		//
+		// Taken in two goes with the seed between them, because there is no pass left here to place
+		// them against. The loop puts the seed before the pass its rank falls on and after the one
+		// before it, which is the passes of a family the frame runs no later than the world running
+		// ahead of it; the family answers the same question for a standalone, and the two halves of
+		// this end are what a pass of its name would have been on either side of.
+		dispatchStandalone(cut, to, Reach.PAST_END_BEFORE_SEED, encoder, device, ready, depth,
+				distant, this.targets.hasPendingClears());
+
 		// A rank that falls exactly on the end of this half is painted here, at its tail, and never
 		// at the head of the next one. The world is drawn before the deferred stage and not after
 		// it: walked as a half open range alone, a seed whose rank equals deferredEnd() - which is
@@ -1390,6 +1428,85 @@ public final class PackChain {
 		// the length of the list, so it equals the end of the last half.
 		if (!this.seeded && seedAt >= from && seedAt <= to) {
 			paintSeed(encoder, ready);
+			this.currentChains.clear();
+		}
+
+		dispatchStandalone(cut, to, Reach.PAST_END_AFTER_SEED, encoder, device, ready, depth,
+				distant, this.targets.hasPendingClears());
+	}
+
+	/**
+	 * Dispatches whatever of this cut stands at that point of the walk, which is nothing for a place
+	 * whose programs all draw.
+	 * <p>
+	 * Between the loop and the end of the range every standalone of the cut is reached exactly once,
+	 * and that rests on one thing: an index below the range cannot happen. The index counts the
+	 * passes that run before the program in frame order, and the head of a cut is the count of
+	 * passes whose rank the earlier cuts carry, every one of which sorts before anything this cut
+	 * holds. A cut added between these two divides the same ranks the same way and keeps it.
+	 *
+	 * @param at       the index the walk has reached
+	 * @param reach    which of them this go takes, every point of the walk being taken in two with
+	 *                 the seed between them
+	 * @param emptying whether targets are still owed their clear, which is paid here for the reason
+	 *                 the chained dispatch pays it: a compute storing into a target still owed one
+	 *                 would have its stores emptied by the pass that follows
+	 */
+	private void dispatchStandalone(Cut cut, int at, Reach reach, CommandEncoder encoder,
+			GpuDevice device, Ready ready, GpuTextureView depth, GpuTextureView distant,
+			boolean emptying) {
+		boolean ran = false;
+		for (Standalone waiting : this.standalone) {
+			if (waiting.cut() != cut || !reach.takes(waiting, at)) {
+				continue;
+			}
+
+			if (emptying && !ran) {
+				this.targets.flushPending(encoder);
+			}
+
+			ran = true;
+			this.compute.dispatchAlone(waiting.program(), encoder, device, this.values, this.targets,
+					waiting.step(), depth, distant, ready.main().width, ready.main().height);
+		}
+
+		if (ran) {
+			this.currentChains.clear();
+		}
+	}
+
+	/**
+	 * Which of a cut's standalones one dispatch takes. The walk reaches each of them once: on the
+	 * index of the pass it runs before, or, past the last pass of the cut, at the end of the range.
+	 * Both points are taken twice, with the scene seed painted between the two goes, and the family
+	 * says which go a standalone belongs to: the seed stands at the world's own rank, and a family
+	 * the frame runs no later than the world is dispatched before it.
+	 */
+	private enum Reach {
+
+		/** On the index the loop has reached, those of a family the frame runs no later than the world. */
+		AT_INDEX_BEFORE_SEED(false, false),
+
+		/** On that index, those of a family it runs after the world. */
+		AT_INDEX_AFTER_SEED(false, true),
+
+		/** Past the last pass, those of a family the frame runs no later than the world. */
+		PAST_END_BEFORE_SEED(true, false),
+
+		/** Past the last pass, those of a family it runs after the world. */
+		PAST_END_AFTER_SEED(true, true);
+
+		private final boolean pastEnd;
+		private final boolean afterSeed;
+
+		Reach(boolean pastEnd, boolean afterSeed) {
+			this.pastEnd = pastEnd;
+			this.afterSeed = afterSeed;
+		}
+
+		boolean takes(Standalone waiting, int at) {
+			return (this.pastEnd ? waiting.at() >= at : waiting.at() == at)
+					&& waiting.afterSeed() == this.afterSeed;
 		}
 	}
 
@@ -1821,13 +1938,25 @@ public final class PackChain {
 			// Said once, because the alternative is a chain that silently runs entirely after the
 			// world again: nothing on screen tells the two apart, and the pack that needs the split
 			// is the one whose water disappears.
-			Vitrail.logger().info("{} of this chain run before the world's translucents, {} after: {}",
-					end, this.programs.size() - end,
-					this.programs.stream().limit(end).map(PackPass::path).toList());
+			//
+			// A place with no full screen pass says what it does instead. The line above would read
+			// as two noughts and an empty list, which is a chain that runs nothing at all, and what
+			// this one really runs is its computes: they are named, since a place that draws no pass
+			// has nothing else to be recognised by.
+			if (this.programs.isEmpty()) {
+				Vitrail.logger().info("This chain draws no full screen pass and runs its computes on "
+						+ "their own: {}", this.standalone.stream()
+								.map(Standalone::program)
+								.toList());
+			} else {
+				Vitrail.logger().info("{} of this chain run before the world's translucents, {} after: {}",
+						end, this.programs.size() - end,
+						this.programs.stream().limit(end).map(PackPass::path).toList());
+			}
 		}
 
 		drawRange(device, ready, 0, end, this.targets.depth().opaque(),
-				this.targets.depth().distantOpaque());
+				this.targets.depth().distantOpaque(), Cut.BEFORE_TRANSLUCENTS);
 	}
 
 	/**
@@ -1884,7 +2013,7 @@ public final class PackChain {
 		}
 
 		drawRange(device, ready, deferredEnd(), this.programs.size(), this.targets.depth().scene(),
-				this.targets.depth().distantScene());
+				this.targets.depth().distantScene(), Cut.AFTER_TRANSLUCENTS);
 
 		// After the whole chain and before the halves swap back, which is where a final would have
 		// drawn. Only on a pack that ships none; ChainPresent says what it stands in for.
@@ -2002,6 +2131,7 @@ public final class PackChain {
 		}
 
 		this.programs = List.copyOf(built);
+		this.standalone = standaloneOf(built);
 		// Asked of the plan and not of the list: ordered() puts the final at the end when there is
 		// one, and where there is none the last of the list is an ordinary composite that writes
 		// its own targets. Drawing that one onto the game's target would be the chain's middle
@@ -2021,6 +2151,126 @@ public final class PackChain {
 		return all;
 	}
 
+	/** The last rank the early cut carries, which is the rank the plan cuts the pass list at. */
+	private static final int DEFERRED_RANK = ProgramNames.frameRank("deferred");
+
+	/**
+	 * A cut of the frame: a stretch of the chain the renderer records at one moment of the game's
+	 * own, drawn by one call of {@link #drawRange}.
+	 * <p>
+	 * A program belongs to the cut its FAMILY'S rank puts it in, and only to that one. A pass has no
+	 * need to be told, holding a place in a list the cuts are windows onto; a compute of a program
+	 * nothing draws holds no such place, so the cut is what it is given and the index only says
+	 * where inside the cut it goes. Deciding it off the index instead read the cut out of the
+	 * boundary between the two, which is the plan's count of what runs early and says nothing about
+	 * a program that is not counted: Pegasus, whose whole chain is composites, has a {@code prepare}
+	 * compute at index nought and a boundary at nought, and the late cut's walk ran it after the
+	 * world.
+	 */
+	private enum Cut {
+
+		/** The begins, the prepares, the seed and the deferreds, before the world's translucents. */
+		BEFORE_TRANSLUCENTS,
+
+		/** The composites and the final, drawn after them. */
+		AFTER_TRANSLUCENTS;
+
+		/**
+		 * Where the frame runs the family of that program. One comparison against the last rank a
+		 * cut carries, which is how another cut is added: the ranks are the same ranks and the
+		 * boundary the frame graph draws is another line through them.
+		 */
+		static Cut of(String program) {
+			return rankOf(program) <= DEFERRED_RANK ? BEFORE_TRANSLUCENTS : AFTER_TRANSLUCENTS;
+		}
+	}
+
+	/**
+	 * Where the frame runs a program, read off its family and never off a position in a list: it is
+	 * what places a program the chain draws nothing for, both against the cut boundary and against
+	 * the scene seed.
+	 */
+	private static int rankOf(String program) {
+		return ProgramNames.frameRank(ProgramNames.familyOf(TargetName.bareName(program)));
+	}
+
+	/**
+	 * A compute of a program this place draws no pass for, with where the walk dispatches it.
+	 *
+	 * @param cut       the cut of the frame its family belongs to, which is the whole of what decides
+	 *                  whether it runs before the world's translucents or after them
+	 * @param at        the index in {@link #programs} of the first pass that runs after it, or the
+	 *                  length of the list where every pass of the chain runs before it. Past the end
+	 *                  of its own cut it is dispatched at that end, the cut being where the frame
+	 *                  stops carrying its family at all
+	 * @param program   the program it hangs off, which is the name its halves and its texture stage
+	 *                  are read under however little of it is drawn
+	 * @param step      the halves it reads, from {@link TargetSchedule#passing} and never from a
+	 *                  pass: there is none, and the step of the pass after it would carry the flips
+	 *                  of every stage opened in between
+	 * @param afterSeed whether the frame runs its family after the world, the scene seed standing at
+	 *                  the world's own rank. Past the last pass of its cut there is nothing left to
+	 *                  place it against, and this is the side of the seed a pass of its name would
+	 *                  have drawn on
+	 */
+	private record Standalone(Cut cut, int at, String program, TargetSchedule.Bound step,
+			boolean afterSeed) {
+	}
+
+	/**
+	 * Places each of them in the walk, at the moment the program it hangs off would have run.
+	 * <p>
+	 * Iris puts its compute-only pass at the index the missing program holds inside its own stage
+	 * ({@code CompositeRenderer.java:137-145}), so the moment is the program's place in the frame
+	 * and not the head of its stage: a pack shipping {@code composite3.csh} with no
+	 * {@code composite3.fsh} runs it after {@code composite2} and before {@code composite4}, and the
+	 * halves it reads are the ones those two left behind. Read off the names for the same reason the
+	 * plan reads its ranks off them: a position in a list moves the moment the day a pass is cut,
+	 * and it moves without a word.
+	 * <p>
+	 * Sorted in frame order, which is what settles two that land on the same index: RenderPearl
+	 * draws no full screen pass at all and ships five such computes, so all five stand on index
+	 * nought, and taken in the order their file names came out of the map its {@code deferred} ran
+	 * after its {@code composite3}.
+	 * <p>
+	 * Each carries which side of the scene seed its family falls on as well, for the index the seed
+	 * is painted at and for the end of a range, where the index has run out of passes to name and
+	 * the seed is the only thing left to be placed against. Noble's world0 paints the seed at index
+	 * nought and stands a {@code prepare} compute on that same index, so without the family the one
+	 * step ran after the world there and before it in its world1, which ships the pass.
+	 */
+	private List<Standalone> standaloneOf(List<PackPass> built) {
+		if (this.compute.standingAlone().isEmpty()) {
+			return List.of();
+		}
+
+		Comparator<String> order = ProgramNames.frameOrder();
+		List<Standalone> waiting = new ArrayList<>();
+		for (String program : this.compute.standingAlone()) {
+			TargetSchedule.Bound step = this.targets.schedule().passing(program).orElse(null);
+			// The plan named it and the schedule did not, which is the plan disagreeing with itself
+			// rather than anything a pack can cause. Left undispatched: a compute pushed with no
+			// halves would be handed no colour target at all and throw once per frame.
+			if (step == null) {
+				Vitrail.logger().warn("compute of {} is not dispatched: the schedule gives it no "
+						+ "halves to read", program);
+				continue;
+			}
+
+			int at = 0;
+			while (at < built.size() && order.compare(built.get(at).program(), program) < 0) {
+				at++;
+			}
+
+			waiting.add(new Standalone(Cut.of(program), at, program, step,
+					rankOf(program) > ProgramNames.GEOMETRY_RANK));
+		}
+
+		waiting.sort(Comparator.comparing(Standalone::program, order));
+
+		return List.copyOf(waiting);
+	}
+
 	/**
 	 * Compiles at most one program a frame, and says whether the chain may be drawn.
 	 * <p>
@@ -2036,38 +2286,31 @@ public final class PackChain {
 	 * the rule. {@link #pumpWarmup} repeats the compiles here for as long as a short budget on
 	 * the frame allows. The device cache itself is only ever written on the render thread: the
 	 * worker builds the objects, {@code GeometryProgram.compile} hands them over.
+	 * <p>
+	 * A place with no full screen pass at all has nothing here to compile and is not refused for
+	 * it, so long as computes stand alone in it. It has a frame to run then: the reference builds
+	 * those into passes whether a program of the place draws or not
+	 * ({@code CompositeRenderer.java:137-145}). RenderPearl is written that way, five computes and
+	 * no {@code .fsh} for any of them, and the whole of its chain used to stop on this line. A place
+	 * with neither is still refused, and {@link #drawable} says what that refusal is worth: nothing
+	 * of the pack would run, and the frame after would paint a target nothing had written over the
+	 * game's own.
+	 * <p>
+	 * Such a place has nothing to compile and the cache still has to be watched under it: its
+	 * terrain and its leftover families are pipelines like any other, and a reload takes them with
+	 * everything else. {@link #warmPresent} keeps the watch there.
 	 *
 	 * @return false while a program is still missing, in which case nothing of the chain is drawn.
 	 *         What the screen holds for those frames is the terrain's answer and not this one, and
 	 *         {@link #drawable} is where the two are joined
 	 */
-	@SuppressWarnings("ReferenceEquality")
 	private boolean warm(GpuDevice device) {
-		if (this.programs.isEmpty()) {
+		if (this.programs.isEmpty() && this.standalone.isEmpty()) {
 			return false;
 		}
 
-		CompiledRenderPipeline first = this.programs.get(0).compile(device);
-		if (!valid(first, this.programs.get(0))) {
-			return false;
-		}
-
-		if (first != this.head) {
-			this.head = first;
-			this.warmed = 1;
-			forgetGeometry();
-
-			return false;
-		}
-
-		if (this.warmed < this.programs.size()) {
-			PackPass pass = this.programs.get(this.warmed);
-			if (!valid(pass.compile(device), pass)) {
-				return false;
-			}
-
-			this.warmed++;
-
+		boolean standing = this.programs.isEmpty() ? warmPresent(device) : warmPasses(device);
+		if (!standing) {
 			return false;
 		}
 
@@ -2095,6 +2338,74 @@ public final class PackChain {
 		}
 
 		this.geometryReady = true;
+
+		return true;
+	}
+
+	/**
+	 * The full screen passes of the chain, one a frame, and whether they are all standing.
+	 *
+	 * @return false while one is still missing or while the first has just come back different,
+	 *         which is the device having emptied its cache under the chain
+	 */
+	@SuppressWarnings("ReferenceEquality")
+	private boolean warmPasses(GpuDevice device) {
+		CompiledRenderPipeline first = this.programs.get(0).compile(device);
+		if (!valid(first, this.programs.get(0))) {
+			return false;
+		}
+
+		if (first != this.head) {
+			this.head = first;
+			this.warmed = 1;
+			forgetGeometry();
+
+			return false;
+		}
+
+		if (this.warmed < this.programs.size()) {
+			PackPass pass = this.programs.get(this.warmed);
+			if (!valid(pass.compile(device), pass)) {
+				return false;
+			}
+
+			this.warmed++;
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * The same watch on the device's cache for a place that draws no full screen pass, kept on the
+	 * one pipeline such a place still owns: {@link ChainPresent}'s, which brings its colour to the
+	 * screen in the stead of the final it has none of. It is asked for every frame anyway, and it is
+	 * the engine's own pipeline rather than the pack's, so a purge always takes it and it always
+	 * comes back new; the pack's own may be carried over one.
+	 * <p>
+	 * The geometry is what the watch is for. Nothing of the chain compiles here, but the terrain and
+	 * the leftover families do, and a place with no pass at all used to be the one place where the
+	 * cache was emptied under them and nothing lowered the flags that say they are compiled. A place
+	 * the plan named no target to bring back for has nothing to watch here and falls back on the
+	 * compile a program's own draw pays, which is the fallback everywhere else too.
+	 *
+	 * @return false on the frame the emptying is noticed, the geometry then compiling back a
+	 *         pipeline a frame as it does after any other reload
+	 */
+	@SuppressWarnings("ReferenceEquality")
+	private boolean warmPresent(GpuDevice device) {
+		if (this.present == null) {
+			return true;
+		}
+
+		CompiledRenderPipeline first = this.present.compiled(device);
+		if (first != this.head) {
+			this.head = first;
+			forgetGeometry();
+
+			return false;
+		}
 
 		return true;
 	}
@@ -2177,12 +2488,16 @@ public final class PackChain {
 	 * seconds of a screen with no world in it, at every F3+T. Terrain pipelines take that same
 	 * road after the composites. Leftover families compile on the worker.
 	 * <p>
-	 * The empty chain answers no rather than yes on a vacuous count. A place with no program has no
-	 * final either, so nothing would ever bring that target back, and {@link #warm} refuses it in
-	 * its first line for the same reason.
+	 * The empty chain answers no rather than yes on a vacuous count, unless it has computes standing
+	 * on their own. A place with no program has no final either, so what brings the target back is
+	 * {@link ChainPresent}, which is built for exactly that; taking the world off the screen for
+	 * that copy is worth it only where something of the pack really runs, and the standalone
+	 * computes are that. {@link #warm} refuses the place with neither on its first line, and the
+	 * two answers have to agree: this one turns the terrain's redirect on, that one lets the frame
+	 * that reads it back be drawn.
 	 */
 	boolean drawable() {
-		return this.programs != null && !this.programs.isEmpty()
+		return this.programs != null && !(this.programs.isEmpty() && this.standalone.isEmpty())
 				&& this.warmed == this.programs.size()
 				&& this.geometryReady;
 	}

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -84,12 +84,12 @@ import java.util.regex.Pattern;
  * The shadow computes run in the parity of the gbuffers that read what they propagate; the
  * volumes they read are the previous frame's shadow-geometry writes, one frame late like the
  * shadow map itself. Complementary's floodfill lives in {@code shadowcomp.csh}. Iris runs it
- * inside its shadow render ({@code ShadowRenderer.java:631-632}, the debug group and the
+ * inside its shadow render ({@code ShadowRenderer.java:632-633}, the debug group and the
  * {@code compositeRenderer.renderAll()} under it), before its gbuffers in the SAME frame. Under
  * this engine's deferred shadow stage, the head of the frame is that moment's translation.
  * <p>
  * The chained computes, {@code deferred4_a.csh} for {@code deferred4}, run where Iris runs them:
- * in a loop right before their pass, with a memory barrier after ({@code CompositeRenderer.java:287-297}),
+ * in a loop right before their pass, with a memory barrier after ({@code CompositeRenderer.java:289-300}),
  * reading and storing the colour targets on the halves that pass reads. Photon builds its sky
  * lighting in one, and without it everything in shadow was black.
  * <p>
@@ -128,10 +128,21 @@ final class PackCompute implements AutoCloseable {
 
 	/**
 	 * The computes hanging off a full screen pass, by that pass, each list in letter order. Iris
-	 * dispatches them right before the pass ({@code CompositeRenderer.java:287-297}, the loop over
+	 * dispatches them right before the pass ({@code CompositeRenderer.java:289-300}, the loop over
 	 * {@code compositePass.computes} with a memory barrier after), and so does the chain here.
 	 */
 	private final Map<String, List<Pass>> chained;
+
+	/**
+	 * The same, by the program they hang off, for the programs this place draws no pass for: the
+	 * pack ships less than both halves of the program, or it switched the program off itself.
+	 * Nothing draws them, so there is no pass to run these before and they are dispatched at that
+	 * program's own moment in the frame, which is where Iris runs them: a stage entry with computes
+	 * and no valid source becomes a pass of computes alone, at its own index of the stage
+	 * ({@code CompositeRenderer.java:137-145}), dispatched and barriered like any other and then
+	 * skipped before the draw ({@code :304-307}).
+	 */
+	private final Map<String, List<Pass>> alone;
 
 	/** The targets some compute writes as {@code colorimgN}, which are created writable for it. */
 	private final Set<Integer> storageTargets;
@@ -142,14 +153,15 @@ final class PackCompute implements AutoCloseable {
 	private final Set<String> announcedChains = new LinkedHashSet<>();
 
 	private PackCompute(List<Pass> passes, Map<String, List<Pass>> chained,
-			Set<Integer> storageTargets) {
+			Map<String, List<Pass>> alone, Set<Integer> storageTargets) {
 		this.passes = List.copyOf(passes);
 		this.chained = Map.copyOf(chained);
+		this.alone = Map.copyOf(alone);
 		this.storageTargets = Set.copyOf(storageTargets);
 	}
 
 	static PackCompute none() {
-		return new PackCompute(List.of(), Map.of(), Set.of());
+		return new PackCompute(List.of(), Map.of(), Map.of(), Set.of());
 	}
 
 	/** The targets to create writable from a compute, read before the first allocation. */
@@ -179,7 +191,11 @@ final class PackCompute implements AutoCloseable {
 	 * than a fold of its own would be.
 	 */
 	boolean readsCenterDepth() {
-		for (List<Pass> passes : this.chained.values()) {
+		return readsCenterDepth(this.chained) || readsCenterDepth(this.alone);
+	}
+
+	private static boolean readsCenterDepth(Map<String, List<Pass>> computes) {
+		for (List<Pass> passes : computes.values()) {
 			for (Pass pass : passes) {
 				for (TranslatedUnit.Uniform sampler : pass.compute.loaded().program().samplers()) {
 					if (sampler.name().equals(SamplerPlan.centerDepth())) {
@@ -202,15 +218,21 @@ final class PackCompute implements AutoCloseable {
 	 * of it to rebuild the same index of the same settings, so a pack with four computes paid for
 	 * four whole readings of itself to translate four files.
 	 *
-	 * @param running the programs the chain draws, which is where a chained compute can hang. A
-	 *                compute whose pass is not among them is read by Iris and dispatched with no
-	 *                fragment stage at all ({@code CompositeRenderer.java:135-141}); here it is
-	 *                named and left, since the chain has no step to hang it off yet
+	 * @param running the programs the chain draws, which is where a chained compute can hang
+	 * @param passing the programs this place draws no pass for, the pack having shipped less than
+	 *                both halves of them or switched them off itself. They draw nothing and so have
+	 *                no pass to hang a compute off; their computes are kept all the same and
+	 *                dispatched at that program's own moment in the frame, as Iris runs them
+	 *                ({@code CompositeRenderer.java:137-145}). Asked before {@code running}, since a
+	 *                program shipped with one half only is in both. A program in neither set has its
+	 *                computes left where they were, and the plan's notes carry the reason
 	 */
 	static PackCompute load(OpenedPack pack, String place, List<String> computes, int load,
-			UniformCatalog shadowCatalog, UniformCatalog chainCatalog, Set<String> running) {
+			UniformCatalog shadowCatalog, UniformCatalog chainCatalog, Set<String> running,
+			Set<String> passing) {
 		List<Pass> passes = new ArrayList<>();
 		Map<String, List<Pass>> chained = new LinkedHashMap<>();
+		Map<String, List<Pass>> alone = new LinkedHashMap<>();
 		Set<Integer> storageTargets = new LinkedHashSet<>();
 		for (String name : computes) {
 			boolean shadow = ProgramNames.shadowComposite(ProgramNames.familyOf(name));
@@ -220,10 +242,16 @@ final class PackCompute implements AutoCloseable {
 				continue;
 			}
 
-			if (!shadow && !running.contains(base.get())) {
-				Vitrail.logger().warn("compute {} hangs off {}, which this chain does not draw, so "
-						+ "it is not dispatched: the reference runs it as a pass of its own",
-						name, base.get());
+			// A program the place merely draws no pass for was never asked about: it is the
+			// reference's own invalid source, and its computes run there, so they run here. What is
+			// left over is a program taken out of the frame on purpose, by the pass filter at the
+			// user's ask or by this engine refusing a sampler it cannot bind, and a final nothing
+			// draws, whose computes the reference builds with the final and never without it. The
+			// plan tells the three apart in its notes; here they take the same road.
+			boolean standalone = !shadow && passing.contains(base.get());
+			if (!shadow && !standalone && !running.contains(base.get())) {
+				Vitrail.logger().warn("compute {} is not dispatched: nothing of this chain runs {}, "
+						+ "and the plan's notes say what took it out", name, base.get());
 				continue;
 			}
 
@@ -252,6 +280,11 @@ final class PackCompute implements AutoCloseable {
 				if (shadow) {
 					passes.add(pass);
 					Vitrail.logger().info("Loaded shadow compute {} ({})", path, sizing(compute.get()));
+				} else if (standalone) {
+					alone.computeIfAbsent(base.get(), _ -> new ArrayList<>()).add(pass);
+					storageTargets.addAll(colourImagesOf(compute.get()));
+					Vitrail.logger().info("Loaded compute {} at the moment of {}, which draws "
+							+ "nothing here ({})", path, base.get(), sizing(compute.get()));
 				} else {
 					chained.computeIfAbsent(base.get(), _ -> new ArrayList<>()).add(pass);
 					storageTargets.addAll(colourImagesOf(compute.get()));
@@ -265,8 +298,10 @@ final class PackCompute implements AutoCloseable {
 
 		chained.values().forEach(list -> list.sort(
 				Comparator.comparing(pass -> ProgramNames.computeLetter(pass.name))));
+		alone.values().forEach(list -> list.sort(
+				Comparator.comparing(pass -> ProgramNames.computeLetter(pass.name))));
 
-		return new PackCompute(passes, chained, storageTargets);
+		return new PackCompute(passes, chained, alone, storageTargets);
 	}
 
 	/** The colour targets a compute names as an image, read off its translated text. */
@@ -306,7 +341,37 @@ final class PackCompute implements AutoCloseable {
 	void dispatchBefore(String program, CommandEncoder encoder, GpuDevice device, PackValues values,
 			ColorTargets targets, TargetSchedule.Bound step, GpuTextureView depth,
 			GpuTextureView distant, int width, int height) {
-		List<Pass> attached = this.chained.get(program);
+		dispatchChain(this.chained.get(program), program, encoder, device, values, targets, step,
+				depth, distant, width, height);
+	}
+
+	/**
+	 * Dispatches the computes hanging off a program this place draws no pass for, at the moment
+	 * that program would have run, which is what Iris does with them. Nothing happens for a name
+	 * with none, which is every name of nearly every pack.
+	 * <p>
+	 * The same road as a chained dispatch and deliberately so: Iris builds one kind of compute for
+	 * both and runs them in the same loop, the only difference being that the pass around them
+	 * draws nothing and is left where the others set their state up
+	 * ({@code CompositeRenderer.java:304-307}). What is not the same is where the halves come from,
+	 * and the caller answers that: {@link TargetSchedule#passing} rather than the step of a pass,
+	 * since there is no pass.
+	 */
+	void dispatchAlone(String program, CommandEncoder encoder, GpuDevice device, PackValues values,
+			ColorTargets targets, TargetSchedule.Bound step, GpuTextureView depth,
+			GpuTextureView distant, int width, int height) {
+		dispatchChain(this.alone.get(program), program, encoder, device, values, targets, step,
+				depth, distant, width, height);
+	}
+
+	/** The programs {@link #dispatchAlone} answers for, which the chain has to find a moment for. */
+	Set<String> standingAlone() {
+		return this.alone.keySet();
+	}
+
+	private void dispatchChain(List<Pass> attached, String program, CommandEncoder encoder,
+			GpuDevice device, PackValues values, ColorTargets targets, TargetSchedule.Bound step,
+			GpuTextureView depth, GpuTextureView distant, int width, int height) {
 		if (attached == null || attached.isEmpty()) {
 			return;
 		}
@@ -314,7 +379,7 @@ final class PackCompute implements AutoCloseable {
 		// The hold first, as the head-of-frame dispatch does: the first pass of a chain half can
 		// still have the geometry's render pass object open over it, and ending the pass
 		// underneath would leave that object to close a pass the encoder no longer has.
-		GeometryHold.flush(() -> "the compute dispatch before " + program);
+		GeometryHold.flush(() -> "the compute dispatch at " + program);
 		GpuRecording.endPass(encoder);
 		VkCommandBuffer commands = commands(encoder);
 		VulkanDevice vulkan = vulkan(device);
@@ -341,7 +406,7 @@ final class PackCompute implements AutoCloseable {
 		}
 
 		if (this.announcedChains.add(program)) {
-			Vitrail.logger().info("Dispatched {} compute pass(es) before {}", attached.size(), program);
+			Vitrail.logger().info("Dispatched {} compute pass(es) at {}", attached.size(), program);
 		}
 	}
 
@@ -415,6 +480,7 @@ final class PackCompute implements AutoCloseable {
 	@Override
 	public void close() {
 		this.passes.forEach(Pass::close);
+		this.alone.values().forEach(list -> list.forEach(Pass::close));
 	}
 
 	private static VkCommandBuffer commands(CommandEncoder encoder) {

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -263,9 +263,12 @@ asked of the device.
 None of this is inference. A compute shader built with that shaderc, dispatched against a storage
 image allocated through VMA, writes texels the same frame reads back unchanged: the road is open,
 and nothing of it was ever in the backend's way. The stage that walks it is `PackCompute`, which
-compiles a pack's `shadowcomp` and dispatches it at the head of the frame, and compiles the
-computes hanging off a full screen pass and dispatches them right before that pass, between two
-barriers of its own since the game's render pass boundary orders graphics against graphics only.
+compiles a pack's `shadowcomp` and dispatches it at the head of the frame, compiles the computes
+hanging off a full screen pass and dispatches them right before that pass, and dispatches a
+compute whose program the place draws no pass for at that program's own moment, its family saying
+whether that falls before the world's translucents or after them and its name where it lands among
+the passes drawn there. Every one of them runs between two barriers of its own, since the game's
+render pass boundary orders graphics against graphics only.
 Which programs it serves, including the pack's own switch deciding whether it serves any at all,
 and why the shadow moment rather than beside the shadow map that feeds it, is answered where the
 pack's chain is.

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -156,10 +156,12 @@ every pack with an unusual dimension name.
 
 **A compute is looked up under the file it ships in, letter included.** A compute hangs off a
 name by a single letter, so `world0/composite21_a` is a key of its own and a pack switching off
-`world0/composite21` has said nothing about it. The reference keeps such a compute and runs it
-with no fragment stage at all, which is why the lookup cannot fall back to the name the letter
-came off. This engine keeps it too, and then has no pass to hang it off: it is named in the log
-as skipped, and its dispatch is a gap still owed.
+`world0/composite21` has said nothing about it. The reference keeps such a compute and runs it as
+a pass with no fragment stage at all, which is why the lookup cannot fall back to the name the
+letter came off. This engine keeps it too, and runs it at the moment the switched-off program
+would have run at: its family says whether that is before the world's translucents or after them,
+and its name says where it falls among the passes drawn there. There is no pass to hang it before,
+so it is dispatched on its own, reading the halves the chain stands on at that point.
 
 Both an empty value and a non-evaluable expression mean enabled: this file is read fail-open.
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -366,11 +366,15 @@ for that path, three different mechanisms, and it is worth knowing which:
   head of the frame, and a compute hanging off a pass the chain draws, begin, prepare, deferred,
   composite or final, right before that pass, the letter-less file first and then in letter
   order, reading and writing the colour targets on the halves the pass itself reads, which is the
-  reference's moment and side for it. Only where the pack keeps it, and a pack that switches the
-  program off takes with it the declarations that program reads, so one switched off does not
-  draw nothing, it does not compile. A setup compute, and a compute whose pass the chain does not
-  draw, which the reference runs as a pass of its own, are named in the log and go no further,
-  translation included.
+  reference's moment and side for it. Only where the pack keeps the compute file itself, and a
+  pack that switches a program off takes with it the declarations that program reads, so one
+  switched off does not draw nothing, it does not compile. A compute whose program this place
+  draws no pass for, the pack having shipped less than both its halves or having switched the
+  program off, runs on its own at that program's own moment: its family puts it before the world's
+  translucents or after them, its name puts it among the passes drawn there, and that is the moment
+  and the side the reference gives it. A setup compute goes no further, and so does a compute of a
+  final this place does not draw and one whose program the pass filter took out of the chain: they
+  are named in the log and nothing translates them.
 - **Storage buffers and storage images are worse than refused on the facade: they are ignored.**
   Reflection asks for uniform buffers, sampled images, outputs and inputs, and never enumerates
   them. On the facade's own walk they pass compilation and are bound to nothing, so the walk is


### PR DESCRIPTION
## What changes

A pack may ship a compute shader for a step of the chain and no drawing program for that step,
either by shipping the compute alone or by shipping both and switching the program off itself. Such
a compute was never dispatched, for want of a pass to dispatch it before, and a place built out of
such computes with no full screen pass at all was refused before its first frame. The compute now
runs at the moment its program would have: its family says whether that is before the world's
translucents or after them, and on which side of the scene seed, and its name says where it lands
among the passes drawn there. A place with no full screen pass is drawn, and keeps the watch on the
device's pipeline cache through the pass that brings its colour to the screen. RenderPearl builds
every one of its worlds that way and none of its computes ever ran; Noble computes the sun's
illuminance and the sky coefficients in one, and everything that lights its world went dark for
want of it.

## How it differs from the reference, and for what obstacle

It does not. Iris builds a pass out of the computes alone at the step's own index
(`pipeline/CompositeRenderer.java:137-145`), refuses a program's name the pack switched off while
still reading its computes (`ShaderPack.java:292-295`, `ProgramSet.java:190-210`), and builds the
computes of a final nothing draws nowhere but inside the final's own map
(`FinalPassRenderer.java:115-125`); this engine follows each of those.

## What proves it

- `gradlew build` green.
- In the game, on this branch's jar: RenderPearl's overworld draws where it used to stop before the
  first frame, and Noble's overworld lights its terrain, its shadows and its fog. The engine's
  own load line names the computes a pass-less place runs alone.
- The sweep of the whole corpus on the jar carrying every fix of this series follows the merge,
  and is where the order of the computes against the world is read off the picture.

## What it leaves owing

A compute standing on a step the user's pass filter cut stays out, as the filter asked. A final
nothing draws keeps its computes out, as the reference does.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
