### PR TITLE
fix(render): run the prepare stage before the world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,15 @@ what the next one holds.
 
 ### Fixed
 
+- **The world is no longer painted over by the stage meant to run before it.** Some packs open the
+  frame with a "prepare" stage, whose job is to fill a table the rest of the frame reads. It ran
+  once the world was already drawn instead of ahead of it, so on a pack whose prepare fills the very
+  image its terrain, its sky or its hand draws into, that table replaced all of them. On MakeUp
+  UltraFast and on E-LITE the ground vanished behind a pale blue field, the held item was not there
+  and the sky stopped being the brightest thing on screen. The stage now runs at the head of the
+  frame, where the world lands over it, and the begin stage that opens it runs ahead of the shadow
+  map rather than behind it.
+
 - **Switching packs no longer leaves graphics memory behind on packs that use compute shaders.**
   A pack can attach a compute program to a step of its chain, and those programs kept their
   pipelines and their buffers when the pack was replaced, so every switch and every press of the
@@ -127,9 +136,9 @@ what the next one holds.
 - **A compute a pack ships for a step of the chain that draws nothing now runs.** It was left out
   on the grounds that there was no pass to run it before; it is now dispatched on its own, at the
   moment the program it hangs off would have run at, which is what Iris does with it: its family
-  says whether that falls before the world's translucents or after them, and its name says where it
-  lands among the passes drawn there. A pack reaches that state by shipping the compute and no
-  drawing program for the step, or by shipping one and switching it off itself, its switch never
+  says whether that falls before the world, before its translucents or after them, and its name says
+  where it lands among the passes drawn there. A pack reaches that state by shipping the compute and
+  no drawing program for the step, or by shipping one and switching it off itself, its switch never
   naming the compute file. A pack may go further and build every one of its worlds out of such
   computes with no full screen pass at all, which used to stop its chain before the first frame:
   RenderPearl is written that way. Noble computes the sun's illuminance and the sky's coefficients

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -32,8 +32,9 @@ import java.util.stream.Stream;
  * The other thing it owns is the honesty of the picture. The chunk passes fill the targets the
  * pack sends them to and the game's own finished frame stands in for the gbuffers nothing draws
  * yet, in a single target; every other target a pass reads before anything writes it holds a clear
