### PR TITLE
feat(render): bind the geometry stage a pack ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ what the next one holds.
 
 ### Added
 
+- **A pack's geometry stage is drawn.** Some packs put a third shader between the two the engine
+  builds every draw from, and use it to work something out per triangle rather than per corner:
+  how coarse the texture on a block face is, whether a sky quad is the moon or the sun. The engine
+  bound the first and the last and nothing in between, so the last one asked for values nobody had
+  written and the whole program was turned away: on iterationT that took the terrain and the moon
+  out of the picture entirely. Those programs now draw.
+
+  It needs a card that can run such a shader, which the desktop cards do and Apple's do not. Where
+  there is none the log names the program, and the world keeps the game's own shader for it rather
+  than drawing it with its middle missing.
+
 - **A pack may now blend one of a pass's targets differently from the others.** A shader pack can
   ask for a blend function per target rather than one for the whole program, and the engine read
   those lines and then dropped them the moment two targets of one pass disagreed, putting the

--- a/NOTICE
+++ b/NOTICE
@@ -99,6 +99,14 @@ GNU Lesser General Public License version 3
   carries the alpha of an earlier version. The names and the shape of the generated code are this
   engine's.
 
+  common/src/main/java/dev/vitrail/render/GeometryStage.java keeps the rule that a program's
+  geometry stage is linked whenever the pack ships the file, from
+  net.irisshaders.iris.gl.program.ProgramBuilder, whose begin builds a third shader out of the
+  .gsh at lines 44 and 45 and hands it to the link at line 55. The rule is what packs are written
+  against: a stage that renames the varyings between the two others is only correct in a pipeline
+  that carries it. Everything under it is this engine's own, Vulkan asking for a device feature,
+  a shaderc kind, a bind group and a stage description where OpenGL asks for a link.
+
   common/src/main/java/dev/vitrail/render/HorizonCone.java takes the shape of the horizon geometry
   from net.irisshaders.iris.pathways.HorizonRenderer, read on 6 August 2026, whose own header, lines
   23 to 31, states what vanilla lacks: an inverted octagonal cone around the player, where the game

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -938,8 +938,11 @@ public final class GlslTranslator {
 		 * <p>
 		 * Between the vertex stage and the fragment stage and no further. Iris carries the colour
 		 * through a tessellation or geometry stage as well
-		 * ({@code pipeline/transform/transformer/EntityPatcher.java:63-106}); no program of the corpus
-		 * has either, and {@link #FOG_COORD} stops at the same place for the same reason.
+		 * ({@code pipeline/transform/transformer/EntityPatcher.java:63-106}); no entity program of
+		 * the corpus ships either, iterationT's two geometry stages being its terrain and its sky,
+		 * and {@link #FOG_COORD} stops at the same place for the same reason. One that did would be
+		 * refused by the game's own pairing, the fragment stage declaring a colour the stage before
+		 * it never wrote, rather than drawn without it.
 		 */
 		public void makesOverlayColour(Set<String> varyings) {
 			if (this.translator.entityWrapped && varyings.contains(ENTITY_COLOR)) {
@@ -2243,8 +2246,9 @@ public final class GlslTranslator {
 
 			if (name.equals("varying")) {
 				// A geometry shader has varyings running both ways and the keyword cannot say
-				// which. Every other stage is unambiguous, and the corpus has few enough geometry
-				// programs that guessing wrong here is visible rather than silent.
+				// which, so this guesses in. Every other stage is unambiguous, and the keyword
+				// belongs to a GLSL older than the one that has a geometry stage at all, so a
+				// pack that writes both is writing something no compiler accepted either.
 				this.tokens.replace(index, this.stage == ProgramStage.VERTEX ? "out" : "in");
 				continue;
 			}
@@ -3888,9 +3892,11 @@ public final class GlslTranslator {
 	 * <p>
 	 * The depth conversion is for vertex stages only. A geometry stage writes {@code gl_Position}
 	 * once per {@code EmitVertex}, so an epilogue would land in the wrong place, and a program
-	 * carrying both would have the conversion done before the geometry stage read the position back.
-	 * The corpus has no geometry stage at all; the day one appears, {@link #prepare} has to be told
-	 * the program has one.
+	 * carrying both has the conversion done before the geometry stage reads the position back.
+	 * The corpus writes one geometry stage, iterationT's, and it passes
+	 * {@code gl_in[i].gl_Position} through untouched, so the converted depth reaches the rasteriser
+	 * as this engine wants it. A stage that did arithmetic on the depth it reads back would be
+	 * working in the reversed volume rather than the OpenGL one the pack was written against.
 	 * <p>
 	 * A fragment stage is wrapped for two reasons, the alpha test and the coverage mask, decided in
 	 * {@link #planAlphaEpilogue} and {@link #planCoverage}. The same wrapping argument holds and the

--- a/common/src/main/java/dev/vitrail/glsl/PackProgram.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackProgram.java
@@ -108,8 +108,8 @@ public final class PackProgram {
 		 * {@code setUsesImages} for the image half ({@code :224-225}) and calls it from nowhere: the
 		 * flag is computed at {@code pipeline/IrisRenderingPipeline.java:453-456} and never read, so
 		 * an image alone decides nothing there. Here it does count, which is this engine's own
-		 * answer and not the reference's. A {@code .gsh} is enough even when this engine never
-		 * binds it; an image uniform that the preprocessor left standing is enough without one. A name gated off, Complementary LOW's {@code voxel_img} behind
+		 * answer and not the reference's. A {@code .gsh} is enough, as it is there; an image
+		 * uniform that the preprocessor left standing is enough without one. A name gated off, Complementary LOW's {@code voxel_img} behind
 		 * {@code COLORED_LIGHTING_INTERNAL}, does not count.
 		 */
 		public boolean voxelises() {

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -345,11 +345,12 @@ public final class ProgramTranslator {
 	 * it was. No pack of the corpus writes one, and the shape is worth naming rather than reading as
 	 * covered.
 	 * <p>
-	 * <strong>The stage before is the vertex stage, and in this game it can be nothing else.</strong>
+	 * <strong>The stage before is usually the vertex stage and is not always.</strong>
 	 * {@code GlslCompiler.compile:62-63} takes one vertex module and one fragment module and pairs
-	 * those two at :86; 26.2 compiles no geometry stage at all. The walk is written over the pipeline
-	 * order anyway rather than reaching for the vertex stage by name, so that a stage appearing
-	 * between them is paired correctly rather than silently skipped.
+	 * those two at :86, and {@code GeometryStage} puts a third between them wherever the pack ships
+	 * one. The walk is written over the pipeline order rather than reaching for the vertex stage by
+	 * name, so the stage that appears between them is paired correctly rather than silently
+	 * skipped.
 	 *
 	 * @param prepared the stages of one program, keyed by stage, in pipeline order
 	 */
@@ -390,8 +391,7 @@ public final class ProgramTranslator {
 	 * {@code layout(location = n)} is still in the body here, {@code liftFragmentOutputs} only
 	 * taking out the ones that carry one. Demoting it would leave the pass compiling, drawing, and
 	 * writing to nothing. It costs nothing to step over: a compute stage is dispatched on its own,
-	 * and {@code GlslCompiler.compile:62-63} pairs one vertex module with one fragment module and
-	 * takes no third.
+	 * and nothing in a pipeline hands it a varying.
 	 *
 	 * @param prepared the stages of one program, keyed by stage, in pipeline order
 	 */

--- a/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
@@ -3,24 +3,38 @@ package dev.vitrail.mixin;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.shaders.ShaderType;
+import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
 import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
 import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
+import com.mojang.blaze3d.vulkan.glsl.ShaderCompileException;
 import dev.vitrail.cache.ModuleCache;
 import dev.vitrail.glsl.LoadClock;
+import dev.vitrail.render.GeometryStage;
 import dev.vitrail.render.RawLocals;
 import dev.vitrail.render.ShaderDebugInfo;
 import dev.vitrail.render.storage.StorageImages;
+import org.lwjgl.util.shaderc.Shaderc;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 
 /**
  * Lets a sampled or stored 3D image through the bind-group walk, gives the compiler's output its
  * zeroes before the reflection reads it, and puts {@link ModuleCache} around the one call that
  * turns a pack's GLSL into a module, which is also where {@link LoadClock} counts what that costs.
+ * <p>
+ * It also binds the geometry stage a pack ships: shaderc is asked for kind 3, the unit joins the
+ * bind group the two other stages share, and the rebind chain runs through it rather than past it.
+ * {@link GeometryStage} carries the road and the reason each piece sits where it does.
  * <p>
  * It also decides, at the compiler's own constructor, whether shaderc writes debug information
  * into every module of the session: {@link ShaderDebugInfo} says what that costs and why the
@@ -49,6 +63,105 @@ import java.nio.ByteBuffer;
  */
 @Mixin(GlslCompiler.class)
 public abstract class GlslCompilerMixin {
+
+	/**
+	 * Stage token hashed into {@link ModuleCache}'s key for a geometry unit, which travels this
+	 * road under {@code ShaderType.VERTEX}. {@code shaderc_glsl_geometry_shader} is 3.
+	 */
+	@Unique
+	private static final String GEOMETRY_STAGE = "GEOMETRY/shaderc-kind3";
+
+	/** {@code shaderc_glsl_geometry_shader}. */
+	@Unique
+	private static final int GEOMETRY_KIND = Shaderc.shaderc_glsl_geometry_shader;
+
+	@Shadow
+	private static void addToBindGroup(List<VulkanBindGroupLayout.Entry> entries,
+			IntermediaryShaderModule shader, RenderPipeline pipeline) throws ShaderCompileException {
+		throw new AssertionError();
+	}
+
+	/**
+	 * Asks shaderc for a geometry unit where {@link GeometryStage} is compiling one. The game maps
+	 * its two-armed {@code ShaderType} to kinds 0 and 1 and has no third arm to add: the enum is
+	 * Minecraft's, a pack's geometry stage is not the game's business, and a constant read off a
+	 * flag raised for the length of one call cannot be reached by anything else compiling on
+	 * another thread.
+	 */
+	@ModifyArg(method = "createIntermediary", require = 1, index = 2,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/util/shaderc/Shaderc;shaderc_compile_into_spv("
+							+ "JLjava/nio/ByteBuffer;ILjava/nio/ByteBuffer;Ljava/nio/ByteBuffer;J)J"))
+	private int vitrail$geometryKind(int kind) {
+		return GeometryStage.compiling() ? GEOMETRY_KIND : kind;
+	}
+
+	/**
+	 * Compiles the pack's geometry stage, where the pipeline being built ships one, and puts what
+	 * it declares into the bind group the two other stages are sharing. Hung off the second walk
+	 * rather than a head injection so it runs after both of them and before the first rebind: a
+	 * name only this stage declares has to be an entry before {@code rebind} looks for it, which
+	 * throws over anything the list never named, and before the layout is created off that same
+	 * list at the end of the method. The entries the two other stages added keep their index, an
+	 * arrival at the end of the list moving none of them.
+	 */
+	@WrapOperation(method = "compile", require = 1,
+			at = @At(value = "INVOKE", ordinal = 1,
+					target = "Lcom/mojang/blaze3d/vulkan/glsl/GlslCompiler;addToBindGroup("
+							+ "Ljava/util/List;Lcom/mojang/blaze3d/vulkan/glsl/IntermediaryShaderModule;"
+							+ "Lcom/mojang/blaze3d/pipeline/RenderPipeline;)V"))
+	private void vitrail$geometryResources(List<VulkanBindGroupLayout.Entry> entries,
+			IntermediaryShaderModule fragment, RenderPipeline pipeline, Operation<Void> original)
+			throws ShaderCompileException {
+		original.call(entries, fragment, pipeline);
+		IntermediaryShaderModule geometry =
+				GeometryStage.begin((GlslCompiler) (Object) this, pipeline);
+		if (geometry != null) {
+			addToBindGroup(entries, geometry, pipeline);
+		}
+	}
+
+	/**
+	 * Rebinds the geometry stage between the two, which is the whole point of the road: OpenGL
+	 * links the stages by name and Vulkan by location, so the fragment stage has to be numbered
+	 * over what the stage BEFORE it writes. That stage is the geometry one wherever a pack ships
+	 * it, and the vertex stage's outputs, which the game hands in here, name the geometry stage's
+	 * inputs instead.
+	 */
+	@WrapOperation(method = "compile", require = 1,
+			at = @At(value = "INVOKE", ordinal = 1,
+					target = "Lcom/mojang/blaze3d/vulkan/glsl/IntermediaryShaderModule;rebind("
+							+ "Ljava/util/List;Ljava/util/List;)V"))
+	private void vitrail$rebindBetween(IntermediaryShaderModule fragment, List<String> written,
+			List<VulkanBindGroupLayout.Entry> entries, Operation<Void> original)
+			throws ShaderCompileException {
+		IntermediaryShaderModule geometry = GeometryStage.building();
+		if (geometry == null) {
+			original.call(fragment, written, entries);
+
+			return;
+		}
+
+		geometry.rebind(written, entries);
+		original.call(fragment, GeometryStage.outputs(geometry), entries);
+	}
+
+	/**
+	 * Creates the device module for the geometry stage, on the one call that has a device in hand.
+	 * The handle waits on the thread for {@code VulkanRenderPipelineMixin}, which is the next call
+	 * on whichever thread is building.
+	 */
+	@WrapOperation(method = "compile", require = 1,
+			at = @At(value = "INVOKE", ordinal = 1,
+					target = "Lcom/mojang/blaze3d/vulkan/glsl/IntermediaryShaderModule;"
+							+ "createVulkanShaderModule(Lcom/mojang/blaze3d/vulkan/VulkanDevice;)J"))
+	private long vitrail$geometryModule(IntermediaryShaderModule fragment, VulkanDevice device,
+			Operation<Long> original) {
+		long id = original.call(fragment, device);
+		GeometryStage.built(device);
+
+		return id;
+	}
 
 	/**
 	 * Skips the one call that asks shaderc for debug information, unless somebody asked for it
@@ -111,7 +224,12 @@ public abstract class GlslCompilerMixin {
 		// store one state's module under the other's key.
 		RawLocals.begin();
 		try {
-			String key = ModuleCache.keyOf(source, type.name());
+			// A geometry stage comes past under VERTEX, the enum having no arm for it, and is
+			// keyed under its own name all the same: the two roads compile the same text to
+			// different bytes, and a blob stored under the wrong one would be served to the wrong
+			// stage.
+			String key = ModuleCache.keyOf(source,
+					GeometryStage.compiling() ? GEOMETRY_STAGE : type.name());
 			IntermediaryShaderModule served = ModuleCache.lookup(key, filename);
 			if (served != null) {
 				return served;

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
@@ -7,6 +7,7 @@ import com.mojang.blaze3d.vulkan.VulkanPhysicalDevice;
 import com.mojang.blaze3d.vulkan.init.VulkanFeature;
 import dev.vitrail.glsl.VendorExtensions;
 import dev.vitrail.render.BufferBlending;
+import dev.vitrail.render.GeometryStage;
 import dev.vitrail.Vitrail;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.vulkan.VK12;
@@ -41,6 +42,12 @@ import java.util.Set;
  * pipeline, the refusal and the symbol all read. The other half is the game's own pipeline builder,
  * which refuses two colour targets naming different functions whatever the device can do, and
  * {@code RenderPipelineBuilderMixin} lifts on this same answer.
+ * <p>
+ * And {@code geometryShader}, for the stage a pack ships between its two. OpenGL asks the driver
+ * for nothing there, so Iris links a {@code .gsh} on any card; Vulkan makes it a feature, and the
+ * game has no geometry stage to ask for it. Answered on to {@link GeometryStage}, which files
+ * nothing on a device that refused it, leaving such a program refused rather than drawn with its
+ * middle stage missing.
  */
 @Mixin(VulkanBackend.class)
 public abstract class VulkanBackendMixin {
@@ -124,6 +131,14 @@ public abstract class VulkanBackendMixin {
 			VulkanBackend.VK12_FEATURES_STRUCT, "uniformAndStorageBuffer8BitAccess",
 			VkPhysicalDeviceVulkan12Features.UNIFORMANDSTORAGEBUFFER8BITACCESS);
 
+	// The stage a pack puts between its vertex and its fragment stage. Iris links a .gsh whenever
+	// the pack ships one and OpenGL asks nothing of the driver for it; Vulkan makes it an optional
+	// feature, and the game, which has no geometry stage of its own, never asks for it.
+	@Unique
+	private static final VulkanFeature GEOMETRY_SHADER = new VulkanFeature(
+			VulkanBackend.VK10_FEATURES_STRUCT, "geometryShader",
+			VkPhysicalDeviceFeatures.GEOMETRYSHADER);
+
 	@Unique
 	private static final String VOXELS = "voxel lighting will not write";
 
@@ -137,6 +152,10 @@ public abstract class VulkanBackendMixin {
 	@Unique
 	private static final String PER_BUFFER = "a pack requiring PER_BUFFER_BLENDING is refused and "
 			+ "every other one keeps a single blend function for all the targets a pass writes";
+
+	@Unique
+	private static final String GEOMETRY = "a program shipping a geometry stage is refused, its "
+			+ "fragment stage asking for varyings that stage renames";
 
 	@WrapOperation(method = "createDevice(JLcom/mojang/blaze3d/shaders/ShaderSource;"
 			+ "Lcom/mojang/blaze3d/shaders/GpuDebugOptions;Ljava/lang/Runnable;)"
@@ -154,6 +173,7 @@ public abstract class VulkanBackendMixin {
 		enable(physical, features, EXTENDED_FORMATS, enabled, VOXELS);
 		enable(physical, features, WRITE_WITHOUT_FORMAT, enabled, VOXELS);
 		BufferBlending.serve(enable(physical, features, INDEPENDENT_BLEND, enabled, PER_BUFFER));
+		GeometryStage.serve(enable(physical, features, GEOMETRY_SHADER, enabled, GEOMETRY));
 		// The vendor extensions a pack may gate a vendor instruction on, answered by the device
 		// and not by the compiler, which defines the macro of every one it knows; the ones the
 		// device has are enabled on it here, since a module using one needs it enabled.

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBindGroupLayoutMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBindGroupLayoutMixin.java
@@ -5,6 +5,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
 import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout.Entry;
 import dev.vitrail.pack.texture.CustomImages;
+import dev.vitrail.render.GeometryStage;
 import dev.vitrail.render.storage.StorageBuffers;
 import dev.vitrail.render.storage.StorageImages;
 import org.lwjgl.vulkan.VkDescriptorSetLayoutBinding;
@@ -56,5 +57,28 @@ public abstract class VulkanBindGroupLayoutMixin {
 		}
 
 		return original.call(binding, type);
+	}
+
+	/**
+	 * Adds the geometry bit to the vertex and fragment the game writes, on the layouts of the
+	 * pipelines that carry a geometry stage. A binding is only readable from the stages its flags
+	 * name, and the pair the game writes names the two stages around the middle one and not the
+	 * middle one itself, so the uniform iterationT's terrain geometry stage reads would be out of
+	 * its reach.
+	 * <p>
+	 * Narrowed to those layouts rather than written on every one of the process: this method builds
+	 * the layout of every pipeline the game and every other mod compiles, and a flag nothing reads
+	 * is still a flag nobody asked for. The question is asked of the thread, which is where the
+	 * stage in flight is held, and this call is the last of the compile that put it there.
+	 */
+	@WrapOperation(method = "create", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/VkDescriptorSetLayoutBinding;stageFlags(I)"
+							+ "Lorg/lwjgl/vulkan/VkDescriptorSetLayoutBinding;"))
+	private static VkDescriptorSetLayoutBinding vitrail$geometryStage(
+			VkDescriptorSetLayoutBinding binding, int flags,
+			Operation<VkDescriptorSetLayoutBinding> original) {
+		return original.call(binding,
+				GeometryStage.buildingHere() ? flags | GeometryStage.STAGE_BIT : flags);
 	}
 }

--- a/common/src/main/java/dev/vitrail/mixin/VulkanRenderPipelineMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanRenderPipelineMixin.java
@@ -1,0 +1,75 @@
+package dev.vitrail.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
+import dev.vitrail.render.GeometryStage;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.Struct;
+import org.lwjgl.system.StructBuffer;
+import org.lwjgl.vulkan.VkPipelineShaderStageCreateInfo;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Puts the geometry stage a pack ships behind the two stages the game builds every pipeline out
+ * of.
+ * <p>
+ * The method callocs room for two stage descriptions and puts a vertex and a fragment into them.
+ * Both halves have to move together: room for three, and a third put before the flip that sets the
+ * count Vulkan reads. Nothing moves for a pipeline that ships no geometry stage, which is every
+ * pipeline of the game and nearly every pipeline of a pack, and {@link GeometryStage#pending}
+ * answers zero for any pipeline but the one this thread is building.
+ * <p>
+ * The module is destroyed as the method returns. A shader module is consumed at pipeline creation,
+ * by specification, so nothing reads it after this point; the two the game keeps on the record are
+ * kept for its own bookkeeping and not because a pipeline still needs them.
+ */
+@Mixin(VulkanRenderPipeline.class)
+public abstract class VulkanRenderPipelineMixin {
+
+	@WrapOperation(method = "compile", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/VkPipelineShaderStageCreateInfo;calloc("
+							+ "ILorg/lwjgl/system/MemoryStack;)"
+							+ "Lorg/lwjgl/vulkan/VkPipelineShaderStageCreateInfo$Buffer;"))
+	private static VkPipelineShaderStageCreateInfo.Buffer vitrail$roomForGeometry(int stages,
+			MemoryStack stack, Operation<VkPipelineShaderStageCreateInfo.Buffer> original,
+			@Local(argsOnly = true) RenderPipeline pipeline) {
+		return original.call(GeometryStage.pending(pipeline) == 0L ? stages : stages + 1, stack);
+	}
+
+	@SuppressWarnings("rawtypes")
+	@WrapOperation(method = "compile", require = 1,
+			at = @At(value = "INVOKE", ordinal = 1,
+					target = "Lorg/lwjgl/vulkan/VkPipelineShaderStageCreateInfo$Buffer;put("
+							+ "Lorg/lwjgl/system/Struct;)Lorg/lwjgl/system/StructBuffer;"))
+	private static StructBuffer vitrail$putGeometry(VkPipelineShaderStageCreateInfo.Buffer stages,
+			Struct fragment, Operation<StructBuffer> original,
+			@Local(argsOnly = true) RenderPipeline pipeline, @Local MemoryStack stack) {
+		StructBuffer put = original.call(stages, fragment);
+		long geometry = GeometryStage.pending(pipeline);
+		if (geometry != 0L) {
+			stages.put(VkPipelineShaderStageCreateInfo.calloc(stack)
+					.sType$Default()
+					.stage(GeometryStage.STAGE_BIT)
+					.module(geometry)
+					.pName(stack.UTF8("main")));
+		}
+
+		return put;
+	}
+
+	@Inject(method = "compile", at = @At("RETURN"), require = 1)
+	private static void vitrail$geometryTaken(VulkanDevice device, VulkanBindGroupLayout layout,
+			RenderPipeline pipeline, long vertexModule, long fragmentModule,
+			CallbackInfoReturnable<VulkanRenderPipeline> callback) {
+		GeometryStage.taken(pipeline);
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -819,6 +819,13 @@ final class GeometryProgram {
 		// descriptor walk can see when it has to answer for a name.
 		ShadowCompare.note(this.pipeline, this.path, loaded);
 
+		// Same filing, same reason: the compile road has the pipeline in hand and nothing else. And
+		// the same refusal the storage block below takes, on the one road that answers no: a pack
+		// ships a geometry stage and the device has not got the feature to run one.
+		if (!GeometryStage.note(this.pipeline, this.path, loaded)) {
+			this.broken = true;
+		}
+
 		// A storage block this engine has no bufferObject for is the one refusal that does not
 		// announce itself. An unbindable sampler stops the pipeline from being built and this class
 		// already falls back on that; a storage block compiles, never enters a bind group, and
@@ -1209,6 +1216,7 @@ final class GeometryProgram {
 		// answers no for every compared name of this program and the variant's depth-reference
 		// lookups run on an ordinary sampler, undefined and silent.
 		ShadowCompare.noteBeside(built, this.pipeline);
+		GeometryStage.noteBeside(built, this.pipeline);
 
 		return built;
 	}

--- a/common/src/main/java/dev/vitrail/render/GeometryStage.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryStage.java
@@ -1,0 +1,355 @@
+package dev.vitrail.render;
+
+import dev.vitrail.glsl.PackProgram;
+import dev.vitrail.glsl.TranslatedUnit;
+import dev.vitrail.mixin.access.IntermediaryShaderModuleAccessor;
+import dev.vitrail.pack.model.ProgramStage;
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.preprocessor.GlslPreprocessor;
+import com.mojang.blaze3d.shaders.ShaderType;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.glsl.GlslCompiler;
+import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
+import com.mojang.blaze3d.vulkan.glsl.ShaderCompileException;
+import org.lwjgl.vulkan.VK12;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * The geometry stage a pack ships, bound between the vertex stage and the fragment stage of the
+ * program it belongs to.
+ * <p>
+ * Iris links a {@code .gsh} whenever the pack ships one, building it as a third shader and passing
+ * it to the link ({@code gl/program/ProgramBuilder.java:44-45,55}), so a pack that renames its
+ * varyings in that stage is written for a pipeline of three. This engine bound two, and the
+ * fragment stage
+ * then asked for inputs nothing wrote: {@code IntermediaryShaderModule.rebind} refuses the module
+ * over the names left unpaired, which took iterationT's terrain and its moon out of every frame.
+ * <p>
+ * <strong>The game has no geometry stage at all</strong>, so every step of the road has to be
+ * opened by hand and each is opened at the narrowest point:
+ * <ul>
+ * <li>{@code ShaderType} carries VERTEX and FRAGMENT, and {@code GlslCompiler.createIntermediary}
+ * reads the shaderc kind off it. The unit is handed in under VERTEX while {@link #begin} holds a
+ * flag up for the length of that one call, which {@code GlslCompilerMixin} reads through
+ * {@link #compiling} to ask shaderc for kind 3 and to key the module cache under this stage rather
+ * than under the vertex one. What that road then does to the unit, the compiler's own two defines,
+ * the debug information {@code rebind} needs, the local zeroes and the cache itself, it does for
+ * this stage as it does for the two others. The pipeline's own defines are laid on here, which is
+ * what {@code GeometryProgram} does for the vertex and fragment stages it compiles itself.</li>
+ * <li>{@code GlslCompiler.compile} builds the bind group out of two modules and pairs them by
+ * name. The third module joins the same group and is rebound between the two: the vertex stage's
+ * outputs name the geometry stage's inputs, and the geometry stage's outputs name the fragment
+ * stage's, which is the chain OpenGL links by name and Vulkan numbers by location.</li>
+ * <li>{@code VulkanBindGroupLayout.create} writes {@code stageFlags} of vertex and fragment, which
+ * names the stages a binding may be read from and leaves out the one between them. The geometry bit
+ * joins them on the layouts of the pipelines that carry such a stage, and on no others.
+ * iterationT's terrain stage reads {@code atlasSize}.</li>
+ * <li>{@code VulkanRenderPipeline.compile} callocs two stage descriptions and puts a vertex and a
+ * fragment into them. A third is put behind them for a pipeline that has one.</li>
+ * </ul>
+ * <p>
+ * <strong>The device has to allow it.</strong> {@code geometryShader} is an optional Vulkan
+ * feature, enabled in {@code VulkanBackendMixin} and answered here. Where it is missing nothing is
+ * filed and {@link #note} answers no, which is how the program is set aside instead of drawn with
+ * its middle stage gone.
+ * <p>
+ * <strong>What this road does NOT reach.</strong> The clip depth is converted in the vertex
+ * stage's epilogue, this engine rasterising with reversed Z where Iris runs against an OpenGL
+ * volume, so a geometry stage reads a position already converted. One that passes
+ * {@code gl_in[i].gl_Position} through, which is what the corpus writes, carries it untouched;
+ * one that did arithmetic on the depth it reads back would be working in the wrong volume. Same
+ * shape for the varyings this engine names for itself, the entity overlay colour among them: they
+ * are emitted into the vertex and fragment stages off one union and a stage between the two would
+ * not carry them, so such a program is refused by the game's own pairing rather than drawn wrong.
+ * No program of the corpus does either.
+ * <p>
+ * <strong>Why the module in flight lives on the thread.</strong> A pipeline is built on the
+ * render thread and on the pack-load worker both, and the two halves of the road, the compiler and
+ * the pipeline, are two calls in a row on whichever thread is building. The pipeline being built
+ * is carried with it so that a leftover from a build that threw between the two is recognised and
+ * dropped rather than bound into the next pipeline that comes past.
+ *
+ * @see <a href="https://github.com/IrisShaders/Iris">Iris ProgramBuilder, LGPL-3.0</a>
+ */
+public final class GeometryStage {
+
+	/** {@code VK_SHADER_STAGE_GEOMETRY_BIT}. */
+	public static final int STAGE_BIT = VK12.VK_SHADER_STAGE_GEOMETRY_BIT;
+
+	/**
+	 * The name of a reflected input or output variable. The record is package-private in the game
+	 * and NeoForge refuses a second export of that package, which is why {@link ComputeShader}
+	 * reads its neighbours the same way.
+	 */
+	private static final Method VARIABLE_NAME;
+
+	static {
+		try {
+			Class<?> variable = Class.forName("com.mojang.blaze3d.vulkan.glsl.SpvVariable");
+			VARIABLE_NAME = variable.getDeclaredMethod("name");
+			VARIABLE_NAME.setAccessible(true);
+		} catch (ReflectiveOperationException e) {
+			throw new ExceptionInInitializerError(e);
+		}
+	}
+
+	/**
+	 * The stage each pipeline ships, weak on the pipeline for the reason {@link ShadowCompare}'s
+	 * registry is: the entry describes the pipeline's lifetime and goes with it on a pack change.
+	 */
+	private static final Map<RenderPipeline, String> SHIPPED =
+			Collections.synchronizedMap(new WeakHashMap<>());
+
+	/** Whether anything is filed at all, so the compile road asks one flag before the map. */
+	private static volatile boolean noted;
+
+	private static volatile boolean served;
+
+	private static final ThreadLocal<Boolean> COMPILING = new ThreadLocal<>();
+
+	private static final ThreadLocal<InFlight> BUILDING = new ThreadLocal<>();
+
+	private GeometryStage() {
+	}
+
+	/** The module being built into the pipeline this thread is compiling. */
+	private static final class InFlight {
+
+		private final RenderPipeline pipeline;
+
+		private IntermediaryShaderModule module;
+
+		/** Kept so that a build abandoned after the device module was made can still free it. */
+		private VulkanDevice device;
+
+		private long handle;
+
+		private InFlight(RenderPipeline pipeline, IntermediaryShaderModule module) {
+			this.pipeline = pipeline;
+			this.module = module;
+		}
+	}
+
+	/**
+	 * Whether the device gave {@code geometryShader}, answered by {@code VulkanBackendMixin} once
+	 * the device is made. Off until it says otherwise, which is what anything with no device to
+	 * ask gets, and which makes {@link #note} refuse rather than promise.
+	 */
+	public static void serve(boolean answer) {
+		served = answer;
+	}
+
+	/**
+	 * Files the geometry stage this program ships, which is the question the compile road asks
+	 * back at every build. Nothing is filed for a program without one, which is nearly all of
+	 * them, and nothing is filed on a device that refused the feature.
+	 * <p>
+	 * <strong>The answer is whether the program can be served at all</strong>, and it is false on
+	 * exactly one road: the pack ships a stage and the device has not got the feature. Drawing it
+	 * without would be a picture missing whatever that stage worked out per primitive, and a stage
+	 * that only renames its varyings would be caught by the game's own pairing while one that
+	 * passes them through would not, so the same pack would be refused on one card and quietly
+	 * wrong on another. A world program is set aside on that answer and the game's own shader draws
+	 * instead, which is what this engine does with every other shape it cannot serve. A full screen
+	 * pass has no such fallback, nothing else drawing a composite, so it says so and is drawn
+	 * without the stage; no pack of the corpus writes one.
+	 *
+	 * @param pipeline the pipeline this program's stages were built into
+	 * @param path     the pack-side path of the program, for the line a refusal prints
+	 * @param loaded   the translated program, whose geometry unit is taken if it has one
+	 * @return whether this program can be drawn here
+	 */
+	public static boolean note(RenderPipeline pipeline, String path, PackProgram.Loaded loaded) {
+		TranslatedUnit unit = loaded.program().stages().get(ProgramStage.GEOMETRY);
+		if (unit == null) {
+			return true;
+		}
+
+		if (!served) {
+			Vitrail.logger().error("{} ships a geometry stage and this device has no "
+					+ "geometryShader feature, so the program is set aside rather than drawn "
+					+ "without the stage", path);
+
+			return false;
+		}
+
+		SHIPPED.put(pipeline, unit.text());
+		noted = true;
+
+		return true;
+	}
+
+	/**
+	 * Files a rebuilt variant beside the pipeline it was rebuilt from. A reshape swaps the vertex
+	 * layout and nothing the middle stage depends on, so the text is the base's.
+	 */
+	public static void noteBeside(RenderPipeline variant, RenderPipeline base) {
+		String text = SHIPPED.get(base);
+		if (text != null) {
+			SHIPPED.put(variant, text);
+		}
+	}
+
+	/** Whether any pipeline ships one, asked before the per-pipeline question is worth asking. */
+	public static boolean noted() {
+		return noted;
+	}
+
+	/**
+	 * Compiles the geometry stage of the pipeline being built, and holds it on this thread until
+	 * the pipeline has taken it. Answers null for a pipeline that ships none, which is the case
+	 * every caller is written around.
+	 * <p>
+	 * A module left over from a build that threw between the compiler and the pipeline is dropped
+	 * here rather than at the point it was abandoned: that point is an exception path with no
+	 * device in hand, and a stage module bound into no pipeline holds nothing but its own memory.
+	 */
+	public static IntermediaryShaderModule begin(GlslCompiler compiler, RenderPipeline pipeline)
+			throws ShaderCompileException {
+		abandon();
+		if (!noted) {
+			return null;
+		}
+
+		String text = SHIPPED.get(pipeline);
+		if (text == null) {
+			return null;
+		}
+
+		IntermediaryShaderModule module;
+		COMPILING.set(Boolean.TRUE);
+		try {
+			module = compiler.createIntermediary(pipeline.getLocation().toDebugFileName() + "/gsh",
+					GlslPreprocessor.injectDefines(text, pipeline.getShaderDefines()),
+					ShaderType.VERTEX);
+		} finally {
+			COMPILING.remove();
+		}
+
+		BUILDING.set(new InFlight(pipeline, module));
+
+		return module;
+	}
+
+	/** Whether the unit shaderc is being asked for right now is a geometry stage. */
+	public static boolean compiling() {
+		return Boolean.TRUE.equals(COMPILING.get());
+	}
+
+	/** The module this thread is building into its pipeline, or null. */
+	public static IntermediaryShaderModule building() {
+		InFlight flight = BUILDING.get();
+
+		return flight == null ? null : flight.module;
+	}
+
+	/**
+	 * Whether the pipeline this thread is building carries a geometry stage, asked by the bind
+	 * group layout so the stage bit lands on the layouts that need it and on no others. True from
+	 * the moment the unit is compiled until the pipeline has taken it, which spans the one call
+	 * that creates the layout.
+	 */
+	public static boolean buildingHere() {
+		return BUILDING.get() != null;
+	}
+
+	/** The names of a module's outputs, in the order {@code createFromSpirv} numbered them. */
+	public static List<String> outputs(IntermediaryShaderModule module) {
+		List<String> names = new ArrayList<>();
+		for (Object output : ((IntermediaryShaderModuleAccessor) (Object) module).vitrail$outputs()) {
+			try {
+				names.add((String) VARIABLE_NAME.invoke(output));
+			} catch (ReflectiveOperationException e) {
+				throw new IllegalStateException(e);
+			}
+		}
+
+		return names;
+	}
+
+	/**
+	 * Creates the device module for the stage in flight, once the bindings have been rebound onto
+	 * its bytes. The intermediary is closed on the spot, as the two stages beside it are on the
+	 * road this engine drives itself: its bytes are in the device module from here on.
+	 */
+	public static void built(VulkanDevice device) {
+		InFlight flight = BUILDING.get();
+		if (flight == null || flight.module == null) {
+			return;
+		}
+
+		flight.device = device;
+		flight.handle = flight.module.createVulkanShaderModule(device);
+		flight.module.close();
+		flight.module = null;
+	}
+
+	/**
+	 * The device module to put behind the vertex and fragment stages of this pipeline, or zero.
+	 * Answers zero for any pipeline but the one this thread is building, so a leftover cannot be
+	 * bound into a neighbour.
+	 */
+	public static long pending(RenderPipeline pipeline) {
+		InFlight flight = BUILDING.get();
+
+		return flight != null && flight.pipeline == pipeline ? flight.handle : 0L;
+	}
+
+	/**
+	 * Called once the pipelines are created. A shader module is consumed at pipeline creation, so
+	 * this is where it stops being anything.
+	 * <p>
+	 * The pipeline that returned is compared against the one the stage was compiled for, and a
+	 * mismatch leaves the stage alone: this runs at the return of every pipeline the process
+	 * builds, the game's own among them, and freeing on the wrong one would take a stage that
+	 * another pipeline is still owed.
+	 */
+	public static void taken(RenderPipeline pipeline) {
+		InFlight flight = BUILDING.get();
+		if (flight == null || flight.pipeline != pipeline) {
+			return;
+		}
+
+		BUILDING.remove();
+		free(flight);
+	}
+
+	/**
+	 * Drops what a build that threw between the compiler and the pipeline left behind, at the head
+	 * of the next build on this thread. The device module goes with it: the device is kept on the
+	 * way past for exactly this, nothing here having one in hand.
+	 */
+	private static void abandon() {
+		InFlight flight = BUILDING.get();
+		if (flight == null) {
+			return;
+		}
+
+		BUILDING.remove();
+		free(flight);
+	}
+
+	private static void free(InFlight flight) {
+		if (flight.module != null) {
+			flight.module.close();
+		}
+
+		if (flight.handle != 0L && flight.device != null) {
+			VK12.vkDestroyShaderModule(flight.device.vkDevice(), flight.handle, null);
+		}
+	}
+
+	/** Called when the client shuts down. */
+	public static void close() {
+		SHIPPED.clear();
+		noted = false;
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -1209,6 +1209,7 @@ public final class PackChain {
 		DistantDraw.close();
 		ConstantTextures.close();
 		ShadowCompare.close();
+		GeometryStage.close();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -298,6 +298,14 @@ final class PackPass {
 		// Filed against the pipeline and not the program, because the pipeline is what the
 		// descriptor walk can see when it has to answer for a name.
 		ShadowCompare.note(this.pipeline, this.path, loaded);
+		// A full screen program shipping a geometry stage on a device that cannot run one: the
+		// compile that follows refuses the pipeline over the varyings that stage was to hand on,
+		// wherever it renames them, and the chain draws the pass without it wherever it does not.
+		// Said here rather than passed over in silence; no pack of the corpus writes one.
+		if (!GeometryStage.note(this.pipeline, this.path, loaded)) {
+			this.notes.add(this.path + " ships a geometry stage and this device cannot run one, so "
+					+ "the pass is drawn without whatever that stage worked out per primitive");
+		}
 
 		noteGaps(declared);
 	}

--- a/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowCullFrustum.java
@@ -189,7 +189,7 @@ public final class ShadowCullFrustum implements Frustum {
 	 * {@code BoxCullingFrustum} ({@code :302-323}). Voxelisation is a geometry stage present
 	 * ({@code :163-165}) <em>or</em>, here alone, an image load / store still standing on that
 	 * program: Iris computes that half and reads it nowhere, its {@code setUsesImages} having no
-	 * caller. Not a {@code .gsh} this engine binds. A bound wider than the loaded
+	 * caller. A bound wider than the loaded
 	 * world, or not positive, drops the box too and keeps everything, which is Iris's
 	 * {@code NonCullingFrustum} ({@code :317-318}), not the light's own volume.
 	 * {@link dev.vitrail.pack.source.ShadowCullState#SAFE_ZONE} still sweeps along the light.

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -83,6 +83,7 @@
 		"VulkanGpuTextureViewMixin",
 		"VulkanQueueSubmitMixin",
 		"VulkanRenderPassMixin",
+		"VulkanRenderPipelineMixin",
 		"WeatherEffectRendererMixin"
 	]
 }

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -265,7 +265,7 @@ never the player's setting, and the safe zone reads neither, its two boxes being
 throughout.
 
 The same first line also drops the sweep when the shadow program voxelises. A geometry stage on
-that program is enough, even when this engine never binds it, and so is an image load / store that
+that program is enough, as it is in the reference, and so is an image load / store that
 the preprocessor left standing. That second half is this engine's alone: the reference has a
 `setUsesImages` for it and calls it from nowhere, so an image load / store decides nothing there.
 A name gated off does not count.


### PR DESCRIPTION
## What changes

A pack may ship a geometry stage, a third shader between the vertex and the fragment one, and use
it to work something out per primitive: how coarse the texture on a block face is, whether a sky
quad is the moon or the sun. The engine bound the first and the last and nothing between them, so
the fragment stage asked for varyings that stage renames and the whole program was refused, which
took iterationT's terrain and its moon out of every frame. The stage is now compiled, put into the
bind group the two others share, rebound in the middle of the chain and bound into the pipeline,
and those programs draw.

The game has no geometry stage anywhere, so each piece is opened at its narrowest point: the unit
goes through the game's own compiler under the vertex arm of its two-armed shader type while a
flag asks shaderc for the geometry kind and keys the module cache apart, the descriptor set layout
of that pipeline alone gains the geometry stage bit, and the device is asked for the
`geometryShader` feature the game never wants.

## How it differs from the reference, and for what obstacle

One divergence, on one road. Iris links the stage on any card, OpenGL asking the driver for
nothing (`gl/program/ProgramBuilder.java:44-45,55`). Vulkan makes it an optional device feature,
so a device can refuse it (`common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java`,
`GeometryStage.serve`). Where it is refused the program is set aside and the game's own shader
draws instead of it: drawing it without the middle stage would lose whatever that stage worked out
per primitive, and a stage that only renames its varyings would be caught by the game's pairing
while one that passes them through would not, so the same pack would be refused on one card and
quietly wrong on another. It costs the image that program on such a device, where the reference
loses nothing.

## What proves it

- `gradlew build` green.
- The off-game harness over the twenty-six packs of the Fabric bench. `Varyings` measures a
  program with a geometry stage over its two links now instead of across it, and iterationT comes
  back with nothing refused, nothing shifted, no location moved. Two one-program packs written for
  the purpose prove both links report a break.
- In game on the Fabric bench, iterationT on the frozen world: the two "Shader expects input
  variables which are not being provided" lines are gone, the terrain and the moon passes draw,
  and `geometryShader` stands in the device feature line.
- Corpus campaign on the frozen world, three sweeps of `dev` and one of this branch at
  1912x1001. iterationT moves 64 percent of its pixels against `dev`, which is the terrain and the
  moon appearing. No other pack moves beyond what two sweeps of `dev` itself move across a
  relaunch, the widest still being photon at 9.3 percent against a control pair of 6.3 to 7.1 in
  the same run.

## What it leaves owing

iterationT's picture is still wrong, and not for this: nineteen of its passes are refused for a
three dimensional custom texture the backend does not bind, so its lighting chain never runs.
A geometry stage reads a clip depth this engine has already converted, which is right for one that
passes the position through and wrong for one that did arithmetic on it; and the varyings the
engine names for itself, the entity overlay colour among them, are emitted into the vertex and
fragment stages only, so an entity program shipping a geometry stage would be refused rather than
drawn without them. No pack of the corpus writes either shape. A full screen pass has no shader to
fall back on, so on a device without the feature it says so and is drawn without the stage.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one.
