### PR TITLE
fix(render): hand the opaque depth copy to every geometry pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,17 @@ what the next one holds.
   the whole target. Where it wrote part of it, or where the pass that writes it did not run, the
   pack was handed one image on one frame and the previous one on the next. It is steady standing
   still and shows as the view moves, so it reads as lighting that slides.
+
+- **A geometry program drawn before the water sees the world's depth again.** The terrain, the
+  mobs, the opaque particles and the held item are drawn before the frame takes its copy of the
+  opaque world, and those programs were handed an empty world where a pack asked for that copy,
+  so a shader that softens or fogs itself against the scene from one of them saw nothing in front
+  of it. They now read the copy as it stands, which at that point of the frame is the frame
+  before's, exactly what the reference hands them; the live depth stays out of reach there, being
+  the very image those programs draw into. Complementary Reimagined and Photon draw the same
+  picture as before: the one only reads that copy from its water, drawn after the take, and the
+  other reads it from its particles and glowing eyes without using it there.
+
 - **A greyscale picture a pack ships is read as the pack wrote it.** Every grey image came out
   lighter than the file, its darks lifted towards white, because the decoder converted the picture
   out of its own colour space instead of taking the bytes as they were written. A pack that compares

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -2093,16 +2093,27 @@ final class GeometryProgram {
 	/**
 	 * What a depth sampler reads, which depends on which side of the frame this pass stands.
 	 * <p>
-	 * The translucent pass gets the opaque world's image. At that point of the frame depthtex0 and
-	 * depthtex1 are one depth, the opaque world's, and that image is exactly it; the live depth
-	 * cannot be the answer for either of them, being an attachment of this very pass, and sampling an
-	 * attachment is a thing Vulkan gives no meaning to. This is what BSL's water fog and refraction
-	 * read.
+	 * The translucent pass gets the opaque world's image for depthtex0 and depthtex1 alike. At that
+	 * point of the frame the two are one depth, the opaque world's, and that image is exactly it; the
+	 * live depth cannot be the answer for either of them, being an attachment of this very pass, and
+	 * sampling an attachment is a thing Vulkan gives no meaning to. This is what BSL's water fog and
+	 * refraction read.
 	 * <p>
-	 * The solid and cutout passes stay on the constant for those two. They draw before the image of
-	 * THIS frame is taken, so the only one in existence at that moment holds the previous frame's,
-	 * and handing them that would be the exact shape of picture this project refuses: plausible, and
-	 * wrong by one frame of camera movement.
+	 * The solid and cutout passes get the same image as depthtex1 and the constant as depthtex0.
+	 * They draw before the image of THIS frame is taken, so what the name holds at their moment is
+	 * the frame before's opaque world, and that is what Iris hands them too: its copy is refreshed
+	 * at {@code beginTranslucents}, one step behind the solid hand
+	 * ({@code mixin/MixinLevelRenderer.java:269-274},
+	 * {@code pipeline/IrisRenderingPipeline.java:1051-1063}), so every gbuffers program drawn ahead
+	 * of that step reads the frame before's copy under that name
+	 * ({@code samplers/IrisSamplers.java:223}). The shadow pass, drawn at the end of the frame here,
+	 * reads this frame's image under the same rule, which is the one Iris's shadow pass reads at the
+	 * head of the next. depthtex0 is the live depth there ({@code samplers/IrisSamplers.java:221}),
+	 * which on the world passes is this pass's own attachment and cannot be sampled, so that one
+	 * stays the far plane: a divergence on the attachment alone, with nothing older than this frame
+	 * ever dressed as the live depth. The shadow pass is left on the far plane with it rather than
+	 * served apart, and there the two engines agree: Iris draws its map at the head of the frame,
+	 * where the game has just cleared its depth, so the live name reads the far plane under it too.
 	 * <p>
 	 * <strong>depthtex2 is asked before that test and not inside it.</strong> It is the one copy
 	 * taken in the middle of the world rather than at the edge of a half:
@@ -2128,10 +2139,11 @@ final class GeometryProgram {
 	 * full screen draw where Iris moves depth to depth. That is a preference, so it does not make a
 	 * divergence admissible, and the honest name for it is an unpaid gap.
 	 * <p>
-	 * What holds it at that: the same passes read the same far plane on {@code main}, this class
-	 * having answered every depth copy with the constant ahead of the deferred stage long before
-	 * there was a third image; the range that added the image changed nothing for them. And no pack
-	 * of the eight measured reads the name from a program drawn there - the readers are BSL's two
+	 * What holds it at that: a pass drawn before the copy is taken falls through to the opaque
+	 * image below, the frame before's world WITH the hand in it, where Iris hands the frame
+	 * before's world without it; the two differ by the hand alone, and the name is read to see past
+	 * that very hand, so the fall through is nearer than the far plane and still not the answer. And
+	 * no pack of the eight measured reads the name from a program drawn there - the readers are BSL's two
 	 * composites, Bliss's deferred, and Sildur's two deferreds, its composite and its final, with no
 	 * gbuffers and no shadow program among them; two more files of Bliss declare the sampler and
 	 * never fetch it. Iris's own table carries a comment asking whether those programs should be
@@ -2145,7 +2157,10 @@ final class GeometryProgram {
 			}
 		}
 
-		if (this.pass.afterDeferred()) {
+		// The two copies read the opaque image wherever it exists, the frame before's ahead of the
+		// take and this frame's behind it; the live name only once the pass stands behind the
+		// deferred stage, where the two are one depth.
+		if (this.pass.afterDeferred() || SamplerPlan.depthCopy(sampler)) {
 			GpuTextureView opaque = this.targets.depth().opaque();
 			if (opaque != null) {
 				return opaque;
@@ -2169,7 +2184,9 @@ final class GeometryProgram {
 	 * 109-110}), and by the time an opaque gbuffers program draws, DH's opaque LODs are already in
 	 * it. What stops that here: the image a pack reads is a converted copy rather than the live
 	 * attachment, and the only copy in existence when the solid passes draw is the previous
-	 * frame's, which is the shape of picture this engine refuses by rule. What it costs: an opaque
+	 * frame's, which is not what Iris hands there either, its live image already holding this
+	 * frame's opaque LODs; the world's depth above has no such gap, the frame before's copy being
+	 * exactly what Iris gives. What it costs: an opaque
 	 * geometry program reading {@code dhDepthTex} sees no far terrain, where under Iris it sees the
 	 * opaque LODs; no program of the eight-pack corpus makes that read, the readers being deferreds
 	 * and composites throughout.
@@ -2303,9 +2320,10 @@ final class GeometryProgram {
 	/**
 	 * Whether the plan answers this name with an image rather than with one pixel. A colour target
 	 * counts even when it is empty at this point of the frame: it is the pack's own image and what
-	 * it holds is a question about the order of the frame, not about the binding. A depth sampler
-	 * counts only on the translucent pass, where the copy answers it, and depthtex2 on the hand's
-	 * solid pass as well, the copy that name reads being taken one line before that pass is drawn.
+	 * it holds is a question about the order of the frame, not about the binding. The two depth
+	 * copies count on every pass, the opaque image answering them wherever it exists, the frame
+	 * before's ahead of the take; the live name counts on the translucent pass alone, where that
+	 * same image answers it.
 	 * <p>
 	 * The plan's answer and not a frame's, and that is the whole of what it is for: this feeds a line
 	 * said once at the load, where no frame has run. A screen too big to allocate a depth image at
@@ -2352,9 +2370,8 @@ final class GeometryProgram {
 				|| (kind == SamplerPlan.Kind.COLORTEX && (!collides(binding) || copied(binding)))
 				|| kind == SamplerPlan.Kind.CUSTOM_IMAGE
 				|| kind == SamplerPlan.Kind.NOISE
-				|| (kind == SamplerPlan.Kind.DEPTH && (this.pass.afterDeferred()
-						|| (SamplerPlan.preHandCopy(sampler)
-								&& this.pass.stage() == RenderStage.HAND_SOLID)))
+				|| (kind == SamplerPlan.Kind.DEPTH
+						&& (this.pass.afterDeferred() || SamplerPlan.depthCopy(sampler)))
 				// The map exists from the first frame, but a pass that draws it reads its own
 				// attachment and is answered with a constant like everything else that collides.
 				|| (!this.pass.shadow() && kind == SamplerPlan.Kind.SHADOW_DEPTH
@@ -2469,8 +2486,8 @@ final class GeometryProgram {
 		}
 
 		if (!flat.isEmpty()) {
-			// What is left is what nothing fills for this pass: the shadow map, the depth on the
-			// passes that draw before the copy of this frame is taken, and the two material maps
+			// What is left is what nothing fills for this pass: the shadow map, the live depth on
+			// the passes that draw ahead of the deferred stage, and the two material maps
 			// wherever the RESOURCE pack ships no file beside the sprites of this pass's atlas. The
 			// last of the three is the one a reader can act on, and it is not a shader pack's doing.
 			Vitrail.logger().warn("{} read one pixel, because nothing fills them yet: {}",

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1112,6 +1112,11 @@ public final class PackChain {
 			return false;
 		}
 
+		// The depth images the screen moved away from go before any geometry pass samples one: the
+		// opaque image is refilled later in the frame at the new size, and until then a geometry
+		// pass would read the frame before's at the old one, stretched over the screen.
+		this.targets.depth().forgetOutgrown(main.width, main.height);
+
 		// Taken here and not held from the load: it is the fog of THIS frame, and the whole value of
 		// clearing colortex0 to it is that the sky the pack has not drawn over reads as distance
 		// rather than as a hole. Read after beginFrame, which every caller of this does first, so the

--- a/common/src/main/java/dev/vitrail/render/PackDepth.java
+++ b/common/src/main/java/dev/vitrail/render/PackDepth.java
@@ -583,16 +583,21 @@ final class PackDepth {
 		this.frameBefore = before;
 
 		if (before) {
-			dropOutgrown(width, height);
+			forgetOutgrown(width, height);
 		}
 	}
 
 	/**
-	 * Forgets every image the screen has moved away from, so that the window serves the far plane
+	 * Forgets every image the screen has moved away from, so that a reader is served the far plane
 	 * for the one frame rather than a depth of the right numbers at the wrong size. Each of them is
 	 * reallocated at its own take later in this frame, where {@code ensure} already stood.
+	 * <p>
+	 * Called where the window opens, and once more at the head of every frame from
+	 * {@code PackChain.openTargets}, which every geometry pass reaches before it samples: the
+	 * opaque image answers those passes with the frame before's depth, and on the frame the screen
+	 * changed size that image is the old screen's until the take refills it.
 	 */
-	private void dropOutgrown(int width, int height) {
+	void forgetOutgrown(int width, int height) {
 		if (outgrown(this.opaque, width, height)) {
 			this.opaqueWritten = false;
 		}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -244,16 +244,17 @@ after the deferred stage, onto a picture the chain has already composed, and tak
 outright. So a pack that writes a normal or a specular map from `gbuffers_hand` can light the hand
 from them, and a sleeve or any half-transparent layer blends against what stands behind it.
 
-What a `gbuffers_hand` reads as depth is not what the reference hands it, and that is a divergence
-rather than a rule of the format. There, at the moment the solid hand is drawn, `depthtex0` is the
-live scene depth and `depthtex1` the opaque copy taken the frame before
-(`mixin/MixinLevelRenderer.java:269-274`, `pipeline/IrisRenderingPipeline.java:1043-1063`); here
-both answer the far plane. The live depth is the attachment the hand's own pass writes, which a
-pass cannot sample on this backend; the frame before's copy is there and withheld, on the ground
-that it stands one frame of camera movement behind, which is a choice and not an obstacle. What it
-costs: a hand program that fogs, occludes or refracts against the scene depth sees no scene at all.
-`depthtex2` is a real copy, taken one line before the pass is drawn, as there: the name a pack
-reads to see what the hand it is holding stands in front of.
+What a `gbuffers_hand` reads as `depthtex1` is the opaque world of the frame before, which is what
+the reference hands it too: its copy is refreshed one step behind the solid hand
+(`mixin/MixinLevelRenderer.java:269-274`, `pipeline/IrisRenderingPipeline.java:1051-1063`), so every
+program drawn ahead of that step reads the frame before's under that name, the terrain and the mobs
+as much as the hand. `depthtex0` is the live scene depth there; here it answers the far plane, and
+that is a divergence: the live depth is the attachment the hand's own pass writes, which a pass
+cannot sample on this backend, and nothing older than this frame is dressed as the live depth. What
+it costs is a hand program that reads `depthtex0` rather than `depthtex1` for the scene it stands
+in, which none of the packs measured does. `depthtex2` is a real copy, taken one line before the
+pass is drawn, as there: the name a pack reads to see what the hand it is holding stands in front
+of.
 
 **The mobs and the block entities are drawn into the pack's own shadow map**, so they cast as
 well as receive, and the log names the shadow passes one by one when a place first draws. A mob's


### PR DESCRIPTION
## What changes

A geometry program drawn ahead of the deferred stage, the terrain, the mobs, the opaque particles,
the held item, the sky, the clouds, the weather and the shadow pass, read the far plane as
`depthtex1` and `depthtex2`. They now read the engine's opaque depth image wherever it exists,
which at that point of the frame is the frame before's, and this frame's for the shadow pass drawn
at the frame's end. `depthtex0` stays the far plane for those passes, the live depth being the
attachment they write. `depthtex2` falls through to the same image when the pre-hand copy is
absent, the world with the hand in it.

## How it differs from the reference, and for what obstacle

`depthtex1` no longer differs: the reference refreshes its copy at `beginTranslucents`, one step
behind the solid hand (`mixin/MixinLevelRenderer.java:269-274`,
`pipeline/IrisRenderingPipeline.java:1051-1063`), so every program drawn ahead of that step reads
the frame before's opaque world under that name (`samplers/IrisSamplers.java:223`).

`depthtex0` still does, on those passes alone. The reference binds the live depth
(`samplers/IrisSamplers.java:221`); here that image is the attachment the pass writes, and sampling
an attachment inside the pass that writes it has no meaning under Vulkan. What it costs: a
geometry program reading `depthtex0` rather than `depthtex1` for the scene it stands in sees the far
plane, which none of the packs measured does. The shadow pass reads the far plane under both
engines, the reference drawing its map at the head of the frame where the game has just cleared
its depth.

On the frame the screen changes size, the opaque image is the old screen's until the take refills
it later in the frame; it is dropped at the head of every frame now, from the call every geometry
pass makes before it samples, so such a frame reads the far plane rather than a stretched depth.

`depthtex2` still does, by the hand alone: the reference hands the frame before's world without the
hand, here it is the world with it when no pre-hand copy was taken this frame. Nearer than the far
plane, and short of the reference by the one shape that name is read to see past.

## What proves it

- `gradlew build` green, rebuilt without the build cache.
- The reference read at the copy moments and at the sampler table.
- In game on the Fabric bench, frozen world, same pinned camera, particles emitted in front of it:
  the load lines that named `depthtex1` among the samplers answered with one pixel on `dev`,
  sixteen of them, are gone, and twenty programs list it among the textures they read. Two
  captures of `dev` set the floor, then this branch, then Iris, on Complementary Reimagined and
  on Photon. On both packs the mean picture at rest sits under the `dev` floor and no nearer to
  nor farther from Iris than `dev` is: Complementary samples that copy only from its water, drawn
  after the take, and Photon samples it from its particles and glowing eyes and uses it only for
  water and the nether portal. The road ran and the picture did not, so the merge rests on the
  reference reading. Pegasus and E-LITE sample the name from their terrain, entities and hand and
  were not captured.

## What it leaves owing

The pre-hand copy on every frame, as the reference takes it, which would close the `depthtex2`
half; and the far plane on `depthtex0` for those passes, which the backend leaves no road for.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