- * colour. Which ones those are, and why, is worked out here and said in the pack's own terms,
- * because the alternative is a plausible image nobody can account for.
+ * colour, or what the frame before left there where the pack keeps that target between frames.
+ * Which ones those are, and why, is worked out here and said in the pack's own terms, because the
+ * alternative is a plausible image nobody can account for.
  */
 public final class ChainPlan {
 
@@ -48,6 +49,19 @@ public final class ChainPlan {
 	 * handed the rank instead would walk the passes again and could reach another answer.
 	 */
 	private static final int DEFERRED_RANK = ProgramNames.frameRank("deferred");
+
+	/**
+	 * Where the prepare stage sits in the frame. Everything at this rank or below belongs before the
+	 * world's opaque geometry, and {@link #prepareEnd()} is the boundary a caller reads instead.
+	 */
+	private static final int PREPARE_RANK = ProgramNames.frameRank("prepare");
+
+	/**
+	 * Where the begin stage sits, which is the head of everything. It cuts the range before the
+	 * world in two, {@link #beginEnd()} being the boundary a caller reads: the begins belong ahead
+	 * of the shadow stage and the prepares behind it.
+	 */
+	private static final int BEGIN_RANK = ProgramNames.frameRank("begin");
 
 	private static final String FINAL = "final";
 
@@ -268,6 +282,8 @@ public final class ChainPlan {
 	}
 
 	private final List<Pass> passes;
+	private final int beginEnd;
+	private final int prepareEnd;
 	private final int deferredEnd;
 	private final Pass last;
 
@@ -335,6 +351,8 @@ public final class ChainPlan {
 			List<String> history) {
 		this.place = place;
 		this.passes = List.copyOf(passes);
+		this.beginEnd = pastRank(this.passes, BEGIN_RANK);
+		this.prepareEnd = pastRank(this.passes, PREPARE_RANK);
 		this.deferredEnd = pastDeferred(this.passes);
 		this.last = last;
 		this.present = present;
@@ -911,15 +929,17 @@ public final class ChainPlan {
 	 * frame before. Which of the two, and why, is what these lines say.
 	 * <p>
 	 * The seed counts from where it is drawn and not from the start of the frame. A begin or a
-	 * prepare runs before the world does, so it reads its target as the clear left it, and calling
-	 * the seed filled from the first pass onwards would drop exactly the notes those passes need.
+	 * prepare runs before the world does, so it reads its target as the frame before left it, and
+	 * calling the seed filled from the first pass onwards would drop exactly the notes those passes
+	 * need.
 	 * <p>
 	 * The world's own passes count from where they are drawn for the same reason, and they are counted
-	 * at all because they really are drawn: the opaque ones before the whole chain, since the chunk
-	 * renderer has finished with them by the time the first half of the frame runs, and the
-	 * translucent ones after the last deferred, which is the whole reason their targets are taken on
-	 * the other snapshot. Reading the geometry off the schedule alone, as this did, blamed the clear
-	 * for a half {@code gbuffers_water} had just written.
+	 * at all because they really are drawn: the opaque ones once the begins and the prepares are
+	 * through, those two stages running while the level's frame graph is built and the chunk renderer
+	 * filling its targets inside it, and the translucent ones after the last deferred, which is the
+	 * whole reason their targets are taken on the other snapshot. Reading the geometry off the
+	 * schedule alone, as this did, blamed the clear for a half {@code gbuffers_water} had just
+	 * written.
 	 *
 	 * @param seed  where the game's finished frame is really painted, or null where the line that
 	 *              paints it is off - or where the plan itself could not say where it would go,
@@ -956,16 +976,22 @@ public final class ChainPlan {
 		// hence one identical Pass: the solid and the cutout pass always, and a pack with no cloud
 		// program of its own has its clouds and its particles answered by the same one too.
 		//
-		// The near side goes in at nought and not where the seed goes. The seed is painted where
-		// OptiFine draws the world, in the middle of the chain, but the game is not: it has drawn the
-		// opaque terrain, the opaque particles and everything else on that side before the first half
-		// of the chain is even asked to run, so a prepare of this engine reads what they wrote in THIS
-		// frame.
+		// The near side goes in where the begins and the prepares end, which is where the seed is
+		// painted and where the game really draws it: those two stages run while the level's frame
+		// graph is being built, and the opaque terrain, the opaque particles and everything else on
+		// that side are drawn after them.
+		//
+		// AT NOUGHT INSTEAD, AS THIS HAD IT, EVERY PREPARE READING A GBUFFER TARGET WAS CALLED A
+		// READER OF A HALF THIS FRAME HAD ALREADY FILLED, and the note it exists to earn was dropped
+		// exactly where the order matters most. What such a pass really reads there is whatever left
+		// that half standing at the end of the frame before, which is the branch below and not
+		// silence.
+		int beforeWorld = pastRank(ordered, PREPARE_RANK);
 		int afterDeferred = pastDeferred(ordered);
 		Map<Integer, Set<Pass>> drawn = new LinkedHashMap<>();
 		world.forEach((key, drawing) -> {
-			drawn.computeIfAbsent(key.afterDeferred() ? afterDeferred : 0, _ -> new LinkedHashSet<>())
-					.add(drawing);
+			drawn.computeIfAbsent(key.afterDeferred() ? afterDeferred : beforeWorld,
+					_ -> new LinkedHashSet<>()).add(drawing);
 			undrawn.removeAll(drawing.targets());
 		});
 
@@ -1009,8 +1035,13 @@ public final class ChainPlan {
 	 * deferreds, so the walk has stopped long before reaching it.
 	 */
 	private static int pastDeferred(List<Pass> ordered) {
+		return pastRank(ordered, DEFERRED_RANK);
+	}
+
+	/** How many of {@code ordered} sit at {@code rank} or below, the list being in frame order. */
+	private static int pastRank(List<Pass> ordered, int rank) {
 		int at = 0;
-		while (at < ordered.size() && ordered.get(at).frameRank() <= DEFERRED_RANK) {
+		while (at < ordered.size() && ordered.get(at).frameRank() <= rank) {
 			at++;
 		}
 
@@ -1041,6 +1072,10 @@ public final class ChainPlan {
 			// Which of the two the reader really gets is the clear directive's answer and never the
 			// order's: a target the pack clears is emptied on BOTH halves at the top of every frame,
 			// so nothing of the frame before is left there to be read.
+			//
+			// The stage that reaches this branch oftenest is the prepares, and the writer it names is
+			// then a gbuffers program: a target the world alone fills holds the world of the FRAME
+			// BEFORE where a prepare samples it, which is what Iris hands one there as well.
 			return new Verdict(name + " is not written until " + later + ", later in the same frame"
 					+ (kept ? before : clear), kept);
 		}
@@ -1147,7 +1182,10 @@ public final class ChainPlan {
 
 	/**
 	 * How many of {@link #passes()} belong before the world's translucents, the deferred stage
-	 * included. It is where the renderer cuts the frame in two.
+	 * included. It is the last of the three points the renderer cuts the frame at, {@link
+	 * #beginEnd()} and {@link #prepareEnd()} being the two before it: what runs ahead of the shadow
+	 * stage, what runs behind it and still before the world, what runs before the world's
+	 * translucents, and what runs after the world.
 	 * <p>
 	 * Answered here and not counted again by the renderer, for the reason this whole class exists:
 	 * the same number already decides where {@link #notes()} puts the translucent chunk pass, and
@@ -1157,6 +1195,41 @@ public final class ChainPlan {
 	 */
 	public int deferredEnd() {
 		return this.deferredEnd;
+	}
+
+	/**
+	 * How many of {@link #passes()} belong before the world's opaque geometry, which is the begins
+	 * and the prepares together. It is the second of the three points the renderer cuts the frame
+	 * at.
+	 * <p>
+	 * <strong>These passes write the very targets the gbuffers write.</strong> A prepare naming a
+	 * draw buffer the terrain, the sky or the hand also names is a full screen write over the half
+	 * they draw into, so run after them it replaces the whole opaque world with whatever the prepare
+	 * computes, which is usually a table built from uniforms alone. OptiFine runs the stage before
+	 * the world and Iris with it, on the last line of its shadow render
+	 * ({@code pipeline/IrisRenderingPipeline.java:1025}, reached before the main pass is submitted),
+	 * so what the gbuffers write lands over the prepare and never under it.
+	 */
+	public int prepareEnd() {
+		return this.prepareEnd;
+	}
+
+	/**
+	 * How many of {@link #passes()} belong ahead of the shadow stage, which is the begins alone. It
+	 * is the first of the three points the renderer cuts the frame at, and everything from here to
+	 * {@link #prepareEnd()} is the prepares.
+	 * <p>
+	 * <strong>The two halves of the range before the world do not run at the same moment.</strong>
+	 * Iris draws its begins at the head of the level render
+	 * ({@code pipeline/IrisRenderingPipeline.java:1014}) and its prepares on the last line of the
+	 * shadow render ({@code :1025}), with the shadow map and the {@code shadowcomp} stage between
+	 * them ({@code shadows/ShadowRenderer.java:632-633}). A pack builds on that order: a prepare
+	 * reads what the shadow stage of this frame has just written, where a begin reads what the frame
+	 * before left, and running the two together puts one of the two at the wrong end of the shadow
+	 * map.
+	 */
+	public int beginEnd() {
+		return this.beginEnd;
 	}
 
 	/** The final. Its attachments are always empty: it writes the game's own target. */

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -809,13 +809,14 @@ public final class TargetPlan {
 	 * <p>
 	 * The scene seed carries in what this engine still leaves to the game - the entities above all,
 	 * already lit and already tone mapped - so this is where that seed goes. It is the point OptiFine
-	 * draws the world at, which is not where the families this engine does draw fill their targets:
-	 * the chunk renderer has finished with the opaque ones before the first pass of the chain runs.
+	 * draws the world at, and it is where the families this engine draws fill their targets too: the
+	 * begins and the prepares run while the level's frame graph is being built, and the chunk
+	 * renderer fills the opaque targets after them and inside it.
 	 * It is answered here rather than downstream because {@link #running()} holds no geometry
 	 * to mark the spot, and a frame that painted the seed anywhere else would contradict the very
 	 * schedule that gave it its half: a begin or a prepare writing the same target would land on
 	 * the wrong side of it, and one sampling it would be handed this frame's world where the walk
-	 * says it reads a clear colour.
+	 * says it reads what the frame before left.
 	 */
 	public int geometryAt() {
 		return this.geometryAt;

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -134,7 +134,7 @@ public final class EngineStages {
 	 * at the end of the frame, for the next one, and this is what the stage needs from here.
 	 * <p>
 	 * It is also the top of the level frame, which is a second thing entirely and is why the first
-	 * line below has nothing to do with the two arguments.
+	 * and the last lines below have nothing to do with the two arguments.
 	 */
 	public static void frameGraphSetup(Matrix4fc modelView, Vec3 cameraPosition) {
 		// First, and before the shadow question below can send this line home: the graph is being
@@ -145,10 +145,32 @@ public final class EngineStages {
 		// mob first comes on screen.
 		PbrTextures.load();
 
-		if (!TerrainDraw.shadows()) {
-			return;
+		// The begins ahead of the shadow stage and the prepares behind it, which is the order
+		// OptiFine runs them in and the order Iris keeps: its begins are the head of the level render
+		// (pipeline/IrisRenderingPipeline.java:1014, from mixin/MixinLevelRenderer.java:123), its
+		// shadow map and the shadowcomp stage that closes it come next
+		// (pipeline/IrisRenderingPipeline.java:1020-1024 over shadows/ShadowRenderer.java:632-633),
+		// and its prepares are the last line of renderShadows (:1025). Drawn as one range on either
+		// side of the shadow stage, one of the two families reads the wrong frame of what that stage
+		// writes: a prepare is meant to read this frame's shadow work, a begin the frame before's.
+		//
+		// Both are outside the shadow gate, because a place with no shadow map still has begins and
+		// prepares, and they belong before the world whether or not anything was drawn from the
+		// light.
+		PackChain.drawBegins();
+
+		if (TerrainDraw.shadows()) {
+			shadowStage(modelView, cameraPosition);
 		}
 
+		PackChain.drawPrepares();
+	}
+
+	/**
+	 * What the shadow map's own stage owes at the head of the level frame, which is only reached
+	 * while a pack draws one.
+	 */
+	private static void shadowStage(Matrix4fc modelView, Vec3 cameraPosition) {
 		ShadowTerrain.capture(modelView, cameraPosition);
 
 		// The pack's shadow compute, HERE at the head of the frame and not beside the shadow map
@@ -183,8 +205,9 @@ public final class EngineStages {
 	 * that: three lines later it copies a depth between two targets, which refuses outright inside
 	 * a pass.
 	 * <p>
-	 * Runs the half of the pack's chain that belongs before the world's translucents: the begins,
-	 * the prepares, the scene seed and the deferred stage. Then redirects the game's translucent
+	 * Runs the half of the pack's chain that belongs before the world's translucents: the scene seed
+	 * and the deferred stage. The begins and the prepares are not in it, having run at the head of
+	 * the frame where the world had yet to be drawn over them. Then redirects the game's translucent
 	 * features into the layer that hands them to the pack's image.
 	 * <p>
 	 * The placement itself and not a refinement of it. BSL's {@code gbuffers_water} reads
@@ -209,7 +232,7 @@ public final class EngineStages {
 		// above has just closed, and BEFORE the deferred stage the last line runs. That is exactly
 		// where Iris puts it, copyPreHandDepth included: beginHand copies, renderSolid draws, and
 		// beginTranslucents then runs the deferreds behind both
-		// (mixin/MixinLevelRenderer.java:277-283, pipeline/IrisRenderingPipeline.java:1051-1073).
+		// (mixin/MixinLevelRenderer.java:271-274, pipeline/IrisRenderingPipeline.java:1043-1065).
 		// Drawn after the deferreds instead, the hand would write gbuffers nothing would ever read.
 		PackChain.markPreHandDepth();
 		HandDraw.drawSolid();
@@ -240,8 +263,8 @@ public final class EngineStages {
 	public static void afterLevel() {
 		// The hand's blending half, before the chain and never after it: what it draws has to be in
 		// the picture the composites read, and this stage is the last moment it can be. Iris draws it
-		// at the same place, one line ahead of its own finalizeLevelRendering
-		// (mixin/MixinLevelRenderer.java:170-179).
+		// at the same place, at the head of the call that ends its level render and so ahead of its
+		// own finalizeLevelRendering (mixin/MixinLevelRenderer.java:162 ahead of :168).
 		HandDraw.drawTranslucent();
 
 		// Nothing is drawn when no pack can be: the game's own image is a better answer than

--- a/common/src/main/java/dev/vitrail/render/HorizonCone.java
+++ b/common/src/main/java/dev/vitrail/render/HorizonCone.java
@@ -57,9 +57,10 @@ import net.minecraft.client.Minecraft;
  * armour decal is the single pipeline that does not blend and does not write depth, and it tests
  * {@code EQUAL}, so it lands only where something in its own phase already wrote one.
  * <p>
- * And the seed never falls outside that half. {@code PackChain.drawRange} paints a rank that lands
- * on the boundary between the two at the tail of the first one, and the plan never puts the world
- * past that boundary: the rank counts the begins and the prepares, and {@code deferredEnd()} counts
+ * And the seed never falls outside that half. Its rank is where that half begins, so
+ * {@code PackChain.drawRange} paints it at the head of the walk, and at the tail of it where the
+ * walk is empty. The plan never puts the world past the far end of the half either: the rank counts
+ * the begins and the prepares, and {@code deferredEnd()} counts
  * those and the deferred stage after them. A place shipping no deferred at all has the two equal,
  * and it is that equality a half open interval loses: the seed would miss the first half and lead
  * the second, at {@code AfterLevel}, by which time the clouds, the weather and the particles are in

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -57,8 +57,10 @@ import java.util.stream.Collectors;
 import java.util.TreeSet;
 
 /**
- * Runs one pack's chain over the finished world: every full screen program the pack keeps on, in
- * frame order, and then its {@code final} onto the game's own target.
+ * Runs one pack's chain around the world: every full screen program the pack keeps on, in frame
+ * order, and then its {@code final} onto the game's own target. Around and not after, the frame
+ * being cut in three: the begins and the prepares before the world is drawn at all, the scene seed
+ * and the deferred stage before its translucents, the composites and the final once it is done.
  * <p>
  * Nothing here decides what runs or which half of a target a pass touches. The plan walked the
  * frame once when the pack was read, {@link ChainPlan} unfolded that walk into attachments, and a
@@ -221,6 +223,12 @@ public final class PackChain {
 	 * names the origin of the world rather than where the player stands.
 	 */
 	private boolean everAdvanced;
+
+	/** Whether the begins, which belong ahead of the shadow stage, have run. */
+	private boolean begun;
+
+	/** Whether the prepares, which belong behind the shadow stage and before the world, have run. */
+	private boolean prepared;
 
 	/** Whether the half of the chain that belongs before the world's translucents has run. */
 	private boolean early;
@@ -947,7 +955,7 @@ public final class PackChain {
 	 * Dispatches {@code shadowcomp} at the head of the frame, over the shadow geometry the frame
 	 * before it wrote.
 	 * <p>
-	 * Iris dispatches it inside its own shadow render ({@code ShadowRenderer.java:631-632}), which is
+	 * Iris dispatches it inside its own shadow render ({@code ShadowRenderer.java:632-633}), which is
 	 * the same moment relative to the READERS: there the map is drawn and read within one frame,
 	 * here the shadow stage stands at the end of a frame and the map is one frame late, so the
 	 * moment that shares the frame of the gbuffers reading the volumes is this one. The caller in
@@ -968,6 +976,16 @@ public final class PackChain {
 		chain.beginFrame();
 		chain.reanchorCustomImages();
 		chain.compute.dispatch(chain.values, chain.targets);
+
+		// And the table goes back to the window every block of the chain is written under, because
+		// the dispatch above leaves the light's standing behind it. This stage stands between the
+		// two ranges the frame opens with, and a compute of the prepares writes its block off the
+		// live table at the moment it is dispatched, where a pass reads a block written once at the
+		// head of the frame: left flipped, a place with a begin ahead of this stage and a shadow
+		// compute in it hands every compute of its prepares the light's window instead of the
+		// screen's. Put back where it is flipped rather than at the head of each range, so that a
+		// range drawn here later cannot forget what it never has to know.
+		chain.values.convention(ClipSpace.REVERSED);
 	}
 
 	/**
@@ -1072,15 +1090,16 @@ public final class PackChain {
 	 * Allocates the colour targets if they are not there and clears them, once a frame, and answers
 	 * whether they can be drawn into.
 	 * <p>
-	 * <strong>This has to happen before the world and not where the chain starts.</strong> The chain
-	 * runs once the world is finished; the terrain writes its targets during it. Clearing where the
-	 * chain starts would therefore throw away everything the terrain had just written, and it would
-	 * do it silently, the targets reading exactly as they do when no geometry runs at all.
+	 * <strong>This has to happen before the world and never where the deferred stage starts.</strong>
+	 * The terrain writes its targets during the world and that stage runs once the world is finished,
+	 * so clearing there would throw away everything the terrain had just written, and it would do it
+	 * silently, the targets reading exactly as they do when no geometry runs at all.
 	 * <p>
 	 * Called from both sides for that reason, whichever comes first: from the terrain, at the point
 	 * the chunk renderer asks for its shader, which is the last moment before it opens a pass; and
-	 * from the chain, for the frames and the configurations where no terrain runs at all. The second
-	 * call is free.
+	 * from the chain, which reaches this at the head of the level frame on a place with a begin or a
+	 * prepare, and on the frames and the configurations where no terrain runs at all otherwise. The
+	 * second call is free.
 	 */
 	boolean openTargets(GpuDevice device) {
 		if (this.opened) {
@@ -1131,6 +1150,8 @@ public final class PackChain {
 		GeometryHold.flush(() -> "the frame before it closing");
 		this.advanced = false;
 		this.opened = false;
+		this.begun = false;
+		this.prepared = false;
 		this.early = false;
 		this.filled = false;
 		this.seeded = false;
@@ -1303,20 +1324,26 @@ public final class PackChain {
 	 * is only the moment the commands are recorded.
 	 *
 	 * @param depth   what this half's programs read as {@code depthtex0}, in the pack's own window:
-	 *                the opaque world before the translucents and the whole scene after
-	 * @param distant what they read as {@code dhDepthTex0}, on the same split: the far terrain
-	 *                before its water and with it after, or null for the far plane on the frames the
-	 *                pack drew no far terrain
+	 *                the opaque world before the translucents and the whole scene after, or null for
+	 *                the far plane on the parts that run before the world, where the game has just
+	 *                emptied its own depth and nothing has drawn into it since
+	 * @param distant what they read as {@code dhDepthTex0}: the far terrain with its water on the
+	 *                parts that run before the world, where the frame before's is what Iris's live
+	 *                image holds, then this frame's without its water up to the world's translucents
+	 *                and with it after, or null for the far plane wherever no far terrain was drawn
+	 * @param seeding whether the game's own frame may be painted inside this range. False on the
+	 *                parts that run before the world: the seed's rank is where the world goes, so it
+	 *                falls on their own end, and there is no world to paint yet
 	 * @param cut     which cut of the frame this range is, which is what says whose standalone
-	 *                computes belong to it. Said rather than read off the bounds: where the whole
-	 *                chain runs before the world the two cuts have the same bounds, and a compute
-	 *                placed by those would run in both of them or in neither
+	 *                computes belong to it. Said rather than read off the bounds: where a cut draws
+	 *                no pass of its own its bounds are empty and sit on a neighbour's, and a compute
+	 *                placed by those would run in the wrong cut or in none
 	 */
 	private void drawRange(GpuDevice device, Ready ready, int from, int to, GpuTextureView depth,
-			GpuTextureView distant, Cut cut) {
+			GpuTextureView distant, boolean seeding, Cut cut) {
 		// Clamped to the list, so that the rank of a chain whose every pass runs before the world is
 		// one the walk below can reach rather than one nothing ever equals.
-		int seedAt = ready.seeding()
+		int seedAt = seeding && ready.seeding()
 				? Math.min(this.chain.chain().seed().map(ChainPlan.Seed::at).orElse(-1),
 						this.programs.size())
 				: -1;
@@ -1333,13 +1360,6 @@ public final class PackChain {
 		// list, and the deferred emptying inside a draw clears every target still owed one.
 		this.currentChains.clear();
 		for (int at = from; at < to; at++) {
-			// The standalones standing on this index are taken in two goes around the seed, as the
-			// end of the range is below: a prepare compute with no prepare pass stands on the first
-			// deferred pass, which is the index the seed is painted at, and its family says it runs
-			// before the world. Noble's world0 is written that way, and taken in one go after the
-			// seed its illuminance was computed over a world already lit by the frame before.
-			dispatchStandalone(cut, at, Reach.AT_INDEX_BEFORE_SEED, encoder, device, ready, depth,
-					distant, this.targets.hasPendingClears());
 			if (!this.seeded && at == seedAt) {
 				paintSeed(encoder, ready);
 				this.currentChains.clear();
@@ -1348,8 +1368,11 @@ public final class PackChain {
 			PackPass pass = this.programs.get(at);
 
 			boolean emptying = this.targets.hasPendingClears();
-			dispatchStandalone(cut, at, Reach.AT_INDEX_AFTER_SEED, encoder, device, ready, depth,
-					distant, emptying);
+			// Where a pass of this index would be drawn, the seed above included: what a cut can still
+			// hold here is of a family the frame runs after the world, the begins and the prepares
+			// having a cut apiece that runs before it and paints no seed at all.
+			dispatchStandalone(cut, at, Reach.AT_INDEX, encoder, device, ready, depth, distant,
+					emptying);
 			if (this.compute.hangsOff(pass.program())) {
 				// The frame's clears are paid before the computes and not inside the draw after
 				// them, where the first pass of the frame pays them: a compute storing into a
@@ -1404,19 +1427,6 @@ public final class PackChain {
 			}
 		}
 
-		// The end of this cut, where the ones no pass of it follows are dispatched: the loop stops
-		// before that index, so without the two calls below the compute of a cut that draws no pass
-		// after it would never run at all. It is where the frame really leaves this part of itself,
-		// and a compute of a family the cut carries has nowhere later to go.
-		//
-		// Taken in two goes with the seed between them, because there is no pass left here to place
-		// them against. The loop puts the seed before the pass its rank falls on and after the one
-		// before it, which is the passes of a family the frame runs no later than the world running
-		// ahead of it; the family answers the same question for a standalone, and the two halves of
-		// this end are what a pass of its name would have been on either side of.
-		dispatchStandalone(cut, to, Reach.PAST_END_BEFORE_SEED, encoder, device, ready, depth,
-				distant, this.targets.hasPendingClears());
-
 		// A rank that falls exactly on the end of this half is painted here, at its tail, and never
 		// at the head of the next one. The world is drawn before the deferred stage and not after
 		// it: walked as a half open range alone, a seed whose rank equals deferredEnd() - which is
@@ -1431,8 +1441,13 @@ public final class PackChain {
 			this.currentChains.clear();
 		}
 
-		dispatchStandalone(cut, to, Reach.PAST_END_AFTER_SEED, encoder, device, ready, depth,
-				distant, this.targets.hasPendingClears());
+		// The end of this cut, where the ones no pass of it follows are dispatched: the loop stops
+		// before that index, so without this call the compute of a cut that draws no pass after it
+		// would never run at all. It is where the frame really leaves this part of itself, and a
+		// compute of a family the cut carries has nowhere later to go. Behind the seed for the reason
+		// the walk's own dispatch is behind it.
+		dispatchStandalone(cut, to, Reach.PAST_END, encoder, device, ready, depth, distant,
+				this.targets.hasPendingClears());
 	}
 
 	/**
@@ -1443,11 +1458,12 @@ public final class PackChain {
 	 * and that rests on one thing: an index below the range cannot happen. The index counts the
 	 * passes that run before the program in frame order, and the head of a cut is the count of
 	 * passes whose rank the earlier cuts carry, every one of which sorts before anything this cut
-	 * holds. A cut added between these two divides the same ranks the same way and keeps it.
+	 * holds. The cuts are lines through the same ranks and nothing else, so however many of them
+	 * the frame is drawn in, each of them keeps it.
 	 *
 	 * @param at       the index the walk has reached
-	 * @param reach    which of them this go takes, every point of the walk being taken in two with
-	 *                 the seed between them
+	 * @param reach    which of them this go takes: those standing on that index, or those the walk
+	 *                 has run out of passes to stand on
 	 * @param emptying whether targets are still owed their clear, which is paid here for the reason
 	 *                 the chained dispatch pays it: a compute storing into a target still owed one
 	 *                 would have its stores emptied by the pass that follows
@@ -1478,35 +1494,17 @@ public final class PackChain {
 	/**
 	 * Which of a cut's standalones one dispatch takes. The walk reaches each of them once: on the
 	 * index of the pass it runs before, or, past the last pass of the cut, at the end of the range.
-	 * Both points are taken twice, with the scene seed painted between the two goes, and the family
-	 * says which go a standalone belongs to: the seed stands at the world's own rank, and a family
-	 * the frame runs no later than the world is dispatched before it.
 	 */
 	private enum Reach {
 
-		/** On the index the loop has reached, those of a family the frame runs no later than the world. */
-		AT_INDEX_BEFORE_SEED(false, false),
+		/** Those standing on the index the loop has reached. */
+		AT_INDEX,
 
-		/** On that index, those of a family it runs after the world. */
-		AT_INDEX_AFTER_SEED(false, true),
-
-		/** Past the last pass, those of a family the frame runs no later than the world. */
-		PAST_END_BEFORE_SEED(true, false),
-
-		/** Past the last pass, those of a family it runs after the world. */
-		PAST_END_AFTER_SEED(true, true);
-
-		private final boolean pastEnd;
-		private final boolean afterSeed;
-
-		Reach(boolean pastEnd, boolean afterSeed) {
-			this.pastEnd = pastEnd;
-			this.afterSeed = afterSeed;
-		}
+		/** Those no pass of the cut follows, taken at the end of the range. */
+		PAST_END;
 
 		boolean takes(Standalone waiting, int at) {
-			return (this.pastEnd ? waiting.at() >= at : waiting.at() == at)
-					&& waiting.afterSeed() == this.afterSeed;
+			return this == PAST_END ? waiting.at() >= at : waiting.at() == at;
 		}
 	}
 
@@ -1516,8 +1514,74 @@ public final class PackChain {
 	}
 
 	/**
-	 * The half of the chain that belongs before the world's translucents: the begins, the prepares,
-	 * the scene seed and the whole deferred stage.
+	 * The begins, which are the head of the chain and belong ahead of the shadow stage.
+	 * <p>
+	 * <strong>The range before the world is cut in two, and the shadow stage stands in the
+	 * cut.</strong> Iris draws its begins at the head of the level render
+	 * ({@code pipeline/IrisRenderingPipeline.java:1014} from
+	 * {@code mixin/MixinLevelRenderer.java:123}), then its shadow map and the {@code shadowcomp}
+	 * stage that closes it ({@code shadows/ShadowRenderer.java:632-633}), and only then its prepares
+	 * ({@code pipeline/IrisRenderingPipeline.java:1025}, the last line of {@code renderShadows}).
+	 * Run together, one of the two ends up on the wrong side of the shadow map: a prepare reads what
+	 * the shadow stage of this frame has just written, and a begin reads what the frame before left.
+	 * <p>
+	 * Called once a frame, while the level's frame graph is being built, which is before any pass of
+	 * it executes and so before one triangle of the world is drawn. Called from {@link #drawEarly}
+	 * too, for the frames that moment came and went on without this being able to draw, and the
+	 * second call is free.
+	 */
+	public static void drawBegins() {
+		PackChain chain = active;
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (disabled || chain == null || device == null || !chainWanted) {
+			return;
+		}
+
+		try {
+			chain.drawBegins(device);
+		} catch (RuntimeException e) {
+			disabled = true;
+			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
+			chain.release();
+		}
+	}
+
+	/**
+	 * The prepares, which belong behind the shadow stage and still before the world's opaque
+	 * geometry.
+	 * <p>
+	 * <strong>These passes write the targets the gbuffers write, so the order between them is the
+	 * picture.</strong> A prepare naming a draw buffer the terrain, the sky or the hand also names
+	 * is a full screen write over the very half they draw into. Run after them it replaces the whole
+	 * opaque world with a table the prepare builds out of uniforms, and what is left on screen is a
+	 * flat field the depth of the scene still shades: the ground gone, the hand gone and the sky no
+	 * longer the brightest thing in the frame.
+	 * <p>
+	 * Called once a frame, from the same moment the begins are and one line behind the shadow stage.
+	 * That is where Iris runs them: the last line of {@code renderShadows}
+	 * ({@code pipeline/IrisRenderingPipeline.java:1025}), which its level renderer mixin calls one
+	 * call ahead of the main pass being submitted ({@code mixin/MixinLevelRenderer.java:181-196}).
+	 * Called from {@link #drawEarly} too, on the same terms as the begins.
+	 */
+	public static void drawPrepares() {
+		PackChain chain = active;
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (disabled || chain == null || device == null || !chainWanted) {
+			return;
+		}
+
+		try {
+			chain.drawPrepares(device);
+		} catch (RuntimeException e) {
+			disabled = true;
+			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
+			chain.release();
+		}
+	}
+
+	/**
+	 * The half of the chain that belongs before the world's translucents: the scene seed and the
+	 * whole deferred stage.
 	 * <p>
 	 * <strong>This is where the deferred stage really belongs, and it is not a refinement.</strong>
 	 * The OptiFine frame runs shadow, prepare, opaque geometry, deferred, translucent geometry,
@@ -1637,8 +1701,8 @@ public final class PackChain {
 	 * one line ahead of it.
 	 * <p>
 	 * The moment is Iris's and so is the reason. Its {@code beginHand} copies the depth and draws no
-	 * hand ({@code pipeline/IrisRenderingPipeline.java:1050-1057}); the solid hand is drawn on the
-	 * line after the call to it, by the mixin ({@code mixin/MixinLevelRenderer.java:279-280}); and the
+	 * hand ({@code pipeline/IrisRenderingPipeline.java:1043-1049}); the solid hand is drawn on the
+	 * line after the call to it, by the mixin ({@code mixin/MixinLevelRenderer.java:271-272}); and the
 	 * {@code beginTranslucents} that copies {@code depthtex1} comes one step behind both. So
 	 * {@code depthtex2} is the only depth of the pair the hand is missing from. A pack reads it to
 	 * see what the hand it is holding stands in front of, and served the image with the hand in it
@@ -1881,10 +1945,147 @@ public final class PackChain {
 		}
 	}
 
+	/**
+	 * Draws the begins, on the far plane and the depths of the frame before.
+	 * <p>
+	 * <strong>The depth names do not answer alike here, and Iris is why.</strong> Its
+	 * {@code depthtex0} is the game's own main depth texture, live
+	 * ({@code samplers/IrisSamplers.java:228-230} through
+	 * {@code targets/RenderTargets.java:139-141}), and the game empties that texture before the
+	 * level renderer is entered at all: {@code GameRenderer.render} clears the main colour and depth
+	 * ({@code GameRenderer.java:408-412}) and only then calls {@code renderLevel} ({@code :429}),
+	 * which is where the frame graph is built. So the name holds a cleared depth at this moment,
+	 * which is the far plane, and nothing of the frame before. Its {@code depthtex1} and
+	 * {@code depthtex2} are two copies Iris owns instead
+	 * ({@code targets/RenderTargets.java:143-153}), rewritten inside {@code beginTranslucents} and
+	 * {@code beginHand} ({@code pipeline/IrisRenderingPipeline.java:1063} and {@code :1048}), both
+	 * later in the frame, so those two really do hand the stage the frame before.
+	 * <p>
+	 * That is what is handed here. The far plane goes in as {@code depthtex0} by passing no image at
+	 * all, which is the answer this engine already gives a {@code dhDepthTex} on a frame with no far
+	 * terrain. {@code depthtex1} is the opaque image, which is not forgotten at the frame boundary
+	 * and so is the frame before's at this point of the frame; {@code depthtex2} and the far
+	 * terrain's two images are forgotten there, and {@link PackDepth#frameBefore} is what serves the
+	 * frame before's for the length of this range and takes them away again after it.
+	 */
+	private void drawBegins(GpuDevice device) {
+		if (this.begun) {
+			return;
+		}
+
+		// A place with nothing at all in this range is left alone entirely, and the early return is
+		// the whole of what keeps it so: everything below opens the frame, writes the blocks and
+		// clears the targets, and a place with neither family goes on paying all three at the moment
+		// it always paid them at rather than at the head of the frame. A compute standing on its own
+		// is something in the range: it is then all the range runs, and refusing it for want of a pass
+		// would drop the one thing the pack asked for there.
+		if (this.chain.chain().beginEnd() == 0 && !standing(Cut.AHEAD_OF_SHADOWS)) {
+			this.begun = true;
+
+			return;
+		}
+
+		Ready ready = ready(device);
+		if (ready == null) {
+			return;
+		}
+
+		this.begun = true;
+		drawBeforeWorld(device, ready, 0, beginEnd(), Cut.AHEAD_OF_SHADOWS);
+	}
+
+	/**
+	 * Draws the prepares, on the same depths the begins were drawn on: the shadow stage stands
+	 * between the two ranges and writes no depth of the world.
+	 */
+	private void drawPrepares(GpuDevice device) {
+		if (this.prepared) {
+			return;
+		}
+
+		// The same early return as the begins', on this range's own emptiness. Together the two keep
+		// a place with neither family out of the head of the frame entirely.
+		if (this.chain.chain().beginEnd() == this.chain.chain().prepareEnd()
+				&& !standing(Cut.BEFORE_WORLD)) {
+			this.prepared = true;
+
+			return;
+		}
+
+		Ready ready = ready(device);
+		if (ready == null) {
+			return;
+		}
+
+		this.prepared = true;
+		drawBeforeWorld(device, ready, beginEnd(), prepareEnd(), Cut.BEFORE_WORLD);
+	}
+
+	/**
+	 * Whether a compute stands alone in that cut, which is a range with work in it and no pass.
+	 * <p>
+	 * Read off the computes the pack shipped and never off {@link #standalone}, which says the same
+	 * thing but only once {@link #build} has filled it. Both callers are early returns that run
+	 * BEFORE {@link #ready}, and build() is inside ready(): read off the field, the answer on the
+	 * first drawable frame of every load is that the range is empty, so the range is latched and the
+	 * one dispatch it holds is lost for that frame, which is the very thing those early returns are
+	 * written not to do. The cut comes from the program's family here exactly as it does there, so
+	 * the two agree from the frame the field is filled on.
+	 */
+	private boolean standing(Cut cut) {
+		for (String program : this.compute.standingAlone()) {
+			if (Cut.of(program) == cut) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** One of the two ranges that run before the world, inside the window of the frame before. */
+	private void drawBeforeWorld(GpuDevice device, Ready ready, int from, int to, Cut cut) {
+		PackDepth depth = this.targets.depth();
+		depth.frameBefore(true, ready.main().width, ready.main().height);
+		try {
+			// Null for the far plane rather than an image, which is what the game has left in its own
+			// depth at this point of the frame. The far terrain's is read inside the window, so what
+			// goes in is the image the frame before drew and not the nothing this frame holds, and it
+			// is the one WITH the water: Iris hands dhDepthTex0 the live texture of Distant Horizons,
+			// which after a frame it drew holds the far terrain's water as well.
+			drawRange(device, ready, from, to, null, depth.distantScene(), false, cut);
+		} finally {
+			depth.frameBefore(false, ready.main().width, ready.main().height);
+		}
+	}
+
 	private void drawEarly(GpuDevice device) {
 		if (this.early) {
 			return;
 		}
+
+		// First, because a frame that never reached the graph's setup with a chain to draw still owes
+		// its begins and its prepares, and owes them before anything below reads what they wrote. On
+		// every ordinary frame both have already run and the two calls cost a field read each.
+		//
+		// WHICH FRAMES REACH THEM HERE, since the depth they read on this road is not the one they
+		// read on the other. The setup runs at the head of every level frame, LevelRenderer.render on
+		// Fabric and the frame graph event on NeoForge, so the only frames left to this line are the
+		// ones where the chain could not draw yet when the graph was built and can by now: the frame
+		// a load or a reload finishes warming on, ready() compiling one pipeline per call and being
+		// called twice a frame, and a frame the pack was turned on in the middle of.
+		//
+		// THE DIVERGENCE THAT LEAVES. Iris always draws them ahead of its own copies: its begins at
+		// IrisRenderingPipeline.java:1014 and its prepares at :1025, both before beginHand rewrites
+		// noHand at :1043-1048, so what they read for depthtex2 and for the far terrain is the frame
+		// before's whatever the frame did. Here EngineStages.java:227 and :237 have already taken
+		// both by the time this line is reached, so on these frames the window serves this frame's
+		// images instead of the previous frame's. It cannot be matched without keeping a second copy
+		// of each all frame long, which is a full screen image apiece to be right on the frames a
+		// pack finishes compiling. What it costs is that a prepare reading depthtex2 or dhDepthTex
+		// there sees the world of the frame it is opening rather than the one behind it, on the one
+		// frame per load where nothing else of the pack is on screen yet either.
+		drawBegins(device);
+		drawPrepares(device);
 
 		Ready ready = ready(device);
 		if (ready == null) {
@@ -1902,19 +2103,18 @@ public final class PackChain {
 				ready.depthView(), ready.main().width, ready.main().height);
 
 		// Here and not after the deferreds, because here is Iris's beginHand: it is called at the
-		// head of iris$beginTranslucents, MixinLevelRenderer.java:277-279, which is before the solid
+		// head of iris$beginTranslucents, MixinLevelRenderer.java:271, which is before the solid
 		// hand, before the world's translucents and before beginTranslucents runs the deferred
 		// stage. So the deferreds below read the value of THIS frame rather than of the one before.
 		// What is NOT the same is that the hand has already been drawn by the time this line is
 		// reached, which is why the fold reads the copy kept before it rather than the image the
 		// line above has just taken. Outside any render pass, since it opens one.
 		//
-		// The begins and the prepares are in the range below too, so they read this frame's texel
-		// where under Iris they would read the previous frame's: it runs both before beginHand,
-		// IrisRenderingPipeline.java:1022 and :1033, the prepares from inside renderShadows and so
-		// before the opaque world exists at all. That difference is where this chain runs its begins
-		// and prepares and not what this line decides, and no pack of the corpus declares the name
-		// in either family.
+		// The begins and the prepares are not in the range below. Both run ahead of beginHand under
+		// Iris: the begins at IrisRenderingPipeline.java:1014, the prepares at :1025 from inside
+		// renderShadows and so before the opaque world exists at all, beginHand itself at :1043. So
+		// what they read of this texel is the frame before's. drawBegins and drawPrepares run them at
+		// that same point of the frame here, and say which of the depth names is the frame before's.
 		sampleCenterDepth(device);
 		// Here because the opaque depth taken above is this frame's, and because the matrices have
 		// been advanced once for this frame already, so what the pass calls the previous pair really
@@ -1932,31 +2132,39 @@ public final class PackChain {
 			vectors.standDown();
 		}
 
+		int world = prepareEnd();
 		int end = deferredEnd();
 		if (!this.split) {
 			this.split = true;
 			// Said once, because the alternative is a chain that silently runs entirely after the
 			// world again: nothing on screen tells the two apart, and the pack that needs the split
-			// is the one whose water disappears.
+			// is the one whose water disappears. The first count is said apart from the second for
+			// the same kind of reason: a prepare run after the world writes over the gbuffers it was
+			// meant to be written over by, and that too looks like a pack of its own rather than
+			// like a misplaced stage.
 			//
-			// A place with no full screen pass says what it does instead. The line above would read
-			// as two noughts and an empty list, which is a chain that runs nothing at all, and what
-			// this one really runs is its computes: they are named, since a place that draws no pass
-			// has nothing else to be recognised by.
+			// A place with no full screen pass says what it does instead. The line below would read
+			// as three noughts and two empty lists, which is a chain that runs nothing at all, and
+			// what this one really runs is its computes: they are named, since a place that draws no
+			// pass has nothing else to be recognised by.
 			if (this.programs.isEmpty()) {
 				Vitrail.logger().info("This chain draws no full screen pass and runs its computes on "
 						+ "their own: {}", this.standalone.stream()
 								.map(Standalone::program)
 								.toList());
 			} else {
-				Vitrail.logger().info("{} of this chain run before the world's translucents, {} after: {}",
-						end, this.programs.size() - end,
-						this.programs.stream().limit(end).map(PackPass::path).toList());
+				Vitrail.logger().info("{} of this chain run before the world {}, {} more before its "
+						+ "translucents {}, {} after",
+						world, this.programs.stream().limit(world).map(PackPass::path).toList(),
+						end - world,
+						this.programs.stream().skip(world).limit(end - world).map(PackPass::path)
+								.toList(),
+						this.programs.size() - end);
 			}
 		}
 
-		drawRange(device, ready, 0, end, this.targets.depth().opaque(),
-				this.targets.depth().distantOpaque(), Cut.BEFORE_TRANSLUCENTS);
+		drawRange(device, ready, world, end, this.targets.depth().opaque(),
+				this.targets.depth().distantOpaque(), true, Cut.BEFORE_TRANSLUCENTS);
 	}
 
 	/**
@@ -1969,6 +2177,16 @@ public final class PackChain {
 	 */
 	private int deferredEnd() {
 		return Math.min(this.chain.chain().deferredEnd(), this.programs.size());
+	}
+
+	/** The same clamp on the boundary the world's opaque geometry is drawn at. */
+	private int prepareEnd() {
+		return Math.min(this.chain.chain().prepareEnd(), this.programs.size());
+	}
+
+	/** The same clamp on the boundary the shadow stage stands at, which the begins end on. */
+	private int beginEnd() {
+		return Math.min(this.chain.chain().beginEnd(), this.programs.size());
 	}
 
 	private void run() {
@@ -2013,7 +2231,7 @@ public final class PackChain {
 		}
 
 		drawRange(device, ready, deferredEnd(), this.programs.size(), this.targets.depth().scene(),
-				this.targets.depth().distantScene(), Cut.AFTER_TRANSLUCENTS);
+				this.targets.depth().distantScene(), true, Cut.AFTER_TRANSLUCENTS);
 
 		// After the whole chain and before the halves swap back, which is where a final would have
 		// drawn. Only on a pack that ships none; ChainPresent says what it stands in for.
@@ -2035,8 +2253,8 @@ public final class PackChain {
 	 * <strong>The opaque world's depth from before the hand</strong>, which is the copy
 	 * {@link #markPreHandDepth} keeps and not the image {@link #drawEarly} has just taken. Iris folds
 	 * the live depth attachment inside {@code beginHand}
-	 * ({@code pipeline/IrisRenderingPipeline.java:1051-1052}), which its level renderer mixin calls
-	 * on the line before the solid hand is drawn ({@code mixin/MixinLevelRenderer.java:279-280}), so
+	 * ({@code pipeline/IrisRenderingPipeline.java:1044}), which its level renderer mixin calls
+	 * on the line before the solid hand is drawn ({@code mixin/MixinLevelRenderer.java:271-272}), so
 	 * what it folds has no hand in it. This chain runs a step later, and folded from the image the
 	 * hand is in, one texel wide, the focus lands on the item being held whenever it covers the
 	 * middle of the screen and the whole scene behind it goes soft. The image with the hand is the
@@ -2151,7 +2369,13 @@ public final class PackChain {
 		return all;
 	}
 
-	/** The last rank the early cut carries, which is the rank the plan cuts the pass list at. */
+	/** The last rank the begins' cut carries, which is the rank the plan cuts the pass list at. */
+	private static final int BEGIN_RANK = ProgramNames.frameRank("begin");
+
+	/** The same for the prepares' cut, and the same boundary of the plan. */
+	private static final int PREPARE_RANK = ProgramNames.frameRank("prepare");
+
+	/** The same for the cut that ends on the world's translucents. */
 	private static final int DEFERRED_RANK = ProgramNames.frameRank("deferred");
 
 	/**
@@ -2166,29 +2390,50 @@ public final class PackChain {
 	 * a program that is not counted: Pegasus, whose whole chain is composites, has a {@code prepare}
 	 * compute at index nought and a boundary at nought, and the late cut's walk ran it after the
 	 * world.
+	 * <p>
+	 * <strong>The prepares are a cut of their own, and that is what answers for a compute of theirs
+	 * against the scene seed.</strong> Noble's world0 stands a {@code prepare} compute on the first
+	 * deferred pass, which is the index the seed is painted at. Carried by the cut its family names,
+	 * it is dispatched before the world is drawn at all, so there is no seed in that range for it to
+	 * fall on either side of; its world1, which ships the pass, runs the same step at the same moment.
 	 */
 	private enum Cut {
 
-		/** The begins, the prepares, the seed and the deferreds, before the world's translucents. */
+		/** The begins, drawn ahead of the shadow stage and before the world. */
+		AHEAD_OF_SHADOWS,
+
+		/** The prepares, drawn behind that stage and still before the world. */
+		BEFORE_WORLD,
+
+		/** The seed and the deferreds, drawn before the world's translucents. */
 		BEFORE_TRANSLUCENTS,
 
 		/** The composites and the final, drawn after them. */
 		AFTER_TRANSLUCENTS;
 
 		/**
-		 * Where the frame runs the family of that program. One comparison against the last rank a
-		 * cut carries, which is how another cut is added: the ranks are the same ranks and the
+		 * Where the frame runs the family of that program. One comparison against the last rank each
+		 * cut carries, which is how another cut is added: the ranks are the same ranks and every
 		 * boundary the frame graph draws is another line through them.
 		 */
 		static Cut of(String program) {
-			return rankOf(program) <= DEFERRED_RANK ? BEFORE_TRANSLUCENTS : AFTER_TRANSLUCENTS;
+			int rank = rankOf(program);
+			if (rank <= BEGIN_RANK) {
+				return AHEAD_OF_SHADOWS;
+			}
+
+			if (rank <= PREPARE_RANK) {
+				return BEFORE_WORLD;
+			}
+
+			return rank <= DEFERRED_RANK ? BEFORE_TRANSLUCENTS : AFTER_TRANSLUCENTS;
 		}
 	}
 
 	/**
 	 * Where the frame runs a program, read off its family and never off a position in a list: it is
-	 * what places a program the chain draws nothing for, both against the cut boundary and against
-	 * the scene seed.
+	 * what places a program the chain draws nothing for, against every boundary the frame is cut
+	 * at.
 	 */
 	private static int rankOf(String program) {
 		return ProgramNames.frameRank(ProgramNames.familyOf(TargetName.bareName(program)));
@@ -2197,24 +2442,19 @@ public final class PackChain {
 	/**
 	 * A compute of a program this place draws no pass for, with where the walk dispatches it.
 	 *
-	 * @param cut       the cut of the frame its family belongs to, which is the whole of what decides
-	 *                  whether it runs before the world's translucents or after them
-	 * @param at        the index in {@link #programs} of the first pass that runs after it, or the
-	 *                  length of the list where every pass of the chain runs before it. Past the end
-	 *                  of its own cut it is dispatched at that end, the cut being where the frame
-	 *                  stops carrying its family at all
-	 * @param program   the program it hangs off, which is the name its halves and its texture stage
-	 *                  are read under however little of it is drawn
-	 * @param step      the halves it reads, from {@link TargetSchedule#passing} and never from a
-	 *                  pass: there is none, and the step of the pass after it would carry the flips
-	 *                  of every stage opened in between
-	 * @param afterSeed whether the frame runs its family after the world, the scene seed standing at
-	 *                  the world's own rank. Past the last pass of its cut there is nothing left to
-	 *                  place it against, and this is the side of the seed a pass of its name would
-	 *                  have drawn on
+	 * @param cut     the cut of the frame its family belongs to, which is the whole of what decides
+	 *                which of the frame's four moments it runs at
+	 * @param at      the index in {@link #programs} of the first pass that runs after it, or the
+	 *                length of the list where every pass of the chain runs before it. Past the end of
+	 *                its own cut it is dispatched at that end, the cut being where the frame stops
+	 *                carrying its family at all
+	 * @param program the program it hangs off, which is the name its halves and its texture stage are
+	 *                read under however little of it is drawn
+	 * @param step    the halves it reads, from {@link TargetSchedule#passing} and never from a pass:
+	 *                there is none, and the step of the pass after it would carry the flips of every
+	 *                stage opened in between
 	 */
-	private record Standalone(Cut cut, int at, String program, TargetSchedule.Bound step,
-			boolean afterSeed) {
+	private record Standalone(Cut cut, int at, String program, TargetSchedule.Bound step) {
 	}
 
 	/**
@@ -2232,12 +2472,6 @@ public final class PackChain {
 	 * draws no full screen pass at all and ships five such computes, so all five stand on index
 	 * nought, and taken in the order their file names came out of the map its {@code deferred} ran
 	 * after its {@code composite3}.
-	 * <p>
-	 * Each carries which side of the scene seed its family falls on as well, for the index the seed
-	 * is painted at and for the end of a range, where the index has run out of passes to name and
-	 * the seed is the only thing left to be placed against. Noble's world0 paints the seed at index
-	 * nought and stands a {@code prepare} compute on that same index, so without the family the one
-	 * step ran after the world there and before it in its world1, which ships the pass.
 	 */
 	private List<Standalone> standaloneOf(List<PackPass> built) {
 		if (this.compute.standingAlone().isEmpty()) {
@@ -2262,8 +2496,7 @@ public final class PackChain {
 				at++;
 			}
 
-			waiting.add(new Standalone(Cut.of(program), at, program, step,
-					rankOf(program) > ProgramNames.GEOMETRY_RANK));
+			waiting.add(new Standalone(Cut.of(program), at, program, step));
 		}
 
 		waiting.sort(Comparator.comparing(Standalone::program, order));
@@ -2585,29 +2818,42 @@ public final class PackChain {
 		// The clocks, the counters and the previous frame's matrices move at the frame boundary and
 		// never here: two passes of one frame have to be handed the same numbers, or the second one
 		// silently reprojects against itself and a smooth() of the pack fades at twice the speed.
-		// A terrain program runs during the world, so it may already have opened this frame.
+		// Idempotent, and whoever gets here first pays it, WHICH IS OFTEN NOT THIS LINE. A pack with
+		// a begin opens the frame here, at the head of the level frame and one step ahead of the
+		// shadow stage. A pack with no begin and a shadow compute opens it at dispatchShadowCompute
+		// instead, PackChain.java:964, which stands between the two ranges and carries a reason of
+		// its own; a pack with a prepare and neither of those opens it here too, one step behind
+		// that stage. On a place with none of the three, the terrain opens it during the world and
+		// this is free.
 		beginFrame();
 
-		// Said rather than inherited. Every pass of the chain draws into a target the game rasterised
-		// under a reversed Z, and the shadow programs, which draw into one of ours and flip this to
-		// the forward window, have already run by the time this does.
+		// Said rather than inherited, and what makes it necessary is that the table is shared rather
+		// than the moment this line runs at. Every value below is left standing by whoever wrote it
+		// last and is put back by nothing in between: from the head of the frame, where a place with
+		// a begin or a prepare reaches this, that is the previous frame's shadow map, drawn at the
+		// tail of it under the forward window; from the deferred stage, where a place with none of
+		// the three still reaches it, that is this frame's sky, terrain and entities. The one flip
+		// this frame makes between the two ranges puts itself back, dispatchShadowCompute saying
+		// why. Every pass of the chain draws into a target the game rasterised under a reversed Z,
+		// whichever it was.
 		this.values.convention(ClipSpace.REVERSED);
 
 		// The same, and for a sharper reason: renderStage is in the table a full screen pass shares
-		// with a geometry one, and the sky, the terrain and the entities have all written theirs by the time
-		// this runs. Left standing, every composite of the frame would be told it was drawing the moon.
+		// with a geometry one, so a stage left standing is read by the whole chain. On the frames
+		// this runs after the sky it would tell every composite it was drawing the moon.
 		this.values.renderStage(RenderStage.NONE);
 
 		// And the same again for three of the four values a pass writes beside it, the alpha
 		// reference being the one kept, ViewSource.passAlphaTest saying why. Two geometry families
 		// set a matrix of their own: the sky pushes the rotation of the day, and the hand is drawn
 		// under an identity model view and sets a whole projection besides, the head-up volume with
-		// its clip depth squeezed to an eighth. Whichever drew last would
-		// otherwise stand in for the camera in every composite of the frame - the hand's case is
-		// the worst of the three, the squeezed volume reprojecting the whole screen - and in the
-		// decoded dump beside it. The frame boundary drops them as
-		// well and that is not the same guard: it drops them at the head of the frame, and every one
-		// of those families writes after it and before this.
+		// its clip depth squeezed to an eighth. Whichever set one last would otherwise stand in for
+		// the camera in every composite of the frame, and in the decoded dump beside it; the hand's
+		// case is the worst of the three, the squeezed volume reprojecting the whole screen.
+		//
+		// Nothing is owed in the other direction. GeometryProgram.writeBlock sets all of these again
+		// before every geometry block it writes, the convention and the render stage included, so
+		// what this line leaves neutral never reaches a pass of the world.
 		this.values.modelView(null, null);
 		this.values.passColour(null);
 		this.values.projection(null);

--- a/common/src/main/java/dev/vitrail/render/PackDepth.java
+++ b/common/src/main/java/dev/vitrail/render/PackDepth.java
@@ -77,7 +77,7 @@ import java.util.Optional;
  * texture beside the other two ({@code targets/RenderTargets.java:73}), rebuilds it on a resize or
  * a depth format change like the pair ({@code targets/RenderTargets.java:172-178}) and refills it
  * once a frame, its copy being called unconditionally
- * ({@code targets/RenderTargets.java:234} from {@code pipeline/IrisRenderingPipeline.java:1056}).
+ * ({@code targets/RenderTargets.java:234} from {@code pipeline/IrisRenderingPipeline.java:1048}).
  * What a pack reads is the same either way, and that is
  * the whole of why the difference is allowed to stand: nothing between the two moments writes the
  * game's depth except the hand's own solid pass, so on a frame that draws no hand the two images
@@ -85,6 +85,52 @@ import java.util.Optional;
  * the difference buys is one full screen image and one conversion a frame, which arrive with
  * {@code hand=on} and go with it: {@link #forgetPreHand} hands the image back the frame the family
  * stops being this engine's, and the conversion is only paid on the frames a hand is really drawn.
+ * <p>
+ * <strong>The images a frame boundary forgets are still served to the one stage that runs before
+ * the world.</strong> The begins and the prepares are drawn while the level's frame graph is being
+ * built, so this frame has taken neither the pre-hand image nor the far terrain's yet, and what
+ * Iris hands those programs there is the frame before's: its {@code noHand} is only rewritten from
+ * inside {@code beginHand} ({@code pipeline/IrisRenderingPipeline.java:1043-1048}) and Distant
+ * Horizons' own depth only where that mod draws, both later in the frame, and neither image is
+ * emptied in between, each name resolving to a texture nothing clears
+ * ({@code targets/RenderTargets.java:151-153} and {@code compat/dh/DHCompatInternal.java:256-258}).
+ * {@link #frameBefore} opens that window here and closes it again. It costs nothing: the
+ * forgettings already lower a flag and leave the image where it was, so what the stage is served is
+ * memory this class was holding anyway, no second conversion is paid for it, and every reader after
+ * the window goes on finding nothing until this frame has filled the image itself.
+ * <p>
+ * <strong>What the window may serve is the frame before and never a frame older than that</strong>,
+ * which is the whole of what the kept flags are for. They are raised at the frame boundary out of
+ * the per frame flags rather than at the take, so each of them says that the frame just ended
+ * really filled that image and nothing weaker.
+ * <p>
+ * The hand's is the one the difference is sharpest on. Iris copies {@code noHand} on every frame
+ * whether a hand is drawn or not, the call sitting at the head of {@code beginHand} and
+ * {@code beginHand} being made unconditionally ({@code mixin/MixinLevelRenderer.java:271}), so what
+ * its {@code depthtex2} holds at the head of a frame is always the opaque world of the frame before
+ * without the hand. Here the image is only taken on the frames a hand is really drawn, so the
+ * window serves it when the frame before drew one and falls through to the opaque image when it did
+ * not, and the fall through is the same depth to the bit: nothing between the two takes writes the
+ * game's depth except the hand's own solid pass, which drew nothing on such a frame. What the
+ * window must never do is serve that image across a run of frames that drew no hand, which is a
+ * pre-hand depth as old as the last held item.
+ * <p>
+ * The far terrain's is the same rule against a different reference. Iris's {@code dhDepthTex0} is
+ * DH's live texture and nothing of Iris's own ({@code compat/dh/DHCompatInternal.java:256-258},
+ * attached at {@code :166-172} from the event that fires as DH clears it), so it holds the far
+ * terrain of the frame before wherever DH drew that frame, water included, and answers texture
+ * nought where DH is absent or its rendering off ({@code compat/dh/DHCompat.java:153-154}). The
+ * window follows both halves: the frame before's images when it drew the far terrain, the far plane
+ * when it did not. {@link #distantScene} is what {@code dhDepthTex0} reads there and
+ * {@link #distantOpaque} what {@code dhDepthTex1} reads, which is the pair Iris keeps and costs no
+ * copy that was not taken already.
+ * <p>
+ * <strong>A screen that moved between the two frames drops what it outgrew.</strong> Every
+ * {@code ensure} of this class runs at take time, which is later in the frame than the window, so a
+ * frame opened at a new size would otherwise find the kept images at the old one and stretch a
+ * depth over the screen rather than fail. Dropping them costs the far plane for one frame, and it
+ * is the cheap half of the choice: resizing them at the window would allocate a full screen image
+ * inside the frame graph build to hold a depth that is about to be retaken anyway.
  */
 final class PackDepth {
 
@@ -245,6 +291,30 @@ final class PackDepth {
 	 */
 	private boolean distantOpaqueWritten;
 	private boolean distantSceneWritten;
+
+	/**
+	 * Whether the third image and the far terrain's pair hold the depth of the frame that has just
+	 * ended, which is the one thing the three per frame flags above cannot say once they are down.
+	 * <p>
+	 * Raised at the frame boundary out of those flags and nowhere else, which is what keeps them
+	 * exactly one frame wide: an image the boundary has forgotten still holds the frame before's
+	 * depth, but only if that frame is the one that filled it, where a fresh image holds whatever
+	 * the driver left there and an image several frames old holds a camera that has moved on. They
+	 * are only ever served inside {@link #frameBefore}'s window.
+	 */
+	private boolean preHandKept;
+	private boolean distantOpaqueKept;
+	private boolean distantSceneKept;
+
+	/**
+	 * Whether the reader is the stage that runs before the world's opaque geometry, which is the one
+	 * window the two images above are served through.
+	 * <p>
+	 * A moment of the frame and not a property of the pass, which is why it is a latch here rather
+	 * than an argument on every draw: a begin, a prepare and a compute hanging off either all ask
+	 * the same question at that point of the frame, and all three want the same answer.
+	 */
+	private boolean frameBefore;
 
 	private boolean broken;
 
@@ -423,9 +493,16 @@ final class PackDepth {
 	 * width, a refusal already logged at this size and being met again, and {@link #fill} finding no
 	 * quad, no live depth or no image to draw into. None of them is a state a line would add
 	 * anything to.
+	 * <p>
+	 * Inside {@link #frameBefore}'s window it is the frame before's image instead, and only when
+	 * that frame is the one that filled it. A frame before that drew no hand falls through to the
+	 * opaque image with the rest, which is the same depth to the bit on such a frame; the class
+	 * comment says why that is the answer there and a held image several frames old is not.
 	 */
 	GpuTextureView preHand() {
-		return this.preHandWritten ? this.preHand.view() : null;
+		return this.preHandWritten || (this.frameBefore && this.preHandKept)
+				? this.preHand.view()
+				: null;
 	}
 
 	/**
@@ -446,14 +523,30 @@ final class PackDepth {
 	/**
 	 * The far terrain's depth without its water, or null while this frame has none. Null falls back
 	 * to the far plane, which is what the name answered before the pack drew the far terrain at all.
+	 * <p>
+	 * Inside {@link #frameBefore}'s window it is the frame before's image, on the same argument as
+	 * the one above: the far terrain of this frame has not been drawn yet when the stage runs, and
+	 * a frame before that drew none leaves the far plane rather than an older far terrain.
 	 */
 	GpuTextureView distantOpaque() {
-		return this.distantOpaqueWritten ? this.distantOpaque.view() : null;
+		return this.distantOpaqueWritten || (this.frameBefore && this.distantOpaqueKept)
+				? this.distantOpaque.view()
+				: null;
 	}
 
-	/** The far terrain's depth with its water in, or null while this frame has none. */
+	/**
+	 * The far terrain's depth with its water in, or null while this frame has none.
+	 * <p>
+	 * Inside {@link #frameBefore}'s window it is the frame before's image, which is what makes it
+	 * the answer for {@code dhDepthTex0} there rather than the one without the water: Iris hands
+	 * that name DH's own live texture, and after a frame DH drew, that texture holds the far terrain
+	 * with its water. The image is retaken on every frame the far terrain is served, so keeping it
+	 * across the boundary costs a flag and no copy.
+	 */
 	GpuTextureView distantScene() {
-		return this.distantSceneWritten ? this.distantScene.view() : null;
+		return this.distantSceneWritten || (this.frameBefore && this.distantSceneKept)
+				? this.distantScene.view()
+				: null;
 	}
 
 	/**
@@ -461,10 +554,64 @@ final class PackDepth {
 	 * hand's image is forgotten there: they are only filled on the frames the pack really drew the
 	 * far terrain, so a flag left standing would serve a stale one. The memory stays, like the
 	 * hand's, because the frames that fill it again are every frame Distant Horizons draws.
+	 * <p>
+	 * What the boundary keeps is exactly what this frame filled, so that the window before the next
+	 * world serves the frame before and a frame that drew no far terrain leaves the far plane there.
 	 */
 	void forgetDistant() {
+		this.distantOpaqueKept = this.distantOpaqueWritten;
+		this.distantSceneKept = this.distantSceneWritten;
 		this.distantOpaqueWritten = false;
 		this.distantSceneWritten = false;
+	}
+
+	/**
+	 * Opens or closes the window in which {@link #preHand}, {@link #distantOpaque} and
+	 * {@link #distantScene} answer with the image the frame before left, which is the range of the
+	 * chain that runs ahead of the world's opaque geometry and nothing else.
+	 * <p>
+	 * The caller closes it in a {@code finally}: left open, a pass drawn later in the frame would
+	 * read a depth one frame of camera movement out of date, which is the one kind of picture this
+	 * class is built to refuse.
+	 * <p>
+	 * The size is the screen the stage is about to draw at, and opening the window drops every kept
+	 * image that is not at it. The class comment says why dropping them is the answer here and
+	 * resizing them at the window is not. Read only while opening: closing the window has nothing to
+	 * decide.
+	 */
+	void frameBefore(boolean before, int width, int height) {
+		this.frameBefore = before;
+
+		if (before) {
+			dropOutgrown(width, height);
+		}
+	}
+
+	/**
+	 * Forgets every image the screen has moved away from, so that the window serves the far plane
+	 * for the one frame rather than a depth of the right numbers at the wrong size. Each of them is
+	 * reallocated at its own take later in this frame, where {@code ensure} already stood.
+	 */
+	private void dropOutgrown(int width, int height) {
+		if (outgrown(this.opaque, width, height)) {
+			this.opaqueWritten = false;
+		}
+
+		if (outgrown(this.preHand, width, height)) {
+			this.preHandKept = false;
+		}
+
+		if (outgrown(this.distantOpaque, width, height)) {
+			this.distantOpaqueKept = false;
+		}
+
+		if (outgrown(this.distantScene, width, height)) {
+			this.distantSceneKept = false;
+		}
+	}
+
+	private static boolean outgrown(TargetSurface surface, int width, int height) {
+		return surface != null && (surface.width() != width || surface.height() != height);
 	}
 
 	/**
@@ -483,16 +630,23 @@ final class PackDepth {
 	 * built again at every one of them would trade one full screen image, whose real size
 	 * {@link #ensurePreHand} prints, for an allocation a frame.
 	 *
+	 * What the boundary keeps is exactly what this frame filled, and that is the difference between
+	 * a window one frame wide and one arbitrarily deep: on a run of frames that drew no hand - third
+	 * person, empty hands - the flag falls with the first of them, and the window before the next
+	 * world reads the opaque image, which on such a frame is the pre-hand depth itself.
+	 *
 	 * @param held whether the hand is still this engine's to draw, which is the load's answer and
 	 *             not the frame's: it goes false when the family is turned off in the options and
 	 *             when {@code EntityDraw} drops it mid session after a failed draw, and the image
 	 *             has nothing left to be for in either case
 	 */
 	void forgetPreHand(boolean held) {
+		this.preHandKept = this.preHandWritten;
 		this.preHandWritten = false;
 
 		if (!held) {
 			this.preHand = close(this.preHand);
+			this.preHandKept = false;
 			this.preHandBroken = false;
 		}
 	}
@@ -507,6 +661,8 @@ final class PackDepth {
 		this.distantScene = close(this.distantScene);
 		this.distantOpaqueWritten = false;
 		this.distantSceneWritten = false;
+		this.distantOpaqueKept = false;
+		this.distantSceneKept = false;
 		this.distantBroken = false;
 	}
 
@@ -524,6 +680,7 @@ final class PackDepth {
 		this.opaqueWritten = false;
 		this.sceneWritten = false;
 		this.preHandWritten = false;
+		this.preHandKept = false;
 		this.preHandBroken = false;
 	}
 
@@ -607,6 +764,9 @@ final class PackDepth {
 		}
 
 		try {
+			// The kept flag falls with the surface it described, or the stage that runs before the
+			// world would dereference an image this very line has just closed.
+			this.preHandKept = false;
 			this.preHand = close(this.preHand);
 			this.preHand =
 					new TargetSurface("Vitrail depth before the hand", FORMAT, false, width, height);
@@ -667,6 +827,8 @@ final class PackDepth {
 			// very block has just closed.
 			this.distantOpaqueWritten = false;
 			this.distantSceneWritten = false;
+			this.distantOpaqueKept = false;
+			this.distantSceneKept = false;
 			this.distantOpaque = close(this.distantOpaque);
 			this.distantScene = close(this.distantScene);
 			this.distantOpaque = new TargetSurface("Vitrail far terrain depth before its water",

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -31,22 +31,49 @@ The terrain renderer does not move any of this. Every decision below is anchored
 points, and a pass placed at the wrong one produces an image that is plausible and wrong rather
 than an error.
 
-## The chain is cut in two around the translucent world
+## The chain is cut in three around the world
 
-A pack's passes are not all run at the same moment. The chain is split, and each half hangs off one
-of the seams above:
+A pack's passes are not all run at the same moment. The chain is cut in three, and each part hangs
+off a different point of the game's frame:
 
-- the begin and prepare stages, the seed, and the deferred stages run at **after opaque
-  features**, which is before the world's translucent geometry;
+- the begin and prepare stages run while the level's frame graph is being built, which is before any
+  pass of that graph executes and so before one triangle of the world is drawn, with the shadow
+  stage between the two: the begins run ahead of it and the prepares behind it, so a prepare reads
+  what this frame's shadow work has just written and a begin reads what the frame before left;
+- the seed and the deferred stages run at **after opaque features**, which is before the world's
+  translucent geometry;
 - the composite stages and the final pass run at **after level**, once the whole world render is
   done.
 
-That split is what lets the pack's own translucent geometry (water, glass) be drawn into the
-pack's targets on the halves that the deferred stages have already written, which is exactly what
-several packs assume when they sample a colour target from inside their water program.
+What each part reads as depth follows from where it sits. The game empties its own colour and depth
+before it enters the level renderer at all, so the first part reads the **far plane** as the depth
+of the world as drawn: nothing of this frame has been written into it, and nothing of the frame
+before survives there either. The copies are the other way round, since nothing rewrites them until
+later in the frame: the pre-translucent copy, the pre-hand copy and the far terrain's own depth all
+hand that part **the frame before's** images.
 
-The consequence for a pack author: a deferred pass sees the opaque world, and a composite sees the
-world with translucents in it. Placing an effect in the wrong stage is not a subtle difference.
+The frame before's, and never one older than that. The pre-hand copy is only taken on the frames the
+engine really draws something held in front of the camera, and the far terrain's only on the frames
+Distant Horizons really drew. A frame that did neither leaves nothing to hand on, and the first part
+of the next one then reads the pre-translucent copy in place of the pre-hand one, which on such a
+frame is the same depth to the bit, and the far plane in place of the far terrain, which is what a
+pack with no Distant Horizons reads anyway. A screen that changed size between the two frames drops
+all of it for one frame, since those images are reallocated later in the frame than this part runs.
+
+The second part reads this frame's opaque world, and the third reads the whole scene with its
+translucents in it.
+
+The cut around the translucents is what lets the pack's own translucent geometry (water, glass) be
+drawn into the pack's targets on the halves that the deferred stages have already written, which is
+exactly what several packs assume when they sample a colour target from inside their water program.
+The cut around the opaque world is what keeps a prepare under the gbuffers rather than over them: a
+prepare that names a draw buffer the terrain, the sky or the hand also names is a full-screen write
+over the very half they draw into, and run after them it replaces the world with a table built out
+of uniforms.
+
+The consequence for a pack author: a prepare sees none of the world, a deferred pass sees the opaque
+world, and a composite sees the world with translucents in it. Placing an effect in the wrong stage
+is not a subtle difference.
 
 ## Colour targets, and the rule that governs every read
 

--- a/docs/internals/uniforms.md
+++ b/docs/internals/uniforms.md
@@ -86,8 +86,11 @@ depends on it:
 
 Iris steps its history on read and gets away with it because it uploads per program. Vitrail writes
 one block per pass, so the boundary has to be a place in the code rather than a convention, and it
-is. The frame may be opened by the chain or, earlier, by a geometry program that runs during the
-world; whichever comes first opens it, and the second one finds it already open.
+is. The frame may be opened by the pack's shadow compute, which is dispatched ahead of anything the
+chain draws and needs this frame's counters to pick the half it writes; by the chain, at the head of
+the level frame on a pack whose chain has something to run before the world; or by a geometry
+program that runs during the world. Whichever comes first opens it, and the others find it already
+open.
 
 The clock is quantised to the millisecond, because that is the time step every smoothed value
 integrates over and an unquantised one puts all of them slightly off the reference for no visible
@@ -100,9 +103,14 @@ the colour it modulates by, and which stage of the frame it is. Those are set be
 write and dropped rather than carried over, in two places that are not one guard written twice. The
 frame boundary drops the model view, the projection and the colour at the head of the frame, which
 covers whatever reads before the first geometry pass. The chain drops those three again and the
-render stage with them, and says its own depth convention rather than inheriting the one the shadow
-programs flipped, before it writes its own blocks: every geometry family has run by then, so what
-would otherwise stand is whatever the last of them set. Left standing from the pass before, the
+render stage with them, and says its own depth convention rather than inheriting it, before it
+writes its own blocks: what would otherwise stand is whatever wrote the table last, and which one
+that is depends on where the chain first reaches this. A place with a begin or a prepare reaches it
+at the head of the level frame, and what stands there is the previous frame's shadow map, drawn at
+the tail of it under the forward window, or this frame's shadow compute, which flips to that same
+window a moment earlier on any pack that ships one. A place with neither reaches it at the deferred
+stage instead, and what stands there is this frame's sky, terrain and entities. Left standing from
+the pass before, the
 render stage would tell every full-screen pass of the frame that it was drawing the moon, because
 that value sits in the same table a full-screen pass shares with a geometry one.
 

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -468,10 +468,13 @@ All eight and not the branch in hand, which costs one thing worth naming: a plac
 and not the other holds the served branch back too, though the two are never drawn together. Every
 pack of the corpus answers both sky programs in the End, so nothing pays for it there today.
 
-Because the sky is drawn before the world, the sky stage is more often than not what opens the
-frame. Not always: `sky=off` in the options stops it, so does a pack that serves no sky program at
-all, and so does the Nether, whose skybox is none and which opens no sky pass whatever. In those
-cases the terrain opens the frame, as it always did.
+Because the sky is drawn before the rest of the world, the sky stage is often what opens the frame.
+Not always, and no longer first either: a pack with a begin or a prepare to run opens the frame at
+the head of the level frame, ahead of the sky, since that part of the chain is drawn before one
+triangle of the world is. Where nothing has opened it by the time the sky is reached, the sky opens
+it, and where the sky stage does not run at all the terrain does, as it always did. `sky=off` in the
+options stops the sky stage, so does a pack that serves no sky program at all, and so does the
+Nether, whose skybox is none and which opens no sky pass whatever.
 
 **And a boss stops it, which is the one worth knowing before diagnosing anything in the End.** The
 game builds no sky pass at all on a frame where a boss bar asks for world fog, and the ender


### PR DESCRIPTION
## What changes

A prepare program is a full screen pass a pack opens the frame with, and OptiFine gives it that
place so that the gbuffers land over whatever it wrote. This engine ran the begins and the prepares
alongside the deferred stage instead, once the opaque world was already in its targets, so a prepare
naming a draw buffer the terrain, the sky or the hand also names overwrote all three: the ground
vanished under a pale field, the held item was not drawn, and the sky stopped being brighter than
the ground. They now run while the level's frame graph is being built, the begins ahead of the
shadow stage and the prepares behind it, on the depths those stages read under the reference at
that point of the frame: the far plane as `depthtex0`, the frame before's copies for the rest. The
computes a pack ships for a begin or a prepare it draws no pass for move with them. The deferred
stage stays where it was, and a place shipping neither family pays nothing new. MakeUp UltraFast
and E-LITE write their gbuffer colour target from their prepare; every other prepare of the corpus
fills a target no geometry touches.

## How it differs from the reference, and for what obstacle

On the frame a pack finishes compiling. Iris draws its begins and its prepares ahead of its own
depth copies whatever the frame does (`pipeline/IrisRenderingPipeline.java:1014` and `:1025`, both
before `beginHand` rewrites the copy at `:1043-1048`), so what they read for `depthtex2` and the far
terrain is the frame before's. Here the level frame's setup is where they run on every ordinary
frame, and the only frames left to the fallback in `drawEarly` are the ones where the chain could
not draw yet when the graph was built and can by now; on those, `EngineStages.java:227` and `:237`
have already taken this frame's copies, so a prepare reading `depthtex2` or `dhDepthTex` there sees
the world it is opening rather than the one behind it. Matching it would keep a second copy of each
image all frame long to be right on one frame per load, where nothing else of the pack is on screen
yet either.

## What proves it

- `gradlew build` green.
- In the game: MakeUp UltraFast and E-LITE draw their terrain, their hand and their sky where a
  pale field stood, and the engine's own load line says how many passes run before the world, how
  many more before its translucents, and how many after.
- The sweep of the whole corpus on the jar carrying every fix of this series follows the merge.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
