### PR TITLE
fix(render): honour the shadow map's nearest directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,19 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack asking for a hard shadow edge gets one.** A shader pack can say that its shadow map is
+  to be read without smoothing, and the engine listed those lines among the pack's settings and
+  then bound the map smoothed anyway, so a pack written for a hard, stepped shadow came out soft.
+  They are read now, on the full screen passes, the world's own programs and the compute passes
+  alike, so one map is read one way across a whole frame.
+
+  A pack that says nothing is unchanged, its map staying smoothed, which is where both engines
+  start. One pack of those at hand does say something: Pegasus asks for its shadow map to be read
+  without smoothing, and now gets it, on a shadow test that steps hard enough for the change to sit
+  on the edge of a shadow rather than across it. The same request on the shadow's colour buffer
+  stays ignored, as it is by the engine packs are tuned against, and asking for a mip chain under
+  the map is a separate line and still ignored too.
+
 - **Smoke, flame and the other solid particles take the colour the pack meant them to.**
   The game draws its quad particles in two goes, the solid ones with the world and the
   see-through ones after the water, and only the second lot were reaching the pack's own

--- a/NOTICE
+++ b/NOTICE
@@ -46,6 +46,15 @@ GNU Lesser General Public License version 3
   GAUX4FORMAT and the promotion of colortex1 on a gdepth uniform, are not implemented. The flip
   state is carried once rather than as the pair BufferFlipper keeps.
 
+  common/src/main/java/dev/vitrail/pack/target/PackDirectives.java takes the names of the
+  shadow depth filtering directives, and which image each one moves, from
+  net.irisshaders.iris.shaderpack.properties.PackShadowDirectives: shadowtexNearest is an
+  alias for the first image alone, shadowtexNNearest and shadowNMinMagNearest name one image
+  each, and the same family on the colour buffers answers to a second spelling of the prefix
+  where the format and clear directives do not. The colour half is parsed by Iris and then
+  overruled at the bind, net.irisshaders.iris.samplers.IrisSamplers binding every shadowcolor
+  through a LINEAR sampler object whatever the pack asked, so it is not honoured here either.
+
   common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java reproduces the sampler aliasing
   rules of net.irisshaders.iris.samplers.IrisSamplers and of
   net.irisshaders.iris.gl.program.ProgramSamplers, read on 19 August 2026: shadow reads the map

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -178,11 +178,14 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 		// road binds the same pair through the descriptor instead of coming here.
 		//
 		// Not conditioned on shadowHardwareFiltering, and nothing here could condition it: the
-		// header is written per stage, before any of the pack's directives are folded. It costs
-		// nothing on this corpus. Without that directive Iris leaves the comparison mode off and
-		// what a sampler2DShadow reads is undefined, so the declaration this translation found is
-		// the only live meaning the directive has; and the harder shape the pair can ask for,
-		// NEAREST_HW, needs shadowtexNearest, which no pack of the corpus writes.
+		// header is written per stage, before any of the pack's directives are folded. Without that
+		// directive Iris leaves the comparison mode off and what a sampler2DShadow reads is
+		// undefined, so the declaration this translation found is the only live meaning the
+		// directive has. What it would cost is the harder shape the pair can ask for, NEAREST_HW,
+		// which needs a nearest directive beside the hardware one, and no pack of the corpus
+		// declares both live: the one that asks for NEAREST asks for no hardware filtering. Named
+		// in ShadowCompare, which is where the unconditional LINEAR of the comparison sampler
+		// lives.
 		//
 		// The sense is LEQUAL, which is what OptiFine sets on a shadow texture and therefore what
 		// every pack is written against: one where the fragment is no further from the light than

