### PR TITLE
fix(render): free the computes hanging off a pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,13 @@ what the next one holds.
 
 ### Fixed
 
+- **Switching packs no longer leaves graphics memory behind on packs that use compute shaders.**
+  A pack can attach a compute program to a step of its chain, and those programs kept their
+  pipelines and their buffers when the pack was replaced, so every switch and every press of the
+  Reload Shaders key added to what was never given back. Long sessions spent trying packs out ended
+  with graphics memory that only closing the game freed. Photon, which builds its sky lighting in
+  such a compute, is among the packs this held on to.
+
 - **A compute a pack ships for a step of the chain that draws nothing now runs.** It was left out
   on the grounds that there was no pass to run it before; it is now dispatched on its own, at the
   moment the program it hangs off would have run at, which is what Iris does with it: its family

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -477,9 +477,26 @@ final class PackCompute implements AutoCloseable {
 		}
 	}
 
+	/**
+	 * Frees every pass this load built: the shadow computes, the ones hanging off a full screen
+	 * pass, and the ones dispatched at the moment of a program this place draws no pass for.
+	 * <p>
+	 * A pass holds a shader module, a descriptor set layout, a pipeline layout, a pipeline and a
+	 * ring of uniform buffers. {@link Pass#destroy} queues the module, both layouts and the
+	 * pipeline on {@link GpuRecording#destroyLater}, and {@link Pass#close} queues the ring there
+	 * as well rather than closing it where it stands, since this is not a quiet moment: every
+	 * error path of a frame calls {@link PackChain#release} in the middle of one, after the chain
+	 * has dispatched these computes, so a pass is closed while frames that still name its objects
+	 * are in flight.
+	 * <p>
+	 * Every container of passes declared above has to be named here, and one added later has to be
+	 * added here with it: {@link Pass} is private to this class, so a pass this method does not
+	 * reach is a pass nothing can reach, and it lives until the process ends.
+	 */
 	@Override
 	public void close() {
 		this.passes.forEach(Pass::close);
+		this.chained.values().forEach(list -> list.forEach(Pass::close));
 		this.alone.values().forEach(list -> list.forEach(Pass::close));
 	}
 
@@ -1127,7 +1144,7 @@ final class PackCompute implements AutoCloseable {
 			}
 
 			if (this.block != null) {
-				this.block.close();
+				GpuRecording.destroyLater(this.block::close);
 				this.block = null;
 			}
 		}


### PR DESCRIPTION
## What changes

Replacing a pack freed the shadow computes and nothing else. The computes hanging off a full screen
pass live in a container of their own that `close()` never reached, so each of them kept its shader
module, its two layouts, its pipeline and its ring of uniform buffers for the life of the process,
and every pack switch and every press of the Reload Shaders key added another set. They are now
freed on the road the shadow computes already take, and the ring of uniform buffers goes with them
rather than closing where it stands: `PackChain.release()` runs on every error path of a frame, after
these computes have been dispatched, so a pass can be closed with frames still in flight that name
its buffers. Photon builds its sky lighting in such a compute, so a switch away from it left one
behind.

## How it differs from the reference, and for what obstacle

It does not apply: what is freed and when is this engine's own resource lifetime, the reference
having nothing to defer.

## What proves it

- `gradlew build` green.
- The freeing goes through `GpuRecording.destroyLater`, which is the road every other pipeline of
  the pack already takes on a switch, and the buffers through the same deferral rather than an
  immediate close.
- In the game: switching between Photon and another pack, then pressing Reload Shaders, without the
  device losing what the pack in flight still names.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
