### PR TITLE
fix(render): copy a target a translucent program reads while writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,15 @@ what the next one holds.
 
 ### Fixed
 
+- **Water that reads the picture behind it draws its fog and its reflections.** Some packs
+  sample one of their own colour targets from the water, the translucent blocks or the particles
+  while drawing into that same target, for the colour of the world behind the surface and for
+  what it reflects; that is what OpenGL hands them, the target as it stands. This engine
+  answered the read with one black pixel, and Sildur's Vibrant Shaders drew its lakes a flat
+  saturated blue with nothing mirrored in them. The read is now served a copy of the target
+  taken just ahead of the pass, which holds the world the pass wants to see behind itself, at
+  the cost of two image copies a frame per such target.
+
 - **A pack written for half precision no longer takes the driver down with it.** RenderPearl
   computes in sixteen and eight bit numbers, and five things stood between it and the screen, one of
   which crashed the game the moment the pack's first program was built. The engine did not know

--- a/NOTICE
+++ b/NOTICE
@@ -310,6 +310,19 @@ GNU Lesser General Public License version 3
   stated in common/src/main/java/dev/vitrail/render/GeometryProgram.java, Iris writing its hand
   colour to the pack's own target where here it reaches the pack through the scene seed.
 
+  common/src/main/java/dev/vitrail/render/TargetCopies.java serves a geometry program that
+  samples one of its own draw targets what the reference's framebuffer holds there: Iris binds
+  colortex4 and up, and none of the first four, to a target's main half, or to its alternate
+  half once the target is flipped, and attaches the draw buffer to that same half,
+  net.irisshaders.iris.samplers.IrisSamplers lines 51 to 69 against
+  net.irisshaders.iris.targets.RenderTargets lines 309 to 320 and 345 to 368, both off the one
+  snapshot net.irisshaders.iris.pipeline.IrisRenderingPipeline takes at lines 359 to 360 and
+  677 to 678, read on 8 September 2026. What is not a transcription is the copy: Iris reads the
+  attachment itself, a read OpenGL leaves undefined and lets a program make where this backend
+  refuses it, so the passes drawn after the deferred stage are handed a copy of the target
+  taken ahead of them, and the passes drawn before it are answered one pixel. The file writes
+  both out.
+
   common/src/main/java/dev/vitrail/render/PackDepth.java keeps a third depth image, the world as it
   stood before the player's own hand was drawn, which is what a pack reads as depthtex2. Both the
   image and the moment it is taken at are net.irisshaders.iris.targets.RenderTargets's, read in

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -254,6 +254,9 @@ public final class EngineStages {
 		// open, and composing opens one of its own where the encoder allows only one at a time.
 		EntityDraw.translucentFeatures(false);
 		PackChain.closeFeatures();
+		// Then the copy a translucent program reads where it samples a target it writes, which
+		// has to hold the layer just composed and everything before it.
+		PackChain.takeReadCopies();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -199,6 +199,12 @@ final class ColorTargets {
 	private final PackDepth depth = new PackDepth();
 
 	/**
+	 * The copies of the targets a translucent geometry program samples on the half it writes,
+	 * held here for the same reason again: they answer a sampler a program binds.
+	 */
+	private final TargetCopies copies = new TargetCopies();
+
+	/**
 	 * The smoothed depth at the centre of the screen, held here for the same reason again: it is a
 	 * sampler a program binds, and everything that binds one already holds this object.
 	 */
@@ -464,6 +470,11 @@ final class ColorTargets {
 					changed |= ensureSide(this.altSide, index, width, height, " alt");
 				}
 			}
+
+			// After the targets and sized on them, and not folded into the debt above: a copy is
+			// filled by the frame before anything reads it, so it is never owed a clear. A refusal
+			// there is the copy's own to keep, one target at a time, and takes nothing else down.
+			this.copies.ensure(this::target);
 		} catch (RuntimeException e) {
 			this.broken = true;
 			this.brokenWidth = screenWidth;
@@ -778,6 +789,14 @@ final class ColorTargets {
 	}
 
 	/**
+	 * The copies served where a translucent geometry program reads a target it writes. Never
+	 * null, and each of its images is null until a frame has filled it.
+	 */
+	TargetCopies copies() {
+		return this.copies;
+	}
+
+	/**
 	 * The one texel {@code centerDepthSmooth} is read out of, and the pass that draws it. Its own
 	 * image is null until a frame has drawn it, and a name bound to it then reads the far plane.
 	 */
@@ -990,6 +1009,7 @@ final class ColorTargets {
 		this.coverage = release(this.coverage);
 		this.shadowMap.release();
 		this.depth.release();
+		this.copies.release();
 		this.centerDepth.release();
 		this.motionVectors.release();
 		this.pendingClears.clear();

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -501,8 +501,12 @@ final class GeometryProgram {
 	 */
 	private boolean discarded;
 
-	/** Targets already reported as read on the half this pass writes. Said once each, not per frame. */
-	private final Set<Integer> collisions = new HashSet<>();
+	/**
+	 * The attachments of this pass some sampler of the program also reads, on the same half.
+	 * Served a copy taken before the world's translucents on a pass drawn after the deferred
+	 * stage, and one pixel on any other; {@link TargetCopies} says why the two differ.
+	 */
+	private final Set<ChainPlan.Attachment> readWhileWritten;
 
 	/** Reused while a descriptor is built: Sodium asks for one per region, not once a frame. */
 	private final List<GpuTextureView> attachedViews = new ArrayList<>();
@@ -704,6 +708,7 @@ final class GeometryProgram {
 				.toArray(Sampled[]::new);
 		this.settledOnce = Arrays.stream(this.bound).filter(one -> !one.followsTheImage())
 				.toArray(Sampled[]::new);
+		this.readWhileWritten = readWhileWritten(targets);
 
 		String vertex = loaded.program().stages().get(ProgramStage.VERTEX).text();
 		String fragment = loaded.program().stages().get(ProgramStage.FRAGMENT).text();
@@ -2186,26 +2191,93 @@ final class GeometryProgram {
 	}
 
 	/**
-	 * A colour target of the pack, on the half the plan reads it from, or black.
+	 * Which of this pass's attachments some sampler of the program reads on the same half,
+	 * settled once: both lists are the plan's and neither moves while the pack is loaded. Said in
+	 * the log here, once per program, because the answer decides what the draw reads.
 	 * <p>
-	 * Black covers two cases and only one of them is temporary. The targets may not be allocated
-	 * yet, which is the first frame or two. And the half being read may be a half this very pass is
-	 * writing, which happens when the pack asks for a target it does not double: one image cannot be
-	 * an attachment and a sampled texture of the same pass, so the read is refused rather than left
-	 * to mean whatever the driver decides that frame.
+	 * A pass drawn after the deferred stage asks for the copy {@link TargetCopies} takes ahead of
+	 * it, which is the picture the reference's framebuffer holds when it is read there. A pass drawn before it keeps the one pixel: what stands in the target at that
+	 * moment is the frame's clear or the pass's own siblings at work, and no copy taken at one
+	 * moment stands in for either. So does a read of the first four targets on any pass, which
+	 * the reference binds to no geometry program at all ({@link TargetCopies#FIRST_SAMPLED}).
 	 */
-	private GpuTextureView colortex(SamplerPlan.Binding binding) {
+	private Set<ChainPlan.Attachment> readWhileWritten(ColorTargets targets) {
+		Set<ChainPlan.Attachment> collided = new HashSet<>();
 		for (ChainPlan.Attachment attachment : this.extra) {
-			if (attachment.target() == binding.index() && attachment.side() == binding.side()) {
-				if (this.collisions.add(binding.index())) {
-					Vitrail.logger().warn("{} reads {} on the half it writes, so it is answered with "
-							+ "one pixel: the pack does not double that target and one image cannot be "
-							+ "both an attachment and a texture of one pass", this.path,
-							TargetName.canonical(binding.index()));
+			for (Sampled one : this.bound) {
+				SamplerPlan.Binding binding = one.binding;
+				if (binding.kind() != SamplerPlan.Kind.COLORTEX
+						|| binding.index() != attachment.target()
+						|| binding.side() != attachment.side()
+						|| !collided.add(attachment)) {
+					continue;
 				}
 
-				return this.constants.black();
+				boolean copied = this.pass.afterDeferred()
+						&& attachment.target() >= TargetCopies.FIRST_SAMPLED;
+				if (copied) {
+					targets.copies().ask(attachment.target(), attachment.side());
+				}
+
+				// Once per program path: the entity family builds one of these per element it serves.
+				if (!targets.copies().firstMention(this.path, attachment.target(), attachment.side())) {
+					continue;
+				}
+
+				if (copied) {
+					Vitrail.logger().info("{} reads {} on the half it writes, so it is served a copy "
+							+ "taken ahead of the pass, which is what the target holds when the "
+							+ "reference reads it there", this.path,
+							TargetName.canonical(attachment.target()));
+				} else if (attachment.target() < TargetCopies.FIRST_SAMPLED) {
+					Vitrail.logger().warn("{} reads {} on the half it writes, so it is answered with "
+							+ "one pixel: one image cannot be both an attachment and a texture of one "
+							+ "pass, and the reference binds none of the first four targets to a "
+							+ "geometry program", this.path, TargetName.canonical(attachment.target()));
+				} else {
+					Vitrail.logger().warn("{} reads {} on the half it writes, so it is answered with "
+							+ "one pixel: one image cannot be both an attachment and a texture of one "
+							+ "pass, and a pass drawn before the deferred stage has no picture a copy "
+							+ "could stand in for", this.path, TargetName.canonical(attachment.target()));
+				}
 			}
+		}
+
+		return Set.copyOf(collided);
+	}
+
+	/** Whether this name reads a target this pass writes, whatever it is answered with. */
+	private boolean collides(SamplerPlan.Binding binding) {
+		return binding.kind() == SamplerPlan.Kind.COLORTEX && this.readWhileWritten.contains(
+				new ChainPlan.Attachment(binding.index(), binding.side()));
+	}
+
+	/** Whether this name is answered with the copy rather than with the target itself. */
+	private boolean copied(SamplerPlan.Binding binding) {
+		return this.pass.afterDeferred() && binding.index() >= TargetCopies.FIRST_SAMPLED
+				&& collides(binding);
+	}
+
+	/**
+	 * A colour target of the pack, on the half the plan reads it from; the copy taken ahead of
+	 * this pass where it writes that half itself; or black.
+	 * <p>
+	 * Black covers three cases and two of them are temporary. The targets may not be allocated
+	 * yet, which is the first frame or two, and the copy may not have been taken yet, which is the
+	 * same frames. And the half being read may be a half this very pass is writing on a pass drawn
+	 * before the deferred stage: one image cannot be an attachment and a sampled texture of the
+	 * same pass, and no copy taken at one moment stands in for a target the pass's own siblings
+	 * are filling, so the read is refused rather than left to mean whatever the driver decides
+	 * that frame; and so is a read of the first four targets, which the reference binds to no
+	 * geometry program. {@link #readWhileWritten} said which at the load.
+	 */
+	private GpuTextureView colortex(SamplerPlan.Binding binding) {
+		if (collides(binding)) {
+			GpuTextureView copy = copied(binding)
+					? this.targets.copies().view(binding.index(), binding.side())
+					: null;
+
+			return copy == null ? this.constants.black() : copy;
 		}
 
 		GpuTextureView view = this.targets.view(binding.index(), binding.side());
@@ -2224,7 +2296,8 @@ final class GeometryProgram {
 			return sampler;
 		}
 
-		return sampler + "=" + TargetName.canonical(binding.index()) + " " + binding.side();
+		return sampler + "=" + TargetName.canonical(binding.index()) + " " + binding.side()
+				+ (copied(binding) ? " copy" : "");
 	}
 
 	/**
@@ -2274,7 +2347,9 @@ final class GeometryProgram {
 		}
 
 		return ATLAS.contains(sampler) || LIGHTMAP.equals(sampler) || OVERLAY.equals(sampler)
-				|| kind == SamplerPlan.Kind.COLORTEX
+				// A target this pass writes counts only where the copy answers it; the pixel stands
+				// in everywhere else, and the load has already said why.
+				|| (kind == SamplerPlan.Kind.COLORTEX && (!collides(binding) || copied(binding)))
 				|| kind == SamplerPlan.Kind.CUSTOM_IMAGE
 				|| kind == SamplerPlan.Kind.NOISE
 				|| (kind == SamplerPlan.Kind.DEPTH && (this.pass.afterDeferred()

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1153,6 +1153,9 @@ public final class PackChain {
 		this.begun = false;
 		this.prepared = false;
 		this.early = false;
+		// A per frame picture like the depths: a frame that takes none reads the pixel, never the
+		// frame before's world.
+		this.targets.copies().forget();
 		this.filled = false;
 		this.seeded = false;
 		this.sceneDepth = false;
@@ -1889,6 +1892,59 @@ public final class PackChain {
 	}
 
 	/**
+	 * Takes, for the second time this frame, the copy a translucent geometry program reads where
+	 * it samples a target it writes, at the last moment before the world's translucents: after the
+	 * deferred stage, the scene seed at its rank among the deferreds, the hand's solid pass, the
+	 * translucent half of the entities and the game's own features composed by
+	 * {@link #closeFeatures}, which are the last writers of what a water program reads behind
+	 * itself. The reference's framebuffer holds all of that when such a program is drawn.
+	 * <p>
+	 * <strong>Two takes and not one, because the readers are drawn on both sides of the game's
+	 * features window.</strong> The translucent half of the entities is drawn inside it, between
+	 * the deferred stage and this line, and what it reads behind itself under the reference is
+	 * the opaque world as the deferreds left it: that is the take at the end of {@code drawEarly}.
+	 * The world's water, the translucent particles, the clouds, the weather and the hand's water
+	 * are drawn after this line, and what they read has the entities and the layer in it: that is
+	 * this one, over the first. One image copy apiece per target read this way, the second only
+	 * where the first was, and a pack whose translucents read no target of their own pays neither.
+	 * <p>
+	 * Outside any render pass, as a copy has to be, which is what {@link #closeFeatures} leaves.
+	 */
+	public static void takeReadCopies() {
+		PackChain chain = active;
+		GpuDevice device = RenderSystem.tryGetDevice();
+		// The early half is the gate and not drawable(): a frame that never reached it has no
+		// deferred stage behind the target, and a copy of that is the picture this refuses.
+		if (disabled || chain == null || device == null || !chainWanted || !chain.early) {
+			return;
+		}
+
+		try {
+			chain.takeReadCopies(device);
+		} catch (RuntimeException e) {
+			disabled = true;
+			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
+			chain.release();
+		}
+	}
+
+	/**
+	 * One take of the copies, with the clears still owed paid first, so a target no pass has
+	 * attached yet in this frame is copied emptied rather than holding the frame before: under
+	 * Iris the clear pass ran at the head of the frame and a water reads the clear colour there.
+	 * Nothing is paid, and no encoder is made, when no copy exists to take.
+	 */
+	private void takeReadCopies(GpuDevice device) {
+		if (!this.targets.copies().any()) {
+			return;
+		}
+
+		CommandEncoder encoder = device.createCommandEncoder();
+		this.targets.flushPending(encoder);
+		this.targets.copies().take(encoder);
+	}
+
+	/**
 	 * Puts the game's overrides back and composes the layer onto the half of the pack's target the
 	 * world's translucents are about to blend onto, which keeps vanilla's order: features first,
 	 * then water.
@@ -2165,6 +2221,12 @@ public final class PackChain {
 
 		drawRange(device, ready, world, end, this.targets.depth().opaque(),
 				this.targets.depth().distantOpaque(), true, Cut.BEFORE_TRANSLUCENTS);
+
+		// The first of the frame's two takes, for the translucent passes drawn inside the game's
+		// features window that opens right after this: the translucent half of the entities reads
+		// the opaque world as the deferreds and the seed left it, which is what stands here.
+		// takeReadCopies says where the second one is and why there are two.
+		takeReadCopies(device);
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/TargetCopies.java
+++ b/common/src/main/java/dev/vitrail/render/TargetCopies.java
@@ -1,0 +1,241 @@
+package dev.vitrail.render;
+
+import dev.vitrail.pack.model.TargetName;
+import dev.vitrail.pack.target.TargetSchedule;
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.textures.GpuTextureView;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+/**
+ * A copy of each colour target a translucent geometry program samples on the half it also writes,
+ * taken at the end of the deferred stage and again once the game's translucent features are
+ * composed, and served to that program where it asks for the target.
+ * <p>
+ * <strong>What the pack was written against.</strong> Under OpenGL a gbuffers program's sampler
+ * and its draw buffer are one texture: Iris binds {@code colortex4} and up to the main half unless
+ * the target is flipped ({@code samplers/IrisSamplers.java:51-69}) and attaches the draw buffer to
+ * the same half on the same rule ({@code targets/RenderTargets.java:309-320} and
+ * {@code :345-368}, both sets taken from one snapshot at
+ * {@code pipeline/IrisRenderingPipeline.java:359-360} and {@code :677-678}). So a
+ * {@code gbuffers_water} that samples the target it draws into reads what the opaque world left
+ * there, its own fog colour behind the water and the scene it reflects, and it is a read the
+ * packs make on purpose: Sildur's {@code gbuffers_water.fsh} samples {@code colortex4} for both
+ * while drawing to it. OpenGL leaves such a read undefined and the drivers hand back what stood
+ * at the texel for a fragment reading its own, which is the read these packs rely on.
+ * <p>
+ * <strong>Why a copy here, which is a divergence and is written up as one.</strong> Vulkan does
+ * not let one image be a colour attachment and a sampled texture of the same pass, whatever the
+ * layout; the game's backend has no feedback loop layout and no input attachment to offer, so the
+ * read was answered with one black pixel, and Sildur's water lost its fog and its reflections.
+ * What Iris's framebuffer holds when the world's translucents are drawn is the opaque world as
+ * the deferred stage, the hand, the translucent entities and the game's features left it, and
+ * what it holds when the translucent entities themselves are drawn is that world without the
+ * last two; both stand in the target at their moment here, so an image copy per such target,
+ * taken outside any pass at each of the two boundaries, is that picture
+ * ({@code PackChain.takeReadCopies} says where). What it costs is the copies, two of one target
+ * a frame per target read this way, and one more image of that target's size. What it leaves: a
+ * translucent draw reading a texel another translucent draw of the same frame has already
+ * written sees the opaque world there, where the reference's read is one the specification
+ * leaves undefined; and the copy carries level nought alone, so a program reading such a target
+ * at a lod is served the base level whatever the lod, where a mipmapped target would have had a
+ * chain.
+ * <p>
+ * Only the passes drawn after the deferred stage are served, and only for the targets the
+ * reference binds to a geometry program at all ({@link #FIRST_SAMPLED}). A pass drawn before that
+ * stage reads a target the frame's clear has just emptied, or that its own siblings are filling,
+ * and neither is a picture a copy taken at one moment can stand in for; those keep the one pixel
+ * and the log line that names it. The hand's translucent pass is served the second copy, so it
+ * sees the world without the water where the reference shows it the water too. And what a
+ * geometry program reads of the first four targets where it does NOT write them is a question
+ * this class leaves where it found it: the live target, where the reference binds nothing.
+ */
+final class TargetCopies {
+
+	/**
+	 * The first target a geometry program may read at all. Iris binds {@code colortex0} to
+	 * {@code colortex3} to its full screen passes alone ({@code samplers/IrisSamplers.java:53-55}),
+	 * so a gbuffers program naming one of them reads whatever stands on its first texture unit
+	 * there, and no copy stands in for that.
+	 */
+	static final int FIRST_SAMPLED = 4;
+
+	private record Key(int target, TargetSchedule.Side side) {
+	}
+
+	/**
+	 * What a program asked for, in the order asked, whether or not a texture exists for it yet.
+	 * Written from the worker threads that build the entity programs and read on the render
+	 * thread, so every touch of it is under this object's lock; nothing else here leaves the
+	 * render thread.
+	 */
+	private final Set<Key> asked = new LinkedHashSet<>();
+
+	/** The program paths whose reads have been said in the log, one line per path and target. */
+	private final Set<String> said = new HashSet<>();
+
+	/** One surface per key, at the size and format of the target it copies. */
+	private final Map<Key, TargetSurface> copies = new LinkedHashMap<>();
+
+	/** The target each copy is taken from, settled by the last {@link #ensure}. */
+	private final Map<Key, TargetSurface> sources = new LinkedHashMap<>();
+
+	/** Keys whose allocation failed, refused for the session rather than retried every frame. */
+	private final Set<Key> refused = new LinkedHashSet<>();
+
+	/**
+	 * Whether {@link #take} has filled the copies this frame. A fresh image holds whatever the
+	 * driver left there, and an image a frame old holds a camera that has moved on; a reader
+	 * served either would read it as the scene, so it is lowered at the frame's close and at every
+	 * allocation.
+	 */
+	private boolean written;
+
+	/**
+	 * Says that a geometry program drawn after the deferred stage samples this target on the half
+	 * it writes. Asked at the program's construction, which is before any frame; a key asked once
+	 * a frame is running is served from the next {@link #ensure} on.
+	 */
+	void ask(int target, TargetSchedule.Side side) {
+		synchronized (this) {
+			this.asked.add(new Key(target, side));
+		}
+	}
+
+	/**
+	 * Whether this program's read of this target is being named for the first time, so that the
+	 * load says it once per program rather than once per piece the program is built for: the
+	 * entity family builds one program per element it serves, off one path.
+	 */
+	boolean firstMention(String path, int target, TargetSchedule.Side side) {
+		synchronized (this) {
+			return this.said.add(path + "|" + target + "|" + side);
+		}
+	}
+
+	/**
+	 * Makes a copy exist for every key asked whose target exists, at that target's size and
+	 * format, reallocating when the target moved. Must run on the render thread and outside any
+	 * render pass, after the targets themselves have been sized for the frame.
+	 *
+	 * @param source the target's own surface for a target and a half, or null when none exists
+	 */
+	void ensure(BiFunction<Integer, TargetSchedule.Side, TargetSurface> source) {
+		List<Key> keys;
+		synchronized (this) {
+			keys = List.copyOf(this.asked);
+		}
+
+		for (Key key : keys) {
+			if (this.refused.contains(key)) {
+				continue;
+			}
+
+			TargetSurface target = source.apply(key.target(), key.side());
+			if (target == null) {
+				continue;
+			}
+
+			TargetSurface copy = this.copies.get(key);
+			if (copy != null && copy.width() == target.width() && copy.height() == target.height()) {
+				this.sources.put(key, target);
+				continue;
+			}
+
+			String name = TargetName.canonical(key.target()) + (key.side() == TargetSchedule.Side.ALT
+					? " alt" : "");
+			try {
+				if (copy == null) {
+					// Named before it is allocated, like the target it copies, so that the last line
+					// written names what was asked for when the allocation is what fails.
+					Vitrail.logger().info("Allocating a copy of {} as {} at {}x{}, read by a "
+							+ "translucent geometry program on the half it writes", name,
+							target.texture().getFormat(), target.width(), target.height());
+					this.copies.put(key, new TargetSurface("Vitrail " + name + " copy",
+							target.texture().getFormat(), false, target.width(), target.height()));
+				} else {
+					copy.resize(target.width(), target.height());
+				}
+			} catch (RuntimeException e) {
+				this.refused.add(key);
+				TargetSurface failed = this.copies.remove(key);
+				if (failed != null) {
+					failed.close();
+				}
+
+				this.sources.remove(key);
+				Vitrail.logger().error("Vitrail could not allocate the copy of {} at {}x{}, so the "
+						+ "programs reading it on the half they write read one pixel there instead",
+						name, target.width(), target.height(), e);
+				continue;
+			}
+
+			// A new image, or an image of another size: nothing has filled it yet.
+			this.written = false;
+			this.sources.put(key, target);
+		}
+	}
+
+	/** Whether any copy exists to take, which is what decides whether the frame pays for one. */
+	boolean any() {
+		return !this.copies.isEmpty();
+	}
+
+	/**
+	 * Copies every target into its copy, level nought whole. Must run on the render thread and
+	 * outside any render pass, at each of the two boundaries {@code PackChain.takeReadCopies}
+	 * names, with the clears still owed paid ahead of it.
+	 */
+	void take(CommandEncoder encoder) {
+		for (Map.Entry<Key, TargetSurface> entry : this.copies.entrySet()) {
+			TargetSurface source = this.sources.get(entry.getKey());
+			TargetSurface copy = entry.getValue();
+			if (source == null || source.texture() == null || copy.texture() == null) {
+				continue;
+			}
+
+			encoder.copyTextureToTexture(source.texture(), copy.texture(), 0, 0, 0, 0, 0,
+					copy.width(), copy.height());
+		}
+
+		this.written = true;
+	}
+
+	/**
+	 * Forgets that this frame's copies were taken, at the frame's close: the next frame reads the
+	 * pixel until it takes its own, never the frame before's world.
+	 */
+	void forget() {
+		this.written = false;
+	}
+
+	/**
+	 * The copy of this target on this half, or null when there is none to serve: nothing asked for
+	 * it, the target does not exist, the allocation was refused, or this frame has not filled it.
+	 */
+	GpuTextureView view(int target, TargetSchedule.Side side) {
+		if (!this.written) {
+			return null;
+		}
+
+		TargetSurface copy = this.copies.get(new Key(target, side));
+
+		return copy == null ? null : copy.view();
+	}
+
+	/** Frees every copy. What was asked stays asked: the programs that asked outlive a resize. */
+	void release() {
+		this.copies.values().forEach(TargetSurface::close);
+		this.copies.clear();
+		this.sources.clear();
+		this.written = false;
+	}
+}

--- a/docs/internals/render-targets.md
+++ b/docs/internals/render-targets.md
@@ -142,7 +142,13 @@ One set is the form to keep, because two copies of one fact is one of them being
 Two facts about who flips:
 
 - **Geometry passes write the side they read and flip nothing.** They paint over the world rather
-  than filter it, so alternating would be meaningless. Only full-screen passes flip.
+  than filter it, so alternating would be meaningless. Only full-screen passes flip. A geometry
+  pass that samples a target it also writes therefore reads the half it is drawing into, which
+  under OpenGL is the attachment itself and here cannot be: a pass drawn after the deferred
+  stage is served a copy of that half taken ahead of it, once at the end of that stage and once
+  after the game's translucent features are composed, and a pass
+  drawn before it, or reading one of the first four targets, which the reference binds to no
+  geometry program, is answered one pixel. `TargetCopies` carries the rule and the cost.
 - **Stage-level pre-flip directives belong to no program.** The reference plays them when it
   constructs each stage's renderer, before its loop, whether or not that stage has any valid source
   in this place. So they are applied at stage opening, driven by the stage's rank rather than by


### PR DESCRIPTION
## What changes

A geometry program that samples one of the pack's colour targets on the same half its own draw buffers write was answered with one black pixel, because one image cannot be a colour attachment and a sampled texture of the same Vulkan pass. Packs make that read on purpose: a `gbuffers_water` samples the target it draws into for the colour of the world behind the water and for what the water reflects, which is what the OpenGL framebuffer hands it. Sildur's Vibrant Shaders drew its lakes a flat saturated blue with nothing mirrored in them for that reason.

The engine now keeps a copy of every such target, one per target and half, taken by an image copy twice a frame: at the end of the deferred stage, for the translucent half of the entities, which is drawn inside the game's features window; and again once that window is composed, for the world's water, the translucent particles, the clouds, the weather and the hand's water, which read the entities and the layer behind them. The clears still owed are paid before a copy, so a target nothing has attached yet is copied emptied, as the reference's clear pass leaves it. A program drawn after the deferred stage reads the copy where it used to read the pixel. A program drawn before that stage keeps the pixel, the target holding the frame's clear or the program's own siblings at work at that moment; so does a read of the first four targets, which Iris binds to no geometry program. The load log says which of the three each program gets.

## How it differs from the reference, and for what obstacle

Iris binds a gbuffers program's `colortexN`, from `colortex4` up, to a target's main half or to its alternate half once the target is flipped (`samplers/IrisSamplers.java:51-69`) and attaches the program's draw buffer to that same half (`targets/RenderTargets.java:309-320` and `:345-368`, both off the snapshot `pipeline/IrisRenderingPipeline.java:359-360` and `:677-678` take), so the read is a feedback loop on the attachment itself. What stops that here: the game's Vulkan backend offers neither a feedback loop layout nor an input attachment, and a pass sampling its own attachment is invalid (`render/TargetCopies.java`, class comment). What it costs: two image copies a frame per target read this way and one more image of that target's size; a translucent draw reading a texel another translucent draw of the same frame has already written sees the world before it, where the reference leaves that read undefined; the copy carries level nought alone; and the hand's water reads the world without the world's water where Iris shows it the water.

## What proves it

- `gradlew build` green, without the build cache.
- The out-of-game harness is untouched: the batch changes no translation.
- In the game, on the frozen world of the corpus campaign at 1912x1001, the whole corpus swept three times, `dev`, this branch and Iris, and compared. Sildur's Vibrant Shaders logs the copy for its six translucent programs where it logged the pixel, and its lake, its river and its shore draw pale and reflective as under Iris where `dev` drew them a flat blue; its lower left water cell falls from a quarter of its pixels moved against Iris to the run's own floor, the others land inside the band the campaign's control pair moves by on its own, the grass and the waves animating. Reverie, Bliss and the three Complementary builds read a target they write from their translucents too, and each moves towards Iris. No pack moves away from Iris beyond that band, and the packs served no copy run the same code as before.

## What it leaves owing

A program drawn before the deferred stage that samples a target it writes is still answered one pixel; Iteration and an outdated Complementary do that from their terrain. A geometry program reading one of the first four targets without writing it is still served the live target, where Iris binds nothing there, a question older than this branch. The hand's water reads the copy taken before the world's water rather than one taken before itself.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
