### PR TITLE
refactor(render): answer owns once for every family program

### DIFF
--- a/common/src/main/java/dev/vitrail/render/CloudProgram.java
+++ b/common/src/main/java/dev/vitrail/render/CloudProgram.java
@@ -115,13 +115,4 @@ final class CloudProgram extends FamilyProgram {
 		return this.body.prepare(device, null);
 	}
 
-	/**
-	 * Whether the pipeline a pass has bound is this program's.
-	 *
-	 * @see GeometryProgram#owns
-	 */
-	boolean owns(RenderPipeline bound) {
-		return this.body.owns(bound);
-	}
-
 }

--- a/common/src/main/java/dev/vitrail/render/FamilyProgram.java
+++ b/common/src/main/java/dev/vitrail/render/FamilyProgram.java
@@ -2,6 +2,7 @@ package dev.vitrail.render;
 
 import dev.vitrail.uniform.WorldState;
 
+import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderPassDescriptor;
@@ -93,6 +94,15 @@ abstract class FamilyProgram implements DumpedProgram {
 	@Override
 	public String label() {
 		return this.body.label();
+	}
+
+	/**
+	 * Whether the pipeline a pass has bound is this program's.
+	 *
+	 * @see GeometryProgram#owns
+	 */
+	boolean owns(RenderPipeline bound) {
+		return this.body.owns(bound);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/SkyProgram.java
+++ b/common/src/main/java/dev/vitrail/render/SkyProgram.java
@@ -129,13 +129,4 @@ final class SkyProgram extends FamilyProgram {
 		this.body.sampler(sampler);
 	}
 
-	/**
-	 * Whether the pipeline a pass has bound is this program's.
-	 *
-	 * @see GeometryProgram#owns
-	 */
-	boolean owns(RenderPipeline bound) {
-		return this.body.owns(bound);
-	}
-
 }

--- a/common/src/main/java/dev/vitrail/render/TerrainProgram.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainProgram.java
@@ -264,15 +264,6 @@ public final class TerrainProgram extends FamilyProgram {
 	}
 
 	/**
-	 * Whether the pipeline a pass has bound is this program's.
-	 *
-	 * @see GeometryProgram#owns
-	 */
-	boolean owns(RenderPipeline bound) {
-		return this.body.owns(bound);
-	}
-
-	/**
 	 * Whether this program can still be served, which everything built on it has to agree with.
 	 *
 	 * @see GeometryProgram#servable

--- a/common/src/main/java/dev/vitrail/render/WeatherProgram.java
+++ b/common/src/main/java/dev/vitrail/render/WeatherProgram.java
@@ -143,13 +143,4 @@ final class WeatherProgram extends FamilyProgram {
 		return this.body.plain();
 	}
 
-	/**
-	 * Whether the pipeline a pass has bound is this program's.
-	 *
-	 * @see GeometryProgram#owns
-	 */
-	boolean owns(RenderPipeline bound) {
-		return this.body.owns(bound);
-	}
-
 }


### PR DESCRIPTION
## What changes

Nothing in the engine's behaviour. Four family adapters, the terrain, the sky, the clouds and the
weather, each carried the same one-line delegation of `owns(RenderPipeline)` to their
`GeometryProgram` body; the base they share, `FamilyProgram`, now carries it once and the four
copies are gone. The three adapters that never wrote it inherit the same answer, which is the
one their body already gave.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

- `gradlew build` green.
- Every caller of `owns` is a draw class asking its own family's program, and each still resolves
  to the body's answer; the method moved, its text did not.
- Nothing in game: a mechanical move with no behaviour to look at.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
