### PR TITLE
fix(pack): read a grey picture of the pack as written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,14 @@ what the next one holds.
 
 ### Fixed
 
+- **A greyscale picture a pack ships is read as the pack wrote it.** Every grey image came out
+  lighter than the file, its darks lifted towards white, because the decoder converted the picture
+  out of its own colour space instead of taking the bytes as they were written. A pack that compares
+  such a picture against a number wrote that number for the picture it made, so the comparison
+  landed somewhere else: on MakeUp UltraFast the sky carried a solid white cover where the pack
+  draws a few clouds. The clouds are clouds again, and every grey lookup table, mask and noise field
+  a pack ships now holds the values it was authored with.
+
 - **The world is no longer painted over by the stage meant to run before it.** Some packs open the
   frame with a "prepare" stage, whose job is to fill a table the rest of the frame reads. It ran
   once the world was already drawn instead of ahead of it, so on a pack whose prepare fills the very

--- a/common/src/main/java/dev/vitrail/render/PackImages.java
+++ b/common/src/main/java/dev/vitrail/render/PackImages.java
@@ -69,7 +69,9 @@ final class PackImages {
 	 *
 	 * @param pixels four channels a texel in the order the encoder wants them, which is the order
 	 *               {@link NoiseTexture} already produces for the noise image; a byte a channel for
-	 *               an image, and the blob's own channel type for a volume laid out flat
+	 *               an image, and the blob's own channel type for a volume laid out flat. A PNG is
+	 *               read sample by sample as the file wrote it, a grey one replicated over red,
+	 *               green and blue rather than converted out of the grey colour space
 	 * @param format what the surface is allocated as, which is what the pixels are
 	 * @param shape  one clause for the log, saying what was read and how big it came out
 	 */

--- a/common/src/main/java/dev/vitrail/uniform/NoiseTexture.java
+++ b/common/src/main/java/dev/vitrail/uniform/NoiseTexture.java
@@ -5,7 +5,11 @@ import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.MemoryCacheImageInputStream;
 
+import java.awt.color.ColorSpace;
 import java.awt.image.BufferedImage;
+import java.awt.image.IndexColorModel;
+import java.awt.image.Raster;
+import java.awt.image.SampleModel;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Iterator;
@@ -71,7 +75,9 @@ public final class NoiseTexture {
 	 * <p>
 	 * Decoded with ImageIO rather than the game's image class, for the same reason the generator
 	 * writes raw bytes: this package names no graphics API, which is what lets the harness measure
-	 * it without starting the game. ImageIO is the JDK's and works headless.
+	 * it without starting the game. ImageIO is the JDK's and works headless. The samples then come
+	 * off the raster as the file wrote them, expanded to four channels the way stb expands a PNG;
+	 * see {@link #pixels}, where the reading is what a grey image turns on.
 	 * <p>
 	 * The header is read before the pixels are, and that is the whole point of going through a
 	 * reader rather than through {@code ImageIO.read}: the size is in the first bytes of the file
@@ -104,8 +110,104 @@ public final class NoiseTexture {
 		}
 	}
 
+	/**
+	 * Four channels a texel, expanded the way stb expands a PNG: one band gives grey, grey, grey and
+	 * opaque, two give grey, grey, grey and the alpha, three give the colour opaque, four are taken
+	 * as they are.
+	 * <p>
+	 * The samples are read off the raster, which is the whole point rather than a detail.
+	 * {@code getRGB} goes through the colour model, and on a grey image it converts the grey colour
+	 * space to sRGB and hands back every byte lifted: MakeUp UltraFast's cloud field comes out with a
+	 * mean of 0.728 where the file holds 0.501, and the pack thresholds that field at 0.55, so a few
+	 * filaments become a full white cover. Iris decodes with stb, which replicates the byte over red,
+	 * green and blue and converts nothing.
+	 * <p>
+	 * A sixteen bit sample is read as its top byte, which is what stb does when it is asked for eight
+	 * bit output.
+	 */
 	private static Image pixels(BufferedImage image, int width, int height) {
 		byte[] pixels = new byte[width * height * 4];
+		if (bands(image)) {
+			raster(image, width, height, pixels);
+		} else {
+			converted(image, width, height, pixels);
+		}
+
+		return new Image(width, height, pixels);
+	}
+
+	/** Whether the bands of the image mean a channel each, which is what lets them be read raw. */
+	private static boolean bands(BufferedImage image) {
+		// An indexed palette is the first of the models whose bands say nothing on their own: the
+		// sample is an index. Whole bytes are the other half of the question, a band of five or of
+		// ten bits being a field of a packed word rather than a channel. Both go through getRGB,
+		// which converts nothing there: a palette and a packed word are both already sRGB.
+		//
+		// A sample is a channel only in a grey or an RGB space with its alpha kept apart: a
+		// premultiplied alpha or a CMYK band would be uploaded as the colour it is not. A PNG never
+		// carries either, so this is about the other formats the reader accepts, which the
+		// reference refuses outright; they take the colour model road rather than a raw one.
+		if (image.getColorModel() instanceof IndexColorModel || image.isAlphaPremultiplied()) {
+			return false;
+		}
+
+		int space = image.getColorModel().getColorSpace().getType();
+		if (space != ColorSpace.TYPE_GRAY && space != ColorSpace.TYPE_RGB) {
+			return false;
+		}
+
+		SampleModel samples = image.getSampleModel();
+		if (samples.getNumBands() > 4) {
+			return false;
+		}
+
+		for (int band = 0; band < samples.getNumBands(); band++) {
+			if (samples.getSampleSize(band) != 8 && samples.getSampleSize(band) != 16) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static void raster(BufferedImage image, int width, int height, byte[] pixels) {
+		Raster raster = image.getRaster();
+		int bands = raster.getNumBands();
+		int[] shift = new int[bands];
+		for (int band = 0; band < bands; band++) {
+			shift[band] = image.getSampleModel().getSampleSize(band) == 16 ? 8 : 0;
+		}
+
+		int minX = raster.getMinX();
+		int minY = raster.getMinY();
+		int[] row = new int[width * bands];
+		for (int y = 0; y < height; y++) {
+			raster.getPixels(minX, minY + y, width, 1, row);
+			for (int x = 0; x < width; x++) {
+				int at = x * bands;
+				int red = sample(row, at, shift, 0);
+				int green = bands < 3 ? red : sample(row, at, shift, 1);
+				int blue = bands < 3 ? red : sample(row, at, shift, 2);
+				int alpha = switch (bands) {
+					case 2 -> sample(row, at, shift, 1);
+					case 4 -> sample(row, at, shift, 3);
+					default -> 255;
+				};
+
+				int offset = (y * width + x) * 4;
+				pixels[offset] = (byte) red;
+				pixels[offset + 1] = (byte) green;
+				pixels[offset + 2] = (byte) blue;
+				pixels[offset + 3] = (byte) alpha;
+			}
+		}
+	}
+
+	private static int sample(int[] row, int at, int[] shift, int band) {
+		return (row[at + band] >> shift[band]) & 0xFF;
+	}
+
+	private static void converted(BufferedImage image, int width, int height, byte[] pixels) {
 		int[] row = new int[width];
 		for (int y = 0; y < height; y++) {
 			image.getRGB(0, y, width, 1, row, 0, width);
@@ -118,8 +220,6 @@ public final class NoiseTexture {
 				pixels[offset + 3] = (byte) (argb >> 24);
 			}
 		}
-
-		return new Image(width, height, pixels);
 	}
 
 	/**

--- a/docs/internals/pack-textures.md
+++ b/docs/internals/pack-textures.md
@@ -109,6 +109,26 @@ awkward interface. Two bounds are applied there: a limit per side, which is what
 accept, and a limit on **total texels**, which is what the memory actually is and what nothing else
 in the pack states.
 
+## A grey image is read, not converted
+
+The pixels are taken sample by sample off the raster the decoder produces, and expanded to four
+channels the way stb expands a PNG: one channel in the file gives grey, grey, grey and opaque, two
+give grey, grey, grey and the alpha, three give the colour opaque, four are taken as they are. A
+sixteen bit sample is read as its top byte.
+
+Asking the decoded image for a colour instead goes through its colour model, and a greyscale PNG
+carries the grey colour space rather than sRGB, so every byte comes back **lifted**: a field written
+with a mean of 0.501 reads 0.728. That is not a subtle shade difference. A pack that thresholds such
+a field a little above its own mean draws something else entirely, a cloud field going from a few
+filaments to a solid cover. The reference decodes with stb, which replicates the byte over the three
+channels and converts nothing, so reading the samples is what agrees with it. A colour PNG comes
+through either road byte for byte, which is why only the grey ones were wrong.
+
+The one model whose samples are not read is an indexed palette, where a sample is an index and means
+nothing on its own, along with any layout whose bands are not whole bytes, a premultiplied alpha, or
+a colour space other than grey and RGB. Those go through the colour model instead, which converts
+nothing for a palette or a packed word; none of them is a shape a PNG takes.
+
 ## A texture that cannot be served costs only that texture
 
 Allocation is attempted and caught per texture. The name that fails reads one black pixel and is

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -436,7 +436,12 @@ naming a stage and a sampler. Both are read through the pack's conditionals, so 
 inside a disabled branch is not bound. A declared texture rebinds that sampler name to the file
 instead of to the colour target that would otherwise carry the same name.
 
-Four rules here were each paid for:
+The rules here were each paid for:
+
+**A greyscale PNG is read as it was written.** Its samples are taken raw and replicated over red,
+green and blue, the way the reference decoder expands one, rather than read through the colour model
+that would convert the grey colour space to sRGB and lift every byte. A pack that thresholds a grey
+field gets the threshold it wrote.
 
 **A cap on file size does not bound decoding.** A flat-colour image of huge dimensions compresses to
 almost nothing and demands gigabytes once decoded, so the decoder reads the image header before the


### PR DESCRIPTION
## What changes

A picture a pack ships as a grey PNG read lighter than written. The bytes were taken through
`BufferedImage.getRGB`, which converts a grey colour model to sRGB on the way out, so a grey value
of 129 came back as 189 and the mean of a whole field rose from a half to nearly three quarters.
MakeUp UltraFast feeds such a picture to its volumetric clouds and thresholds it, so a few
filaments became a white cover over most of the sky. The samples are now read off the raster as
they are, a one band picture replicated over red, green and blue and given an opaque alpha, two
bands giving grey and alpha, three and four as written, sixteen bit samples taking their top byte;
only an indexed palette still goes through the colour model, where nothing is converted. Colour
PNGs read the same bytes as before.

## How it differs from the reference, and for what obstacle

It does not: Iris decodes a pack PNG with stb, which replicates the raw byte over the three
channels (`targets/backed/NativeImageBackedCustomTexture.java:51`), and that is now what this
reads.

## What proves it

- `gradlew build` green.
- Off the game, the three pictures of the pack read through the new code: the clouds field's
  mean comes back to the value written in the file, its samples read what the file holds, and the
  colour water picture reads byte for byte what it read before. The grey and alpha picture of
  E-LITE moves the same way; the indexed pictures of E-LITE and AstraLex do not move.
- In the game: MakeUp UltraFast's sky, to be looked at on the test instance with this branch's
  jar or on the next sweep; the picture is owed.

## What it leaves owing

MakeUp UltraFast's own picture, and a look at E-LITE and AstraLex, which ship grey pictures too.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
