### PR TITLE
fix(render): give the opaque particles the pack's own targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,20 @@ what the next one holds.
 
 ### Fixed
 
+- **Smoke, flame and the other solid particles take the colour the pack meant them to.**
+  The game draws its quad particles in two goes, the solid ones with the world and the
+  see-through ones after the water, and only the second lot were reaching the pack's own
+  image. The first lot were painted into the game's picture instead and carried in from
+  there, already finished, so a pack that lights its particles itself was handed a colour
+  somebody else had already lit: under Photon a campfire's smoke came out a warm haze where
+  it should be dark, and any pack asking for more than one target had everything past the
+  first written nowhere. They are now drawn into the targets the pack asked for, as the rest
+  of the world is.
+
+  Packs that had this half handed back to the game altogether get it too: a pack whose
+  particle program writes a target the world's own picture is not painted into was refused
+  for a road it no longer travels.
+
 - **Water that reads the picture behind it draws its fog and its reflections.** Some packs
   sample one of their own colour targets from the water, the translucent blocks or the particles
   while drawing into that same target, for the colour of the world behind the surface and for

--- a/NOTICE
+++ b/NOTICE
@@ -356,9 +356,12 @@ GNU Lesser General Public License version 3
   it can hand over as it stands.
 
   common/src/main/java/dev/vitrail/render/ParticleDraw.java draws the game's particles with the
-  pack's programs, and three of its answers are Iris's, read in August 2026. The alpha test of one
-  tenth both particle keys of ShaderKey carry, lines 58 and 59, the game's own particle pipeline
-  declaring no cutout define there is anything to inherit from. The render stage posed over the
+  pack's programs, and four of its answers are Iris's. The alpha test of one
+  tenth both particle keys of ShaderKey carry, lines 94 and 96, the game's own particle pipeline
+  declaring no cutout define there is anything to inherit from. Which draw buffers each half writes
+  into, common/src/main/java/dev/vitrail/render/ParticleProgram.java taking the pack's own declared
+  list for both, as net.irisshaders.iris.pipeline.IrisRenderingPipeline builds every gbuffers
+  framebuffer over that same list, lines 677 and 678. The render stage posed over the
   whole of the particle renderer rather than per half,
   net.irisshaders.iris.mixin.MixinParticleEngine lines 24 to 30. And leaving the game's own shader
   on a layer the table has no key for, which is what an unassigned pipeline gets there,

