### PR TITLE
fix(glsl): draw RenderPearl and load Iteration's final passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,13 +118,15 @@ what the next one holds.
 ### Fixed
 
 - **A pack written for half precision no longer takes the driver down with it.** RenderPearl
-  declares the colour it writes as a sixteen bit vector, and the engine did not know that type: the
-  declaration stayed where the pack wrote it, a second one was laid on the same slot, and the
-  program that did get through asked the card for a sixteen bit output it does not have. Those types
-  are known now, an output declared under one is declared under its ordinary width, and the value
-  written is the same. The same pack tells the compiler it leaves the depth alone, and the engine's
-  own code wrote that depth above the pack's line, which the compiler refuses as a redeclaration
-  after use: the engine's code now comes after the pack's, where the reference puts its own.
+  computes in sixteen and eight bit numbers, and three things stood between it and the screen. The
+  engine did not know those types, so the colour output declared under one stayed where the pack
+  wrote it and a second output was laid on the same slot; it is declared under its ordinary width
+  now, and the value written is the same. The programs asked the card for arithmetic the game never
+  turns on, and a program asking for what was not turned on is invalid: the engine now turns on
+  every such feature the card reports. The same pack tells the compiler it leaves the depth alone,
+  and the engine's own code wrote that depth above the pack's line, which the compiler refuses as a
+  redeclaration after use: the engine's code now comes after the pack's, where the reference puts
+  its own.
 
 - **A greyscale picture a pack ships is read as the pack wrote it.** Every grey image came out
   lighter than the file, its darks lifted towards white, because the decoder converted the picture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,17 +118,21 @@ what the next one holds.
 ### Fixed
 
 - **A pack written for half precision no longer takes the driver down with it.** RenderPearl
-  computes in sixteen and eight bit numbers, and four things stood between it and the screen. The
-  engine did not know those types, so the colour output declared under one stayed where the pack
-  wrote it and a second output was laid on the same slot; it is declared under its ordinary width
-  now, and the value written is the same. The programs asked the card for arithmetic the game never
-  turns on, and a program asking for what was not turned on is invalid: the engine now turns on
-  every such feature the card reports. The pack passes its values between the two stages in a block
-  of its own, which the game counts as one value when it numbers them, so the value after the block
-  landed inside it: the block's members are passed one by one now, at the cost of the packing the
-  pack had chosen. The same pack tells the compiler it leaves the depth alone, and the engine's own
-  code wrote that depth above the pack's line, which the compiler refuses as a redeclaration after
-  use: the engine's code now comes after the pack's, where the reference puts its own.
+  computes in sixteen and eight bit numbers, and five things stood between it and the screen, one of
+  which crashed the game the moment the pack's first program was built. The engine did not know
+  those types, so the colour output declared under one stayed where the pack wrote it and a second
+  output was laid on the same slot; it is declared under its ordinary width now, and the value
+  written is the same. The programs asked the card for arithmetic the game never turns on, and a
+  program asking for what was not turned on is invalid: the engine now turns on every such feature
+  the card reports. The pack passes its values between the two stages in a block of its own, which
+  the game counts as one value when it numbers them, so the value after the block landed inside it:
+  the block's members are passed one by one now, at the cost of the packing the pack had chosen. And
+  the pack asks whether the card has an AMD instruction before using it, a question the shader
+  compiler answered yes on every card, and the instruction is what took the driver down on a
+  GeForce: the engine now answers it the way the card does, so the pack takes the road it wrote for
+  that card. The same pack tells the compiler it leaves the depth alone, and the engine's own code
+  wrote that depth above the pack's line, which the compiler refuses as a redeclaration after use:
+  the engine's code now comes after the pack's, where the reference puts its own.
 
 - **A pack that declares its own output where another of its branches wrote the old-style one loads
   again.** Iteration keeps every one of its final passes in one file, one writing the old-style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,13 @@ what the next one holds.
   code wrote that depth above the pack's line, which the compiler refuses as a redeclaration after
   use: the engine's code now comes after the pack's, where the reference puts its own.
 
+- **A pack that declares its own output where another of its branches wrote the old-style one loads
+  again.** Iteration keeps every one of its final passes in one file, one writing the old-style
+  output and the others declaring their own under the same number, and only one branch is ever
+  taken. The engine counted the branch nobody took, laid its own output on that number, and six of
+  the pack's passes were refused for two outputs on one slot. The pack's own declaration takes the
+  slot now.
+
 - **A greyscale picture a pack ships is read as the pack wrote it.** Every grey image came out
   lighter than the file, its darks lifted towards white, because the decoder converted the picture
   out of its own colour space instead of taking the bytes as they were written. A pack that compares

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,15 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack written for half precision no longer takes the driver down with it.** RenderPearl
+  declares the colour it writes as a sixteen bit vector, and the engine did not know that type: the
+  declaration stayed where the pack wrote it, a second one was laid on the same slot, and the
+  program that did get through asked the card for a sixteen bit output it does not have. Those types
+  are known now, an output declared under one is declared under its ordinary width, and the value
+  written is the same. The same pack tells the compiler it leaves the depth alone, and the engine's
+  own code wrote that depth above the pack's line, which the compiler refuses as a redeclaration
+  after use: the engine's code now comes after the pack's, where the reference puts its own.
+
 - **A greyscale picture a pack ships is read as the pack wrote it.** Every grey image came out
   lighter than the file, its darks lifted towards white, because the decoder converted the picture
   out of its own colour space instead of taking the bytes as they were written. A pack that compares

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,15 +118,17 @@ what the next one holds.
 ### Fixed
 
 - **A pack written for half precision no longer takes the driver down with it.** RenderPearl
-  computes in sixteen and eight bit numbers, and three things stood between it and the screen. The
+  computes in sixteen and eight bit numbers, and four things stood between it and the screen. The
   engine did not know those types, so the colour output declared under one stayed where the pack
   wrote it and a second output was laid on the same slot; it is declared under its ordinary width
   now, and the value written is the same. The programs asked the card for arithmetic the game never
   turns on, and a program asking for what was not turned on is invalid: the engine now turns on
-  every such feature the card reports. The same pack tells the compiler it leaves the depth alone,
-  and the engine's own code wrote that depth above the pack's line, which the compiler refuses as a
-  redeclaration after use: the engine's code now comes after the pack's, where the reference puts
-  its own.
+  every such feature the card reports. The pack passes its values between the two stages in a block
+  of its own, which the game counts as one value when it numbers them, so the value after the block
+  landed inside it: the block's members are passed one by one now, at the cost of the packing the
+  pack had chosen. The same pack tells the compiler it leaves the depth alone, and the engine's own
+  code wrote that depth above the pack's line, which the compiler refuses as a redeclaration after
+  use: the engine's code now comes after the pack's, where the reference puts its own.
 
 - **A greyscale picture a pack ships is read as the pack wrote it.** Every grey image came out
   lighter than the file, its darks lifted towards white, because the decoder converted the picture

--- a/NOTICE
+++ b/NOTICE
@@ -922,6 +922,14 @@ Apache License, Version 2.0
   same conditionals, and Iris runs the same preprocessor over them too. None of jcpp's code is
   here.
 
+  common/src/main/java/dev/vitrail/glsl/Emitter.java writes the main that stands in for a pack's
+  own after the pack's body, at the end of the file, which is where
+  net.irisshaders.iris.pipeline.transform.transformer.VanillaTransformer injects the one wrapping
+  main it writes, the one that widens lines, lines 200 to 223, read on 8 September 2026. What is
+  taken is the place: a builtin the wrapper writes, gl_FragDepth, may be redeclared by the pack
+  with a depth layout, and a use above that redeclaration is refused by the compiler. The wrapper
+  itself, and what it writes, are this engine's.
+
 AMD FidelityFX Super Resolution 1.0, https://github.com/GPUOpen-Effects/FidelityFX-FSR
 Copyright (c) 2021 Advanced Micro Devices, Inc.
 MIT License

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -389,60 +389,72 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 		// not meet today. They are ordered anyway rather than left to that argument holding.
 		this.owedOutputs.forEach((name, qualified) -> lines.add(outDeclaration(name, qualified)));
 
