### PR TITLE
fix(pack): serve the ENTITY_TRANSLUCENT feature name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,15 @@ what the next one holds.
   name stands for nothing the engine can read, the step still covers the whole screen and the log
   says which word it could not read.
 
+- **A pack that says it cannot be drawn without the translucent entity program now loads.**
+  RenderPearl names that capability in its own file, the engine did not count the name among the
+  ones it serves, and the pack was turned away before any of its programs was read, with nothing of
+  it on screen. The capability itself was already there: a blending entity draw asks for the pack's
+  `gbuffers_entities_translucent` and a blending block entity for its `gbuffers_block_translucent`,
+  each falling back on the opaque file of its own family where the pack ships neither. The name is
+  now served, and announced as a define beside the others so that a pack testing for it reads the
+  truth.
+
 - **The world is no longer painted over by the stage meant to run before it.** Some packs open the
   frame with a "prepare" stage, whose job is to fill a table the rest of the frame reads. It ran
   once the world was already drawn instead of ahead of it, so on a pack whose prepare fills the very

--- a/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
+++ b/common/src/main/java/dev/vitrail/pack/option/EngineDefines.java
@@ -189,6 +189,18 @@ public final class EngineDefines {
 		// emission under it.
 		defines.put("IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE", "");
 
+		// A blending entity draw asks for the pack's own gbuffers_entities_translucent rather than
+		// for the opaque entity file, and its block entity twin for gbuffers_block_translucent
+		// (render/EntityDraw), each falling back onto its own opaque name so a pack that ships one
+		// entity program still draws its whole family with the file it wrote
+		// (pack/model/ProgramFallbacks). That is the whole of what the name buys: Iris routes the
+		// blending entity pipelines through getTranslucent whatever the pack declared
+		// (pipeline/IrisPipelines.java:35,38,210-220) and reads the flag nowhere else, holding it
+		// usable on every machine (features/FeatureFlags.java:18). A pack that ships the program
+		// without declaring the name is therefore drawn the same on both, which is what BSL,
+		// Complementary and Noble do.
+		defines.put("IRIS_FEATURE_ENTITY_TRANSLUCENT", "");
+
 		// shadowtex0HW and shadowtex1HW are bound, the same two depth images as the plain pair and
 		// compared where the pack declares them so (SamplerPlan.SHADOW_DEPTH). Iris poses this one
 		// whatever the hardware, features/FeatureFlags.java:12.

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -331,8 +331,10 @@ public final class PackChoice {
 			// light into the eight it asked for, a storage block is bound off the pack's own
 			// bufferObject, compute passes are dispatched at the head of the frame and before the
 			// pass they hang off, a per buffer blend directive is built into the attachment whose
-			// rank its target holds, and custom images are served now, so a pack that cannot draw
-			// without one of those is simply right about what it needs. The list is the one EngineDefines poses
+			// rank its target holds, a blending entity draw reaches the pack's own
+			// gbuffers_entities_translucent and a blending block entity its block twin, and custom
+			// images are served now, so a pack that cannot draw without one of those is simply right
+			// about what it needs. The list is the one EngineDefines poses
 			// IRIS_FEATURE_ for, and the two have to move together: a define is a promise, and a
 			// refusal is the same promise refused.
 			//
@@ -345,7 +347,8 @@ public final class PackChoice {
 			// serves. ShaderProperties.declares already reads the same lists that way.
 			Set<String> served = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 			served.addAll(List.of("BLOCK_EMISSION_ATTRIBUTE", "COMPUTE_SHADERS", "CUSTOM_IMAGES",
-					PackDirectives.HIGHER_SHADOWCOLOR, "SSBO", "SEPARATE_HARDWARE_SAMPLERS"));
+					"ENTITY_TRANSLUCENT", PackDirectives.HIGHER_SHADOWCOLOR, "SSBO",
+					"SEPARATE_HARDWARE_SAMPLERS"));
 			// The one name of the list the DEVICE answers for rather than the engine, and Iris makes
 			// the same call on the same ground: its own flag is usable only where the driver parts
 			// the blend state of one attachment from the next (features/FeatureFlags.java:15). Ours

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -63,12 +63,12 @@ and did not get, the log listing them, rather than the symptom that would have c
 name Reverie declares is served now, so it is no longer refused there.
 
 **Any name this engine has not built refuses the declaration.** The names built and served today
-are `BLOCK_EMISSION_ATTRIBUTE`, `COMPUTE_SHADERS`, `CUSTOM_IMAGES`, `HIGHER_SHADOWCOLOR`,
-`PER_BUFFER_BLENDING`, `SEPARATE_HARDWARE_SAMPLERS` and `SSBO`, so a pack that requires those
-alone loads, and every other name still refuses the pack, with the list in the log. The served
-flags are also the only `IRIS_FEATURE_` defines a pack finds: a capability define is a promise, so
-each appears the day its feature is served and not before, and the optional declarations keep
-reading the truth.
+are `BLOCK_EMISSION_ATTRIBUTE`, `COMPUTE_SHADERS`, `CUSTOM_IMAGES`, `ENTITY_TRANSLUCENT`,
+`HIGHER_SHADOWCOLOR`, `PER_BUFFER_BLENDING`, `SEPARATE_HARDWARE_SAMPLERS` and `SSBO`, so a pack
+that requires those alone loads, and every other name still refuses the pack, with the list in the
+log. The served flags are also the only `IRIS_FEATURE_` defines a pack finds: a capability define
+is a promise, so each appears the day its feature is served and not before, and the optional
+declarations keep reading the truth.
 
 One of those names is the device's answer rather than the engine's. `PER_BUFFER_BLENDING` lets a
 pack give one of the targets a pass writes a different blend function from the others, and Vulkan
@@ -113,9 +113,10 @@ message is one of its passes, and it is drawn because a capability test in its c
 The test reads capability defines. This engine announces itself the way Iris does, but a capability
 define is a promise, so it defines only what the backend actually serves, which today is
 `IRIS_FEATURE_BLOCK_EMISSION_ATTRIBUTE`, `IRIS_FEATURE_COMPUTE_SHADERS`,
-`IRIS_FEATURE_CUSTOM_IMAGES`, `IRIS_FEATURE_HIGHER_SHADOWCOLOR`,
-`IRIS_FEATURE_SEPARATE_HARDWARE_SAMPLERS`, `IRIS_FEATURE_SSBO` and, where the driver parts the
-blend state of one attachment from the next, `IRIS_FEATURE_PER_BUFFER_BLENDING`, and nothing else.
+`IRIS_FEATURE_CUSTOM_IMAGES`, `IRIS_FEATURE_ENTITY_TRANSLUCENT`,
+`IRIS_FEATURE_HIGHER_SHADOWCOLOR`, `IRIS_FEATURE_SEPARATE_HARDWARE_SAMPLERS`,
+`IRIS_FEATURE_SSBO` and, where the driver parts the blend state of one attachment from the next,
+`IRIS_FEATURE_PER_BUFFER_BLENDING`, and nothing else.
 The section above says why the features behind the other names are closed. A pack that finds the
 announcement without the capability it wants concludes it is running on OptiFine, the only
 renderer in that position when the pack was written, and words its message for it. Read "OptiFine"


### PR DESCRIPTION
## What changes

A pack may declare that it cannot be drawn without the translucent entity program, through the
`ENTITY_TRANSLUCENT` feature name in its own file. The engine did not count that name among the
ones it serves, so the pack was turned away before any of its programs was read and nothing of it
reached the screen. The capability was already there: a blending entity draw reaches the pack's
`gbuffers_entities_translucent` and a blending block entity its `gbuffers_block_translucent`, each
falling back on the opaque file of its family where the pack ships neither. The name is now served
and announced as a define beside the other feature names, so a pack testing for it reads the truth.
RenderPearl is the pack this showed on: it requires the name and was refused as a whole.

## How it differs from the reference, and for what obstacle

It does not. Iris holds the flag usable on every machine (`features/FeatureFlags.java:18`), routes
the blending entity pipelines through `getTranslucent` whatever the pack declared
(`pipeline/IrisPipelines.java:35,38,210-220`), sends a blending block entity to the block twin
(`:215-217`), falls back on `gbuffers_entities` where the program is missing
(`shaderpack/loading/ProgramId.java:40`), and reads the flag nowhere else.

## What proves it

- `gradlew build` green.
- No rendering code moves: every behaviour the name promises is read off `render/EntityDraw` and
  `pack/model/ProgramFallbacks` as they stand, line by line against the reference above.
- In the game: not yet. RenderPearl has never been past the refusal on this engine, so its first
  picture is owed before this merges, on the test instance with this branch's jar.

## What it leaves owing

RenderPearl's own picture, which this branch makes possible and does not show.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