--- a/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/ChainPlan.java
@@ -128,12 +128,12 @@ public final class ChainPlan {
 			// where the verdicts are handed their map.
 			SKY_PROGRAMS.stream()
 					.map(program -> new NamedProgram(program, CLOUD_PROGRAM.equals(program),
-							false, NOT_EVERYWHERE)),
+							NOT_EVERYWHERE)),
 			Stream.of(
 					// The entity halves are the two the file has to ask for, and they are drawn in
 					// every place once it has: what decides them is the line and not the format.
-					new NamedProgram("gbuffers_entities", false, false, Families::entities),
-					new NamedProgram("gbuffers_block", false, false, Families::entities),
+					new NamedProgram("gbuffers_entities", false, Families::entities),
+					new NamedProgram("gbuffers_block", false, Families::entities),
 					// The blending half of those same two, on the far side of the stage: the game
 					// draws them among its translucent features, which is after the deferreds have
 					// run. Five entries for four names because the side is half the key, and the
@@ -154,9 +154,9 @@ public final class ChainPlan {
 					// render/FeatureLayer composes, so the glyph lands there drawn by the PACK
 					// rather than by the game. Nothing about the text decides that: it is the
 					// family's answer, and FeatureLayer names it beside the other two roads in.
-					new NamedProgram("gbuffers_entities_translucent", true, false,
+					new NamedProgram("gbuffers_entities_translucent", true,
 							Families::entities),
-					new NamedProgram("gbuffers_block_translucent", true, false, Families::entities),
+					new NamedProgram("gbuffers_block_translucent", true, Families::entities),
 					// The OPAQUE entity name on the far side, which reads like a contradiction and is
 					// the energy swirl over a charged creeper: Iris pins that row to ENTITIES_CUTOUT
 					// outright (pipeline/IrisPipelines.java:60) while the game blends it, so it is
@@ -171,7 +171,7 @@ public final class ChainPlan {
 					// carry. Where a pack ships no gbuffers_entities_translucent of its own the
 					// blending name falls back on this very file, and that entry counts it; three
 					// packs of the corpus are in that case and this entry moves nothing for them.
-					new NamedProgram("gbuffers_entities", true, false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_entities", true, NOT_EVERYWHERE),
 					// The glowing eyes of a mob, drawn among the translucent features beside the two
 					// above and on the same side of the stage. One entry and not two: its two
 					// pipelines ask for the one name, both blend, and neither is ever drawn before
@@ -182,7 +182,7 @@ public final class ChainPlan {
 					// front of the camera. A verdict that took the eyes for drawn would report
 					// targets as written in every place a plan is built for, which is every place
 					// none of the six is standing.
-					new NamedProgram("gbuffers_spidereyes", true, false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_spidereyes", true, NOT_EVERYWHERE),
 					// The overlay over a block being mined, drawn among the translucent features
 					// beside the eyes and on the same side of the stage. Left out of this list, its
 					// family drew one output onto the game's cleared target, and the multiply the
@@ -190,7 +190,7 @@ public final class ChainPlan {
 					//
 					// Not counted, on the hand's argument: a crack is drawn where somebody is mining
 					// a block, which is a per frame answer no per place map may carry.
-					new NamedProgram("gbuffers_damagedblock", true, false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_damagedblock", true, NOT_EVERYWHERE),
 					// The game's lines, the block outline first among them, drawn among the
 					// translucent features beside the overlay and on the same side of the stage.
 					// The same entry the overlay owed: without it the line program resolved to no
@@ -200,7 +200,7 @@ public final class ChainPlan {
 					//
 					// Not counted, on the hand's argument: an outline is drawn where somebody is
 					// aiming at a block, a per frame answer no per place map may carry.
-					new NamedProgram("gbuffers_line", true, false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_line", true, NOT_EVERYWHERE),
 					// The hand's two passes, which straddle the stage as the particles do and for the
 					// same kind of reason: the solid one is drawn among the game's opaque features and
 					// the blending one at the end of the level. Not counted, and not by a switch:
@@ -212,8 +212,8 @@ public final class ChainPlan {
 					// gbuffers_hand, and that is exactly why they are two entries rather than one: a
 					// single walk would put one key in and leave the other side of the same file
 					// unanswered, which is the silence the head of this list is about.
-					new NamedProgram("gbuffers_hand", false, false, NOT_EVERYWHERE),
-					new NamedProgram("gbuffers_hand_water", true, false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_hand", false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_hand_water", true, NOT_EVERYWHERE),
 					// An enchantment's glint, which straddles the stage for a reason of its own: what
 					// CARRIES it decides which half the game executes it in. An enchanted book is
 					// submitted among the solid features, foil and all, since the sort looks at the
@@ -225,20 +225,20 @@ public final class ChainPlan {
 					// Not counted, and on the hand's argument rather than the weather's: a glint is
 					// drawn where somebody is holding or wearing something enchanted, which is a per
 					// frame answer no per place map may carry.
-					new NamedProgram("gbuffers_armor_glint", false, false, NOT_EVERYWHERE),
-					new NamedProgram("gbuffers_armor_glint", true, false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_armor_glint", false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_armor_glint", true, NOT_EVERYWHERE),
 					// Drawn, and still not counted: the game draws no rain and no snow where there is
 					// no weather, which is every place but the overworld.
-					new NamedProgram("gbuffers_weather", true, false, NOT_EVERYWHERE),
+					new NamedProgram("gbuffers_weather", true, NOT_EVERYWHERE),
 					// The one family that straddles the stage: the game submits every particle group
 					// twice, and the two land on either side of it. Counted wherever its line is on,
 					// and what earns it is that particles are drawn in every place there is.
 					//
-					// And the last name of this list riding on the seed: its opaque half never asks
-					// for a coverage mask, so its first output makes the trip through the game's
-					// own target and reaches the pack's picture through the seed and nowhere else.
-					new NamedProgram("gbuffers_particles", false, true, Families::particles),
-					new NamedProgram("gbuffers_particles_translucent", true, false,
+					// Its opaque half writes the coverage mask as the entities do, so it owns the
+					// draw buffers the pack asked for and the seed's own target says nothing about
+					// whether its draw was taken.
+					new NamedProgram("gbuffers_particles", false, Families::particles),
+					new NamedProgram("gbuffers_particles_translucent", true,
 							Families::particles),
 					// And Distant Horizons' far terrain, on both sides of the stage: that mod draws
 					// its own two halves from the head of the game's opaque chunk group and from the
@@ -252,23 +252,14 @@ public final class ChainPlan {
 					// rule is decided why the seed could not carry it. Neither half is counted, for
 					// the reason no family with a switch is: the far terrain is drawn where that mod
 					// is installed and running, which is no place in particular.
-					new NamedProgram("dh_terrain", false, false, NOT_EVERYWHERE),
-					new NamedProgram("dh_water", true, false, NOT_EVERYWHERE)))
+					new NamedProgram("dh_terrain", false, NOT_EVERYWHERE),
+					new NamedProgram("dh_water", true, NOT_EVERYWHERE)))
 			.toList();
 
 	/**
 	 * One name of that list, the side of the deferred stage the family asking for it draws on, and
 	 * when a verdict may take its targets for filled.
 	 *
-	 * @param ridesTheSeed whether this name's FIRST output reaches the pack's picture through the
-	 *                   scene seed rather than being written into the pack's own target. It is what
-	 *                   holds a name to the seed's own target below, and it is a question about the
-	 *                   coverage mask and not about the side of the stage: a family drawn before the
-	 *                   seed that writes the mask keeps the seed off the pixels it wrote and takes
-	 *                   its first draw buffer outright, so the seed's target is no longer its
-	 *                   business. Only the opaque particles ride it, which
-	 *                   {@code render/ParticleDraw} says in the same words and {@code GeometryProgram}
-	 *                   lists among the halves that never asked for a mask
 	 * @param everywhere whether this engine draws that family, with the switches it was handed, in
 	 *                   EVERY place a plan is built for. Not simply whether it draws it: a plan is
 	 *                   per place, and a family drawn in the overworld alone would have a verdict
@@ -277,7 +268,7 @@ public final class ChainPlan {
 	 *                   about the verdicts, which are the one place that must not tell a reader a
 	 *                   target holds a clear colour when a family of ours has just written it
 	 */
-	private record NamedProgram(String program, boolean afterDeferred, boolean ridesTheSeed,
+	private record NamedProgram(String program, boolean afterDeferred,
 			Predicate<Families> everywhere) {
 	}
 
@@ -468,9 +459,9 @@ public final class ChainPlan {
 	 *                  the one road into the pack's picture for a family drawn BEFORE the deferred
 	 *                  stage that writes no coverage mask, so off it takes the seed's own target with
 	 *                  it and hands the opaque particles back to the game, which is
-	 *                  {@code render/ParticleDraw.writes} refusing on the same answer. The entities
-	 *                  are not on that road: they write the mask and take their first draw
-	 *                  buffer in the pack's own targets, so this switch moves nothing for them
+	 *                  and nothing of the pack's is written there. No family of the game is on
+	 *                  that road any more: each writes the mask and takes its first draw buffer in
+	 *                  the pack's own targets, so this switch moves nothing for them
 	 */
 	public record Families(boolean terrain, boolean entities, boolean particles, boolean seed) {
 
@@ -602,25 +593,15 @@ public final class ChainPlan {
 		// WHAT IT LEAVES OPEN, said rather than hidden: those notes stay wrong, and the only honest
 		// way to close them is a per place answer rather than a per name one, which this record
 		// cannot carry. The End's sky widened that by one place the day it was served.
-		// AND, on the near side, only where the draw is really taken. A family whose FIRST output
-		// reaches the pack's picture through the scene seed takes over a pass the renderer opened
-		// with one attachment of its own, so it can only be redirected when that output is the seed's
-		// target and half; where it is not, the game keeps its own shader and nothing of the pack's
-		// is written. That is leadsWithSeed, and ParticleDraw refuses on the same answer. Bliss is
-		// why it is here: its seed is colortex1 against a first output of colortex2, so its opaque
-		// particles are handed back in all three places, and counting them would silence three notes
-		// that are true. Nothing on the corpus moves for it - Bliss's colortex9 is silenced by the
-		// translucent half, which carries no such condition - and that is the point: it costs no note
-		// and it stops the map claiming a draw that never happened.
-		//
-		// IT IS THE SEED'S ROAD AND NOT THE SIDE OF THE STAGE, and the two parted company when the
-		// entities took their first draw buffer in the pack's own targets. A family drawn before the
-		// seed that writes the coverage mask keeps the seed off the pixels it wrote, so its first
-		// output never makes the trip and the seed's target says nothing about whether its draw was
-		// taken; render/EntityDraw stopped asking, and a map still asking would hand the entities
-		// back on any pack whose entity program leads with a target other than the seed's - and on
-		// every pack under seed=off, where the family is served all the same. ridesTheSeed carries
-		// which names are left on that road, and only the opaque particles are.
+		// AND, on the near side, nothing about the seed's own target any more. A family drawn
+		// before the deferred stage that writes the coverage mask keeps the seed off the pixels it
+		// wrote and takes its first draw buffer in the pack's own targets, so where the seed is
+		// painted says nothing about whether its draw was taken. The entities were the first to
+		// leave that road and the opaque particles were the last on it; a map still asking would
+		// hand a family back on any pack whose program leads with a target other than the seed's,
+		// and on every pack under seed=off, where the family is served all the same. Bliss is the
+		// pack that shows it: its seed is colortex1 against a first output of colortex2, so its
+		// opaque particles were handed back in all three of its places and are now drawn there.
 		//
 		// WHAT THAT OVER-CLAIMS, said rather than hidden: this map cannot know whether the mask was
 		// really placed, which is the translation's answer and per FILE. A pack whose entity program
@@ -645,11 +626,8 @@ public final class ChainPlan {
 		// them refused here, would be counted half drawn while the family served nothing. No pack of
 		// the corpus reaches that case.
 		//
-		// WHAT THIS MAP DELIBERATELY DOES NOT FOLLOW: with chain=off the opaque particles are still
-		// drawn even with seed=off, which render/ParticleDraw spells out - it is the one
-		// configuration that tells a wrong gbuffer from a wrong composite. This map has them handed
-		// back there. It costs nothing worth the branch: with the chain off, no pass of it draws, so
-		// every line these notes carry is about a frame that does not happen.
+		// WHAT THIS MAP DELIBERATELY DOES NOT FOLLOW: with chain=off no pass of it draws, so every
+		// line these notes carry is about a frame that does not happen, whatever the families say.
 		Map<Key, Pass> world = new LinkedHashMap<>();
 		if (families.terrain()) {
 			terrainKeys.values().forEach(key -> world.put(key, attachments.get(key)));
@@ -658,8 +636,7 @@ public final class ChainPlan {
 		for (NamedProgram named : NAMED_PROGRAMS) {
 			Key key = named.everywhere().test(families) ? namedKeys.get(named) : null;
 			Pass drawing = key == null ? null : attachments.get(key);
-			if (drawing != null && drawing.size().equals(TargetSize.ofScreen())
-					&& (!named.ridesTheSeed() || leadsWithSeed(painted, drawing))) {
+			if (drawing != null && drawing.size().equals(TargetSize.ofScreen())) {
 				world.put(key, drawing);
 			}
 		}
@@ -1325,13 +1302,9 @@ public final class ChainPlan {
 	 * attachment of its own, so an engine that redirects the draw can only redirect the first output,
 	 * and the only target where that is not a loss is the one already carrying the game's frame.
 	 * <p>
-	 * Answered here because two readers need the same answer and they are far apart. The one that
-	 * acts on it is {@code render/ParticleDraw}, which hands the opaque half back to the game when
-	 * this is false; the one that reports on it is {@link #verdicts}, which must not count a family's
-	 * targets as filled where the draw was handed back. Bliss is the pack that separates them: its
-	 * seed is colortex1 and its particle program writes colortex2 first, so the opaque half is
-	 * refused in all three of its places while the translucent half, which has no such condition,
-	 * draws.
+	 * One reader is left, {@code render/EntityDraw}, which hands a piece back to the game when this
+	 * is false. Every other family that used to ask writes the coverage mask instead and takes its
+	 * first draw buffer outright, which is what took the question away from them.
 	 */
 	public static boolean leadsWithSeed(Seed seed, Pass pass) {
 		if (seed == null || pass == null || pass.attachments().isEmpty()) {

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -566,7 +566,7 @@ final class GeometryProgram {
 		// so anything sent there would simply vanish; when the plan had no answer there is nowhere
 		// else to send it; when a half that ASKED for a mask could not be given one, the seed would
 		// repaint the whole target and take the geometry with it; when a half never asked for one,
-		// which is the opaque particles and the weather, the seed carries it in by design; and the
+		// which is the weather alone, the seed carries it in by design; and the
 		// last is what the statement after next is about, a blending pass drawn before the seed with
 		// nothing marking the pixels it blends onto. Either way the pass draws where Sodium would
 		// have, which is also what keeps the pipeline's one state the pass's.

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -458,12 +458,12 @@ public final class PackChain {
 		// that stage instead, and that is why they need the switch and this does not.
 		this.weather = new WeatherDraw(this, packPath, chain.place(), chosen, profile, values,
 				this.load, chain.chain(), chain.targets(), chainWanted, this.targets);
-		// And the sixth, which needs the seed's switch as the entities do and only for half of
-		// itself: its opaque half is drawn among the game's solid features, before the deferred
-		// stage, and that half's first output has the same one road into the pack's picture.
+		// And the sixth, which straddles the deferred stage: its opaque half is drawn among the
+		// game's solid features and writes the coverage mask as the entities do, its translucent
+		// half after the world's water. Neither half asks whether the seed is painted, both owning
+		// the draw buffers the pack asked for.
 		this.particles = new ParticleDraw(this, packPath, chain.place(), chosen, profile, values,
-				this.load, chain.chain(), chain.targets(), chainWanted,
-				seedEnabled && this.seed != null, this.targets);
+				this.load, chain.chain(), chain.targets(), chainWanted, this.targets);
 		// And the seventh, read on demand like the five before it and for the sharpest reason of
 		// them: most sessions have no Distant Horizons at all, and the ones that do only reach this
 		// on the frames DH really draws a far terrain.

--- a/common/src/main/java/dev/vitrail/render/ParticleDraw.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleDraw.java
@@ -7,7 +7,6 @@ import dev.vitrail.pack.model.AlphaTest;
 import dev.vitrail.pack.model.RenderStage;
 import dev.vitrail.pack.source.OpenedPack;
 import dev.vitrail.pack.target.ChainPlan;
-import dev.vitrail.pack.model.TargetName;
 import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.model.TargetSize;
 import dev.vitrail.Vitrail;
@@ -101,12 +100,13 @@ public final class ParticleDraw extends FamilyDraw {
 		/**
 		 * What the pack has to be read for to serve this half, in terms the translation knows.
 		 * <p>
-		 * No coverage mask on either half, which {@link ParticleProgram} sets out where it decides
-		 * the same thing for the pass.
+		 * The coverage mask goes on the half drawn before the scene seed and on that one alone,
+		 * which is the entities' rule word for word ({@code EntityDraw.Piece.covers}), and
+		 * {@link ParticleProgram} says what it buys.
 		 */
 		private PackProgram.GeometryElement asked() {
 			return new PackProgram.GeometryElement(this.element, this.program, CUTOUT,
-					VertexInputs.PARTICLE, false);
+					VertexInputs.PARTICLE, !this.afterDeferred);
 		}
 
 		/**
@@ -143,10 +143,6 @@ public final class ParticleDraw extends FamilyDraw {
 	private final ChainPlan plan;
 	private final TargetPlan chainTargets;
 	private final boolean chainRuns;
-
-	/** Whether the game's finished frame is painted in under the chain, which the opaque half rides
-	 * on and the translucent one does not. */
-	private final boolean seeded;
 	private final ColorTargets targets;
 
 	/** One program per half the pack serves. Empty until the pack has been read. */
@@ -195,7 +191,7 @@ public final class ParticleDraw extends FamilyDraw {
 
 	ParticleDraw(PackChain owner, Path packPath, String place, Map<String, OptionValue> chosen,
 			String profile, PackValues values, int load, ChainPlan plan, TargetPlan chainTargets,
-			boolean chainRuns, boolean seeded, ColorTargets targets) {
+			boolean chainRuns, ColorTargets targets) {
 		this.owner = owner;
 		this.packPath = packPath;
 		this.place = place;
@@ -206,7 +202,6 @@ public final class ParticleDraw extends FamilyDraw {
 		this.plan = plan;
 		this.chainTargets = chainTargets;
 		this.chainRuns = chainRuns;
-		this.seeded = seeded;
 		this.targets = targets;
 	}
 
@@ -625,23 +620,20 @@ public final class ParticleDraw extends FamilyDraw {
 	 * all for the file that serves this half, and what puts a file there is the one list
 	 * {@link ChainPlan#geometry} carries. No place of the corpus is in that case.
 	 * <p>
-	 * Null is a refusal, and the reasons are not the same for the two halves. Both refuse a place
-	 * whose targets are not the size of the screen, one render pass having one render area. The
-	 * OPAQUE half refuses two more, and they are the entities' two, word for word and for the same
-	 * reason: it is drawn before the deferred stage over pixels the scene seed is cut out of, so its
-	 * first output has no road into the pack's picture but the seed, and that road only lands where
-	 * the pack asked if the seed paints the target the program writes first.
+	 * Null is a refusal, and there is one left for both halves alike: a place whose targets are not
+	 * the size of the screen, one render pass having one render area.
+	 * <p>
+	 * <strong>The opaque half used to refuse two more and no longer does, because the coverage mask
+	 * took their reason away.</strong> Both rested on the same premise, that its first output had no
+	 * road into the pack's picture but the scene seed: one refused a place where the seed is off, the
+	 * other a place where the seed paints a target the program does not write first. With the mask
+	 * the half owns draw buffer nought outright and writes the pack's own target, which is what Iris
+	 * does with it and what {@link ParticleProgram} sets out. Kept, they would hand a half back for a
+	 * road it no longer travels; Bliss was the corpus case, its {@code gbuffers_textured_lit} writing
+	 * colortex2 first where the seed paints colortex1.
 	 */
 	private List<ChainPlan.Attachment> writes(Element element, PackProgram.Loaded loaded) {
 		String servedBy = loaded.path().substring(loaded.path().lastIndexOf('/') + 1);
-		if (this.chainRuns && !element.afterDeferred() && !this.seeded) {
-			Vitrail.logger().info("The scene seed is off, and it is the only way the first output of an "
-					+ "opaque particle reaches the pack's picture, so the game keeps its own shader for "
-					+ "that half: served, it would write every other draw buffer and no colour");
-
-			return null;
-		}
-
 		Optional<ChainPlan.Pass> geometry = this.plan.geometryOf(servedBy, element.afterDeferred());
 		if (geometry.isEmpty()) {
 			return List.of();
@@ -652,26 +644,6 @@ public final class ParticleDraw extends FamilyDraw {
 			Vitrail.logger().warn("{} writes targets the pack asked to be scaled, so they cannot share "
 					+ "a pass with the game's own target and the game keeps its own shader for the {} "
 					+ "particles", servedBy, element.afterDeferred() ? "translucent" : "opaque");
-
-			return null;
-		}
-
-		if (element.afterDeferred()) {
-			return pass.attachments();
-		}
-
-		// The plan answers it rather than this file working it out again, and the reason is not
-		// tidiness: the verdicts have to know the same thing, so that a half handed back here is not
-		// counted as filled there. Two readings of one condition would drift, and the drift shows up
-		// as a diagnostic saying a target holds the pack's particles when the game drew them.
-		ChainPlan.Attachment first = pass.attachments().get(0);
-		Optional<ChainPlan.Seed> seed = this.plan.seed();
-		if (!ChainPlan.leadsWithSeed(seed.orElse(null), pass)) {
-			Vitrail.logger().warn("{} writes {} first and the scene seed paints {}, so the first output "
-					+ "of an opaque particle would be carried into a target the pack did not ask for: "
-					+ "the game keeps its own shader for that half", servedBy,
-					TargetName.canonical(first.target()),
-					seed.map(where -> TargetName.canonical(where.target())).orElse("nothing"));
 
 			return null;
 		}

--- a/common/src/main/java/dev/vitrail/render/ParticleProgram.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleProgram.java
@@ -23,12 +23,12 @@ import java.util.Set;
  * <p>
  * <strong>The two halves stand on opposite sides of the frame</strong>, which is the whole reason
  * they are two programs rather than one with two blends. The opaque half is drawn among the game's
- * solid features, before the deferred stage, so it is in the entities' position: it writes every draw
- * buffer but the first, and the first reaches the pack's picture through the scene seed. The
- * translucent half is drawn last of all, after the world's own water, so it is in the weather's
- * position: it blends onto a picture the chain has already put there and takes draw buffer nought
- * outright. Nothing here decides that - {@link GeometryProgram} reads it off whether the game's
- * pipeline blends - and it is worth naming because the two halves look interchangeable and are not.
+ * solid features, before the deferred stage, so it is in the entities' position: it writes the
+ * coverage mask and owns every draw buffer the pack asked for, nought included. The translucent
+ * half is drawn last of all, after the world's own water, so it is in the weather's position: it
+ * blends onto a picture the chain has already put there and owns draw buffer nought on the strength
+ * of its side. What the mask buys the opaque half is written where this class builds the pass, and
+ * it is worth naming because the two halves look interchangeable and are not.
  * <p>
  * <strong>The image belongs to the draw.</strong> One pass draws every particle of its half, and the
  * layers inside it come off three different atlases, so a pack reading {@code gtexture} has to be
@@ -88,15 +88,32 @@ final class ParticleProgram extends FamilyProgram {
 		return new ParticleProgram(new GeometryProgram(new GeometryProgram.Pass(FAMILY,
 				element.element(), NAMESPACE, ANSWERED, false,
 				game.getColorTargetState().blendFunction(),
-				// No coverage mask, on the opaque half as well as on the translucent one, and the two
-				// have different reasons. The translucent half is the sky's star quad again, mostly
-				// transparent and claiming every pixel it spans. The opaque half is the entities'
-				// case: it is drawn over pixels the seed is going to repaint anyway, and marking one
-				// would only take the game's own picture away from whatever is drawn there next.
+				// The coverage mask on the opaque half and not on the translucent one, which is the
+				// entities' rule and is what decides whether the pack owns draw buffer nought.
+				//
+				// WITHOUT IT THE OPAQUE HALF NEVER WRITES THE PACK'S TARGET AT ALL. Draw buffer
+				// nought falls back to the game's own, so a pack whose particle program declares one
+				// draw buffer writes nothing of the pack's and its colour reaches the picture only
+				// through the seed, already tone mapped and flat. Photon is that pack: its
+				// gbuffers_particles writes colortex1, which is its gbuffer, and the deferred stage
+				// shades what it finds there. Reached through the seed instead, the smoke arrives as
+				// a finished LDR colour the deferred stage then reads as gbuffer data, which is the
+				// warm haze a capture pair put beside Iris's dark smoke.
+				//
+				// Iris binds every gbuffers program to a framebuffer over the pack's own declared
+				// draw buffers, the particles among them (pipeline/IrisRenderingPipeline.java:677-678
+				// with the two particle keys at pipeline/programs/ShaderKey.java:94,96), so the
+				// pack's colour never makes that trip there.
+				//
+				// The translucent half owes no mask for the reason every after-deferred pass owes
+				// none: the seed has run long before it draws, and it owns draw buffer nought on the
+				// strength of its side alone.
+				//
 				// claimed: no sibling marks these pixels for them. The opaque half is drawn with
 				// RenderPipelines.OPAQUE_PARTICLE, which blends nothing, so the question does not
 				// arise there either.
-				false, false, element.afterDeferred(), game.getPrimitiveTopology(), game.isCull(),
+				!element.afterDeferred(), false, element.afterDeferred(),
+				game.getPrimitiveTopology(), game.isCull(),
 				game.getDepthStencilState(), element.stage(),
 				// Nothing of the game's bound beside the mesh, unlike the clouds: a particle carries
 				// its whole geometry in the vertex buffer the renderer fills.


### PR DESCRIPTION
## What changes

The game submits every quad particle group twice, the solid ones among the world's opaque features
and the see-through ones after the water. Only the second lot reached the pack's own image. The
first lot wrote no coverage mask, so their first output fell back on the game's target and the pack
was handed nothing: a program declaring one draw buffer wrote none of the pack's, one declaring
several had everything past the first written nowhere, and what reached the screen came in through
the scene seed as a finished, tone mapped colour for the deferred stage to read back as gbuffer
data. Under Photon a campfire's smoke came out a warm haze where it should be dark. The solid half
now writes the mask and owns the draw buffers the pack asked for, which is the rule the entities
already follow, and two refusals fall with it: both rested on that trip through the seed, one
turning the half away where the seed is off and the other where the seed paints a target the
program does not write first.

The second commit removes what is left over: the named table carried a flag for a name whose first
output travelled that road, and with no name left on it the flag is always false. Held to it, the
diagnostic map reports the game as having drawn what the pack now draws.

## How it differs from the reference, and for what obstacle

It does not. Iris builds every gbuffers framebuffer over the pack's own declared draw buffers,
`pipeline/IrisRenderingPipeline.java:677-678` on the 26.2 branch, with the two particle keys at
`pipeline/programs/ShaderKey.java:94,96`; this is that behaviour, reached here through the coverage
mask because the game's own renderer opens the pass.

## What proves it

- `gradlew build` green on every commit of the series.
- The off-game harness: the verdict map over the whole shaderpack folder is byte for byte identical
  before and after, which is the control the second commit owes.
- In the game, on both Fabric benches at 1912x1001, frozen world, camera pinned, with three particle
  clusters emitted in front of it and every pack at its own defaults. The plume's mean colour under
  Photon, red minus blue, goes from 33.6 to 20.6 against the reference's 20.3, where a patch of sky
  carrying no particle drifts 0.4 between two launches. The see-through half does not move, 42.8
  against 44.0. Across the twenty-six packs of the corpus every plume stays inside that drift except
  iterationT, whose solid particles now write the three targets it asks for and whose picture is
  wrong on both engines for a cause this does not touch.

## What it leaves owing

iterationT's plume moves further from the reference, inside a picture that is already almost
entirely wrong there: nineteen of its passes are refused for a three dimensional custom texture this
backend does not bind, so what its chain makes of a correctly written gbuffer cannot be read yet.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one: the two particle
      files, the named table and its verdict walk, the draw buffer report, and the `NOTICE` entry,
      whose two stale line numbers are re-anchored on the 26.2 branch in the same pass.
