### PR TITLE
feat(pack): serve the volume of floats a pack ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ what the next one holds.
 
 ### Added
 
+- **A pack's three dimensional lookup table is served whatever it holds.** Some packs ship a block
+  of numbers rather than a picture, a table their shaders read in three directions: an atmosphere
+  sampled by height, by sun angle and by view angle, a noise field a cloud is carved out of. The
+  engine laid out the small ones and turned away any table written in full precision numbers, and
+  it read no pack file over eight megabytes at all, a limit meant for shader text. A pack whose
+  table was either lost every program that read it: on iterationT that was nineteen of the passes
+  it draws the overworld with, which left the bare picture on screen with none of its sky, its
+  clouds or its water put in. Such a table is now read to the length its own declaration announces,
+  however long the file is, and at the precision the pack wrote it.
+
+  Where a card cannot blend between two of those values, Apple's among them, the table is read at
+  its nearest entry instead and the log says so.
+
 - **A pack's geometry stage is drawn.** Some packs put a third shader between the two the engine
   builds every draw from, and use it to work something out per triangle rather than per corner:
   how coarse the texture on a block face is, whether a sky quad is the moon or the sun. The engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,14 @@ what the next one holds.
   of numbers rather than a picture, a table their shaders read in three directions: an atmosphere
   sampled by height, by sun angle and by view angle, a noise field a cloud is carved out of. The
   engine laid out the small ones and turned away any table written in full precision numbers, and
