### PR TITLE
fix(pack): give a full screen pass colortex0 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,15 @@ what the next one holds.
   frame, where the world lands over it, and the begin stage that opens it runs ahead of the shadow
   map rather than behind it.
 
+- **A pack that calls the screen by one of the game's texture names draws its picture again.** In a
+  full screen pass, OptiFine leaves the first colour target as the default texture, so a pack may
+  read the scene under a name that means something else in the world pass, `tex` and `texture` among
+  them. Those names read nothing here, so every pass of such a chain worked on black and what
+  reached the screen was black. They now read the screen, in the compute passes of those stages as
+  well, and a pack that lays a picture of its own over the first colour target has that picture read
+  instead, as it does under the reference. The log names them once per pass. I Like Vanilla is the
+  pack this showed on, and it showed on the whole picture.
+
 - **Switching packs no longer leaves graphics memory behind on packs that use compute shaders.**
   A pack can attach a compute program to a step of its chain, and those programs kept their
   pipelines and their buffers when the pack was replaced, so every switch and every press of the

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -434,6 +434,18 @@ public final class GlslTranslator {
 	private final List<Scoped> hardwareComparisonSamplers = new ArrayList<>();
 
 	/**
+	 * The FILE SCOPE declarations whose type this translation really rewrote, and nothing else.
+	 * <p>
+	 * It is the one set a reader can compare the pack's own text against: the type the translated
+	 * unit carries for these names is not the type the pack wrote. A parameter is kept out however
+	 * its type ends up, because a parameter is a name inside a function and the declaration it
+	 * shadows is untouched: Bliss declares {@code sampler2D tex} at file scope and takes
+	 * {@code in sampler2DShadow tex} in a helper of {@code lib/texFiltering.glsl}, and counting that
+	 * helper would say the pack's own {@code tex} had been retyped when nothing touched it.
+	 */
+	private final List<Scoped> retypedSamplers = new ArrayList<>();
+
+	/**
 	 * The samplers a function takes as a parameter, over the lines of that function. Nothing is
 	 * rewritten from them; they are what {@link #countDepthLookup} measures the blind spot with.
 	 */
@@ -4373,6 +4385,7 @@ public final class GlslTranslator {
 			} else {
 				this.tokens.replace(index, plain);
 				this.comparisonSamplers.addAll(introduced);
+				this.retypedSamplers.addAll(introduced);
 			}
 		}
 
@@ -4990,7 +5003,7 @@ public final class GlslTranslator {
 				this.fragCoordZ, this.fragCoordXyz,
 				this.fragCoordUnhandled, this.fragDepthWrites, this.fragDepthUnhandled,
 				List.copyOf(this.conflicts), comparedSamplers(), hardwareComparedSamplers(),
-				List.copyOf(this.storageBlocks),
+				retypedSamplers(), List.copyOf(this.storageBlocks),
 				this.volumes.lookups(), this.volumes.leftAlone(), this.trigCalls, this.gameTextureMatrix,
 				this.gameModelView);
 	}