-		// Below the block, since it reads it, and below the outputs and the ascending function for a
-		// reason that decides the picture: a wrapper standing above them would be the first place the
-		// compiler met an output name, and the rank it hands out there is the location the game
-		// writes back. It has to be the ascending function that gets there first, so this goes last.
-		// The pack's body is concatenated after the header, so its own main is only a name here and
-		// has to be declared before it can be called.
-		// Asked of the one thing that decides it, which is whether the pack's own main was renamed.
-		// Every reason to wrap sets that flag as it renames, so this is the list of reasons said
-		// once instead of twice, and it cannot fall out of step with them. It used to be the list
-		// itself, and a split taken back out by dropUnprovidedSplits after the rename then left a
-		// stage whose main was called ofPackMain and whose wrapper nobody wrote: no entry point,
-		// which is the fragment stage of Sildur's gbuffers_textured.
-		if (this.mainWrapped) {
-			lines.add("void " + GlslTranslator.PACK_MAIN + "();");
-			// The lines mesh runs the pack's main twice, the far end of the edge first and the
-			// vertex itself second, so that every varying holds the vertex's own value when the
-			// epilogues below read them, and widens between the two clip positions: Iris's own
-			// order (VanillaTransformer.java:214-222). The depth conversion still lands after,
-			// on the widened position, whose z the widening leaves alone.
-			String body = this.linesWrapped
-					? LinesVertex.OFFSET + " = Normal.xyz; " + GlslTranslator.PACK_MAIN
-							+ "(); vec4 of_LineEnd = "
-							+ "gl_Position; gl_Position = vec4(0.0); " + LinesVertex.OFFSET
-							+ " = vec3(0.0); " + GlslTranslator.PACK_MAIN + "(); " + LinesVertex.WIDEN
-							+ "(gl_Position, of_LineEnd);"
-					: GlslTranslator.PACK_MAIN + "();";
-			// The mask goes last of all, after the discard: a fragment the alpha test threw away
-			// covered nothing, and marking it covered would leave a hole where a leaf was.
-			lines.add("void main() { "
-					+ (this.terrainPrologue ? SodiumVertex.PROLOGUE + "(); " : "")
-					+ (this.distantPrologue ? DistantVertex.PROLOGUE + "(); " : "")
-					+ overlayPrologue()
-					+ identifierPrologue(varyings)
-					+ (wrapsFragment() ? GlslTranslator.ORDER_OUTPUTS + "(); " : "")
-					+ coveragePrologue()
-					+ owedPrologue()
-					+ this.splits.matrixPrologue()
-					+ this.splits.structPrologue()
-					+ this.splits.arrayPrologue()
-					+ body
-					+ this.splits.matrixEpilogue()
-					+ this.splits.structEpilogue()
-					+ this.splits.arrayEpilogue()
-					+ (this.depthEpilogue ? " gl_Position.z = " + GlslTranslator.DEPTH_CONV
-							+ ".x * gl_Position.z + " + GlslTranslator.DEPTH_CONV
-							+ ".y * gl_Position.w;" : "")
-					+ (this.alphaEpilogue
-							? " " + this.alphaTest.discard(outputName(0, shadowed) + ".a")
-							: "")
-					+ (this.covers ? " " + COVERAGE + " = " + writtenDepth() + ";" : "")
-					+ " }");
+		return String.join("\n", lines) + "\n";
+	}
+
+	/**
+	 * The {@code main} that stands in for the pack's own, written AFTER the pack's body, or nothing
+	 * where the pack's main was left its name.
+	 * <p>
+	 * After the body and not in the header, for two reasons that both decide the picture. The
+	 * header's ascending function has to be the first place the compiler meets an output name, the
+	 * rank it hands out there being the location the game writes back, and a wrapper below the body
+	 * cannot get there first. And the wrapper may write {@code gl_FragDepth}, which a pack is free to
+	 * redeclare with a depth layout, as RenderPearl does on every terrain stage, {@code
+	 * depth_greater} or {@code depth_unchanged} by branch: a builtin used above its redeclaration
+	 * is refused, {@code cannot redeclare after use}, so the use has to come below it. Iris injects
+	 * its own wrapping main, the one that widens lines, at the end of the file too
+	 * ({@code VanillaTransformer.java:200-223}, {@code ASTInjectionPoint.END}).
+	 * <p>
+	 * Asked of the one thing that decides it, which is whether the pack's own main was renamed.
+	 * Every reason to wrap sets that flag as it renames, so this is the list of reasons said once
+	 * instead of twice, and it cannot fall out of step with them. It used to be the list itself,
+	 * and a split taken back out by dropUnprovidedSplits after the rename then left a stage whose
+	 * main was called ofPackMain and whose wrapper nobody wrote: no entry point, which is the
+	 * fragment stage of Sildur's gbuffers_textured.
+	 */
+	String wrapper(Set<String> varyings, Set<String> shadowed) {
+		if (!this.mainWrapped) {
+			return "";
 		}
 
-		return String.join("\n", lines) + "\n";
+		// The lines mesh runs the pack's main twice, the far end of the edge first and the vertex
+		// itself second, so that every varying holds the vertex's own value when the epilogues
+		// below read them, and widens between the two clip positions: Iris's own order
+		// (VanillaTransformer.java:215-223). The depth conversion still lands after, on the widened
+		// position, whose z the widening leaves alone.
+		String body = this.linesWrapped
+				? LinesVertex.OFFSET + " = Normal.xyz; " + GlslTranslator.PACK_MAIN
+						+ "(); vec4 of_LineEnd = "
+						+ "gl_Position; gl_Position = vec4(0.0); " + LinesVertex.OFFSET
+						+ " = vec3(0.0); " + GlslTranslator.PACK_MAIN + "(); " + LinesVertex.WIDEN
+						+ "(gl_Position, of_LineEnd);"
+				: GlslTranslator.PACK_MAIN + "();";
+		// The mask goes last of all, after the discard: a fragment the alpha test threw away
+		// covered nothing, and marking it covered would leave a hole where a leaf was.
+		return "void main() { "
+				+ (this.terrainPrologue ? SodiumVertex.PROLOGUE + "(); " : "")
+				+ (this.distantPrologue ? DistantVertex.PROLOGUE + "(); " : "")
+				+ overlayPrologue()
+				+ identifierPrologue(varyings)
+				+ (wrapsFragment() ? GlslTranslator.ORDER_OUTPUTS + "(); " : "")
+				+ coveragePrologue()
+				+ owedPrologue()
+				+ this.splits.matrixPrologue()
+				+ this.splits.structPrologue()
+				+ this.splits.arrayPrologue()
+				+ body
+				+ this.splits.matrixEpilogue()
+				+ this.splits.structEpilogue()
+				+ this.splits.arrayEpilogue()
+				+ (this.depthEpilogue ? " gl_Position.z = " + GlslTranslator.DEPTH_CONV
+						+ ".x * gl_Position.z + " + GlslTranslator.DEPTH_CONV
+						+ ".y * gl_Position.w;" : "")
+				+ (this.alphaEpilogue
+						? " " + this.alphaTest.discard(outputName(0, shadowed) + ".a")
+						: "")
+				+ (this.covers ? " " + COVERAGE + " = " + writtenDepth() + ";" : "")
+				+ " }\n";
 	}
 
 	/** Whether there is anything owed AND a wrapped main to assign it from. */

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -773,6 +773,7 @@ public final class GlslTranslator {
 		settleRedefinedMacros();
 		dropRedeclaredVertexBlock();
 		flattenInterfaceBlocks();
+		hideAbsentExtensionMacros();
 		rewriteIdentifiers();
 		// After the identifiers, because the goldberg idiom's sine has become ofReducedSin by then
 		// and that is one of the two names the site is recognised under, the other being the plain
@@ -1464,14 +1465,16 @@ public final class GlslTranslator {
 	 * So they are hoisted instead: the header re-emits them straight after the version, where the
 	 * language wants them, and {@link #extensions} is what carries them there.
 	 * <p>
-	 * <strong>All of them, and as {@code enable} rather than as the {@code require} the pack
-	 * wrote.</strong> Both halves are deliberate. A pack gates its extensions on macros this
+	 * <strong>All the device has, and as {@code enable} rather than as the {@code require} the
+	 * pack wrote.</strong> Both halves are deliberate. A pack gates its extensions on macros this
 	 * engine's own {@code #if} evaluation cannot answer, since what defines them is the compiler
 	 * further down the road, so keeping only the live ones would keep none of the ones that
 	 * matter; and a name the compiler does not know is a warning under {@code enable} where
 	 * {@code require} is an error, which turns a pack asking for a vendor extension it will not
 	 * get into a pack that still compiles. What decides whether the pack's code USES an extension
-	 * is unchanged either way: its own macro test, answered by the compiler and not by us.
+	 * is unchanged either way: its own macro test, answered by the compiler, which for a vendor
+	 * extension the device has not got is given the device's answer to read
+	 * ({@link #hideAbsentExtensionMacros}, {@link VendorExtensions}).
 	 */
 	private void dropVersionAndExtensions() {
 		for (int index = 0; index < this.tokens.size(); index++) {
@@ -1483,7 +1486,11 @@ public final class GlslTranslator {
 			if (token.directive().equals("extension")) {
 				this.strippedExtensions++;
 				String named = extensionNamed(index);
-				if (named != null) {
+				// Not hoisted where the device has not got it: the compiler would take the line
+				// and emit the vendor instruction, which is the one thing the device cannot run
+				// (VendorExtensions). The pack's own guard on the macro is hidden further down,
+				// so its fallback is what compiles.
+				if (named != null && !VendorExtensions.absent(named)) {
 					this.extensions.add(named);
 				}
 			} else if (!token.directive().equals("version")) {
@@ -1983,6 +1990,27 @@ public final class GlslTranslator {
 	/** Blanks a {@code layout(...)} whose every key is {@code location} or {@code component}. */
 	private void dropLocationLayout(int layout) {
 		dropLayoutOf(layout, Set.of("location", "component"));
+	}
+
+	/**
+	 * Renames, in the pack's own preprocessor lines, the macro of every vendor extension the device
+	 * has not got, so that the compiler answers {@code defined} the way the device would.
+	 * <p>
+	 * The reason is with {@link VendorExtensions}: the compiler defines the macro of every
+	 * extension it knows, and a pack gating a vendor instruction on that macro takes the branch on
+	 * a card that cannot run the instruction. Under a GL driver the macro is only defined where the
+	 * card has the extension, which is the answer restored here. Every line is rewritten, live or
+	 * not, since the question is what the compiler will read; the engine's own evaluation already
+	 * answered undefined for a name it never defines, so the two agree afterwards.
+	 */
+	private void hideAbsentExtensionMacros() {
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.directive() != null && token.kind() == Kind.IDENTIFIER
+					&& VendorExtensions.absent(token.text())) {
+				this.tokens.replace(index, VendorExtensions.hidden(token.text()));
+			}
+		}
 	}
 
 	/** Blanks the {@code layout(...)} at this token when every key it carries is one of these. */

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -772,6 +772,7 @@ public final class GlslTranslator {
 		dropVersionAndExtensions();
 		settleRedefinedMacros();
 		dropRedeclaredVertexBlock();
+		flattenInterfaceBlocks();
 		rewriteIdentifiers();
 		// After the identifiers, because the goldberg idiom's sine has become ofReducedSin by then
 		// and that is one of the two names the site is recognised under, the other being the plain
@@ -1621,6 +1622,390 @@ public final class GlslTranslator {
 				this.tokens.blankRange(keyword, end);
 			}
 		}
+	}
+
+	/** The qualifiers a block or a member may carry in front of its type, interpolation apart. */
+	private static final Set<String> INTERPOLATION_QUALIFIERS = Set.of("flat", "smooth", "noperspective");
+	private static final Set<String> OTHER_QUALIFIERS = Set.of("centroid", "sample", "invariant", "precise",
+			"highp", "mediump", "lowp");
+
+	/** One member of a block as the pass read it, applied only once every member of the block read. */
+	private record BlockMember(int typeAt, List<Integer> names, int layoutAt, Set<String> qualifiers) {
+	}
+
+	/**
+	 * Turns a pack's own {@code in} or {@code out} block into one varying per member, named after
+	 * the block, and rewrites every {@code instance.member} of the unit to that name.
+	 * <p>
+	 * A workaround for the game's linker, paid in nothing the image can see. Iris leaves the block
+	 * as the pack wrote it, and OpenGL takes a block whose members carry their own locations and
+	 * components, which is how RenderPearl packs nine varyings into four slots ({@code
+	 * lib/v_data_lit.glsl}). The game numbers a stage's outputs itself, one location per output
+	 * VARIABLE in the order its reflection lists them, and rebinds the next stage's inputs by name
+	 * to those numbers ({@code IntermediaryShaderModule.java:112-116} and {@code rebind}). A block
+	 * is one variable there and spans as many locations as it has members, so whichever output
+	 * the reflection lists after it lands inside that span, two outputs on one location, which the
+	 * validator refuses ({@code VUID-StandaloneSpirv-OpEntryPoint-08722}). Which output that is
+	 * depends on the order the compiler met them in: the pack's own modules validated alone and
+	 * failed once the engine's {@code entityColor} joined them after the wrapping main moved below
+	 * the body. With the block gone, every member is a varying the game numbers like any other,
+	 * and the matrix split and the varying collection read it like any other too, since the
+	 * storage word put in front of it is a real token and not injected text.
+	 * <p>
+	 * The name is the block's and not the instance's, because the two stages need not agree on the
+	 * instance: Reverie writes {@code out Data {...} DataOut;} against {@code in Data {...}
+	 * DataIn;}, and the game matches the two sides by name. A member keeps its own qualifiers,
+	 * takes the block's where the block carries one it does not, and loses its location and
+	 * component, the game renumbering every location anyway: what the pack loses is the packing by
+	 * component. The preprocessor lines inside the block stay where they are, so a member behind
+	 * an {@code #ifdef} is declared under the same condition as before; the head may be written
+	 * across a conditional, {@code out} under one branch and {@code in} under the other, which is
+	 * read through, the live word deciding; and a read of the instance inside a macro body is
+	 * rewritten with the rest. A block with no instance name already reads its members as globals
+	 * and is only unwrapped. Left whole: a block declared as an array, which only a geometry or
+	 * tessellation stage reads and this engine binds neither; a {@code patch} block, for the same
+	 * reason; {@code gl_PerVertex}, the compiler's block and not a pack's; and a block one of
+	 * whose members the pass cannot read, since half a block is worse than the whole one. What is
+	 * not told apart is a local named like the instance whose own field is named like a member,
+	 * which no pack of the corpus writes.
+	 */
+	private void flattenInterfaceBlocks() {
+		int[] lines = this.tokens.lineNumbers();
+		List<TokenStream.Insertion> insertions = new ArrayList<>();
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.directive() != null || !(token.identifier("in") || token.identifier("out"))
+					|| !this.unit.isLive(lines[index])) {
+				continue;
+			}
+
+			int name = blockNameAfter(index);
+			if (name < 0 || this.tokens.get(name).text().startsWith("gl_")) {
+				continue;
+			}
+
+			int brace = this.tokens.significantAfter(name);
+			if (brace < 0 || !this.tokens.get(brace).operator("{")) {
+				continue;
+			}
+
+			int close = this.tokens.matchingBracket(brace);
+			int after = close < 0 ? -1 : this.tokens.significantAfter(close);
+			if (after < 0) {
+				continue;
+			}
+
+			String instance = null;
+			int end = after;
+			if (this.tokens.get(after).kind() == Kind.IDENTIFIER) {
+				instance = this.tokens.get(after).text();
+				end = this.tokens.significantAfter(after);
+			}
+
+			if (end < 0 || !this.tokens.get(end).operator(";")) {
+				index = close;
+				continue;
+			}
+
+			// The qualifiers the block carries as a whole, in front of its storage word: handed
+			// down to every member without them, and dropped with the head along with a layout,
+			// the members being numbered by the game. A patch block belongs to a stage this
+			// engine never binds.
+			int start = index;
+			List<String> carried = new ArrayList<>();
+			boolean patch = false;
+			for (int before = this.tokens.significantBefore(index); before >= 0;
+					before = this.tokens.significantBefore(before)) {
+				Token qualifier = this.tokens.get(before);
+				if (qualifier.identifier("patch")) {
+					patch = true;
+				} else if (qualifier.kind() == Kind.IDENTIFIER && (INTERPOLATION_QUALIFIERS.contains(qualifier.text())
+						|| OTHER_QUALIFIERS.contains(qualifier.text()))) {
+					carried.add(0, qualifier.text());
+				} else if (qualifier.operator(")")) {
+					int layout = layoutBefore(before);
+					if (layout < 0) {
+						break;
+					}
+
+					before = layout;
+				} else {
+					break;
+				}
+
+				start = before;
+			}
+
+			if (patch) {
+				index = close;
+				continue;
+			}
+
+			List<BlockMember> members = new ArrayList<>();
+			List<Integer> declaration = new ArrayList<>();
+			boolean readable = true;
+			for (int at = brace + 1; at < close && readable; at++) {
+				Token piece = this.tokens.get(at);
+				if (piece.directive() != null || piece.trivia() || piece.kind() == Kind.NEWLINE
+						|| piece.text().isEmpty()) {
+					continue;
+				}
+
+				if (!piece.operator(";")) {
+					declaration.add(at);
+					continue;
+				}
+
+				BlockMember member = readBlockMember(declaration);
+				readable = member != null;
+				members.add(member);
+				declaration.clear();
+			}
+
+			if (!readable || !declaration.isEmpty()) {
+				index = close;
+				continue;
+			}
+
+			String storage = token.text();
+			String prefix = instance == null ? "" : "of_" + this.tokens.get(name).text() + "_";
+			List<String> names = new ArrayList<>();
+			for (BlockMember member : members) {
+				flattenMember(member, storage, carried, prefix, names, insertions);
+			}
+
+			blankCode(start, brace);
+			blankCode(close, end);
+			if (instance != null) {
+				rewriteBlockReads(instance, prefix, names);
+			}
+
+			index = close;
+		}
+
+		this.tokens.insertTokens(insertions);
+	}
+
+	/**
+	 * The name of the block a storage word opens, or -1 where what follows is not a block. Only
+	 * trivia, directive lines and the other branch's storage word may stand between the two.
+	 */
+	private int blockNameAfter(int storage) {
+		for (int scan = storage + 1; scan < this.tokens.size(); scan++) {
+			Token token = this.tokens.get(scan);
+			if (token.trivia() || token.kind() == Kind.NEWLINE || token.directive() != null
+					|| token.identifier("in") || token.identifier("out")) {
+				continue;
+			}
+
+			return token.kind() == Kind.IDENTIFIER ? scan : -1;
+		}
+
+		return -1;
+	}
+
+	/** The {@code layout} a closing parenthesis ends, or -1 where it closes something else. */
+	private int layoutBefore(int closing) {
+		int depth = 0;
+		for (int scan = closing; scan >= 0; scan--) {
+			Token token = this.tokens.get(scan);
+			if (token.kind() != Kind.OPERATOR || token.directive() != null) {
+				continue;
+			}
+
+			if (token.operator(")")) {
+				depth++;
+			} else if (token.operator("(")) {
+				depth--;
+				if (depth == 0) {
+					int keyword = this.tokens.significantBefore(scan);
+					return keyword >= 0 && this.tokens.get(keyword).identifier("layout") ? keyword : -1;
+				}
+			}
+		}
+
+		return -1;
+	}
+
+	/**
+	 * One member of a block read off the significant tokens of its declaration: an optional
+	 * layout, qualifiers, a type, then one or more names each with an optional array size. Null
+	 * where the declaration is not of that shape.
+	 */
+	private BlockMember readBlockMember(List<Integer> declaration) {
+		int part = 0;
+		int layoutAt = -1;
+		Set<String> qualifiers = new HashSet<>();
+		while (part < declaration.size()) {
+			int at = declaration.get(part);
+			Token piece = this.tokens.get(at);
+			if (piece.identifier("layout")) {
+				int closing = this.tokens.matchingBracket(this.tokens.callOpener(at));
+				if (closing < 0 || layoutAt >= 0) {
+					return null;
+				}
+
+				layoutAt = at;
+				while (part < declaration.size() && declaration.get(part) <= closing) {
+					part++;
+				}
+			} else if (piece.kind() == Kind.IDENTIFIER && (INTERPOLATION_QUALIFIERS.contains(piece.text())
+					|| OTHER_QUALIFIERS.contains(piece.text()))) {
+				qualifiers.add(piece.text());
+				part++;
+			} else {
+				break;
+			}
+		}
+
+		if (part >= declaration.size() || this.tokens.get(declaration.get(part)).kind() != Kind.IDENTIFIER) {
+			return null;
+		}
+
+		int typeAt = declaration.get(part++);
+		List<Integer> names = new ArrayList<>();
+		boolean expectName = true;
+		for (; part < declaration.size(); part++) {
+			int at = declaration.get(part);
+			Token piece = this.tokens.get(at);
+			if (expectName) {
+				if (piece.kind() != Kind.IDENTIFIER) {
+					return null;
+				}
+
+				names.add(at);
+				expectName = false;
+			} else if (piece.operator("[")) {
+				int closing = this.tokens.matchingBracket(at);
+				if (closing < 0) {
+					return null;
+				}
+
+				while (part + 1 < declaration.size() && declaration.get(part + 1) <= closing) {
+					part++;
+				}
+			} else if (piece.operator(",")) {
+				expectName = true;
+			} else {
+				return null;
+			}
+		}
+
+		return names.isEmpty() || expectName ? null : new BlockMember(typeAt, names, layoutAt, qualifiers);
+	}
+
+	/**
+	 * A member becomes a varying of its own, or several where it lists several names: the storage
+	 * word goes in front of its type as a token of its own, the block's qualifiers before that
+	 * where the member lacks them, each name takes the block's prefix, and a location or component
+	 * layout on the member is dropped.
+	 */
+	private void flattenMember(BlockMember member, String storage, List<String> carried, String prefix,
+			List<String> names, List<TokenStream.Insertion> insertions) {
+		if (member.layoutAt() >= 0) {
+			dropLocationLayout(member.layoutAt());
+		}
+
+		for (int nameAt : member.names()) {
+			String name = this.tokens.get(nameAt).text();
+			names.add(name);
+			this.tokens.replace(nameAt, prefix + name);
+		}
+
+		boolean interpolated = member.qualifiers().stream().anyMatch(INTERPOLATION_QUALIFIERS::contains);
+		for (String qualifier : carried) {
+			boolean interpolation = INTERPOLATION_QUALIFIERS.contains(qualifier);
+			if (interpolation ? !interpolated : !member.qualifiers().contains(qualifier)) {
+				insertions.add(new TokenStream.Insertion(member.typeAt(), new Token(Kind.IDENTIFIER, qualifier, null)));
+				insertions.add(new TokenStream.Insertion(member.typeAt(), new Token(Kind.SPACE, " ", null)));
+			}
+		}
+
+		insertions.add(new TokenStream.Insertion(member.typeAt(), new Token(Kind.IDENTIFIER, storage, null)));
+		insertions.add(new TokenStream.Insertion(member.typeAt(), new Token(Kind.SPACE, " ", null)));
+	}
+
+	/** Blanks a range of code, leaving the directive lines inside it standing. */
+	private void blankCode(int start, int end) {
+		for (int at = start; at <= end; at++) {
+			if (this.tokens.get(at).directive() == null) {
+				this.tokens.blankRange(at, at);
+			}
+		}
+	}
+
+	/**
+	 * Rewrites every {@code instance.member} of a flattened block to the member's own name, in the
+	 * pack's macro bodies as well as in its code, and never the field of something else that
+	 * happens to be named like the instance. Only the two tokens of the access are blanked, one
+	 * by one, so that a spliced line inside a macro body keeps its splice.
+	 */
+	private void rewriteBlockReads(String instance, String prefix, List<String> members) {
+		for (int index = 0; index < this.tokens.size(); index++) {
+			Token token = this.tokens.get(index);
+			if (token.macroName() || !token.identifier(instance) || fieldAccess(index)) {
+				continue;
+			}
+
+			int dot = this.tokens.significantAfter(index);
+			if (dot < 0 || !this.tokens.get(dot).operator(".")) {
+				continue;
+			}
+
+			int member = this.tokens.significantAfter(dot);
+			if (member < 0 || this.tokens.get(member).kind() != Kind.IDENTIFIER
+					|| !members.contains(this.tokens.get(member).text())) {
+				continue;
+			}
+
+			this.tokens.replace(index, prefix + this.tokens.get(member).text());
+			this.tokens.blank(dot);
+			this.tokens.blank(member);
+		}
+	}
+
+	/** Whether the token at this index is reached through a dot on its own line, a field of something. */
+	private boolean fieldAccess(int index) {
+		for (int scan = index - 1; scan >= 0; scan--) {
+			Token token = this.tokens.get(scan);
+			if (token.kind() == Kind.NEWLINE) {
+				return false;
+			}
+
+			if (!token.trivia()) {
+				return token.operator(".");
+			}
+		}
+
+		return false;
+	}
+
+	/** Blanks a {@code layout(...)} whose every key is {@code location} or {@code component}. */
+	private void dropLocationLayout(int layout) {
+		dropLayoutOf(layout, Set.of("location", "component"));
+	}
+
+	/** Blanks the {@code layout(...)} at this token when every key it carries is one of these. */
+	private void dropLayoutOf(int layout, Set<String> keys) {
+		int open = this.tokens.callOpener(layout);
+		int close = this.tokens.matchingBracket(open);
+		if (open < 0 || close < 0) {
+			return;
+		}
+
+		// A key is the identifier that opens an entry: the first inside the parenthesis and every
+		// one that follows a comma.
+		boolean opensEntry = true;
+		for (int part : this.tokens.significantRange(open + 1, close - 1)) {
+			Token token = this.tokens.get(part);
+			if (opensEntry && !(token.kind() == Kind.IDENTIFIER && keys.contains(token.text()))) {
+				return;
+			}
+
+			opensEntry = token.operator(",");
+		}
+
+		this.tokens.blankRange(layout, close);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -1056,8 +1056,11 @@ public final class GlslTranslator {
 
 	private TranslatedUnit render(List<TranslatedUnit.Uniform> block,
 			List<TranslatedUnit.Uniform> samplers, Set<String> varyings, Set<String> shadowed) {
+		Emitter emitter = emitter();
+
 		return new TranslatedUnit(this.unit.entry(), this.stage,
-				emitter().header(block, samplers, varyings, shadowed) + body(shadowed) + "\n", notes(),
+				emitter.header(block, samplers, varyings, shadowed) + body(shadowed) + "\n"
+						+ emitter.wrapper(varyings, shadowed), notes(),
 				List.copyOf(this.drawBuffers), List.copyOf(block), List.copyOf(samplers));
 	}
 
@@ -3307,7 +3310,11 @@ public final class GlslTranslator {
 			return;
 		}
 
-		if (this.packOutputs.putIfAbsent(location, new Output(name.text(), type)) == null) {
+		// Declared under its 32 bit type where the pack wrote a 16 bit one: the reason is with
+		// LegacyGlsl.widened, and the pack's own assignments still fit, a half converting to a
+		// float on its own.
+		Output output = new Output(name.text(), LegacyGlsl.widened(type));
+		if (this.packOutputs.putIfAbsent(location, output) == null) {
 			this.tokens.blankRange(start, end);
 		}
 	}

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -3690,8 +3690,17 @@ public final class GlslTranslator {
 		// A location the pack spelled out as a number. Anything else, a macro or nothing at all,
 		// leaves no way to say where the output belongs, and inventing one would be worse than the
 		// disorder this exists to fix.
+		//
+		// A slot a gl_FragData subscript or a gl_FragColor already claimed is not refused: that
+		// rewrite counts dead branches too, and a pack that writes gl_FragData under one program
+		// symbol and declares its own output under another has both in one file, with only the
+		// declaration live. The pack's name then takes the slot in the header and the synthesized
+		// one is never declared, which is what the compiler sees of the pack's own text where it
+		// and the expander agree on the live branch. Where they do not (rewriteFragmentOutputs
+		// says why they may), the renamed write names an output nobody declares, a refusal where
+		// the two declarations on one location were a refusal before.
 		int location = literalLocation(parts, cursor);
-		if (location < 0 || location >= MAX_FRAGMENT_OUTPUTS || location <= this.maxFragmentOutput) {
+		if (location < 0 || location >= MAX_FRAGMENT_OUTPUTS) {
 			return;
 		}
 

--- a/common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java
+++ b/common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java
@@ -439,6 +439,9 @@ public final class LegacyGlsl {
 			"packHalf2x16", "unpackHalf2x16",
 			"bitfieldExtract", "bitfieldInsert", "bitfieldReverse", "bitCount", "findLSB", "findMSB");
 
+	/** The 8 and 16 bit types, each with the 32 bit type {@link #widened} declares it under. */
+	private static final Map<String, String> NARROW_TYPES = narrowTypes();
+
 	/**
 	 * Built-in type names. Used to tell a declaration from a use: an identifier straight after one
 	 * of these is being named, anywhere else it is being read.
@@ -599,7 +602,77 @@ public final class LegacyGlsl {
 			}
 		}
 
+		// The explicitly sized types of GL_EXT_shader_explicit_arithmetic_types, which a pack
+		// written for a recent card declares its outputs and varyings under. Left out, a
+		// declaration under one of them read as a use, so the declaration was neither lifted nor
+		// counted, and RenderPearl's f16vec4 output stayed in the body under an ofFragData0 laid on
+		// the same location.
+		names.addAll(NARROW_TYPES.keySet());
+		names.addAll(List.of("float32_t", "float64_t", "int32_t", "int64_t", "uint32_t", "uint64_t"));
+		for (String prefix : List.of("f32", "f64", "i32", "i64", "u32", "u64")) {
+			for (int size = 2; size <= 4; size++) {
+				names.add(prefix + "vec" + size);
+			}
+		}
+
+		for (String prefix : List.of("f32", "f64")) {
+			for (int rows = 2; rows <= 4; rows++) {
+				names.add(prefix + "mat" + rows);
+				for (int columns = 2; columns <= 4; columns++) {
+					names.add(prefix + "mat" + rows + "x" + columns);
+				}
+			}
+		}
+
 		return Set.copyOf(names);
+	}
+
+	/**
+	 * The 8 and 16 bit types, each mapped onto the 32 bit type it converts to on its own: the
+	 * extension lets a narrow value flow into a wider variable with no cast, so a variable declared
+	 * under the wide name still takes every value the pack assigns it.
+	 */
+	private static Map<String, String> narrowTypes() {
+		Map<String, String> widened = new LinkedHashMap<>();
+		widened.put("float16_t", "float");
+		widened.put("int16_t", "int");
+		widened.put("uint16_t", "uint");
+		widened.put("int8_t", "int");
+		widened.put("uint8_t", "uint");
+
+		for (int size = 2; size <= 4; size++) {
+			widened.put("f16vec" + size, "vec" + size);
+			widened.put("i16vec" + size, "ivec" + size);
+			widened.put("u16vec" + size, "uvec" + size);
+			widened.put("i8vec" + size, "ivec" + size);
+			widened.put("u8vec" + size, "uvec" + size);
+		}
+
+		for (int rows = 2; rows <= 4; rows++) {
+			widened.put("f16mat" + rows, "mat" + rows);
+			for (int columns = 2; columns <= 4; columns++) {
+				widened.put("f16mat" + rows + "x" + columns, "mat" + rows + "x" + columns);
+			}
+		}
+
+		return Collections.unmodifiableMap(widened);
+	}
+
+	/**
+	 * The type a fragment output is declared under in the translation: the pack's own, unless it is
+	 * an 8 or 16 bit one, which becomes its 32 bit form.
+	 * <p>
+	 * A workaround, and it is paid in nothing the image can see. Iris leaves the declaration as the
+	 * pack wrote it, since OpenGL takes a narrow output on any card that takes the extension. On
+	 * Vulkan a narrow variable in the input or output storage class asks the module for the
+	 * {@code StorageInputOutput16} capability, which GeForce does not expose, so the module is
+	 * invalid on that card. The value written is the same either way: the attachment holds the
+	 * format the pack gave it, and a half is widened to float on the way in whether the conversion
+	 * happens in the shader or in the write. A varying declared narrow is left as written, no pack
+	 * of the corpus declaring one; the same capability would refuse it.
+	 */
+	static String widened(String type) {
+		return NARROW_TYPES.getOrDefault(type, type);
 	}
 
 	private static Map<String, String> engineAttributes() {

--- a/common/src/main/java/dev/vitrail/glsl/TokenStream.java
+++ b/common/src/main/java/dev/vitrail/glsl/TokenStream.java
@@ -76,6 +76,43 @@ final class TokenStream implements Iterable<Token> {
 	record Closing(int at, String text, String directive) {
 	}
 
+	/** One token to put in before the token at this index, kept as the kind it is given. */
+	record Insertion(int at, Token token) {
+	}
+
+	/**
+	 * Inserts tokens of the kinds they are given, in the order given where several share a
+	 * position, once the scan that decided them has finished reading. The one difference from
+	 * {@link #insertClosings} is the kind: a closing is raw text no later pass reads, where a
+	 * storage word put in front of a member has to be read as the identifier it is by every pass
+	 * that follows, the varying collection and the matrix split among them.
+	 */
+	void insertTokens(List<Insertion> insertions) {
+		if (insertions.isEmpty()) {
+			return;
+		}
+
+		this.functionEndFor = -1;
+		this.lineTable = null;
+		List<Insertion> ordered = new ArrayList<>(insertions);
+		ordered.sort(Comparator.comparingInt(Insertion::at));
+		List<Token> rebuilt = new ArrayList<>(this.tokens.size() + ordered.size());
+		int next = 0;
+		for (int at = 0; at <= this.tokens.size(); at++) {
+			while (next < ordered.size() && ordered.get(next).at() == at) {
+				rebuilt.add(ordered.get(next).token());
+				next++;
+			}
+
+			if (at < this.tokens.size()) {
+				rebuilt.add(this.tokens.get(at));
+			}
+		}
+
+		this.tokens.clear();
+		this.tokens.addAll(rebuilt);
+	}
+
 	/**
 	 * Inserting shifts every index after it, so the last insertion is made first.
 	 * <p>

--- a/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
@@ -378,6 +378,9 @@ public final class TranslationCache {
 		// the trig substitution and the shadow comparison both change what it emits and neither
 		// says so in the text it was handed.
 		feed(digest, GlslTranslator.emissionSwitches());
+		// And the device's answer on the vendor extensions, which decides which branch of a pack
+		// compiles: a card that has one of them translates differently from a card that has not.
+		feed(digest, VendorExtensions.key());
 
 		// The whole table, in its own order, which is fixed by the code that builds it. It carries
 		// the game version, the operating system, the driver's vendor and renderer, the mipmap

--- a/common/src/main/java/dev/vitrail/glsl/VendorExtensions.java
+++ b/common/src/main/java/dev/vitrail/glsl/VendorExtensions.java
@@ -1,0 +1,118 @@
+package dev.vitrail.glsl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * The vendor GLSL extensions the device does not have, so that a pack testing for one reads the
+ * answer the device gives and not the one the compiler gives.
+ * <p>
+ * The compiler defines the macro of every extension it KNOWS, whether the device has it or not,
+ * and it knows the AMD, Intel and NVIDIA ones. A pack written against OpenGL gates its use of
+ * them on that macro, which a GL driver only defines for what the card really has: RenderPearl
+ * takes {@code max3} from {@code GL_AMD_shader_trinary_minmax} when the macro is defined and
+ * falls back on two {@code max} otherwise. Compiled here, the macro is defined on every card, the
+ * pack asks for the AMD instruction, and the module carries an {@code OpExtInst} of an extension
+ * GeForce does not implement. The NVIDIA driver does not refuse that module: it dies with a null
+ * read inside {@code vkCreateGraphicsPipelines}, on the pack's first pipeline, which is what took
+ * the game down on every launch of the pack. Measured off game, one pipeline at a time, the
+ * trinary maximum alone reproducing it and two nested {@code max} not.
+ * <p>
+ * The device answers at creation ({@link #serve}), which both records what it lacks and enables
+ * what it has, since an extension a module uses must be enabled on the device and the game
+ * enables none of these. Until it has answered, and off game, every vendor extension counts as
+ * absent. A translation is keyed on the answer ({@link #key}), so a cache written on one card is
+ * not served to another.
+ * <p>
+ * Five extensions are answered absent on every device, and one of them is a divergence. {@code
+ * GL_NV_gpu_shader5} has no Vulkan form at all, while an NVIDIA GL driver has it, so a pack
+ * gating on it takes its fallback here where under Iris on a GeForce it takes the extension.
+ * Noble, the one pack of the corpus gating on it, falls to the explicit arithmetic types
+ * extension, which gives it the same 16 bit types under the compiler here, and translates and
+ * validates on that road. The AMD ballot needs the subgroup ballot extension beside it, which
+ * is not enabled here either. The Intel integer functions, the NVIDIA
+ * streaming multiprocessor builtins and the ARM core builtins each sit behind a device feature of
+ * their own that this engine does not enable, so enabling the extension alone would not make a
+ * module using them valid.
+ */
+public final class VendorExtensions {
+
+	/** Each vendor GLSL extension with the device extension that implements it on Vulkan. */
+	private static final Map<String, String> DEVICE_EXTENSIONS = deviceExtensions();
+
+	private static volatile Set<String> absent = Collections.unmodifiableSet(
+			new TreeSet<>(DEVICE_EXTENSIONS.keySet()));
+
+	private VendorExtensions() {
+	}
+
+	/**
+	 * Records what the device has and enables it, asked once at the device's creation.
+	 *
+	 * @param hasDeviceExtension whether the physical device offers a device extension
+	 * @param enable             where a device extension to enable at creation is added
+	 * @return the device extensions enabled, for the log
+	 */
+	public static List<String> serve(Predicate<String> hasDeviceExtension, Consumer<String> enable) {
+		Set<String> missing = new TreeSet<>();
+		List<String> enabled = new ArrayList<>();
+		DEVICE_EXTENSIONS.forEach((glsl, device) -> {
+			if (device.isEmpty() || !hasDeviceExtension.test(device)) {
+				missing.add(glsl);
+			} else {
+				enable.accept(device);
+				enabled.add(device);
+			}
+		});
+		absent = Collections.unmodifiableSet(missing);
+
+		return enabled;
+	}
+
+	/** Whether a pack's {@code #extension} of this name asks for something the device lacks. */
+	static boolean absent(String glslExtension) {
+		return absent.contains(glslExtension);
+	}
+
+	/** The absent names, joined, for a cache key. */
+	public static String key() {
+		return String.join(",", absent);
+	}
+
+	/** The hidden spelling of a macro the compiler would define and the device would not answer for. */
+	static String hidden(String glslExtension) {
+		return "OF_ABSENT_" + glslExtension;
+	}
+
+	private static Map<String, String> deviceExtensions() {
+		Map<String, String> table = new LinkedHashMap<>();
+		// Extensions that stand on their own: enabling the device extension is all a module
+		// using them needs.
+		table.put("GL_AMD_shader_trinary_minmax", "VK_AMD_shader_trinary_minmax");
+		table.put("GL_AMD_gpu_shader_half_float", "VK_AMD_gpu_shader_half_float");
+		table.put("GL_AMD_gpu_shader_int16", "VK_AMD_gpu_shader_int16");
+		table.put("GL_AMD_gcn_shader", "VK_AMD_gcn_shader");
+		table.put("GL_AMD_shader_explicit_vertex_parameter", "VK_AMD_shader_explicit_vertex_parameter");
+		table.put("GL_AMD_shader_fragment_mask", "VK_AMD_shader_fragment_mask");
+		table.put("GL_AMD_shader_image_load_store_lod", "VK_AMD_shader_image_load_store_lod");
+		table.put("GL_AMD_texture_gather_bias_lod", "VK_AMD_texture_gather_bias_lod");
+		table.put("GL_NV_shader_subgroup_partitioned", "VK_NV_shader_subgroup_partitioned");
+		// Absent on every device: no Vulkan form, a second extension or a device feature of their
+		// own that is not enabled here, so the module would be invalid with the extension enabled
+		// alone.
+		table.put("GL_NV_gpu_shader5", "");
+		table.put("GL_AMD_shader_ballot", "");
+		table.put("GL_INTEL_shader_integer_functions2", "");
+		table.put("GL_NV_shader_sm_builtins", "");
+		table.put("GL_ARM_shader_core_builtins", "");
+
+		return Collections.unmodifiableMap(table);
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
@@ -5,6 +5,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.vulkan.VulkanBackend;
 import com.mojang.blaze3d.vulkan.VulkanPhysicalDevice;
 import com.mojang.blaze3d.vulkan.init.VulkanFeature;
+import dev.vitrail.glsl.VendorExtensions;
 import dev.vitrail.render.BufferBlending;
 import dev.vitrail.Vitrail;
 import org.lwjgl.system.MemoryStack;
@@ -153,6 +154,14 @@ public abstract class VulkanBackendMixin {
 		enable(physical, features, EXTENDED_FORMATS, enabled, VOXELS);
 		enable(physical, features, WRITE_WITHOUT_FORMAT, enabled, VOXELS);
 		BufferBlending.serve(enable(physical, features, INDEPENDENT_BLEND, enabled, PER_BUFFER));
+		// The vendor extensions a pack may gate a vendor instruction on, answered by the device
+		// and not by the compiler, which defines the macro of every one it knows; the ones the
+		// device has are enabled on it here, since a module using one needs it enabled.
+		List<String> vendor = VendorExtensions.serve(physical::hasDeviceExtension, extensions::add);
+		if (!vendor.isEmpty()) {
+			Vitrail.logger().info("Vulkan vendor extensions: {}", String.join(", ", vendor));
+		}
+
 		enable(physical, features, SHADER_FLOAT16, enabled, NARROW);
 		enable(physical, features, SHADER_INT8, enabled, NARROW);
 		enable(physical, features, SHADER_INT16, enabled, NARROW);

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
@@ -12,6 +12,8 @@ import org.lwjgl.vulkan.VK12;
 import org.lwjgl.vulkan.VkDevice;
 import org.lwjgl.vulkan.VkPhysicalDeviceFeatures;
 import org.lwjgl.vulkan.VkPhysicalDeviceFeatures2;
+import org.lwjgl.vulkan.VkPhysicalDeviceVulkan11Features;
+import org.lwjgl.vulkan.VkPhysicalDeviceVulkan12Features;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -28,9 +30,8 @@ import java.util.Set;
  * ({@code UpdateVoxelMap} under {@code SHADOW && VERTEX_SHADER}). Vulkan ignores those stores
  * unless {@code vertexPipelineStoresAndAtomics} is enabled, and {@code r16ui} / {@code rgba16f}
  * are not core storage formats unless {@code shaderStorageImageExtendedFormats} is on. The game's
- * {@code VulkanBackend} enables neither: its required set is draw-indirect, anisotropy and
- * dynamic rendering. Without this, floodfill runs on a volume that stays empty and the pack's
- * coloured lamps never light.
+ * {@code VulkanBackend} enables neither. Without this, floodfill runs on a volume that stays
+ * empty and the pack's coloured lamps never light.
  * <p>
  * And {@code independentBlend}, which is the device's half of {@code PER_BUFFER_BLENDING}. A pass
  * writing several targets under a {@code blend.<program>.<buffer>} directive needs each attachment
@@ -68,8 +69,69 @@ public abstract class VulkanBackendMixin {
 			VulkanBackend.VK10_FEATURES_STRUCT, "independentBlend",
 			VkPhysicalDeviceFeatures.INDEPENDENTBLEND);
 
+	// The narrow arithmetic a pack written for a recent card asks for. RenderPearl computes in
+	// float16_t, int16_t and int8_t throughout and keeps a half in its storage buffers, so its
+	// modules carry the Float16, Int16, Int8 and 16 and 8 bit storage capabilities, each of which
+	// is only valid on a device that enabled the matching feature. The game enables none, so a
+	// module carrying one of them is invalid on the device it was built for, which the validation
+	// layer refuses and no driver is bound to run. OpenGL, where Iris runs, exposes the same
+	// arithmetic through GL_EXT_shader_explicit_arithmetic_types with nothing to enable.
+	//
+	// storageInputOutput16 is not asked for: GeForce does not have it, and the translator
+	// declares a 16 bit fragment output under its 32 bit type on every card rather than answer
+	// it per device (LegacyGlsl.widened). A 16 bit varying is left as the pack wrote it, and no
+	// pack of the corpus declares one.
+	@Unique
+	private static final VulkanFeature SHADER_FLOAT16 = new VulkanFeature(
+			VulkanBackend.VK12_FEATURES_STRUCT, "shaderFloat16",
+			VkPhysicalDeviceVulkan12Features.SHADERFLOAT16);
+
+	@Unique
+	private static final VulkanFeature SHADER_INT8 = new VulkanFeature(
+			VulkanBackend.VK12_FEATURES_STRUCT, "shaderInt8",
+			VkPhysicalDeviceVulkan12Features.SHADERINT8);
+
+	@Unique
+	private static final VulkanFeature SHADER_INT16 = new VulkanFeature(
+			VulkanBackend.VK10_FEATURES_STRUCT, "shaderInt16",
+			VkPhysicalDeviceFeatures.SHADERINT16);
+
+	// Subgroup operations over those types, which the pack reaches through the extended types
+	// subgroup extensions: a reduction over a half vector is refused without this one.
+	@Unique
+	private static final VulkanFeature SUBGROUP_EXTENDED = new VulkanFeature(
+			VulkanBackend.VK12_FEATURES_STRUCT, "shaderSubgroupExtendedTypes",
+			VkPhysicalDeviceVulkan12Features.SHADERSUBGROUPEXTENDEDTYPES);
+
+	@Unique
+	private static final VulkanFeature STORAGE_16 = new VulkanFeature(
+			VulkanBackend.VK11_FEATURES_STRUCT, "storageBuffer16BitAccess",
+			VkPhysicalDeviceVulkan11Features.STORAGEBUFFER16BITACCESS);
+
+	@Unique
+	private static final VulkanFeature UNIFORM_STORAGE_16 = new VulkanFeature(
+			VulkanBackend.VK11_FEATURES_STRUCT, "uniformAndStorageBuffer16BitAccess",
+			VkPhysicalDeviceVulkan11Features.UNIFORMANDSTORAGEBUFFER16BITACCESS);
+
+	@Unique
+	private static final VulkanFeature STORAGE_8 = new VulkanFeature(
+			VulkanBackend.VK12_FEATURES_STRUCT, "storageBuffer8BitAccess",
+			VkPhysicalDeviceVulkan12Features.STORAGEBUFFER8BITACCESS);
+
+	@Unique
+	private static final VulkanFeature UNIFORM_STORAGE_8 = new VulkanFeature(
+			VulkanBackend.VK12_FEATURES_STRUCT, "uniformAndStorageBuffer8BitAccess",
+			VkPhysicalDeviceVulkan12Features.UNIFORMANDSTORAGEBUFFER8BITACCESS);
+
 	@Unique
 	private static final String VOXELS = "voxel lighting will not write";
+
+	@Unique
+	private static final String NARROW = "a pack computing in 16 or 8 bit types cannot be built";
+
+	@Unique
+	private static final String NARROW_SUBGROUP =
+			"a pack reducing 16 or 8 bit values across a subgroup cannot be built";
 
 	@Unique
 	private static final String PER_BUFFER = "a pack requiring PER_BUFFER_BLENDING is refused and "
@@ -91,6 +153,14 @@ public abstract class VulkanBackendMixin {
 		enable(physical, features, EXTENDED_FORMATS, enabled, VOXELS);
 		enable(physical, features, WRITE_WITHOUT_FORMAT, enabled, VOXELS);
 		BufferBlending.serve(enable(physical, features, INDEPENDENT_BLEND, enabled, PER_BUFFER));
+		enable(physical, features, SHADER_FLOAT16, enabled, NARROW);
+		enable(physical, features, SHADER_INT8, enabled, NARROW);
+		enable(physical, features, SHADER_INT16, enabled, NARROW);
+		enable(physical, features, SUBGROUP_EXTENDED, enabled, NARROW_SUBGROUP);
+		enable(physical, features, STORAGE_16, enabled, NARROW);
+		enable(physical, features, UNIFORM_STORAGE_16, enabled, NARROW);
+		enable(physical, features, STORAGE_8, enabled, NARROW);
+		enable(physical, features, UNIFORM_STORAGE_8, enabled, NARROW);
 		if (!enabled.isEmpty()) {
 			Vitrail.logger().info("Vulkan device features: {}", String.join(", ", enabled));
 		}

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -243,7 +243,17 @@ and would take rank zero whatever the entry point does. For the same reason, any
 adds around the pack's entry point (the alpha test epilogue, for instance, which reads the alpha
 of output zero) has to be emitted **after** both the declarations and the ordering function. A
 wrapper emitted above them reorders every attachment in the program, and the result is a complete,
-convincing, wrong image.
+convincing, wrong image. It is in fact emitted after the pack's whole body, at the end of the
+file, the way the reference places its own: a wrapper that writes `gl_FragDepth` above a pack's
+`layout(depth_unchanged)` redeclaration of it is refused by the compiler, a builtin having been
+used before it was redeclared.
+
+**A fragment output declared under a 16 bit type is declared under the 32 bit one.** The
+reference leaves such a declaration alone, OpenGL taking it on any card that takes the
+extension. On Vulkan a 16 bit variable in the input or output storage class asks the module for
+a capability GeForce does not expose, so the module is invalid on that card. The value written is
+the same either way, the attachment holding whatever format the
+pack gave it, and the pack's own assignments still fit, a half converting to a float on its own.
 
 ## Identity, caching and reload
 


### PR DESCRIPTION
## What changes

RenderPearl loads and draws instead of taking the driver down at its first pipeline, and Iteration's final passes load. The translator knows the explicitly sized types, so a fragment output declared under a 16 bit one is lifted and declared under its 32 bit form, and the wrapping `main` is emitted after the pack's body, below the pack's depth layout line. The device enables the narrow arithmetic features a card reports beside the storage image and blend features it already asked for. A pack's own `in`/`out` block is passed as one varying per member. A vendor GLSL extension is answered the way the device answers it: the device says at creation which it has and enables those, an absent one is neither hoisted nor left defined as a macro, and the translation cache is keyed on the answer. And an output declared at a location a dead `gl_FragData` or `gl_FragColor` also claimed is lifted rather than refused.

## How it differs from the reference, and for what obstacle

Three workarounds, each for something OpenGL takes and Vulkan or the game does not.

- Iris leaves a 16 bit output declaration as written. Here it asks for `StorageInputOutput16`, which GeForce does not expose (`LegacyGlsl.widened`). Cost: none to the value written.
- Iris leaves a pack's interface block as written. The game numbers each output variable one location in reflection order and rebinds the next stage's inputs by name (`IntermediaryShaderModule.java:112-116`), so the output listed after a block lands inside it (`GlslTranslator.flattenInterfaceBlocks`). Cost: the packing by component, nine slots where RenderPearl used four.
- A GL driver defines a vendor extension macro only for what the card has; shaderc defines every one it knows (`VendorExtensions`). One divergence inside: `GL_NV_gpu_shader5` has no Vulkan form, so Noble takes the explicit arithmetic types road here where under Iris on a GeForce it takes the NVIDIA one, the same 16 bit types either way.

## What proves it

- `gradlew build` green on every commit of the series.
- The off-game harness over the whole corpus: the `Translation` table is identical to `dev` except RenderPearl gaining units. On RenderPearl, `Translation` and `Varyings` as NVIDIA give zero refusal against nine overlapping locations and thirty three unread varyings on `dev`, and every module passes `spirv-val`. On Iteration, six overlapping locations become zero.
- In the game, Fabric bench, RenderPearl on the frozen world under the validation layer: every module the game builds validates, terrain, water, shadow, sky, hand and particles draw, where `dev` dies in `vkCreateGraphicsPipelines` on the first pipeline. The image is still flat blue: three compute refusals the log names. Iteration loads with its final passes in.

## What it leaves owing

- RenderPearl's computes: raw `.bin` custom textures used as samplers, `colortex0` not writable from a compute, a local size written as an expression.
- Iteration: the geometry stage a pack ships is never bound, and a `TEXTURE_3D` custom texture is refused, its file past the source reader's ceiling.
- A 16 bit varying is left as written, no pack of the corpus declaring one; the AMD ballot and the Intel, NVIDIA and ARM builtin extensions are answered absent everywhere.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