-  it read no pack file over eight megabytes at all, a limit meant for shader text. A pack whose
-  table was either lost every program that read it: on iterationT that was nineteen of the passes
-  it draws the overworld with, which left the bare picture on screen with none of its sky, its
-  clouds or its water put in. Such a table is now read to the length its own declaration announces,
-  however long the file is, and at the precision the pack wrote it.
+  it read no pack file over eight megabytes at all, a limit meant for shader text. It also read
+  such a table only where the shader asked for it in the plainest of the two ways GLSL offers, and
+  a program that asked the other way was turned away with its table sitting ready in memory. A pack
+  hitting any of the three lost every program that read the table: on iterationT that was every
+  pass it draws the overworld with bar a handful, which left the bare picture on screen with none
+  of its sky, its clouds or its water put in. Such a table is now read to the length its own
+  declaration announces, however long the file is, at the precision the pack wrote it, and through
+  either way of asking.
 
   Where a card cannot blend between two of those values, Apple's among them, the table is read at
   its nearest entry instead and the log says so.

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -302,8 +302,10 @@ public final class GlslTranslator {
 	private static final String DRAW_MODEL_VIEW =
 			"(" + LegacyGlsl.CAMERA_BOB + " * " + LegacyGlsl.GAME_MODEL_VIEW + ")";
 
-	/** The one call a volume lookup may be written as. */
+	/** The two calls a volume lookup may be written as, the second carrying a level or a bias. */
 	static final String LOOKUP = "texture";
+
+	static final String LEVELLED_LOOKUP = "textureLod";
 
 	/** What the word sampler is followed by when the declaration asks for a comparison. */
 	private static final String SHADOW_SHAPE = "Shadow";

--- a/common/src/main/java/dev/vitrail/glsl/VolumeFlattening.java
+++ b/common/src/main/java/dev/vitrail/glsl/VolumeFlattening.java
@@ -38,6 +38,13 @@ final class VolumeFlattening {
 	/** The number of arguments {@link GlslTranslator#LOOKUP} takes where it reads a volume. */
 	private static final int LOOKUP_ARGUMENTS = 2;
 
+	/**
+	 * The same with a level or a bias behind it, which is how iterationT reads all three of its
+	 * volumes: {@code textureLod(colortex8, uvw, 0.0)}. An atlas carries one level, so what that
+	 * third argument asks for is what it gets whatever it says.
+	 */
+	private static final int LEVELLED_ARGUMENTS = 3;
+
 	private final TokenStream tokens;
 	private final ExpandedUnit unit;
 
@@ -103,10 +110,12 @@ final class VolumeFlattening {
 	 * out, and that file is what every one of those declarations was going to read.
 	 * <p>
 	 * Nothing is moved unless everything can be. A name this unit reaches any other way than as
-	 * {@code texture(name, vec3)}, the name being the declared one or a macro the unit defines as
-	 * exactly that name, is counted and left exactly as it stands, declaration included, so the
-	 * program stays refused with the message it had. There is no site in the corpus like that, and
-	 * the count is what would say one had appeared.
+	 * {@code texture(name, vec3)} or {@code textureLod(name, vec3, level)}, the name being the
+	 * declared one or a macro the unit defines as exactly that name, is counted and left exactly as
+	 * it stands, declaration included, so the program stays refused with the message it had. The
+	 * levelled form is not a nicety: iterationT writes every one of its reads that way, and reading
+	 * only the plain one left five of its passes refused while all three of its volumes were laid
+	 * out and uploaded.
 	 */
 	void flatten() {
 		if (this.volumes.isEmpty()) {
@@ -240,9 +249,12 @@ final class VolumeFlattening {
 	}
 
 	/**
-	 * The {@code texture} this name is the first argument of, or -1 when it is reached any other
-	 * way. The argument count is checked as well as the name: {@code texture(s, p, bias)} compiles
-	 * and means something else, and the helper takes two.
+	 * The lookup this name is the first argument of, or -1 when it is reached any other way.
+	 * <p>
+	 * The argument count is checked as well as the name, and both counts are served because the
+	 * helper is emitted twice over: a level or a bias asks for something an atlas of one level
+	 * answers the same way, where a fourth argument is an offset in texels of a volume this has
+	 * laid out flat and could not honour.
 	 */
 	private int plainLookup(int index) {
 		int open = this.tokens.significantBefore(index);
@@ -251,13 +263,19 @@ final class VolumeFlattening {
 		}
 
 		int callee = this.tokens.significantBefore(open);
-		if (callee < 0 || !this.tokens.get(callee).identifier(GlslTranslator.LOOKUP)) {
+		if (callee < 0 || !(this.tokens.get(callee).identifier(GlslTranslator.LOOKUP)
+				|| this.tokens.get(callee).identifier(GlslTranslator.LEVELLED_LOOKUP))) {
 			return -1;
 		}
 
 		int close = this.tokens.matchingBracket(open);
+		if (close < 0) {
+			return -1;
+		}
 
-		return close >= 0 && arguments(open, close) == LOOKUP_ARGUMENTS ? callee : -1;
+		int arguments = arguments(open, close);
+
+		return arguments == LOOKUP_ARGUMENTS || arguments == LEVELLED_ARGUMENTS ? callee : -1;
 	}
 
 	/** How many arguments a call holds, counting the commas that belong to it and not to a nested one. */
@@ -329,6 +347,15 @@ final class VolumeFlattening {
 		lines.add("\tvec2 ofB = (vec2(ofFar % " + tiles + ", ofFar / " + tiles
 				+ ") * ofTile + ofIn) / ofSize;");
 		lines.add("\treturn mix(texture(ofMap, ofA), texture(ofMap, ofB), clamp(ofZ - ofBase, 0.0, 1.0));");
+		lines.add("}");
+
+		// The levelled form, which is what every read of iterationT's three volumes is written as.
+		// It drops the level rather than passing it on, and that is exact rather than a shortcut:
+		// the atlas is allocated with one level, so the only level any of these reads could ever
+		// have landed on is the one this reads. A bias behind texture() arrives here too, and a
+		// bias on a texture with no chain is worth exactly as much.
+		lines.add("vec4 " + VOLUME_LOOKUP + name + "(sampler2D ofMap, vec3 ofAt, float ofLevel) {");
+		lines.add("\treturn " + VOLUME_LOOKUP + name + "(ofMap, ofAt);");
 		lines.add("}");
 
 		return lines;

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderPackSource.java
@@ -546,6 +546,42 @@ public final class ShaderPackSource implements AutoCloseable {
 		return Files.size(file);
 	}
 
+	/**
+	 * The first {@code wanted} bytes of a file, for a raw texture whose own declaration says how
+	 * many there are to read.
+	 * <p>
+	 * The ceiling on {@link #bytes} is the one a shader SOURCE gets, and a raw texture is not one.
+	 * iterationT ships a thirty three megabyte atmosphere table, four times that ceiling, and
+	 * reading it under the source's rule left the pack with a {@code sampler3D} nothing stood
+	 * behind and nineteen passes of its overworld that could not be built. What bounds this read
+	 * instead is the declaration: {@code PackTextures} refuses one longer than the file it names
+	 * before this is ever called, and the atlas laid out for it has already had to fit inside what
+	 * this engine will spend on one.
+	 * <p>
+	 * The tail past the declaration is not read at all, which is what the note beside such a
+	 * declaration says out loud: what the file holds is the author's business, what the directive
+	 * announces is what the shaders address.
+	 *
+	 * @throws IOException if the file holds fewer than {@code wanted} bytes, which would otherwise
+	 *                     go up padded with zeroes and read as a lookup table
+	 */
+	public byte[] head(Path file, long wanted) throws IOException {
+		if (wanted < 0 || wanted > Integer.MAX_VALUE) {
+			throw new IOException(rel(file) + " is asked for " + wanted
+					+ " bytes, which is not a length anything here can hold");
+		}
+
+		try (InputStream in = Files.newInputStream(file)) {
+			byte[] read = in.readNBytes((int) wanted);
+			if (read.length < wanted) {
+				throw new IOException(rel(file) + " holds " + read.length
+						+ " bytes where the declaration asks for " + wanted);
+			}
+
+			return read;
+		}
+	}
+
 	/** A file's raw bytes, under the same ceiling as the sources: an image is not exempt. */
 	public byte[] bytes(Path file) throws IOException {
 		long size = Files.size(file);

--- a/common/src/main/java/dev/vitrail/pack/texture/VolumeAtlas.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/VolumeAtlas.java
@@ -45,14 +45,15 @@ public final class VolumeAtlas {
 	/**
 	 * What the atlas is allowed to come out as, which is not what the volume is allowed to be.
 	 * <p>
-	 * A blob is bounded by the ceiling on a pack file and its declaration is checked against its
-	 * length, so a volume is at most a few million texels; the atlas is what those texels are laid
-	 * out AS, and one long axis lays them out in a line. A megabyte declared as
-	 * {@code 4096 1 2048} spreads to a hundred and eighty eight thousand texels across, which no
-	 * device will allocate and which nothing in the file said. The sides are what a device takes and
-	 * the total is what the memory is, counted in bytes because a texel is four to eight of them: a
-	 * hundred and twenty eight mebibytes at the very most, and a megabyte for the noise volumes of
-	 * the corpus.
+	 * A blob is bounded by nothing but the file the pack ships and the declaration checked against
+	 * its length, and THIS is what bounds it: nothing downstream reads a blob whose atlas was
+	 * refused here. The atlas is what the volume's texels are laid out AS, and one long axis lays
+	 * them out in a line. A megabyte declared as {@code 4096 1 2048} spreads to a hundred and
+	 * eighty eight thousand texels across, which no device will allocate and which nothing in the
+	 * file said. The sides are what a device takes and the total is what the memory is, counted in
+	 * bytes because a texel is four to sixteen of them: a hundred and twenty eight mebibytes at the
+	 * very most, which is a megabyte for the noise volumes of the corpus and thirty seven for
+	 * iterationT's atmosphere table.
 	 */
 	private static final int MAX_SIDE = 16384;
 
@@ -65,15 +66,20 @@ public final class VolumeAtlas {
 	private static final int ALPHA = 3;
 
 	/**
-	 * The channel types this lays out: unsigned bytes and shorts, and half floats, the types the
-	 * corpus's noise volumes and Photon's atmosphere table are made of. Everything else is refused
-	 * until a pack ships it, and two of the refusals are not a matter of writing more: a single
-	 * float a channel would be allocated in a format Vulkan does not promise to filter linearly,
-	 * which is the whole of what the atlas asks the hardware to do, and an integer format is read
-	 * through an integer sampler the helper is not written for.
+	 * The channel types this lays out: unsigned bytes and shorts, and floats of both widths, the
+	 * types the corpus's noise volumes and iterationT's atmosphere table are made of. An integer
+	 * format stays out, and that refusal is not a matter of writing more: it is read through an
+	 * integer sampler the helper is not written for.
+	 * <p>
+	 * A single float a channel goes up as the pack declared it, which is what Iris uploads and what
+	 * GL filters for it. Vulkan only PERMITS a device to filter a thirty two bit float format
+	 * linearly where it requires it of a half, so on a device that does not the sampler falls back
+	 * to nearest and says so, which costs the blend between two entries of a lookup table and
+	 * nothing else. Laying such a blob out in halves instead would keep the filtering and round
+	 * every value, and a table like this one is read for its values.
 	 */
 	private static final Set<PixelType> TYPES = Set.of(PixelType.UNSIGNED_BYTE,
-			PixelType.UNSIGNED_SHORT, PixelType.HALF_FLOAT);
+			PixelType.UNSIGNED_SHORT, PixelType.HALF_FLOAT, PixelType.FLOAT);
 
 	/** The channel orders laid out as they come: a swapped order would have to be swapped back. */
 	private static final Set<PixelFormat> FORMATS = Set.of(PixelFormat.RED, PixelFormat.RG,
@@ -211,6 +217,7 @@ public final class VolumeAtlas {
 			case UNSIGNED_BYTE -> new byte[] {(byte) 0xFF};
 			case UNSIGNED_SHORT -> new byte[] {(byte) 0xFF, (byte) 0xFF};
 			case HALF_FLOAT -> new byte[] {0x00, 0x3C};
+			case FLOAT -> new byte[] {0x00, 0x00, (byte) 0x80, 0x3F};
 			default -> throw new IllegalStateException(this.type + " is not a type this lays out");
 		};
 	}

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 
@@ -180,6 +181,24 @@ final class ColorTargets {
 
 	/** One surface per texture the pack ships, allocated and uploaded with the constants. */
 	private final Map<PackImages.Image, TargetSurface> packSurfaces = new LinkedHashMap<>();
+
+	/**
+	 * Which formats this device blends between two texels of, asked once each and kept.
+	 * <p>
+	 * Keyed on the FORMAT and filled where it is read rather than beside the surfaces, because the
+	 * two do not happen in that order: the passes are built before the targets are prepared
+	 * ({@code PackChain.ready}), so a pass captures what it reads from a name while
+	 * {@link #packSurfaces} is still empty. A table filled at allocation would have answered every
+	 * pass nearest.
+	 * <p>
+	 * Concurrent because it is written from two threads. A geometry program is built on the
+	 * pack-load worker ({@code FamilyWarmup}) and asks {@link #packSource} from its constructor,
+	 * where a full screen pass asks the same method on the render thread; {@code TargetCopies}
+	 * guards its own two collections for exactly that reason. Every format that reaches here is one
+	 * an allocated image is in, and {@link #ensurePackTextures} asks for all of them on the render
+	 * thread, so the device itself is answered before any worker exists.
+	 */
+	private final Map<GpuFormat, Boolean> filterable = new ConcurrentHashMap<>();
 
 	/**
 	 * The shadow map, allocated and cleared with the rest.
@@ -1018,6 +1037,7 @@ final class ColorTargets {
 
 		this.packSurfaces.values().forEach(TargetSurface::close);
 		this.packSurfaces.clear();
+		this.filterable.clear();
 		this.storageImages.close();
 		this.storageBuffers.close();
 
@@ -1113,6 +1133,14 @@ final class ColorTargets {
 		for (PackImages.Image image : images) {
 			Vitrail.logger().info("The pack supplies {}", PackImages.describe(image));
 
+			// On the render thread, and before the pack-load worker exists: this is what answers the
+			// device for every format the pack supplies, so a geometry program built off thread
+			// reads the table rather than filling it. The note belongs here for the same reason.
+			if (image.texture().blur() && !filterable(image.format())) {
+				note(image.texture().sampler() + " is read at the nearest texel, this device not "
+						+ "filtering " + image.format() + " linearly");
+			}
+
 			// One at a time, because one refusal here must cost one texture and not the pack. These
 			// are the only surfaces of the engine whose size comes from a downloaded file rather
 			// than from the window, and everything else in this method is on the road that sets
@@ -1172,9 +1200,42 @@ final class ColorTargets {
 
 		boolean flat = !sampler.equals(SamplerPlan.behind(sampler));
 
-		return new PackSource(image,
-				image.texture().blur() ? FilterMode.LINEAR : FilterMode.NEAREST,
-				!flat && !image.texture().clamp());
+		return new PackSource(image, filterFor(image), !flat && !image.texture().clamp());
+	}
+
+	/**
+	 * How one supplied texture is read: what the pack asked for, unless this device cannot filter
+	 * the format it went up in.
+	 * <p>
+	 * The formats that can lose here are the ones the specification does not require a device to
+	 * filter, which among the four an atlas is allocated as are the thirty two bit float and the
+	 * sixteen bit normalised one. What is lost is the blend between two entries of a lookup table:
+	 * read at the nearest entry it still draws the picture the pack drew, banded.
+	 */
+	private FilterMode filterFor(PackImages.Image image) {
+		return image.texture().blur() && filterable(image.format())
+				? FilterMode.LINEAR
+				: FilterMode.NEAREST;
+	}
+
+	/**
+	 * Asked of the device the first time a format is met here, and said once when it answers no.
+	 * <p>
+	 * The log line rather than a note, because this is reachable from the pack-load worker and the
+	 * note list is the render thread's; {@link #ensurePackTextures} writes the note for every format
+	 * the pack really supplies, which is every format that can reach here.
+	 */
+	private boolean filterable(GpuFormat format) {
+		return this.filterable.computeIfAbsent(format, one -> {
+			boolean answer = GpuFormats.filtersLinearly(one);
+			if (!answer) {
+				Vitrail.logger().warn("This device does not filter {} linearly, so what the pack "
+						+ "supplies in it is read at the nearest texel where its directive asked for "
+						+ "a blend", one);
+			}
+
+			return answer;
+		});
 	}
 
 	/** The view behind a supplied image, or null while nothing could be put behind it. */

--- a/common/src/main/java/dev/vitrail/render/GpuFormats.java
+++ b/common/src/main/java/dev/vitrail/render/GpuFormats.java
@@ -97,10 +97,36 @@ final class GpuFormats {
 	 * False with no Vulkan device to ask, which is no device to store into either.
 	 */
 	static boolean storageCapable(GpuFormat format) {
+		return feature(format, VK10.VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT, false);
+	}
+
+	/**
+	 * Whether this device blends between two texels of that format, which is what a pack asks for
+	 * every time it leaves blur on.
+	 * <p>
+	 * Asked of the device because the specification only REQUIRES it of some formats. A sixteen bit
+	 * float is one of them; a thirty two bit float is not, and neither is the sixteen bit
+	 * normalised pair, which are two of the four an atlas is allocated as. The thirty two bit float
+	 * is what iterationT's atmosphere table goes up in, and Metal does not filter that width at
+	 * all, so under MoltenVK the answer here is no and the sampler falls back to nearest rather
+	 * than asking for something the driver never promised. GL required it of every one of them,
+	 * which is why Iris asks nothing.
+	 * <p>
+	 * Yes with no Vulkan device to ask, which is the opposite default to {@link #storageCapable}
+	 * and for the opposite reason: a storage image the engine cannot prove is a compute it must not
+	 * schedule, where a filter it cannot prove would take linear filtering away from every texture
+	 * of every pack on a reading that proves nothing.
+	 */
+	static boolean filtersLinearly(GpuFormat format) {
+		return feature(format, VK10.VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT, true);
+	}
+
+	/** One bit of what this device does with that format, or {@code absent} with no device to ask. */
+	private static boolean feature(GpuFormat format, int bit, boolean absent) {
 		GpuDevice device = RenderSystem.tryGetDevice();
 		if (device == null
 				|| !(((GpuDeviceAccessor) device).vitrail$backend() instanceof VulkanDevice vulkan)) {
-			return false;
+			return absent;
 		}
 
 		try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -108,7 +134,7 @@ final class GpuFormats {
 			VK10.vkGetPhysicalDeviceFormatProperties(vulkan.vkDevice().getPhysicalDevice(),
 					VulkanConst.toVk(format), properties);
 
-			return (properties.optimalTilingFeatures() & VK10.VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT) != 0;
+			return (properties.optimalTilingFeatures() & bit) != 0;
 		}
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/PackImages.java
+++ b/common/src/main/java/dev/vitrail/render/PackImages.java
@@ -127,7 +127,14 @@ final class PackImages {
 		declared.refused().forEach(refused -> notes.add("Dropped " + refused));
 
 		for (PackTexture texture : declared.supplied()) {
-			VolumeAtlas atlas = flat.get(texture.sampler());
+			// The layout is this declaration's own, not the name's: iterationT points colortex8 at a
+			// volume for the sampler3D and at a PNG for the sampler2D, exactly as the reference
+			// files the two apart, and handing the atlas to the PNG would spread an image over
+			// nothing and leave six programs reading a lookup table.
+			VolumeAtlas atlas = texture.raw().filter(VolumeAtlas::serves).isPresent()
+					? flat.get(texture.sampler())
+					: null;
+
 			Image image = decode(texture, atlas, source, notes);
 			if (image == null) {
 				continue;
@@ -171,15 +178,19 @@ final class PackImages {
 		}
 
 		try {
-			byte[] bytes = source.bytes(file.get());
 			if (atlas != null) {
+				// Read to the length the declaration announces and no further, which is what lets a
+				// blob past the ceiling a shader source gets be read at all: iterationT's atmosphere
+				// table is four times that ceiling.
 				PackTexture.Raw raw = texture.raw().orElseThrow();
 
 				return new Image(texture, atlas.atlasWidth(), atlas.atlasHeight(),
-						atlas.spread(bytes), format(atlas), raw.sizeX() + "x" + raw.sizeY() + "x"
-								+ raw.sizeZ() + " laid out flat as " + atlas.atlasWidth() + "x"
-								+ atlas.atlasHeight());
+						atlas.spread(source.head(file.get(), raw.bytes())), format(atlas),
+						raw.sizeX() + "x" + raw.sizeY() + "x" + raw.sizeZ() + " laid out flat as "
+								+ atlas.atlasWidth() + "x" + atlas.atlasHeight());
 			}
+
+			byte[] bytes = source.bytes(file.get());
 
 			// Any other blob means what its own format says it means, and nothing here turns one of
 			// those into an image. The corpus ships none; a pack that starts to has to be named
@@ -341,6 +352,7 @@ final class PackImages {
 			case UNSIGNED_BYTE -> GpuFormat.RGBA8_UNORM;
 			case UNSIGNED_SHORT -> GpuFormat.RGBA16_UNORM;
 			case HALF_FLOAT -> GpuFormat.RGBA16_FLOAT;
+			case FLOAT -> GpuFormat.RGBA32_FLOAT;
 			default -> throw new IllegalStateException(atlas.type() + " is not a type an atlas holds");
 		};
 	}

--- a/common/src/main/java/dev/vitrail/render/PackImages.java
+++ b/common/src/main/java/dev/vitrail/render/PackImages.java
@@ -135,6 +135,29 @@ final class PackImages {
 					? flat.get(texture.sampler())
 					: null;
 
+			// The FIRST volume under that name is the one whose layout was printed into every
+			// shader, and PackTextures keeps the first too, so a second one is handed that same
+			// atlas rather than a second copy of it. A pack writing two files for one name on two
+			// stages would otherwise have the last file spread over the first one's tiles, and what
+			// comes out of that still looks like noise; writing the SAME file twice, which is what
+			// a directive per stage makes a pack do, spread iterationT's atmosphere table twice for
+			// one lookup.
+			Image already = atlas == null ? null : volumes.get(texture.sampler());
+			if (already != null) {
+				// The extents count as much as the path: the same file declared at two sizes is one
+				// of the two layouts printed into the shaders and one blob spread over the other's
+				// tiles, which comes out looking exactly like the noise it is not.
+				if (!already.texture().path().equals(texture.path())
+						|| !already.texture().raw().equals(texture.raw())) {
+					notes.add(texture.path() + " is a second volume under the name "
+							+ texture.sampler() + ", and the shaders read " + already.shape()
+							+ " of " + already.texture().path());
+				}
+
+				byTexture.put(texture, already);
+				continue;
+			}
+
 			Image image = decode(texture, atlas, source, notes);
 			if (image == null) {
 				continue;
@@ -143,14 +166,7 @@ final class PackImages {
 			images.add(image);
 			byTexture.put(texture, image);
 			if (atlas != null) {
-				// The FIRST declaration under that name, which is the one whose layout was printed
-				// into every shader: PackTextures keeps the first too. A pack writing two files for
-				// one name on two stages would otherwise have the last file spread over the first
-				// one's tiles, and what comes out of that still looks like noise.
-				if (volumes.putIfAbsent(texture.sampler(), image) != null) {
-					notes.add(texture.path() + " is a second volume under the name "
-							+ texture.sampler() + ", and the shaders read the first");
-				}
+				volumes.put(texture.sampler(), image);
 			}
 		}
 

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -464,10 +464,17 @@ What forces that is the data rather than the type: the blob is uploaded as one f
 and nothing builds a three-dimensional view over a texture a pack ships. The declared type stopped
 being the obstacle the day a mixin made the bind group's walk read `SpvDim3D` as 2D, which is what a
 volume an `image` directive fills is bound through.
-The atlas keeps the blob's own channel type, an unsigned byte, an unsigned short or a half float
-a channel, and the addressing the pack asked for is baked into it: a repeating volume carries the far edge in the
+The atlas keeps the blob's own channel type, an unsigned byte, an unsigned short or a float of
+either width a channel, and the addressing the pack asked for is baked into it: a repeating volume
+carries the far edge in the
 gutter of each slice and the helper wraps, a clamped one carries the edge again and the helper
-clamps. A read written through a macro that stands for exactly the sampler's name is a read of the
+clamps. The file is read to the length the declaration announces and no further, so a blob past the
+ceiling a shader source gets is read all the same and a tail past the declaration is uploaded by
+neither engine. Two of the four formats an atlas is allocated as are ones Vulkan only PERMITS a
+device to filter linearly rather than requiring it, the thirty two bit float and the sixteen bit
+normalised one, so the device is asked and a refusal leaves that atlas read at its nearest texel
+with a line in the log.
+A read written through a macro that stands for exactly the sampler's name is a read of the
 volume; one reached any other way leaves the program refused, and the log counts it. The volume
 answers only the `sampler3D` declarations of its name: a `sampler2D` of the same name in the same
 stage goes on reading the colour target, as under the reference, which renames a declaration to a

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -474,8 +474,9 @@ neither engine. Two of the four formats an atlas is allocated as are ones Vulkan
 device to filter linearly rather than requiring it, the thirty two bit float and the sixteen bit
 normalised one, so the device is asked and a refusal leaves that atlas read at its nearest texel
 with a line in the log.
-A read written through a macro that stands for exactly the sampler's name is a read of the
-volume; one reached any other way leaves the program refused, and the log counts it. The volume
+A read is `texture(name, coordinate)` or `textureLod(name, coordinate, level)`, the level dropped
+because an atlas carries one, and the name may be a macro standing for exactly the sampler's name;
+one reached any other way leaves the program refused, and the log counts it. The volume
 answers only the `sampler3D` declarations of its name: a `sampler2D` of the same name in the same
 stage goes on reading the colour target, as under the reference, which renames a declaration to a
 custom texture only when its type matches the texture's shape.


### PR DESCRIPTION
## What changes

A pack can ship a three dimensional lookup table as a raw blob and sample it as a `sampler3D`, and
this engine serves that by laying the slices out on a flat atlas and rewriting each read onto a
helper. Three things kept iterationT out of that road, each of them alone costing every program
that read the table its pipeline: the atlas refused a single float a channel, which is what its
atmosphere table is written in; the pack file reader capped every file at eight megabytes, a
ceiling written for shader text, and that table is thirty three; and the rewrite covered only
`texture(name, vec3)` where the pack writes every read as `textureLod(name, vec3, 0.0)`, which also
kept two passes out over the cloud noise this engine had been laying out flat all along.

Now the blob goes up at its own width, the file is read to the length its own declaration announces
rather than under the source ceiling, and both spellings of the read reach the atlas. A volume
declared for two stages is laid out once instead of twice. And since the specification only
requires a device to filter some formats linearly, the device is asked, and a texture in a format
it refuses is read at its nearest texel with a line in the log.

## How it differs from the reference, and for what obstacle

It does not. The reference files a raw directive under a forged name keyed by the sampler's name,
its type and its stage, so a `sampler3D` and a `sampler2D` of one name coexist; this engine already
mirrors that. The flat atlas is a workaround it already carried, and the branch only widens what
reaches it.

The one place a reader could see a difference is the filter. GL required linear filtering of every
format an atlas is allocated as; Vulkan requires it of two of the four and permits the other two,
so on a device that does not offer it a lookup table comes out banded where the reference blends.
No device of this bench refuses, and the log names it where one would.

## What proves it

- `gradlew build` green, after the rebase.
- Off game, over the twenty six pack corpus: the atlas round trip lays the atmosphere table out at
  3084x780 with zero wrong texels, and one twisted byte makes the counter read one, so it bites.
- In game, Fabric bench, frozen world, every pack of the corpus shown in turn: not one program of
  any pack is refused, where iterationT lost nineteen of its overworld passes before.
- Against the reference, same world and camera: iterationT goes from an average difference of 84
  levels over 91 percent of the picture to 3.9 over 9 percent, inside what two captures of the same
  jar move on an animated pack. What is left is cloud drift between the captures, read on the crop.
  A third sweep on the base jar puts every other pack inside its own capture to capture noise.

## What it leaves owing

The atlas is bound clamped and the addressing done in the helper, so a volume read any way other
than through those two calls still leaves its program refused, and the load counts it. RenderPearl
still draws flat blue, its computes failing for reasons of their own, none of them this.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one: the javadoc of
      the atlas, the flattening and the format table, `docs/pack-format.md`, and the load line that
      names how a supplied texture is read.