@@ -5008,6 +5021,11 @@ public final class GlslTranslator {
 	/** The bound ones of the road that kept its spelling, which the binding owes a comparison. */
 	private List<String> hardwareComparedSamplers() {
 		return descriptors(this.hardwareComparisonSamplers.stream());
+	}
+
+	/** The bound ones this unit declares under a type the pack did not write. */
+	private List<String> retypedSamplers() {
+		return descriptors(this.retypedSamplers.stream());
 	}
 
 	private List<String> descriptors(Stream<Scoped> scoped) {

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -217,16 +217,9 @@ public final class PackProgram {
 		 * serves it.
 		 */
 		public Loaded rebind(TargetPlan plan, Optional<TargetSchedule.Bound> step) {
-			List<String> declared = new ArrayList<>();
-			Map<String, String> types = new LinkedHashMap<>();
-			for (TranslatedUnit.Uniform sampler : this.program.samplers()) {
-				declared.add(sampler.name());
-				types.putIfAbsent(sampler.name(), sampler.type());
-			}
-
 			return new Loaded(this.packName, this.path, this.program, plan,
-					SamplerPlan.of(declared, types, plan, step, this.supplied), this.alphaTest,
-					this.supplied);
+					SamplerPlan.of(declaredIn(this.program), typesIn(this.program), plan, step,
+							this.supplied), this.alphaTest, this.supplied);
 		}
 	}
 
@@ -465,7 +458,7 @@ public final class PackProgram {
 		/**
 		 * How many groups to dispatch over a pass run at that size, for a program {@link #sized()}
 		 * answers for. Iris hands its shadow composites the main render target's size
-		 * ({@code ShadowCompositeRenderer.java:212}), so that is the size this is asked about, and
+		 * ({@code ShadowCompositeRenderer.java:213-214}), so that is the size this is asked about, and
 		 * the answer moves with the window.
 		 */
 		public int[] groupsAt(int width, int height) {
@@ -1529,21 +1522,56 @@ public final class PackProgram {
 	private static Loaded bind(String packName, String path,
 			ProgramTranslator.TranslatedProgram program, TargetPlan targets, AlphaTest alphaTest,
 			PackTextures textures) {
-		List<String> declared = new ArrayList<>();
-		Map<String, String> types = new LinkedHashMap<>();
-		for (TranslatedUnit.Uniform sampler : program.samplers()) {
-			declared.add(sampler.name());
-			types.putIfAbsent(sampler.name(), sampler.type());
-		}
-
 		// The stage of the program the pass draws, which is what narrows a texture.STAGE.NAME
 		// override to the half of the frame the pack meant it for.
-		Set<String> supplied = TextureStage.of(programOf(path))
-				.map(textures::suppliedTo)
-				.orElse(Set.of());
+		Optional<TextureStage> stage = TextureStage.of(programOf(path));
+		Set<String> supplied = stage.map(textures::suppliedTo).orElse(Set.of());
 
 		return new Loaded(packName, path, program, targets,
-				SamplerPlan.of(declared, types, targets, path, supplied), alphaTest, supplied);
+				SamplerPlan.of(declaredIn(program), typesIn(program), targets, path, supplied,
+						stage.map(textures::picturesTo).orElse(Set.of())),
+				alphaTest, supplied);
+	}
+
+	/** Every sampler the program declares, in the order the stages were folded together. */
+	private static List<String> declaredIn(ProgramTranslator.TranslatedProgram program) {
+		return program.samplers().stream().map(TranslatedUnit.Uniform::name).toList();
+	}
+
+	/**
+	 * The type each of those names was declared under, as the PACK wrote it and not as the
+	 * translated text carries it.
+	 * <p>
+	 * The two part on one declaration. A comparison sampler whose comparison cannot be left to the
+	 * hardware is declared ordinary in the translated text, the comparison being made in arithmetic
+	 * at each lookup instead, so {@code uniform sampler2DShadow tex} arrives here spelled
+	 * {@code sampler2D}. Handing that on would make the binding move a name that reads unit nought
+	 * through a comparison, which {@code SamplerPlan.takesDefault} refuses, and which the text
+	 * {@code TargetPlan} reads refuses too: the two ends would then disagree over one declaration,
+	 * one giving it the colour target and the other allocating nothing for it. Such a name is left
+	 * untyped here, which is the answer both ends already give a declaration nothing could type.
+	 * <p>
+	 * The declarations the translation really rewrote and no others, which is why the narrow list
+	 * is the one read: {@code comparedSamplers} carries the samplers a function takes as a
+	 * PARAMETER as well, and a parameter that spells a name the file also declares says nothing
+	 * about that declaration. Bliss declares {@code uniform sampler2D tex} and takes
+	 * {@code in sampler2DShadow tex} in a helper of {@code lib/texFiltering.glsl}; read off the
+	 * wider list, its {@code tex} would lose the type it was really written under and with it the
+	 * screen a full screen pass reads through that name.
+	 */
+	private static Map<String, String> typesIn(ProgramTranslator.TranslatedProgram program) {
+		Set<String> retyped = program.stages().values().stream()
+				.flatMap(stage -> stage.notes().retypedSamplers().stream())
+				.collect(Collectors.toSet());
+
+		Map<String, String> types = new LinkedHashMap<>();
+		for (TranslatedUnit.Uniform sampler : program.samplers()) {
+			if (!retyped.contains(sampler.name())) {
+				types.putIfAbsent(sampler.name(), sampler.type());
+			}
+		}
+
+		return types;
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
@@ -33,7 +33,7 @@ import java.util.Map;
 final class TranslatedProgramCodec {
 
 	/** Bumped by hand when the layout changes. It is part of the key, so old blobs go unread. */
-	static final String FORMAT = "vitrail-translation-4";
+	static final String FORMAT = "vitrail-translation-5";
 
 	private TranslatedProgramCodec() {
 	}
@@ -152,6 +152,7 @@ final class TranslatedProgramCodec {
 		names(out, notes.conflictNames());
 		names(out, notes.comparedSamplers());
 		names(out, notes.hardwareCompared());
+		names(out, notes.retypedSamplers());
 		storageBlocks(out, notes.storageBlocks());
 		out.writeInt(notes.volumeLookups());
 		out.writeInt(notes.volumesLeftAlone());
@@ -165,7 +166,7 @@ final class TranslatedProgramCodec {
 				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(),
 				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt(),
 				in.readInt(), in.readInt(),
-				names(in), names(in), names(in), storageBlocks(in),
+				names(in), names(in), names(in), names(in), storageBlocks(in),
 				in.readInt(), in.readInt(), in.readInt(), in.readInt(), in.readInt());
 	}
 

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedUnit.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedUnit.java
@@ -119,6 +119,14 @@ public record TranslatedUnit(String entry, ProgramStage stage, String text, Note
 	 *                           binding owes each a comparison sampler and the lookup is the
 	 *                           hardware's. The rest are declared ordinary, with the comparison
 	 *                           made in arithmetic where each lookup stood
+	 * @param retypedSamplers    the file scope declarations this unit carries under a type the pack
+	 *                           did not write, which is that second road seen from the other end. A
+	 *                           reader answering for the type the PACK wrote has to take these names
+	 *                           as untyped, the text saying {@code sampler2D} where the pack said
+	 *                           {@code sampler2DShadow}. Narrower than {@code comparedSamplers},
+	 *                           which carries the function parameters as well: a parameter that
+	 *                           shadows a file scope uniform would otherwise say that uniform had
+	 *                           been rewritten when nothing touched it
 	 * @param storageBlocks      the storage blocks this unit declares at file scope, each with the
 	 *                           binding it was written at. A {@code bufferObject} that matches one
 	 *                           by name or by binding is bound; the rest refuse the program that
@@ -149,7 +157,8 @@ public record TranslatedUnit(String entry, ProgramStage stage, String text, Note
 			int fragCoordZ, int fragCoordXyz, int fragCoordUnhandled,
 			int fragDepthWrites, int fragDepthUnhandled,
 			List<String> conflictNames, List<String> comparedSamplers,
-			List<String> hardwareCompared, List<StorageBlock> storageBlocks,
+			List<String> hardwareCompared, List<String> retypedSamplers,
+			List<StorageBlock> storageBlocks,
 			int volumeLookups, int volumesLeftAlone, int trigCalls, int gameTextureMatrix,
 			int gameModelView) {
 	}

--- a/common/src/main/java/dev/vitrail/pack/model/ProgramNames.java
+++ b/common/src/main/java/dev/vitrail/pack/model/ProgramNames.java
@@ -104,6 +104,23 @@ public final class ProgramNames {
 	}
 
 	/**
+	 * Whether one program's moment in the frame comes before another's, which is
+	 * {@link #frameOrder} asked of two names rather than sorted over a list.
+	 * <p>
+	 * It is how a compute whose program draws nothing is placed against the passes that do draw:
+	 * the compute runs where its own name falls, so everything the walk has reached is everything
+	 * that sorts before it. The chain places its dispatch that way and the plan answers what such
+	 * a compute reads the same way, and the two have to agree name for name, a compute placed one
+	 * pass late reading a half nothing wrote yet.
+	 * <p>
+	 * The compute letter says nothing here, {@code prepare_a} and {@code prepare} being one family
+	 * and one slot, which is what lets either spelling be handed in.
+	 */
+	public static boolean before(String program, String other) {
+		return frameOrder().compare(program, other) < 0;
+	}
+
+	/**
 	 * The order Iris folds directives in, from {@code ProgramSet.locateDirectives}. Setup programs
 	 * are not in it: they go to the compute list there and are only ever read for their work group
 	 * size, so they declare no format however they are written.

--- a/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
@@ -20,8 +20,14 @@ import java.util.Set;
  * here is the same list, in the same order, that builds the bind group layout, and the Vulkan
  * backend throws {@code Missing sampler} the moment a name in the layout is not bound. So a name
  * this engine has no answer for cannot be dropped; it has to come back as {@link Kind#UNSERVED}
- * and be given something harmless, and it has to be named in the log rather than quietly given
- * the scene, which draws a program that looks as though it works.
+ * and be given something harmless.
+ * <p>
+ * <strong>A full screen program is the one place where a name nothing answers for is given the
+ * scene on purpose</strong>, because that is the rule its pack was written against and the reason
+ * is in {@link #of(List, Map, TargetPlan, Optional, Set, Kind, boolean)}. It is not given quietly:
+ * {@link Binding#defaulted} marks every name that took it, {@link #defaulted()} lists them, and
+ * the caller prints that list once per program. A name given the scene without being named would
+ * draw a program that looks as though it works.
  * <p>
  * The side of a colour target is answered here too, from the schedule and for this program, so
  * that no caller has to work out where the ping pong stands.
@@ -108,6 +114,18 @@ public final class SamplerPlan {
 	 */
 	private static final int MAX_SHADOW_COLOURS = PackDirectives.MAX_SHADOW_COLOURS;
 
+	/** The colour target a full screen program reads under a name nothing else answers for. */
+	public static final int DEFAULT_TARGET = 0;
+
+	/**
+	 * The one declared type the default sampler is moved onto, spelled out rather than reduced to a
+	 * shape: {@link SamplerTypes#shapeOf} strips the integer and unsigned prefixes
+	 * ({@code SamplerTypes.java:59-63}), so a shape of {@code 2D} also covers {@code isampler2D}
+	 * and {@code usampler2D}, which read the same unit through a different sampling type and come
+	 * back with something that is not the scene.
+	 */
+	private static final String FLAT = "sampler2D";
+
 	private final List<Binding> bindings;
 	private final Map<String, Binding> byName;
 	private final boolean waterShadow;
@@ -137,11 +155,19 @@ public final class SamplerPlan {
 	/**
 	 * What one sampler name of the program is bound to.
 	 *
-	 * @param index the colour target for {@link Kind#COLORTEX}, the shadow colour target for
-	 *              {@link Kind#SHADOW_COLOUR}, -1 otherwise. The two families are numbered apart and
-	 *              never share a texture, so the kind has to be read before the index means anything
+	 * @param index     the colour target for {@link Kind#COLORTEX}, the shadow colour target for
+	 *                  {@link Kind#SHADOW_COLOUR}, -1 otherwise. The two families are numbered apart
+	 *                  and never share a texture, so the kind has to be read before the index means
+	 *                  anything
+	 * @param defaulted whether the name got what it got as the default sampler of a full screen
+	 *                  program rather than by naming it. The kind is then whatever {@code colortex0}
+	 *                  resolves to, so the binding side needs no second rule; what this flag is for
+	 *                  is telling the log, and telling a supplied texture apart from one the name
+	 *                  really asked for, since the file was named against {@code colortex0} and has
+	 *                  to be looked up under that name and not under this one
 	 */
-	public record Binding(String sampler, Kind kind, int index, TargetSchedule.Side side) {
+	public record Binding(String sampler, Kind kind, int index, TargetSchedule.Side side,
+			boolean defaulted) {
 	}
 
 	/**
@@ -166,7 +192,19 @@ public final class SamplerPlan {
 	 *                 narrowed to it
 	 */
 	public static Kind classify(String name, String type, Set<String> supplied) {
-		if (CustomImages.named(name)) {
+		return classify(name, type, supplied, CustomImages.names());
+	}
+
+	/**
+	 * The same, told the pack's image names instead of asking the registry for them.
+	 *
+	 * @param images every name an {@code image.} directive of THIS pack hangs on,
+	 *               {@link CustomImages#namesOf} being where they come from either way. The
+	 *               registry is installed by the translation, so a caller running before it, the
+	 *               target plan above all, would otherwise be answered for the pack before
+	 */
+	public static Kind classify(String name, String type, Set<String> supplied, Set<String> images) {
+		if (images.contains(name)) {
 			return Kind.CUSTOM_IMAGE;
 		}
 
@@ -286,6 +324,12 @@ public final class SamplerPlan {
 
 	/**
 	 * Works out what each sampler the program declares will be bound to.
+	 * <p>
+	 * The full screen flag is read off the program's own name, so the default sampler is on for a
+	 * composite and off for a gbuffers pass. <strong>No name takes it here whatever the family</strong>,
+	 * because no types are handed in and a name the reader could not type takes no default: what
+	 * this overload reports for a pack that reads the screen under a name of its own is the
+	 * {@link Kind#UNSERVED} the name has before a type is known, not the scene.
 	 *
 	 * @param declared the sampler names the translated program declares, in that order
 	 * @param program  the program the plan is for, so the flip snapshot is the right one
@@ -295,27 +339,50 @@ public final class SamplerPlan {
 	}
 
 	/**
-	 * The same, with the types the reader managed to put on those names.
+	 * The same, with the types the reader managed to put on those names. The full screen flag is
+	 * still the program's own name, and a name typed {@code sampler2D} that nothing else answers
+	 * for now takes the default in the families that have one.
 	 *
 	 * @param types the declared type of each name. A name missing from it is one the reader could
-	 *              not type, and is taken at its word rather than refused on a guess
+	 *              not type, and is taken at its word rather than refused on a guess, except for
+	 *              the default sampler, which no untyped name takes
 	 */
 	public static SamplerPlan of(List<String> declared, Map<String, String> types, TargetPlan plan,
 			String program) {
-		return of(declared, types, plan, program, Set.of());
+		return of(declared, types, plan, program, Set.of(), Set.of());
 	}
 
 	/**
-	 * The same, told which names the pack supplies a file for.
+	 * The same, told which names the pack supplies a file for and nothing about what the pack lays
+	 * over {@code colortex0}, so the default sampler stands on the colour target. That is the
+	 * answer a reader measuring what a pack takes over under its own names wants, the file behind
+	 * the first target changing none of those.
+	 */
+	public static SamplerPlan of(List<String> declared, Map<String, String> types, TargetPlan plan,
+			String program, Set<String> supplied) {
+		return of(declared, types, plan, program, supplied, Set.of());
+	}
+
+	/**
+	 * The same, told which of those names a flat picture stands on. The full screen flag is the
+	 * program's own name here too, and what the default sampler stands on is decided from those
+	 * names: a picture the pack laid over {@code colortex0} for the stage stands there instead of
+	 * the target.
 	 *
 	 * @param supplied every name the pack supplies a file for at this program's stage. What is
 	 *                 still standing by the time this program draws is worked out here rather than
 	 *                 handed in, because it is the plan that knows
+	 * @param pictures the ones of those the default sampler can stand on, which
+	 *                 {@link #byDefault} says the rest of
 	 */
 	public static SamplerPlan of(List<String> declared, Map<String, String> types, TargetPlan plan,
-			String program, Set<String> supplied) {
+			String program, Set<String> supplied, Set<String> pictures) {
+		// The picture is narrowed the way the declared override is, and by the same walk: Iris
+		// deactivates an override once its target has been flipped, whichever road reads it
+		// (gl/program/ProgramSamplers.java:258).
 		return of(declared, types, plan, plan.schedule().step(program),
-				standing(plan, program, supplied));
+				standing(plan, program, supplied),
+				byDefault(standing(plan, program, pictures)), fullscreen(program));
 	}
 
 	/**
@@ -323,6 +390,12 @@ public final class SamplerPlan {
 	 * needs: its halves are the pass's and not the file's. The translucent pass reads its colour
 	 * targets on the sides the deferred stage leaves them, and looking the file up in the schedule
 	 * would answer for the wrong side of that boundary.
+	 * <p>
+	 * <strong>There is no full screen flag to read off a step, so this overload turns the default
+	 * sampler OFF.</strong> That is the answer these callers want rather than a shortcut: the step
+	 * is handed in exactly by the geometry programs, which reserve their first texture units for
+	 * the game's own atlas and have no default unit to spare
+	 * ({@code samplers/IrisSamplers.java:36} against {@code :39}).
 	 *
 	 * @param step where the reader stands in the frame, deciding the half of every colour target.
 	 *             Empty falls back to MAIN everywhere, as it always has
@@ -333,24 +406,115 @@ public final class SamplerPlan {
 	}
 
 	/**
-	 * The same, with the program's step in the schedule and its overrides already worked out.
+	 * The same, with the program's step in the schedule and its overrides already worked out. The
+	 * default sampler is OFF here as well, and for the same reason: a step names no family.
 	 *
 	 * @param supplied the names the pack supplies a file for, already narrowed to this program's
 	 *                 stage and to the overrides that still stand
 	 */
 	public static SamplerPlan of(List<String> declared, Map<String, String> types, TargetPlan plan,
 			Optional<TargetSchedule.Bound> step, Set<String> supplied) {
+		return of(declared, types, plan, step, supplied, Kind.UNSERVED, false);
+	}
+
+	/**
+	 * The same, told whether the program is drawn over the whole screen.
+	 * <p>
+	 * <strong>What the flag decides is the name nothing else answers for.</strong> A full screen
+	 * program of Iris is built with no reserved texture unit at all
+	 * ({@code samplers/IrisSamplers.java:39}), and {@code colortex0} is handed the first one through
+	 * {@code addDefaultSampler} ({@code :93-95}), which takes unit nought whatever names the program
+	 * carries and refuses to run anywhere else
+	 * ({@code gl/program/ProgramSamplers.java:155-162}). Every sampler uniform Iris then never
+	 * assigns a unit to keeps the value GLSL gives it, which is nought, so it reads whatever unit
+	 * nought holds. That is the whole of OptiFine's rule that the first colour target is the
+	 * default texture of a composite, and Iris never binds the geometry names over it either: the
+	 * composite and the final renderers ask for the render target samplers alone
+	 * ({@code pipeline/CompositeRenderer.java:398}, {@code pipeline/FinalPassRenderer.java:368}) and
+	 * call {@code addLevelSamplers} nowhere.
+	 * <p>
+	 * A descriptor set has no such default: a name is bound or the draw throws, so a name nothing
+	 * served used to be given one black texel. That reads as a rule until a pack writes its chain
+	 * against the OptiFine one. I Like Vanilla calls the screen {@code tex} throughout
+	 * ({@code shaders/basics/common.glsl:59}) and names {@code colortex0} only in directives, in
+	 * the format block it keeps commented ({@code shaders/basics/settings.glsl:9}) and in the
+	 * mipmap flag of the pass that reads the screen at a level
+	 * ({@code shaders/program/composite10.glsl:7}, whose body fetches {@code tex} at that level):
+	 * the one target it never declares a sampler for is the one every pass of its chain reads. All
+	 * of them read black, and the picture the pack presents is exactly zero.
+	 * <p>
+	 * <strong>What unit nought holds is not always the colour target</strong>, so the name nothing
+	 * answers for is given whatever the default sampler itself stands on, standing overrides and
+	 * all. A pack may lay a flat picture of its own over {@code colortex0} for a stage, and Iris
+	 * then replaces the default sampler by it rather than binding the target
+	 * ({@code gl/program/ProgramSamplers.java:298-306}); the defaulted name follows, which is why
+	 * {@link Binding#defaulted} exists, the file having been named against {@code colortex0}.
+	 * <p>
+	 * <strong>A picture is the one shape that reaches it, and the two engines agree on that.</strong>
+	 * Only the picture form of {@code texture.<stage>.<name>} enters the map the interceptor looks
+	 * in ({@code ShaderProperties.java:485-486}); a declaration that spells a raw blob out, the 1D,
+	 * the rectangle and the volume alike, goes to the renaming road instead ({@code :480}), which
+	 * retypes the declaration naming it and never touches a name nothing serves. {@link #byDefault}
+	 * counts the same one form, so a blob laid over {@code colortex0} leaves the default sampler on
+	 * the target on both sides. Photon lays a 64 cube of noise there for its composites
+	 * ({@code shaders/shaders.properties:357}) and its composites go on reading the colour target
+	 * under that name in either engine, with no defaulted name at all besides.
+	 * <p>
+	 * Only a plain two dimensional sampler takes the default, and only one whose type was really
+	 * read: a name the reader could not type is left alone, since the name is not evidence for a
+	 * question that is about a name nothing answers for. A cube or a shadow declaration under an
+	 * unknown name would read unit nought through its own type, where Iris put a 2D texture and
+	 * nothing else, so black is what it reads there as well; a storage image is not a sampler at
+	 * all and keeps its own road. A volume the backend refuses stays refused, and a texture of the
+	 * pack's own that could not be read stays black, both for the reasons they already carry.
+	 *
+	 * @param stands     what the default sampler stands on for this program, which is a property of
+	 *                   the program and not of any name: what a reader with no unit of its own lands
+	 *                   on is one texture unit, whatever the pack called it
+	 * @param fullscreen whether the program covers the screen, which is the begin, prepare,
+	 *                   deferred, composite and final families
+	 */
+	private static SamplerPlan of(List<String> declared, Map<String, String> types, TargetPlan plan,
+			Optional<TargetSchedule.Bound> step, Set<String> supplied, Kind stands,
+			boolean fullscreen) {
 		List<Binding> bindings = new ArrayList<>();
+		Kind byDefault = fullscreen ? stands : Kind.UNSERVED;
+		Set<String> images = CustomImages.names();
 
 		for (String name : declared) {
-			Kind kind = classify(name, types.get(name), supplied);
+			String type = types.get(name);
+			Kind kind = classify(name, type, supplied, images);
+			if (fullscreen && takesDefault(name, type, supplied, images)) {
+				// Through the same allocation test the target's own name goes through below, and
+				// for the same reason: a plan that decides everything before a frame has nothing to
+				// bind for an index nothing allocated. TargetPlan allocates it wherever a full
+				// screen program of the place declares a name that lands here, which is where Iris
+				// creates it on demand (samplers/IrisSamplers.java:60-62 and
+				// targets/RenderTargets.java:118), so the target is there whenever a pack asks for
+				// it; the name falls back to the black texel where it is not, on the pass road and
+				// on the compute road both, rather than the plan handing out an index the binding
+				// then has to refuse.
+				if (byDefault == Kind.COLORTEX && plan.allocated().contains(DEFAULT_TARGET)) {
+					bindings.add(new Binding(name, Kind.COLORTEX, DEFAULT_TARGET,
+							side(step, DEFAULT_TARGET), true));
+					continue;
+				}
+
+				if (byDefault == Kind.PACK_TEXTURE) {
+					bindings.add(new Binding(name, Kind.PACK_TEXTURE, -1,
+							TargetSchedule.Side.MAIN, true));
+					continue;
+				}
+			}
+
 			if (kind == Kind.SHADOW_COLOUR) {
-				bindings.add(new Binding(name, kind, shadowColour(name), TargetSchedule.Side.MAIN));
+				bindings.add(new Binding(name, kind, shadowColour(name), TargetSchedule.Side.MAIN,
+						false));
 				continue;
 			}
 
 			if (kind != Kind.COLORTEX) {
-				bindings.add(new Binding(name, kind, -1, TargetSchedule.Side.MAIN));
+				bindings.add(new Binding(name, kind, -1, TargetSchedule.Side.MAIN, false));
 				continue;
 			}
 
@@ -360,17 +524,96 @@ public final class SamplerPlan {
 			// there is nothing to bind. Saying so by name is the whole difference between a gap
 			// and a wrong image.
 			if (!plan.allocated().contains(index)) {
-				bindings.add(new Binding(name, Kind.UNSERVED, -1, TargetSchedule.Side.MAIN));
+				bindings.add(new Binding(name, Kind.UNSERVED, -1, TargetSchedule.Side.MAIN, false));
 				continue;
 			}
 
-			int wanted = index;
-			TargetSchedule.Side side = step.map(bound -> bound.read(wanted))
-					.orElse(TargetSchedule.Side.MAIN);
-			bindings.add(new Binding(name, Kind.COLORTEX, index, side));
+			bindings.add(new Binding(name, Kind.COLORTEX, index, side(step, index), false));
 		}
 
 		return new SamplerPlan(bindings);
+	}
+
+	/** Which half of one colour target a reader standing at this step reads. */
+	private static TargetSchedule.Side side(Optional<TargetSchedule.Bound> step, int index) {
+		return step.map(bound -> bound.read(index)).orElse(TargetSchedule.Side.MAIN);
+	}
+
+	/**
+	 * Whether a declaration reads the one texture unit the default sampler fills, which is a plain
+	 * two dimensional one and nothing else.
+	 * <p>
+	 * The type has to be KNOWN and it has to be exactly that one, which is the opposite of the rule
+	 * the rest of this class follows for a name it could not type. Everywhere else an untyped name
+	 * is taken at its word because the name is evidence; here there is no name to go on, the whole
+	 * question being what to do with a name nothing answers for, so a reader that saw no type saw
+	 * nothing at all. Letting one through moved the default onto declarations of every shape under
+	 * a caller that hands in no types: Reverie's {@code sampler3D worleyNoiseTexture} read as
+	 * colour target nought that way.
+	 */
+	private static boolean flat(String type) {
+		return FLAT.equals(type);
+	}
+
+	/**
+	 * Whether a name a full screen program declares falls to the default sampler, asked in the one
+	 * place so that what is ALLOCATED for the default and what is BOUND to it cannot drift apart.
+	 * {@code TargetPlan} asks it while the plan is built and {@link #of} asks it again per program.
+	 * <p>
+	 * Two questions stand between them and have to be answered the same way twice. The type: the
+	 * allocation reads the pack's own text, the binding reads a translated unit, and a translation
+	 * may declare ordinary a comparison sampler it had to move into arithmetic. The name is handed
+	 * in untyped there rather than under the type the rewrite left ({@code PackProgram.typesIn}),
+	 * so a comparison is a comparison on both sides and neither moves it. And the pack's images,
+	 * which is why they are handed in: the registry behind {@link CustomImages#named} is installed
+	 * by the translation, so the allocation reads the directives itself and both ends are answered
+	 * for the pack in hand.
+	 *
+	 * @param type     the declared type as the PACK wrote it, or null for a name that could not be
+	 *                 typed, which takes no default
+	 * @param supplied the names the pack supplies a file for at this program's stage
+	 * @param images   the names the pack's own {@code image.} directives hang on
+	 */
+	public static boolean takesDefault(String name, String type, Set<String> supplied,
+			Set<String> images) {
+		return classify(name, type, supplied, images) == Kind.UNSERVED && flat(type);
+	}
+
+	/**
+	 * What the default sampler stands on at a stage: the colour target, or the flat picture the
+	 * pack laid over its name there. {@link Kind#COLORTEX} is the only answer that needs an
+	 * allocation.
+	 *
+	 * @param pictures the names the pack lays a flat picture over IN THIS STAGE, which is the one
+	 *                 form of override that reaches the default sampler and which
+	 *                 {@code PackTextures.picturesTo} answers for. Iris takes that form of
+	 *                 {@code texture.<stage>.<name>} into the map its interceptor replaces the
+	 *                 default sampler out of ({@code ShaderProperties.java:485-486} into
+	 *                 {@code pipeline/CustomTextureManager.java:56-67}); a raw blob goes to the
+	 *                 renaming road at {@code ShaderProperties.java:480} instead and the default
+	 *                 sampler stays on the target, and so does the whole {@code customTexture.}
+	 *                 family, which names no stage and is bound by name alone
+	 *                 ({@code samplers/IrisSamplers.java:237-239})
+	 */
+	public static Kind byDefault(Set<String> pictures) {
+		return pictures.contains(TargetName.canonical(DEFAULT_TARGET))
+				? Kind.PACK_TEXTURE
+				: Kind.COLORTEX;
+	}
+
+	/**
+	 * Whether a program is drawn over the whole screen, which is the one thing the default sampler
+	 * turns on. Read off the family the way {@link #standing} reads it, so the two answers cannot
+	 * drift apart.
+	 * <p>
+	 * A compute file answers yes through its own family, {@code composite1_a} parsing as a
+	 * composite, and that is wanted rather than tolerated: Iris builds the computes of a stage with
+	 * the same call and the same full screen flag as the passes they hang off
+	 * ({@code pipeline/CompositeRenderer.java:454} beside {@code :398}), so the name that reads the
+	 * screen in {@code composite1.fsh} reads it in {@code composite1_a.csh} too.
+	 */
+	public static boolean fullscreen(String program) {
+		return stageOf(TargetName.bareName(program)) != null;
 	}
 
 	/**
@@ -399,9 +642,23 @@ public final class SamplerPlan {
 			return supplied;
 		}
 
+		// The pass a compute hangs off, because a compute is in no running order: composite1_a is
+		// not a pass and a walk looking for its own name would run to the end of the stage, count
+		// the writes of every pass AFTER it, and drop an override the pass beside it keeps. Iris
+		// snapshots what has been flipped once it reaches the index and hands that same snapshot to
+		// the pass (CompositeRenderer.java:134 taken, :151 given it), to the computes hanging off
+		// it (:154) and to a compute whose program draws nothing (:141), so all of them stop here.
+		String upTo = ProgramNames.computeBase(bare).orElse(bare);
+
+		// Stopped where the name FALLS in the frame rather than where it is found, because the
+		// program a compute hangs off may draw nothing and be in no running order either: Pegasus
+		// ships prepare_a and no prepare.fsh, and a walk looking for that name would again run to
+		// the end of the stage. This is the moment the chain dispatches such a compute at
+		// (PackChain.standaloneOf places it before the first pass that does not sort ahead of it),
+		// and the two have to be one answer.
 		Set<String> abandoned = new LinkedHashSet<>();
 		for (String earlier : plan.running()) {
-			if (earlier.equals(bare)) {
+			if (!ProgramNames.before(earlier, upTo)) {
 				break;
 			}
 
@@ -447,7 +704,7 @@ public final class SamplerPlan {
 		Binding found = this.byName.get(sampler);
 
 		return found == null
-				? new Binding(sampler, Kind.UNSERVED, -1, TargetSchedule.Side.MAIN)
+				? new Binding(sampler, Kind.UNSERVED, -1, TargetSchedule.Side.MAIN, false)
 				: found;
 	}
 
@@ -464,6 +721,21 @@ public final class SamplerPlan {
 
 	public List<String> unserved() {
 		return named(Kind.UNSERVED);
+	}
+
+	/**
+	 * The names that took the default sampler without asking for it, in declaration order.
+	 * <p>
+	 * Meant to be printed once for the program: it is the one binding a reader cannot work out from
+	 * the pack's own text, since the pack never wrote {@code colortex0} beside these names, and it
+	 * decides whether a pass reads the scene or reads nothing. Empty for everything that is not
+	 * drawn over the whole screen.
+	 */
+	public List<String> defaulted() {
+		return this.bindings.stream()
+				.filter(Binding::defaulted)
+				.map(Binding::sampler)
+				.toList();
 	}
 
 	/** Names declared under a type no pipeline of this backend can carry. Empty is the norm. */

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -3,6 +3,7 @@ package dev.vitrail.pack.target;
 import dev.vitrail.pack.model.TargetFormat;
 import dev.vitrail.pack.model.TargetName;
 import dev.vitrail.pack.model.TargetSize;
+import dev.vitrail.pack.model.TextureStage;
 import dev.vitrail.pack.option.OptionIndex;
 import dev.vitrail.pack.option.SettingSet;
 import dev.vitrail.pack.model.BlendMode;
@@ -14,6 +15,8 @@ import dev.vitrail.pack.source.DimensionSet;
 import dev.vitrail.pack.source.IncludeExpander;
 import dev.vitrail.pack.source.ShaderPackSource;
 import dev.vitrail.pack.source.ShaderProperties;
+import dev.vitrail.pack.texture.CustomImages;
+import dev.vitrail.pack.texture.PackTextures;
 
 import dev.vitrail.pack.source.IncludeExpander.ExpandedUnit;
 
@@ -68,10 +71,19 @@ public final class TargetPlan {
 	/**
 	 * Sampler declarations are found in the text rather than by translating, because thirty one
 	 * programs are read here and one of them is translated. Optional precision qualifiers are
-	 * allowed for; several packs still write them.
+	 * allowed for; several packs still write them. So is a {@code layout}, on EITHER side of the
+	 * {@code uniform}: a pack writes it to pin a binding of its own and writes it both ways round,
+	 * the translation reads either without trouble, and a declaration carrying one has to be seen
+	 * here too, or it would be bound to the default sampler and allocated by nothing.
+	 * <p>
+	 * One line at a time, and only one: a declaration the pack spread over several lines matches
+	 * nothing here and the name it carries is read by nothing here either. A {@code layout} holding
+	 * parentheses of its own is out of scope with them, the group inside stopping at the first
+	 * closing one.
 	 */
 	private static final Pattern SAMPLER = Pattern.compile(
-			"^\\s*uniform\\s+(?:(?:lowp|mediump|highp)\\s+)?([iu]?sampler\\w*)\\s+([^;]*);.*$");
+			"^\\s*(?:layout\\s*\\([^)]*\\)\\s*)?uniform\\s+(?:layout\\s*\\([^)]*\\)\\s*)?"
+					+ "(?:(?:lowp|mediump|highp)\\s+)?([iu]?sampler\\w*)\\s+([^;]*);.*$");
 
 	private static final String FINAL = "final";
 
@@ -213,14 +225,160 @@ public final class TargetPlan {
 
 		Map<String, String> defines = settings.globalDefines(options);
 		draft.blend = properties.blend(defines);
-		read(source, options, settings, properties, entries, draft);
+
+		// What the pack lays over a name for each stage, which the default sampler is decided
+		// against: a picture over colortex0 stands where the target would, so the target is not
+		// allocated on its account. Kept for the opening rather than read per place, since the
+		// directives are the pack's and the same for all twenty five of them.
+		PackTextures textures = source.derived(List.of(PackTextures.class, defines),
+				() -> PackTextures.read(properties, defines, source));
+
+		// Read from the directives rather than asked of CustomImages, which the TRANSLATION
+		// installs and which still holds the pack before while this runs: a name an image.
+		// directive gives a sampler to is served by that image and asks for no colour target, and
+		// answering that against another pack's directives allocates a target nothing reads, or
+		// leaves a name reading one this place never opened.
+		Set<String> images = CustomImages.namesOf(properties.imageDirectives(defines));
+
+		read(source, options, settings, properties, entries, textures, images, draft);
 		// Ahead of the walk and it used to follow it: the walk owes a moment in the frame to every
 		// program a compute hangs off, and it cannot know which those are before this has said so.
 		// Nothing here reads what the walk writes, so the two only ever ran in this order by habit.
 		computes(properties, options, defines, programs, draft);
+		// After the computes, whose two lists it reads to leave out the files this place never
+		// opens. Nothing in the computes reads what this writes.
+		defaults(source, options, settings, properties, defines, programs, textures, images, draft);
 		walk(properties, options, defines, programs, entries, filter, draft);
 
 		return new TargetPlan(draft);
+	}
+
+	/**
+	 * Allocates the default target for the stages the one walk above does not open.
+	 * <p>
+	 * That walk reads the FRAGMENT entry points of the place, which is every stage that says
+	 * anything about a colour target, and until there was a default sampler it was every stage that
+	 * said anything at all. It is not: the samplers of a program are the union of its stages
+	 * ({@code glsl/ProgramTranslator} folds them into one bind group), and a compute of a full
+	 * screen stage is a program of its own. So a name that reads the screen in {@code composite1.vsh}
+	 * or in {@code composite1_a.csh} and nowhere else asks for the first colour target as loudly as
+	 * one in the fragment stage, and would have been handed an index this place never allocated.
+	 * <p>
+	 * <strong>Nothing is opened once the target is allocated</strong>, which is what keeps this from
+	 * being a second reading of the archive on every pack. The target is written or sampled by
+	 * something in all but a handful of places, the walk above has already said so by the time this
+	 * runs, and there is then no question left to answer.
+	 * <p>
+	 * Only that question is asked of these files. What a program writes, the format tables it
+	 * carries and the shadow buffers it names are read off the fragment stages alone, as they always
+	 * were: a vertex stage declares no draw buffer, and a compute that names a shadow colour nothing
+	 * else names is the divergence {@code render/PackCompute} carries.
+	 * <p>
+	 * <strong>A file this place never opens asks for nothing.</strong> Iris builds no program at
+	 * all for a name its own switch turns off, computes included
+	 * ({@code shaderpack/ShaderPack.java:292-295}), and it never reads a compute past a gap in its
+	 * letters ({@code ProgramSet.readComputeArray}), so neither creates a target on demand. Both
+	 * lists are the ones {@link #computes} drew up, which is why this runs after it.
+	 */
+	private static void defaults(ShaderPackSource source, OptionIndex options, SettingSet settings,
+			ShaderProperties properties, Map<String, String> defines, ProgramSet programs,
+			PackTextures textures, Set<String> images, Draft draft) {
+		if (draft.written.contains(SamplerPlan.DEFAULT_TARGET)
+				|| draft.sampled.contains(SamplerPlan.DEFAULT_TARGET)) {
+			return;
+		}
+
+		Map<String, Boolean> toggles = properties.programToggles(defines, options);
+		IncludeExpander expander = new IncludeExpander(source, settings);
+		for (ProgramSet.ProgramKey key : programs.keys()) {
+			String bare = key.name().baseName();
+			if (key.stage() == ProgramStage.FRAGMENT || !key.dimension().equals(draft.place)
+					|| !SamplerPlan.fullscreen(bare) || off(key, bare, toggles, draft)) {
+				continue;
+			}
+
+			Set<String> supplied = suppliedTo(textures, bare);
+			if (SamplerPlan.byDefault(picturesTo(textures, bare)) != SamplerPlan.Kind.COLORTEX) {
+				continue;
+			}
+
+			Optional<Path> file = source.file(key.file());
+			if (file.isEmpty()) {
+				continue;
+			}
+
+			ExpandedUnit unit;
+			try {
+				unit = expander.expand(file.get());
+			} catch (IOException | RuntimeException e) {
+				// One unreadable stage must not cost the pack the target every other one asks for.
+				draft.unreadable.add(key.file());
+				continue;
+			}
+
+			for (Declaration sampler : samplers(unit)) {
+				if (SamplerPlan.takesDefault(sampler.name(), sampler.type(), supplied, images)) {
+					draft.sampled.add(SamplerPlan.DEFAULT_TARGET);
+					return;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Whether a switch has taken this file out of the frame, which is the question asked of each
+	 * kind of file where its own answer lives.
+	 * <p>
+	 * A compute is switched off under its OWN name, letter and all, and is dropped past a gap in
+	 * the letters before it; the two lists are {@link #computes}'s. Anything else is switched off
+	 * under the program's name, which is the key the pack wrote, place included, for the reason the
+	 * walk gives: a pack conditions {@code world0/composite1} and {@code world-1/composite1} on two
+	 * different expressions.
+	 */
+	private static boolean off(ProgramSet.ProgramKey key, String bare, Map<String, Boolean> toggles,
+			Draft draft) {
+		if (key.stage() == ProgramStage.COMPUTE) {
+			String stem = stemOf(key.file(), draft.place);
+			return draft.disabledComputes.containsKey(stem)
+					|| draft.unreachableComputes.contains(stem);
+		}
+
+		return Boolean.FALSE.equals(toggles.get(pathOf(bare, draft.place)));
+	}
+
+	/** The name a program is switched off under, the place in front of it where there is one. */
+	private static String pathOf(String name, String place) {
+		return place.isEmpty() ? name : place + "/" + name;
+	}
+
+	/**
+	 * The name a compute file is known by: its own, letter included, without its extension and
+	 * relative to the place. {@code deferred4_a} and {@code deferred4} are two computes of one pass
+	 * and the stage that runs them opens each under its own name.
+	 */
+	private static String stemOf(String file, String place) {
+		int dot = file.lastIndexOf('.');
+		String path = dot < 0 ? file : file.substring(0, dot);
+		String prefix = place.isEmpty() ? "" : place + "/";
+
+		return path.startsWith(prefix) ? path.substring(prefix.length()) : path;
+	}
+
+	/**
+	 * Every name the pack lays a file over in the stage a program is drawn in.
+	 * <p>
+	 * The whole stage, where the binding narrows the same set to the overrides no earlier
+	 * program of the stage has written over ({@code SamplerPlan.standing}). The two cannot part
+	 * on the one name this asks about: what that narrowing drops, it drops because a program
+	 * wrote that target, and writing a target is what allocates it.
+	 */
+	private static Set<String> suppliedTo(PackTextures textures, String program) {
+		return TextureStage.of(program).map(textures::suppliedTo).orElse(Set.of());
+	}
+
+	/** The ones of those the default sampler can stand on, which is where the target is decided. */
+	private static Set<String> picturesTo(PackTextures textures, String program) {
+		return TextureStage.of(program).map(textures::picturesTo).orElse(Set.of());
 	}
 
 	/**
@@ -253,14 +411,8 @@ public final class TargetPlan {
 			// world0/composite21 has said nothing about it. Iris keeps those computes and runs
 			// them as a pass with no fragment stage at all (CompositeRenderer.java:137-145), and
 			// so does the chain here: passingOf below names that program.
-			String file = key.file();
-			int dot = file.lastIndexOf('.');
-			String path = dot < 0 ? file : file.substring(0, dot);
-			// The file, letter included, relative to the place: deferred4_a and deferred4 are two
-			// computes of one pass, run in that order, and the stage that runs them opens each
-			// under its own name.
-			String prefix = draft.place.isEmpty() ? "" : draft.place + "/";
-			String stem = path.startsWith(prefix) ? path.substring(prefix.length()) : path;
+			String stem = stemOf(key.file(), draft.place);
+			String path = pathOf(stem, draft.place);
 			if (Boolean.FALSE.equals(toggles.get(path))) {
 				off.put(stem, conditions.getOrDefault(path, "shaders.properties"));
 				continue;
@@ -532,7 +684,8 @@ public final class TargetPlan {
 	}
 
 	private static void read(ShaderPackSource source, OptionIndex options, SettingSet settings,
-			ShaderProperties properties, List<ProgramSet.ProgramKey> entries, Draft draft) {
+			ShaderProperties properties, List<ProgramSet.ProgramKey> entries, PackTextures textures,
+			Set<String> images, Draft draft) {
 		IncludeExpander expander = new IncludeExpander(source, settings);
 		TargetDirectives.Builder builder = TargetDirectives.builder();
 		long began = System.nanoTime();
@@ -605,12 +758,39 @@ public final class TargetPlan {
 				draft.written.addAll(writes);
 			}
 
+			// A full screen program reads colortex0 under every name nothing else answers for, which
+			// is what SamplerPlan gives it and why Iris hands its default sampler the first colour
+			// target (samplers/IrisSamplers.java:93-95). Iris pays for that target when the binding
+			// asks for it (targets/RenderTargets.java:118); a plan that decides everything before a
+			// frame has to pay for it here, or the one name a pack like I Like Vanilla reads the
+			// screen through would be given a target this place never allocated.
+			//
+			// Asked in the words the binding will ask it in, SamplerPlan.takesDefault, and not off
+			// the name: the type decides, so a sampler3D under a name of the pack's own pays for
+			// nothing, and what the pack lays over the stage decides, so a name it supplies a file
+			// for takes no default and a picture laid over colortex0 stands where the target would.
+			//
+			// It joins what the PLACE samples, which is what allocates, and not what this PROGRAM
+			// samples: the second list is the indices the pack itself named, and the chain's
+			// verdicts are phrased against it. A name the pack wrote as tex is this engine saying
+			// it will read colortex0, not the pack saying so.
+			String bare = key.name().baseName();
+			Set<String> supplied = suppliedTo(textures, bare);
+			boolean screen = SamplerPlan.fullscreen(bare)
+					&& SamplerPlan.byDefault(picturesTo(textures, bare)) == SamplerPlan.Kind.COLORTEX;
+
 			Set<Integer> indices = new TreeSet<>();
-			for (String sampler : samplers(unit)) {
+			for (Declaration declaration : samplers(unit)) {
+				String sampler = declaration.name();
+				if (screen
+						&& SamplerPlan.takesDefault(sampler, declaration.type(), supplied, images)) {
+					draft.sampled.add(SamplerPlan.DEFAULT_TARGET);
+				}
+
 				// Under the same ceiling, which is what stops a name from allocating an image Iris
 				// would not have. Iris binds a shadow colour sampler by walking the array it sized
 				// off the declaration and building each one it finds a name for
-				// (samplers/IrisSamplers.java:159-163), so shadowcolor2 in a pack that never asked
+				// (samplers/IrisSamplers.java:159-164), so shadowcolor2 in a pack that never asked
 				// for the eight is a name nothing answers rather than an image.
 				if (SamplerPlan.isShadowColour(sampler)
 						&& SamplerPlan.shadowColour(sampler) < draft.shadowCeiling) {
@@ -631,13 +811,37 @@ public final class TargetPlan {
 		draft.expandMillis = (System.nanoTime() - began) / 1_000_000L;
 	}
 
-	/** Every name declared as a sampler on a live line, whatever the sampler is for. */
-	private static List<String> samplers(ExpandedUnit unit) {
-		List<String> names = new ArrayList<>();
+	/**
+	 * One sampler a program declares, under the type it was declared with.
+	 * <p>
+	 * The type travels with the name because the default sampler is decided on it: {@code sampler3D
+	 * worleyNoiseTexture} and {@code sampler2D tex} are the same name to everything else here and
+	 * two different questions to that one.
+	 */
+	private record Declaration(String name, String type) {
+	}
+
+	/**
+	 * Every name declared as a sampler on a live line, whatever the sampler is for.
+	 * <p>
+	 * Live means both things a line can be crossed out by. The preprocessor is one, and the pack's
+	 * own comments are the other: Sildur's puts a whole block of declarations behind a {@code /*} in
+	 * two of its dimensions, and read as text those are samplers nothing compiles, one of which
+	 * would allocate the first colour target for a program that never asks for it.
+	 * <p>
+	 * A line that OPENS a comment and declares nothing before it matches nothing anyway, the
+	 * pattern wanting the declaration at the head of the line, so what has to be tracked is only
+	 * whether a block comment was already open when the line began.
+	 */
+	private static List<Declaration> samplers(ExpandedUnit unit) {
+		List<Declaration> names = new ArrayList<>();
 		List<String> lines = unit.lines();
+		boolean commented = false;
 
 		for (int line = 0; line < lines.size(); line++) {
-			if (!unit.isLive(line)) {
+			boolean opened = commented;
+			commented = afterLine(lines.get(line), commented);
+			if (opened || !unit.isLive(line)) {
 				continue;
 			}
 
@@ -646,6 +850,7 @@ public final class TargetPlan {
 				continue;
 			}
 
+			String type = matcher.group(1);
 			for (String declarator : matcher.group(2).split(",", -1)) {
 				String name = declarator.trim();
 				int bracket = name.indexOf('[');
@@ -654,12 +859,35 @@ public final class TargetPlan {
 				}
 
 				if (!name.isEmpty()) {
-					names.add(name);
+					names.add(new Declaration(name, type));
 				}
 			}
 		}
 
 		return names;
+	}
+
+	/**
+	 * Whether a block comment is still open once this line has been read. A line comment closes at
+	 * the end of the line and so ends the walk of it; inside a block, neither form opens anything
+	 * and only the closing pair is looked for.
+	 */
+	private static boolean afterLine(String line, boolean commented) {
+		for (int at = 0; at < line.length() - 1; at++) {
+			if (commented) {
+				if (line.charAt(at) == '*' && line.charAt(at + 1) == '/') {
+					commented = false;
+					at++;
+				}
+			} else if (line.charAt(at) == '/' && line.charAt(at + 1) == '/') {
+				return false;
+			} else if (line.charAt(at) == '/' && line.charAt(at + 1) == '*') {
+				commented = true;
+				at++;
+			}
+		}
+
+		return commented;
 	}
 
 	public String packName() {

--- a/common/src/main/java/dev/vitrail/pack/texture/CustomImages.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/CustomImages.java
@@ -5,6 +5,7 @@ import dev.vitrail.pack.model.TargetFormat;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -48,7 +49,7 @@ public final class CustomImages {
 		}
 
 		byName = Map.copyOf(images);
-		names = Set.copyOf(images.keySet());
+		names = namesOf(reading);
 	}
 
 	public static void clear() {
@@ -56,9 +57,34 @@ public final class CustomImages {
 		names = Set.of();
 	}
 
+	/**
+	 * Every name an {@code image.} directive hangs on, the image and the sampler that reads the
+	 * same volume, read straight off the directives.
+	 * <p>
+	 * This is what {@link #named} answers once {@link #install} has run, and it is exposed so that
+	 * a caller needing the answer BEFORE that asks the same question of the same text instead of
+	 * asking a registry that still holds the pack before. A target plan is built while the registry
+	 * is another pack's, and a name read as unserved there and as an image here is a target
+	 * allocated for nobody, or a name handed a colour target the plan never opened.
+	 */
+	public static Set<String> namesOf(ImageInformation.Reading reading) {
+		Set<String> named = new LinkedHashSet<>();
+		for (ImageInformation image : reading.images()) {
+			named.add(image.name());
+			image.sampler().ifPresent(named::add);
+		}
+
+		return Set.copyOf(named);
+	}
+
 	/** Image name or sampler name hanging off an {@code image.} directive. */
 	public static boolean named(String name) {
 		return names.contains(name);
+	}
+
+	/** The same names as a set, for a reader that asks about more than one of them. */
+	public static Set<String> names() {
+		return names;
 	}
 
 	/** The image uniform itself, as opposed to the sampler that reads the same volume. */

--- a/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
@@ -537,6 +537,31 @@ public final class PackTextures {
 		return names;
 	}
 
+	/**
+	 * The names of that stage a flat picture stands on, which are the ones a program's DEFAULT
+	 * sampler can land on rather than on the colour target.
+	 * <p>
+	 * Narrower than {@link #suppliedTo} three times over, and each is Iris's own line. The stage
+	 * form alone: {@code customTexture.NAME} names no stage and is bound by name and nothing else
+	 * ({@code samplers/IrisSamplers.java:237-239}), so it never stands where a name nothing serves
+	 * lands. The picture alone: a declaration that spells a raw blob out goes to the renaming road
+	 * ({@code ShaderProperties.java:480}), and only a picture enters the map the default sampler is
+	 * swapped out of ({@code :485-486}). And a name with nothing behind it at all is not one of
+	 * them: a picture Iris fails to read leaves its stage map without that name
+	 * ({@code pipeline/CustomTextureManager.java:56-67}), so the default sampler goes back to the
+	 * target, which is what a name this engine refused does here.
+	 */
+	public Set<String> picturesTo(TextureStage stage) {
+		Set<String> names = new LinkedHashSet<>();
+		this.overrides.getOrDefault(stage, Map.of()).forEach((sampler, texture) -> {
+			if (texture.raw().isEmpty()) {
+				names.addAll(spellings(sampler));
+			}
+		});
+
+		return names;
+	}
+
 	/** A colour target under both its names, anything else under its own. */
 	private static List<String> spellings(String sampler) {
 		OptionalInt index = TargetName.index(sampler);

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2491,8 +2491,10 @@ public final class PackChain {
 				continue;
 			}
 
+			// The same test the plan stops its walk of the overrides on, so that the moment this
+			// dispatch takes and the halves the plan says it reads are the one answer.
 			int at = 0;
-			while (at < built.size() && order.compare(built.get(at).program(), program) < 0) {
+			while (at < built.size() && ProgramNames.before(built.get(at).program(), program)) {
 				at++;
 			}
 

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -179,7 +179,7 @@ final class PackCompute implements AutoCloseable {
 	 * like the passes on the declaration surviving the translation. Such a compute is handed the
 	 * texel the same way its pass is, so a chain whose only reader is one has to fold it the same
 	 * way: Iris arms the fold from its compute builder as it does from a composite
-	 * ({@code pipeline/CompositeRenderer.java:466}).
+	 * ({@code pipeline/CompositeRenderer.java:470}).
 	 * <p>
 	 * The shadow computes do not count. They run at the head of the frame, before the opaque
 	 * world whose depth the fold takes exists, and Iris hands them no such sampler at all: its
@@ -291,6 +291,18 @@ final class PackCompute implements AutoCloseable {
 					Vitrail.logger().info("Loaded compute {} before {} ({})", path, base.get(),
 							sizing(compute.get()));
 				}
+
+				// The one binding the pack's own text cannot be read for, said here for a compute
+				// as PackPass.describe says it for a pass. Past all three roads rather than on one
+				// of them, and once per program: a compute of a full screen family takes the
+				// default whether or not the program it hangs off draws anything, and Pegasus,
+				// whose prepare stage is four computes and no pass, would never have said so.
+				List<String> defaulted = compute.get().loaded().samplers().defaulted();
+				if (!defaulted.isEmpty()) {
+					Vitrail.logger().info("{} reads {} by default under {}", path,
+							TargetName.canonical(SamplerPlan.DEFAULT_TARGET),
+							String.join(", ", defaulted));
+				}
 			} catch (IOException | RuntimeException e) {
 				Vitrail.logger().warn("compute {} could not be translated: {}", path, e.toString());
 			}
@@ -332,9 +344,9 @@ final class PackCompute implements AutoCloseable {
 	 *                and so what its computes read under the same name: Iris hands a compute the
 	 *                three depth names of the pass it hangs off through the same
 	 *                {@code IrisSamplers.addCompositeSamplers} call
-	 *                ({@code pipeline/CompositeRenderer.java:458} against {@code :402}), and the
+	 *                ({@code pipeline/CompositeRenderer.java:462} against {@code :406}), and the
 	 *                far terrain's through the same {@code addRenderTargetSamplers}
-	 *                ({@code :450} against {@code :394})
+	 *                ({@code :454} against {@code :398})
 	 * @param distant what that pass reads as {@code dhDepthTex0}, on the same split, or null for
 	 *                the far plane on the frames the pack drew no far terrain
 	 */
@@ -451,7 +463,7 @@ final class PackCompute implements AutoCloseable {
 		// before any of it: on the first frame after a pack loads the fields are still nought,
 		// which is a dispatch of no groups at all, and every resize afterwards would size a frame
 		// by the window it had before. Iris asks the same object at the same moment,
-		// ShadowCompositeRenderer.java:211-212.
+		// ShadowCompositeRenderer.java:213-214.
 		Minecraft minecraft = Minecraft.getInstance();
 		RenderTarget main = minecraft == null ? null : minecraft.gameRenderer.mainRenderTarget();
 		int width = main == null ? 0 : main.width;
@@ -547,20 +559,19 @@ final class PackCompute implements AutoCloseable {
 					orWhite(targets, shadow == null ? null : shadow.depthWithoutTranslucents());
 			// Every name SamplerPlan reads as a shadow colour, the bare shadowcolor with them, and
 			// the white stand-in for one no program of the place named. That is the rule a full
-			// screen pass follows for the same names (PackPass.java:585), and the ceiling is not
+			// screen pass follows for the same names (PackPass.java:640), and the ceiling is not
 			// consulted here because it does not have to be: a buffer the pack may not reach was
 			// never allocated, so colour() answers null for it and white is what the compute reads,
 			// exactly as it does for a buffer nothing has written.
 			//
 			// White covers one more case than it should, and that is a divergence rather than a
-			// rule: what gets allocated is read off the FRAGMENT stages of the place alone
-			// (TargetPlan.build walks fragmentsOf), so a shadowcolor that only a COMPUTE of the
-			// place names is never opened, and this hands the compute white for a buffer the pack
-			// does mean to read. Iris opens it from the compute itself, addShadowSamplers calling
-			// createIfEmpty for each shadowcolor the program declares, on the compute path as on
-			// the composite one (CompositeRenderer.java:461, samplers/IrisSamplers.java:156-163).
-			// Closing it means expanding every compute of the pack while the plan is built, which
-			// is a second reading of the archive, and nothing of the corpus asks for it: every
+			// rule: which shadow buffers get allocated is read off the FRAGMENT stages of the place
+			// alone (TargetPlan.read fills shadowNamed there and nowhere else), so a shadowcolor
+			// that only a COMPUTE of the place names is never seen, and this hands the compute
+			// white for a buffer the pack does mean to read. Iris opens it from the compute itself,
+			// addShadowSamplers calling createIfEmpty for each shadowcolor the program declares, on
+			// the compute path as on the composite one (CompositeRenderer.java:465,
+			// samplers/IrisSamplers.java:156-164). Nothing of the corpus asks for it: every
 			// shadowcolor a compute of it names is named by a fragment stage of the same place too.
 			default -> SamplerPlan.isShadowColour(name)
 					? orWhite(targets, shadow == null ? null : shadow.colour(SamplerPlan.shadowColour(name)))
@@ -732,9 +743,9 @@ final class PackCompute implements AutoCloseable {
 				VK12.vkCmdBindPipeline(commands, VK12.VK_PIPELINE_BIND_POINT_COMPUTE, this.pipeline);
 				pushDescriptors(commands, stack, targets, step, depth, distant);
 				// The screen and not the shadow map: Iris sizes a shadow composite's compute off
-				// the main render target, ShadowCompositeRenderer.java:212, and the resolution of
-				// the shadow map is what it sizes the shadow GEOMETRY computes off instead,
-				// IrisRenderingPipeline.java:916.
+				// the main render target, ShadowCompositeRenderer.java:213-214, and the resolution
+				// of the shadow map is what it sizes the shadow GEOMETRY computes off instead,
+				// IrisRenderingPipeline.java:908.
 				int[] groups = this.compute.groupsAt(width, height);
 				VK12.vkCmdDispatch(commands, groups[0], groups[1], groups[2]);
 			}
@@ -1031,7 +1042,7 @@ final class PackCompute implements AutoCloseable {
 					// The depth of the pass this compute hangs off, under the three names, the far
 					// terrain's and the smoothed centre depth, answered by the methods that answer
 					// the pass itself: Iris gives a compute the depth samplers of its pass
-					// (CompositeRenderer.java:458 and :461), and Reverie's cloud compute reads
+					// (CompositeRenderer.java:462 and :470), and Reverie's cloud compute reads
 					// depthtex1 to know where the sky ends. Ahead of the engine set below because
 					// that set carries no depth, and a name it did not carry threw on every
 					// dispatch, so the compute never ran and said so once.
@@ -1060,6 +1071,54 @@ final class PackCompute implements AutoCloseable {
 						write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
 						write.pImageInfo(imageInfo);
 						continue;
+					}
+
+					// And last, the default sampler of the family this compute hangs off. Iris
+					// builds a compute of a stage with the same call and the same full screen flag
+					// as the passes of that stage (CompositeRenderer.java:454 beside :398), so a
+					// name that reads the screen in composite1.fsh reads it in composite1_a.csh as
+					// well, and a rule posed on one and not the other kills the compute over a
+					// declaration the pass takes in its stride. The plan already worked out what
+					// colortex0 is for this program, standing overrides and all; a shadow compute
+					// has no such default and its plan carries none.
+					SamplerPlan.Binding byDefault =
+							this.compute.loaded().samplers().binding(entry.name());
+					if (byDefault.defaulted()) {
+						String screen = TargetName.canonical(SamplerPlan.DEFAULT_TARGET);
+						// The colour target needs the step, its half being the pass's; the file the
+						// pack lays over the target does not, being one image whichever half the
+						// compute is dispatched on, so the second road is not held behind the first
+						// one's condition.
+						if (byDefault.kind() == SamplerPlan.Kind.COLORTEX && step != null
+								&& colourTarget(write, imageInfo, screen, targets, step,
+										this.program)) {
+							continue;
+						}
+
+						ColorTargets.PackBinding laid = targets.packTexture(this.textureStage, screen);
+						if (laid != null && laid.view() instanceof VulkanGpuTextureView served) {
+							imageInfo.sampler(((VulkanGpuSampler) PackPass.sampler(laid.repeat(),
+									laid.filter(), false)).vkSampler());
+							imageInfo.imageView(served.vkImageView());
+							imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+							write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+							write.pImageInfo(imageInfo);
+							continue;
+						}
+
+						// And one black texel where the default resolved to nothing, which is what
+						// the pass beside this compute binds for the very same name
+						// (PackPass.java:724). The pass draws on black there; taking the compute
+						// out of the frame instead would be this engine answering one declaration
+						// two ways.
+						if (targets.black() instanceof VulkanGpuTextureView blank) {
+							imageInfo.sampler(samplerFor(entry.name()));
+							imageInfo.imageView(blank.vkImageView());
+							imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+							write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+							write.pImageInfo(imageInfo);
+							continue;
+						}
 					}
 
 					throw new IllegalStateException("Missing storage image " + entry.name());
@@ -1116,8 +1175,21 @@ final class PackCompute implements AutoCloseable {
 			}
 
 			TargetSurface surface = targets.surface(index.getAsInt(), step.read(index.getAsInt()));
+
+			// One black texel for a target this place never allocated, which is the answer a full
+			// screen pass gives the same name (PackPass.java:724). Throwing here took the whole
+			// compute out of the frame over a declaration the pass beside it draws with.
 			if (surface == null || !(surface.view() instanceof VulkanGpuTextureView view)) {
-				throw new IllegalStateException(name + " is not an allocated colour target");
+				if (!(targets.black() instanceof VulkanGpuTextureView blank)) {
+					return false;
+				}
+
+				imageInfo.sampler(samplerFor(name));
+				imageInfo.imageView(blank.vkImageView());
+				imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
+				write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+				write.pImageInfo(imageInfo);
+				return true;
 			}
 
 			// Clamped, filtered and mipmapped the way the pass this hangs off binds the same

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -202,8 +202,15 @@ final class PackPass {
 		this.samplerBindings = this.samplers.stream().map(loaded.samplers()::binding).toList();
 		List<ColorTargets.PackSource> sources = new ArrayList<>();
 		for (int at = 0; at < this.samplers.size(); at++) {
-			sources.add(this.samplerBindings.get(at).kind() == SamplerPlan.Kind.PACK_TEXTURE
-					? targets.packSource(this.textureStage, this.samplers.get(at))
+			SamplerPlan.Binding binding = this.samplerBindings.get(at);
+			// A name that took the default is looked up under colortex0 and not under itself: the
+			// pack wrote the directive against the target, and the name only reaches the file
+			// because it landed on the same texture unit.
+			String named = binding.defaulted()
+					? TargetName.canonical(SamplerPlan.DEFAULT_TARGET)
+					: this.samplers.get(at);
+			sources.add(binding.kind() == SamplerPlan.Kind.PACK_TEXTURE
+					? targets.packSource(this.textureStage, named)
 					: null);
 		}
 		this.packSources = Collections.unmodifiableList(sources);
@@ -451,11 +458,21 @@ final class PackPass {
 							+ " pixels");
 		}
 
-		return line.append(", ")
+		line.append(", ")
 				.append(this.loaded.program().uniforms().size()).append(" uniforms and ")
 				.append(this.samplers.size()).append(" samplers, ")
-				.append(descriptors()).append(" descriptors")
-				.toString();
+				.append(descriptors()).append(" descriptors");
+
+		// Said here and nowhere else, because this is the one binding the pack's own text cannot be
+		// read for: the pack never wrote colortex0 beside these names, and whether they read the
+		// scene or read nothing is the whole picture on a pack that calls the screen tex.
+		List<String> defaulted = this.loaded.samplers().defaulted();
+		if (!defaulted.isEmpty()) {
+			line.append(", ").append(TargetName.canonical(SamplerPlan.DEFAULT_TARGET))
+					.append(" by default for ").append(String.join(", ", defaulted));
+		}
+
+		return line.toString();
 	}
 
 	private String writes() {
@@ -763,7 +780,7 @@ final class PackPass {
 	 * The one texel {@code centerDepthSmooth} is read out of, and white until the pass behind it
 	 * has drawn once: the far plane in the pack's own window, so a focus point at the horizon,
 	 * where black would be one at the camera. Package private for the compute road, which Iris
-	 * hands the same texel ({@code pipeline/CompositeRenderer.java:461}).
+	 * hands the same texel ({@code pipeline/CompositeRenderer.java:470}).
 	 */
 	static GpuTextureView centerDepth(ColorTargets targets) {
 		return or(targets.centerDepth().view(), targets.white());

--- a/docs/internals/material-maps.md
+++ b/docs/internals/material-maps.md
@@ -32,9 +32,14 @@ pass. That is what lets the block atlas, the item atlas and the particle atlas e
 themselves: the terrain reads the block atlas's companions, a particle reads whichever atlas that
 layer came off, and neither has to be told which it is.
 
-Only the geometry programs are served, which is what Iris does too. What a composite declaring one
-of the names reads is not the same on both sides: here it reads one black pixel, where Iris leaves
-the sampler unassigned and it falls to whatever texture unit nought holds.
+Only the geometry programs are served, which is what Iris does too, and a composite declaring one of
+the names as a plain `sampler2D` is not left with nothing: it is simply not this file that answers
+it. A name a full screen pass assigns no texture unit to falls to the default sampler, which holds
+the first colour target unless the pack lays a flat picture of its own over that target for the
+stage, in which case it holds the picture. So what such a composite reads is the scene, or whatever
+the pack put in its place, and not a map. Both sides work that way, and on the same one shape: a
+picture is what the default sampler can stand on, and a raw blob, a volume among them, goes to the
+renaming road instead and leaves the target where it was.
 
 A sprite the resource pack ships no map for reads the same flat value the whole companion is cleared
 to: a normal pointing straight out of the face with nothing occluded, and a material that is nought


### PR DESCRIPTION
## What changes

A pack may read the scene in a full screen pass under one of the world pass names, `tex` and
`texture` among them, because OptiFine leaves the first colour target on the default texture unit
of a composite and Iris keeps that: `colortex0` sits on unit nought and a sampler the program
assigns no unit to reads whatever that unit holds. A descriptor set has no default, so those names
were handed one black texel and every pass of such a chain worked on black. An unserved plain
`sampler2D` name in a begin, prepare, deferred, composite or final program, and in the computes of
those stages, now reads what `colortex0` resolves to: the target, or the file the pack laid over it
for that stage, looked up under the target's name as the directive wrote it. The target is
allocated wherever a full screen program of the place declares such a name, and where it is not
the name falls to the black texel rather than to an index nothing opened. Only a declaration the
reader really typed `sampler2D` moves: a storage image, a cube, an integer or unsigned form, a
comparison sampler the translator retyped, and a name no type could be put on keep the roads they
had. Every name that took the default is named in the log once per program. I Like Vanilla calls
the screen `tex` throughout and presented an image of exactly zero.

## How it differs from the reference, and for what obstacle

One shape. Iris throws the override's texture type away on that road
(`gl/program/ProgramSamplers.java:298-306` handing it on, `:155-162` binding `TEXTURE_2D`
regardless), so a blob laid over `colortex0` that is neither a flat picture nor a volume reaches
the default sampler as a two dimensional image there. Here nothing turns such a blob into an image
(`render/PackImages.java:185-191` names it and serves one black texel), so a defaulted name reads
black where Iris read the file's bytes as a picture. No pack of the corpus is on that road: the only
override on `colortex0` in it is Photon's volume, which both engines keep out.

## What proves it

- `gradlew build` green.
- The out-of-game harness, over the whole corpus against the same reading on the parent commit:
  the names that move from unserved to the first colour target are all in the full screen families
  and their computes, none moves the other way, and the allocation table is unchanged. I Like
  Vanilla's `tex` is among them on every composite; Complementary, Mellow, Pegasus, Reverie and
  Spooklementary carry names of the same kind.
- In the game: I Like Vanilla draws its picture where it drew black. The sweep of the whole corpus
  on the jar carrying every fix of this series follows the merge.

## What it leaves owing

A sampler declared over several lines, or behind a `layout` carrying nested parentheses, is bound
but not allocated, and reads black; no pack of the corpus writes one.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
