### PR TITLE
fix(render): copy a kept target back instead of swapping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,12 @@ what the next one holds.
   the pack's passes were refused for two outputs on one slot. The pack's own declaration takes the
   slot now.
 
+- **An effect a pack carries from one frame to the next no longer alternates between two images
+  while the view moves.** The two halves of such a target were exchanged at the end of the frame
+  instead of one being copied over the other, which is the same thing only where the frame wrote
+  the whole target. Where it wrote part of it, or where the pass that writes it did not run, the
+  pack was handed one image on one frame and the previous one on the next. It is steady standing
+  still and shows as the view moves, so it reads as lighting that slides.
 - **A greyscale picture a pack ships is read as the pack wrote it.** Every grey image came out
   lighter than the file, its darks lifted towards white, because the decoder converted the picture
   out of its own colour space instead of taking the bytes as they were written. A pack that compares

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -76,9 +76,8 @@ import java.util.stream.Collectors;
  * A target the schedule turns over carries two textures, and which half a program reads and
  * writes is the schedule's answer rather than a flag kept here. The one thing this class owes the
  * ping pong is {@link #swapBack}: a target the pack keeps between frames and that the chain left
- * on the alternate half has to become the main one, because the next frame starts its walk
- * from an empty flipped set and would otherwise read the half nothing wrote. The two surfaces
- * swap names. Copying the texels would be another GPU stop for the same fact.
+ * on the alternate half has to come back to the main one, because the next frame starts its walk
+ * from an empty flipped set and would read the half nothing wrote.
  * <p>
  * The files the pack ships as textures of its own live here too, and for one reason: they are
  * allocated, uploaded and freed at exactly the moments the constants are, and a second holder
@@ -746,37 +745,58 @@ final class ColorTargets {
 	}
 
 	/**
-	 * Makes the alternate half the main one, for the targets the plan named and no others. After
-	 * the last pass of the frame, and only a name swap: the next frame walks the chain from an
-	 * empty flipped set, so it reads the main half of everything before anything has written it.
-	 * Without this the pack would be handed, once per frame, the half it filled two frames ago.
+	 * Copies the alternate half back over the main one, for the targets the plan named and no
+	 * others. Must run outside any render pass, and after the last one of the frame.
 	 * <p>
-	 * The texels stay where they are. A copy would be a GPU stop, and both halves already carry
-	 * the same format. Mip levels past nought are rebuilt from nought before any program reads
-	 * one, the same as they were when this used to copy.
+	 * Only a target the pack keeps between frames is ever in that list. The next frame walks the
+	 * chain from an empty flipped set, so it reads the main half of everything before anything has
+	 * written it; without this the pack would be handed, once per frame, the half it filled two
+	 * frames ago. Both halves carry the same format, so this is a copy of bits that mean the same
+	 * thing on both sides rather than a reinterpretation.
 	 * <p>
-	 * Iris copies here and says in the same breath that it would rather not:
-	 * {@code FinalPassRenderer} carries "we merely copy it from alt to main, this works for the
-	 * most part but it's not perfect", the better approach being framebuffers for every other
-	 * frame. This backend builds its pass descriptor per frame, so it can have that for nothing.
+	 * <strong>Exchanging the two surfaces instead of copying is NOT the same operation, and the
+	 * difference is what the frame did not write.</strong> A copy leaves the two halves carrying
+	 * the same image; an exchange leaves main on the last write and alt on the one before it. The
+	 * two only agree where the frame covered the whole target. Where it did not, because the pass
+	 * blends over a region rather than painting the surface, because a program the plan counted
+	 * failed to build, or because the chain is still warming up, the copy converges in one frame
+	 * and the exchange alternates for as long as the pack stays loaded. That alternation is
+	 * invisible while the player stands still, both halves then holding the same scene, and shows
+	 * as soon as the view moves and they hold two.
 	 * <p>
-	 * <strong>The debug labels cross over and are not corrected.</strong> A surface is named at
-	 * allocation and keeps that name, so after an odd number of frames the texture labelled
-	 * {@code Vitrail colortexN alt} is the main half. It costs nothing at runtime and it misreads
-	 * badly in a GPU capture, which is where a target is looked up by name.
+	 * Iris copies here, {@code pipeline/FinalPassRenderer.java:139-162} and the
+	 * {@code glCopyTexSubImage2D} at {@code :290-303}, and it skips the targets
+	 * it is about to clear the same way this skips the ones the pack does not keep. Its own note
+	 * says a copy "works for the most part" and that the better approach would be a second set of
+	 * framebuffers on every other frame. That approach is not the exchange below: it needs the
+	 * chain walk itself to start from the other side on odd frames, where this engine starts every
+	 * frame from an empty flipped set, so exchanging the surfaces under a fixed walk moves the
+	 * image without moving the reader.
+	 * <p>
+	 * The list handed in keeps the plan's name for it, {@code ChainPlan.swapBack}: it names the
+	 * targets the frame leaves on the far half, whatever is done to bring them back, and the
+	 * harness reads it under that name.
 	 */
-	void swapBack(List<Integer> targets) {
+	void swapBack(CommandEncoder encoder, List<Integer> targets) {
 		for (int index : targets) {
 			TargetSurface alt = this.altSide.get(index);
 			TargetSurface main = this.mainSide.get(index);
 			if (alt == null || main == null) {
-				note("nothing to swap back for " + TargetName.canonical(index) + ": the plan asks "
+				note("nothing to copy back for " + TargetName.canonical(index) + ": the plan asks "
 						+ "for it and only one half of it exists");
 				continue;
 			}
 
-			this.mainSide.put(index, alt);
-			this.altSide.put(index, main);
+			GpuTexture from = alt.texture();
+			GpuTexture to = main.texture();
+			if (from != null && to != null) {
+				// Level nought alone, chain or no chain. The levels past it are refilled from it
+				// ahead of the next pass that reads one, so copying them here would be work whose
+				// result is overwritten before that pass can read it. A compute dispatched ahead of
+				// that refill samples the frame before's levels over this frame's nought, which is
+				// what Iris hands it too, its copy being level nought as well.
+				encoder.copyTextureToTexture(from, to, 0, 0, 0, 0, 0, main.width(), main.height());
+			}
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -75,7 +75,7 @@ import java.util.stream.Collectors;
  * <p>
  * A target the schedule turns over carries two textures, and which half a program reads and
  * writes is the schedule's answer rather than a flag kept here. The one thing this class owes the
- * ping pong is {@link #swapBack}: a target the pack keeps between frames and that the chain left
+ * ping pong is {@link #copyBack}: a target the pack keeps between frames and that the chain left
  * on the alternate half has to come back to the main one, because the next frame starts its walk
  * from an empty flipped set and would read the half nothing wrote.
  * <p>
@@ -777,7 +777,7 @@ final class ColorTargets {
 	 * targets the frame leaves on the far half, whatever is done to bring them back, and the
 	 * harness reads it under that name.
 	 */
-	void swapBack(CommandEncoder encoder, List<Integer> targets) {
+	void copyBack(CommandEncoder encoder, List<Integer> targets) {
 		for (int index : targets) {
 			TargetSurface alt = this.altSide.get(index);
 			TargetSurface main = this.mainSide.get(index);

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2295,17 +2295,17 @@ public final class PackChain {
 		drawRange(device, ready, deferredEnd(), this.programs.size(), this.targets.depth().scene(),
 				this.targets.depth().distantScene(), true, Cut.AFTER_TRANSLUCENTS);
 
-		// After the whole chain and before the halves swap back, which is where a final would have
-		// drawn. Only on a pack that ships none; ChainPresent says what it stands in for.
+		// After the whole chain and before the kept targets are copied back, which is where a final
+		// would have drawn. Only on a pack that ships none; ChainPresent says what it stands in for.
 		if (this.present != null && this.present.prepare(device)) {
 			this.present.draw(device.createCommandEncoder(), this.quad, ready.mainView(),
 					this.targets);
 		}
 
 		// Outside any pass, and after the last one. Only the targets the pack keeps between frames
-		// and that the chain left on the far half swap names: the next frame walks from an empty
+		// and that the chain left on the far half are copied: the next frame walks from an empty
 		// flipped set and would otherwise be handed what was written two frames ago.
-		this.targets.swapBack(this.chain.chain().swapBack());
+		this.targets.swapBack(device.createCommandEncoder(), this.chain.chain().swapBack());
 	}
 
 	/**
@@ -2967,8 +2967,8 @@ public final class PackChain {
 
 		List<Integer> back = unfolded.swapBack();
 		if (!back.isEmpty()) {
-			Vitrail.logger().info("{} targets swap their two halves at the end of every frame, because "
-					+ "the pack keeps them and the chain left them on the far one: {}",
+			Vitrail.logger().info("{} targets are copied back from their far half at the end of every "
+					+ "frame, because the pack keeps them and the chain left them there: {}",
 					back.size(), back);
 		}
 

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -2305,7 +2305,7 @@ public final class PackChain {
 		// Outside any pass, and after the last one. Only the targets the pack keeps between frames
 		// and that the chain left on the far half are copied: the next frame walks from an empty
 		// flipped set and would otherwise be handed what was written two frames ago.
-		this.targets.swapBack(device.createCommandEncoder(), this.chain.chain().swapBack());
+		this.targets.copyBack(device.createCommandEncoder(), this.chain.chain().swapBack());
 	}
 
 	/**

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -132,16 +132,16 @@ accident to debug.
 
 ### A copy is not a conversion
 
-The one copy left on a target is between the two halves of the shadow depth pair, where the format
-is the same on both sides by construction. The doubled colour targets are not copied at all: the two
-surfaces swap names at the end of the frame, and only for those still flipped when the last pass has
-run and kept between frames, which is the same fact for nothing. Copying between two *different*
-formats passes every check and hands back nonsense: the texture copy reinterprets bits rather than
-converting them, and what checks it on the way in depends on the loader. The bare game checks no
-format at all; the NeoForge build checks that the two agree on whether they carry a colour aspect,
-and that they are the same format where the source carries depth or stencil. Two colour formats pass
-either way. The game's colour target is eight-bit RGBA and a typical pack target is a packed float
-triple; both are thirty-two bits per pixel and hold completely different things.
+A copy on a target is always between two images of one format by construction: the two halves of
+the shadow depth pair, the two halves of a doubled colour target still flipped when the last pass
+has run and kept between frames, or a shadow map and the store a frame keeps it in. Copying between
+two *different* formats passes every check
+and hands back nonsense: the texture copy reinterprets bits rather than converting them, and what
+checks it on the way in depends on the loader. The bare game checks no format at all; the NeoForge
+build checks that the two agree on whether they carry a colour aspect, and that they are the same
+format where the source carries depth or stencil. Two colour formats pass either way. The game's
+colour target is eight-bit RGBA and a typical pack target is a packed float triple; both are
+thirty-two bits per pixel and hold completely different things.
 
 This is why the game's image is brought into a pack target by a **full-screen draw** and never by a
 texture copy.


### PR DESCRIPTION
## What changes

At the end of a frame, a colour target the pack keeps between frames and that the chain left on
its alternate half is copied back onto its main half, level nought only, instead of the two halves
exchanging names. An exchange is the same thing only where the frame rewrote the whole target;
where a pass blends over a region, where a program the plan counted failed to build, or while the
chain is still warming up, the exchange handed the pack one image on one frame and the one before
it on the next, for as long as the pack stayed loaded. That alternation holds still while the
player does and shows as soon as the view moves, as lighting that slides. The copy converges in
one frame. The method is named for what it does now, and the log line at load says copied rather
than swapped.

## How it differs from the reference, and for what obstacle

It does not: this is what the reference does at the end of its final pass
(`pipeline/FinalPassRenderer.java:139-162`, the copy itself at `:290-303`), skipping the targets
the pack clears each frame the same way this skips the ones the pack does not keep. The reference's
own note says it would rather have a second set of framebuffers on odd frames; that road is not the
exchange this replaces, since this engine walks every frame from an empty flipped set.

## What proves it

- `gradlew build` green, rebuilt without the build cache.
- The reference read line by line on the frame-end copy, and the selection of targets compared
  with the plan's list.
- In game on the Fabric bench, frozen world, same pinned camera, one frame in thirty: the log
  names four targets copied back on Complementary Reimagined and ten on Photon. Two captures of
  `dev` set the floor, then this branch, then Iris. On both packs the mean picture at rest sits
  under the `dev` floor and no nearer to nor farther from Iris than `dev` is, and a burst series
  of two minutes, at rest and with the camera walking, gives this branch the same frame-to-frame
  change and the same one-frame comeback as `dev`. Nothing moved on that scene: the road ran and
  the picture did not, so the merge rests on the reference reading.

## What it leaves owing

One copy of one mip level a frame per kept target the chain leaves on its far half, the GPU stop
the exchange had saved; the cost is small and unmeasured here. A compute dispatched ahead of the
pass that refills a chain samples the frame before's levels over the copied level nought, as it
does under the reference, whose copy is level nought too. The chain's list of targets keeps its
old name in the plan, the harness reading it under that one.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