--- a/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
+++ b/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
@@ -89,6 +89,7 @@ public final class PackDirectives {
 	private final float shadowFarPlane;
 	private final float shadowIntervalSize;
 	private final Map<Integer, ShadowColour> shadowColours;
+	private final List<Boolean> shadowDepthNearest;
 
 	/**
 	 * What one {@code shadowcolor} buffer asks for: the format to allocate it in, whether the shadow
@@ -130,6 +131,7 @@ public final class PackDirectives {
 		Map<Integer, ShadowColour> colours = new TreeMap<>();
 		builder.shadowColours.forEach((index, setting) -> colours.put(index, setting.build()));
 		this.shadowColours = Collections.unmodifiableMap(colours);
+		this.shadowDepthNearest = List.of(builder.depthNearest[0], builder.depthNearest[1]);
 	}
 
 	/** What a pack that declares nothing gets, which is what most of the corpus gets. */
@@ -311,6 +313,28 @@ public final class PackDirectives {
 		return this.shadowColours.keySet();
 	}
 
+	/**
+	 * Whether the pack asked for NEAREST on one of the two depth images of the map,
+	 * {@code shadowtex0} at nought and {@code shadowtex1} at one, which is the pair Iris carries
+	 * ({@code shaderpack/properties/PackShadowDirectives.java:184-198}).
+	 * <p>
+	 * False is where both engines start, and it is not where the whole corpus stays: Pegasus asks
+	 * for NEAREST on both images. Several other packs carry the names too, set to false, or inside
+	 * a block comment, which is why the corpus is asked through the reader and never through a
+	 * grep: {@code .local/harness/ShadowSampling} answers it in one command.
+	 * <p>
+	 * The colour buffers have the same family of names and it is deliberately not read, because
+	 * <strong>Iris parses those and then binds the buffer through a LINEAR sampler object
+	 * regardless</strong> ({@code samplers/IrisSamplers.java:156-176}, {@code GlSampler.LINEAR} on
+	 * every {@code shadowcolor} bind), and a GL sampler object overrules the texture's own
+	 * parameters. OptiFine does honour them, so honouring them here would be a divergence from the
+	 * engine packs are tuned against, on the one buffer where a pack blurs light across a penumbra.
+	 */
+	public boolean shadowDepthNearest(int index) {
+		return index >= 0 && index < this.shadowDepthNearest.size()
+				&& this.shadowDepthNearest.get(index);
+	}
+
 	public static final class Builder {
 
 		private static final float DRYNESS_HALFLIFE = 200.0F;
@@ -326,6 +350,11 @@ public final class PackDirectives {
 		private static final int MAX_NOISE_RESOLUTION = 4096;
 
 		private static final String SHADOW_COLOUR = "shadowcolor";
+
+		/** {@code shadowtex0} and {@code shadowtex1}, the two depth names OptiFine's model has. */
+		private static final int SHADOW_DEPTHS = 2;
+
+		private final boolean[] depthNearest = new boolean[SHADOW_DEPTHS];
 
 		private static final ShadowColour SHADOW_COLOUR_DEFAULT = new ShadowColour(
 				TargetFormat.defaultFormat(), true, new TargetDirectives.Colour(1.0F, 1.0F, 1.0F, 1.0F),
@@ -395,6 +424,18 @@ public final class PackDirectives {
 				case "shadowNearPlane" -> asFloat(directive, value -> this.shadowNearPlane = value);
 				case "shadowFarPlane" -> asFloat(directive, value -> this.shadowFarPlane = value);
 				case "shadowIntervalSize" -> asFloat(directive, value -> this.shadowIntervalSize = value);
+				// How the depth pair is read back. The family is folded in text order like everything
+				// else here: Iris registers one consumer per name and then walks the declarations of
+				// every fragment stage in order, so a per-image spelling wins over the blanket one
+				// only by standing after it ({@code shaderpack/programs/ProgramSet.java:255-268}).
+				//
+				// shadowtexNearest is the older spelling of shadowtex0Nearest and has no shadowtex1
+				// equivalent, which is Iris's shape as well: it hands the name to the first sampler
+				// of the list ({@code shaderpack/properties/PackShadowDirectives.java:185-187}).
+				case "shadowtexNearest", "shadowtex0Nearest", "shadow0MinMagNearest" ->
+						asBool(directive, value -> this.depthNearest[0] = value);
+				case "shadowtex1Nearest", "shadow1MinMagNearest" ->
+						asBool(directive, value -> this.depthNearest[1] = value);
 				default -> shadowColour(directive);
 			}
 		}
@@ -485,6 +526,22 @@ public final class PackDirectives {
 			}
 		}
 
+		/**
+		 * A {@code const bool} and nothing else. Anything but the two words is dropped without a
+		 * default, which is what Iris does with it as well: its boolean dispatch takes {@code true}
+		 * and {@code false} and leaves the setting where it stood otherwise.
+		 */
+		private static void asBool(ConstDirectives.Directive directive, BooleanSetter setter) {
+			if (!directive.type().equals("bool")) {
+				return;
+			}
+
+			String value = directive.value().trim();
+			if (value.equals("true") || value.equals("false")) {
+				setter.set(value.equals("true"));
+			}
+		}
+
 		/** One buffer's three answers while they are still being folded, any of them still unsaid. */
 		private static final class ShadowSetting {
 
@@ -504,6 +561,11 @@ public final class PackDirectives {
 		@FunctionalInterface
 		private interface FloatSetter {
 			void set(float value);
+		}
+
+		@FunctionalInterface
+		private interface BooleanSetter {
+			void set(boolean value);
 		}
 
 		@FunctionalInterface

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -373,7 +373,7 @@ final class ColorTargets {
 	 */
 	ColorTargets(TargetPlan plan, int noiseResolution, NoiseTexture.Image noiseImage,
 			PackImages packImages, ImageInformation.Reading storageImages, int shadowResolution,
-			List<PackDirectives.ShadowColour> shadowColours) {
+			List<PackDirectives.ShadowColour> shadowColours, List<Boolean> shadowDepthNearest) {
 		this.plan = plan;
 		this.packImages = packImages;
 		this.storageImages = new StorageImages(storageImages);
@@ -389,8 +389,8 @@ final class ColorTargets {
 		// count, on the rule the colour targets themselves follow: a pack naming shadowcolor2 gets
 		// the image, a pack writing nought alone pays for nought alone. The ceiling those names were
 		// read against comes from the same place, being the pack's own declaration and not ours.
-		this.shadowMap = new ShadowTargets(shadowResolution, shadowColours, plan.shadowAllocated(),
-				plan.shadowCeiling());
+		this.shadowMap = new ShadowTargets(shadowResolution, shadowColours, shadowDepthNearest,
+				plan.shadowAllocated(), plan.shadowCeiling());
 		this.doubled = Set.copyOf(plan.schedule().doubled());
 
 		// The format and the starting colour are read once and kept. Neither moves while a pack

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -2409,7 +2409,10 @@ final class GeometryProgram {
 		// and cloud shapes from it and counts on the interpolation. Iris binds it LINEAR_REPEAT,
 		// and reading it NEAREST shatters every one of those surfaces into facets. A shadow colour
 		// is continuous in the same way, carrying the light that came through glass and water
-		// across a penumbra, and both OptiFine and Iris filter it linearly.
+		// across a penumbra, and it stays LINEAR whatever the pack declares: OptiFine filters it
+		// linearly unless the pack writes shadowcolorNNearest, while Iris parses that name and
+		// binds the buffer through GlSampler.LINEAR regardless (IrisSamplers.java:156-176). Reading
+		// it as the pack asked would diverge from the engine packs are tuned against.
 		//
 		// The shadow DEPTH is LINEAR too, and the reason a reader reaches for to keep it NEAREST
 		// does not hold: where the compare mode is on, a sampler averages the RESULTS of the
@@ -2417,17 +2420,20 @@ final class GeometryProgram {
 		// nowhere. Iris filters this LINEAR unless the pack asks otherwise, its SamplingSettings
 		// starting at nearest=false and shadowtexNearest with its per-index spellings turning that
 		// round (shadows/ShadowRenderer.java:267-280), and adds GL_COMPARE_REF_TO_TEXTURE on top
-		// only where the pack writes shadowHardwareFiltering. Those three names are not read here
-		// and no pack of the corpus writes one, which is what PackPass says of the same bind two
-		// files away. The manual PCF loops packs write are the whole point either way,
-		// since every tap of such a loop rides on this filter. It has to match PackPass, which binds
-		// the same name for the full screen passes: the two halves of one frame reading one map
-		// through two filters is a difference nothing would ever explain.
+		// only where the pack writes shadowHardwareFiltering. Those names are read, and LINEAR is
+		// what a pack that writes none of them gets, which is not all of them: Pegasus declares
+		// the depth pair NEAREST. The manual PCF loops packs write are the
+		// whole point either way, since every tap of such a loop rides on this filter. The map
+		// itself is asked rather than this line deciding, which is what makes the answer PackPass's
+		// as well, it binding the same name for the full screen passes: the two halves of one frame
+		// reading one map through two filters is a difference nothing would ever explain.
 		// A custom image follows its format, and it is asked of one place for the same reason the
 		// shadow map is: a volume read one way here and another from a composite is a difference
 		// nothing would ever explain. PackPass.customImageFilter is that place.
 		return switch (binding.kind()) {
-			case NOISE, SHADOW_COLOUR, SHADOW_DEPTH -> FilterMode.LINEAR;
+			case NOISE, SHADOW_COLOUR -> FilterMode.LINEAR;
+			case SHADOW_DEPTH -> this.targets.shadow()
+					.depthFilter(this.loaded.samplers().withoutTranslucents(sampler));
 			case CUSTOM_IMAGE -> PackPass.customImageFilter(sampler);
 			default -> FilterMode.NEAREST;
 		};

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -399,7 +399,7 @@ public final class PackChain {
 		// runs while the client is still starting up, off the render thread.
 		this.targets = new ColorTargets(chain.targets(), values.noiseResolution(),
 				values.noiseImage(), values.packImages(), values.storageImages(),
-				values.shadowResolution(), values.shadowColours());
+				values.shadowResolution(), values.shadowColours(), values.shadowDepthNearest());
 		this.seed = chain.chain().seed()
 				.filter(where -> this.targets.has(where.target()))
 				.map(where -> new SceneSeed(where, this.targets.format(where.target()),

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -597,18 +597,24 @@ final class PackCompute implements AutoCloseable {
 	/**
 	 * The same sampler state the graphics passes bind for the name. The noise field repeats and
 	 * is filtered, Iris's choice: a pack indexes it in texels well past one, and clamped it reads
-	 * the same edge row for the whole volume. The shadow set is filtered the way Iris filters its
-	 * shadow samplers. A volume the pack declared follows its format, through the one place that
-	 * answers that for every road, so a compute reads it exactly as the composite after it will.
+	 * the same edge row for the whole volume. A shadow colour stays LINEAR, which is what the two
+	 * graphics roads bind for it whatever the pack declares; a shadow depth is filtered the way the
+	 * map itself says, and it is asked of the map for the reason a volume is asked of its format: a
+	 * compute reads an image exactly as the composite after it will.
+	 * <p>
+	 * The kind comes from the plan and not from the spelling of the name. {@code shadow} and
+	 * {@code watershadow} read a depth image without carrying the word, and which of the pair they
+	 * read is the program's answer rather than the name's.
 	 */
-	private static long samplerFor(String name) {
+	private static long samplerFor(ColorTargets targets, SamplerPlan samplers, String name) {
 		boolean noise = "noisetex".equals(name);
-		boolean shadow = name.startsWith("shadowtex") || name.startsWith("shadowcolor");
 		// Every other name keeps the answer this line gave before there was one place to ask:
 		// customImageFilter is NEAREST for a name no image directive declared.
-		FilterMode filter = noise || shadow
-				? FilterMode.LINEAR
-				: PackPass.customImageFilter(name);
+		FilterMode filter = noise ? FilterMode.LINEAR : switch (samplers.binding(name).kind()) {
+			case SHADOW_COLOUR -> FilterMode.LINEAR;
+			case SHADOW_DEPTH -> targets.shadow().depthFilter(samplers.withoutTranslucents(name));
+			default -> PackPass.customImageFilter(name);
+		};
 
 		return ((VulkanGpuSampler) PackPass.sampler(noise, filter, false)).vkSampler();
 	}
@@ -1044,8 +1050,8 @@ final class PackCompute implements AutoCloseable {
 					continue;
 				}
 
-				if (bound == null && step != null && colourTarget(write, imageInfo, entry.name(),
-						targets, step, this.program)) {
+				if (bound == null && step != null && colourTarget(write, imageInfo, entry.name(), targets,
+						this.compute.loaded().samplers(), step, this.program)) {
 					continue;
 				}
 
@@ -1064,7 +1070,7 @@ final class PackCompute implements AutoCloseable {
 						default -> null;
 					};
 					if (read instanceof VulkanGpuTextureView served) {
-						imageInfo.sampler(samplerFor(entry.name()));
+						imageInfo.sampler(samplerFor(targets, this.compute.loaded().samplers(), entry.name()));
 						imageInfo.imageView(served.vkImageView());
 						imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
 						write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
@@ -1076,7 +1082,7 @@ final class PackCompute implements AutoCloseable {
 					// set among them: shadowcomp reads them the way a composite does, and only a
 					// name neither the pack's images nor this set carries is a real miss.
 					if (engineView(targets, entry.name()) instanceof VulkanGpuTextureView served) {
-						imageInfo.sampler(samplerFor(entry.name()));
+						imageInfo.sampler(samplerFor(targets, this.compute.loaded().samplers(), entry.name()));
 						imageInfo.imageView(served.vkImageView());
 						imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
 						write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
@@ -1101,8 +1107,8 @@ final class PackCompute implements AutoCloseable {
 						// compute is dispatched on, so the second road is not held behind the first
 						// one's condition.
 						if (byDefault.kind() == SamplerPlan.Kind.COLORTEX && step != null
-								&& colourTarget(write, imageInfo, screen, targets, step,
-										this.program)) {
+								&& colourTarget(write, imageInfo, screen, targets,
+										this.compute.loaded().samplers(), step, this.program)) {
 							continue;
 						}
 
@@ -1123,7 +1129,7 @@ final class PackCompute implements AutoCloseable {
 						// out of the frame instead would be this engine answering one declaration
 						// two ways.
 						if (targets.black() instanceof VulkanGpuTextureView blank) {
-							imageInfo.sampler(samplerFor(entry.name()));
+							imageInfo.sampler(samplerFor(targets, this.compute.loaded().samplers(), entry.name()));
 							imageInfo.imageView(blank.vkImageView());
 							imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
 							write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
@@ -1136,7 +1142,8 @@ final class PackCompute implements AutoCloseable {
 				}
 
 				boolean storage = bound.storage();
-				imageInfo.sampler(storage ? 0L : samplerFor(entry.name()));
+				imageInfo.sampler(storage ? 0L
+						: samplerFor(targets, this.compute.loaded().samplers(), entry.name()));
 				imageInfo.imageView(bound.view());
 				imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
 				write.descriptorType(storage
@@ -1161,7 +1168,7 @@ final class PackCompute implements AutoCloseable {
 		 */
 		private static boolean colourTarget(VkWriteDescriptorSet write,
 				VkDescriptorImageInfo.Buffer imageInfo, String name, ColorTargets targets,
-				TargetSchedule.Bound step, String program) {
+				SamplerPlan samplers, TargetSchedule.Bound step, String program) {
 			Matcher image = COLOUR_IMAGE.matcher(name);
 			if (image.matches()) {
 				int index = Integer.parseInt(image.group(1));
@@ -1195,7 +1202,7 @@ final class PackCompute implements AutoCloseable {
 					return false;
 				}
 
-				imageInfo.sampler(samplerFor(name));
+				imageInfo.sampler(samplerFor(targets, samplers, name));
 				imageInfo.imageView(blank.vkImageView());
 				imageInfo.imageLayout(VK12.VK_IMAGE_LAYOUT_GENERAL);
 				write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -674,11 +674,15 @@ final class PackPass {
 			// The noise image is LINEAR for the same reason the terrain reads it LINEAR: it is a
 			// continuous field the pack interpolates surfaces out of, and Iris binds it that way.
 			//
-			// A shadow COLOUR is LINEAR as well, and that is both authorities rather than a taste:
-			// OptiFine filters shadowcolor linearly unless the pack writes shadowcolorNNearest, and
-			// Iris binds it LINEAR outright (IrisSamplers.addShadowSamplers). It carries the light
-			// that came through stained glass and water, which a pack blurs across a penumbra; read
-			// NEAREST it steps in blocks the size of a shadow texel.
+			// A shadow COLOUR is LINEAR as well, whatever the pack declares, and that is the
+			// reference rather than a taste: OptiFine filters shadowcolor linearly unless the pack
+			// writes shadowcolorNNearest, while Iris parses that name and then binds the buffer
+			// through GlSampler.LINEAR regardless (IrisSamplers.java:156-176), a sampler object
+			// overruling the texture's own parameters. Honouring it here would diverge from the
+			// engine packs are tuned against, on the buffer that carries the light which came
+			// through stained glass and water: a pack blurs that across a penumbra, and read
+			// NEAREST it steps in blocks the size of a shadow texel. Pegasus declares
+			// shadowcolor0Nearest and sees it ignored under Iris.
 			//
 			// The shadow DEPTH is LINEAR for a reason of its own, and the reason a reader reaches
 			// for to keep it NEAREST does not hold. An averaged depth would indeed be a comparison
@@ -693,14 +697,21 @@ final class PackPass {
 			// NEAREST every edge of such a loop walks in texels of the map however many taps it
 			// pays for.
 			//
-			// The three names that would ask for NEAREST back - shadowtexNearest, shadowtexNNearest
-			// and shadowNMinMagNearest - are not read: no pack of the corpus writes one.
+			// The names that ask for NEAREST back on the DEPTH pair are read: shadowtexNearest,
+			// shadowtexNNearest and shadowNMinMagNearest. The depth paragraph above is what a pack
+			// that writes none of them gets, and that is not the whole corpus: Pegasus declares
+			// shadowtex0Nearest and shadowtex1Nearest true and reads its map through a manual PCF
+			// loop, so what it was shown was a map smoothed against its own declaration. The map
+			// itself is asked rather than this line deciding, which is what keeps the three roads
+			// that bind it - here, a geometry program and a compute - reading it one way.
 			//
 			// A custom image is the image's own answer and not this pass's, which is why it is
 			// asked of one place rather than decided here: see customImageFilter.
 			FilterMode filter = supplied != null ? source.filter() : switch (binding.kind()) {
 				case COLORTEX -> targets.filter(binding.index());
-				case NOISE, SHADOW_COLOUR, SHADOW_DEPTH -> FilterMode.LINEAR;
+				case NOISE, SHADOW_COLOUR -> FilterMode.LINEAR;
+				case SHADOW_DEPTH -> targets.shadow()
+						.depthFilter(this.loaded.samplers().withoutTranslucents(binding.sampler()));
 				case CUSTOM_IMAGE -> customImageFilter(sampler);
 				default -> FilterMode.NEAREST;
 			};

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -529,6 +529,16 @@ public final class PackValues {
 	}
 
 	/**
+	 * Whether the pack asked for NEAREST on {@code shadowtex0} and on {@code shadowtex1}, in that
+	 * order. Beside {@link #shadowColours()} rather than inside it: the depth pair takes no format
+	 * and no clear colour, and the one thing a pack says about it is how it is read back.
+	 */
+	public List<Boolean> shadowDepthNearest() {
+		return List.of(this.state.directives().shadowDepthNearest(0),
+				this.state.directives().shadowDepthNearest(1));
+	}
+
+	/**
 	 * How far the pack tilts the path the sun and the moon travel, in degrees, nought unless the
 	 * pack says otherwise. BSL asks for minus forty.
 	 * <p>

--- a/common/src/main/java/dev/vitrail/render/ShadowCompare.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowCompare.java
@@ -40,6 +40,11 @@ import java.util.WeakHashMap;
  * ({@code ShadowRenderTargets.getSamplerFor}, under {@code shadowHardwareFiltering}), {@code
  * GL_LINEAR} plus {@code GL_COMPARE_REF_TO_TEXTURE}; every pack of the corpus that declares the
  * type writes that directive, and without it Iris leaves what such a declaration reads undefined.
+ * <strong>LINEAR here is unconditional where Iris's is not</strong>: a pack that writes one of the
+ * nearest directives beside the hardware one gets NEAREST_HW from Iris. No pack of the corpus
+ * writes both live, so nothing measures it today. This sampler is one object kept for the device's
+ * life, so serving it would need a second one, and such a pack reads the map NEAREST on the
+ * ordinary bind and blended over four texels here.
  * The sense is LEQUAL: OptiFine sets that on a shadow texture, so it is what every pack is written
  * against, and the map stores the forward window where nearer is smaller. Filtered, the hardware
  * compares each of the four texels and blends the RESULTS with the bilinear weights, which is

--- a/common/src/main/java/dev/vitrail/render/ShadowTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowTargets.java
@@ -10,6 +10,7 @@ import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderPassDescriptor;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuTexture;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import org.joml.Vector4f;
@@ -94,6 +95,14 @@ final class ShadowTargets {
 	private final List<PackDirectives.ShadowColour> asked;
 	private final List<GpuFormat> formats;
 	private final List<Vector4fc> clearColours;
+
+	/**
+	 * Whether the pack asked for NEAREST on each depth image, {@code shadowtex0} at nought and
+	 * {@code shadowtex1} at one. Kept here so that the three roads that bind the map ask one place:
+	 * a full screen pass, a geometry program and a compute reading one image through two filters is
+	 * a difference nothing would ever explain.
+	 */
+	private final List<Boolean> depthNearest;
 
 	/**
 	 * How many of them this pack may reach, its own declaration deciding. Clamped to what the arrays
@@ -198,9 +207,11 @@ final class ShadowTargets {
 	 *                program declaring nothing is {@code {0, 1}} in there, which is the one way the
 	 *                pair reaches this class
 	 * @param ceiling how many the pack may reach, from {@code TargetPlan.shadowCeiling}
+	 * @param depthNearest whether the pack asked for NEAREST on {@code shadowtex0} and on
+	 *                {@code shadowtex1}, in that order
 	 */
-	ShadowTargets(int resolution, List<PackDirectives.ShadowColour> asked, Set<Integer> named,
-			int ceiling) {
+	ShadowTargets(int resolution, List<PackDirectives.ShadowColour> asked,
+			List<Boolean> depthNearest, Set<Integer> named, int ceiling) {
 		// Clamped rather than refused: a directive that survived a setting nobody expanded can be
 		// any number at all, and a shadow map is not worth taking the pack down for.
 		this.resolution = Math.clamp(resolution, 1, MAX_RESOLUTION);
@@ -224,11 +235,31 @@ final class ShadowTargets {
 					one.format().alphaAdded() && !one.declaresClearColour() ? 1.0F : colour.a());
 		}).toList();
 
+		this.depthNearest = List.copyOf(depthNearest);
 		this.ceiling = Math.clamp(ceiling, 1, MAX_COLOURS);
 		SortedSet<Integer> live = new TreeSet<>(Set.of(0));
 		named.stream().filter(index -> index > 0 && index < this.ceiling).forEach(live::add);
 		this.live = List.copyOf(live);
 	}
+
+	/**
+	 * How one depth image of the map is filtered, LINEAR unless the pack asked otherwise.
+	 * <p>
+	 * LINEAR is where both engines start ({@code shadows/ShadowRenderer.java:267-280}), and what it
+	 * decides is the read every pack of the corpus makes: a PCF loop sampling {@code shadowtex} as a
+	 * plain {@code sampler2D}, every tap of which rides on this filter. A pack that writes
+	 * {@code shadowtexNearest} or one of its per-index spellings is asking for those taps to land in
+	 * texels of the map, and is tuned against an engine that gives it that.
+	 *
+	 * @param withoutTranslucents whether the name reads {@code shadowtex1}, the image drawn without
+	 *                            the translucents, which is the second of the pair
+	 */
+	FilterMode depthFilter(boolean withoutTranslucents) {
+		return this.depthNearest.get(withoutTranslucents ? 1 : 0)
+				? FilterMode.NEAREST
+				: FilterMode.LINEAR;
+	}
+
 
 	/**
 	 * Makes the map exist and empties it once. Must run on the render thread and outside any render


### PR DESCRIPTION
## What changes

A shader pack can declare that its shadow map is to be sampled without smoothing, through
`shadowtexNearest`, `shadowtexNNearest` or `shadowNMinMagNearest`. Those names reached the pack's
option list and nothing else: both depth images were bound LINEAR whatever the pack said, so a
pack written for a hard, stepped shadow was shown a smoothed one. They are read now, and the
answer is asked of the shadow map itself on the three roads that bind it, the full screen passes,
the world's own programs and the compute passes, so one map is read one way across a frame.

The compute road also asked the sampler's NAME for its kind, which missed `shadow` and
`watershadow`: both read a depth image without carrying the `shadowtex` prefix, and both were
handed the filter meant for a custom image. It asks the program's own plan now, like the other
two.

## How it differs from the reference, and for what obstacle

The colour half of the same family is a deliberate divergence, and it is a divergence from
OptiFine rather than from Iris. Iris parses `shadowcolorNNearest` and then binds every shadowcolor
through a hardcoded LINEAR sampler object, `samplers/IrisSamplers.java:156-176`, which overrules
the texture's own parameters; OptiFine honours it. Following OptiFine would leave the buffer that
carries the light coming through stained glass and water stepping in blocks the size of a shadow
texel, on packs tuned against Iris. The names are therefore not read at all rather than read and
dropped.

## What proves it

- `gradlew build` green, `--no-build-cache`, after the rebase.
- The off-game harness over the 26 pack corpus: a new tool asks the engine's own reader what each
  pack declares. One pack asks for NEAREST, on both images, and the twenty five others do not. That
  question cannot be answered by searching the pack sources, which is how it was got wrong first:
  packs comment whole blocks of directives out, and a search that does not track `/* */` reads a
  dead line as a declaration.
- In the game, on the flat measurement world, the same jar apart from this change: two sweeps of
  four packs moved 0.04 to 0.05 percent of pixels against a control floor of 0.01 to 0.02, and the
  difference image traces edges rather than surfaces. That is what the change can do on a pack
  whose shadow test multiplies the depth difference by 256 and clamps: only the pixels within a
  texel of an edge can move. An image comparison is therefore not the instrument for this family,
  and the reader above is.

## What it leaves owing

Two names of the same family stay unread. The mip chain under the map, `generateShadowMipmap` and
its per-image spellings, needs the depth image to leave the `TextureTarget` it shares with
`shadowcolor0`, that class being unable to express a chain while the sharing is what keeps the two
attachments of one render pass on one size. And NEAREST_HW, which Iris gives a pack that writes a
nearest directive beside `shadowHardwareFiltering`, needs a second comparison sampler: ours is one
object kept for the device's life with an unconditional LINEAR. No pack at hand asks for both.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one: the four comments
      that said no pack of the corpus writes these names, the `NOTICE` entry for the directive
      names taken from the reference, and the changelog.
