### PR TITLE
fix(target): allocate a colour target a program stores into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,24 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack that paints its picture with compute shaders draws it.** A few packs do their whole
+  post-processing in compute programs rather than in full screen passes, and store the finished
+  frame into a colour buffer of their own. The engine only ever opened a colour buffer for what a
+  drawing program painted into or read from, so the buffer such a pack hands the screen was never
+  opened at all: the program holding the picture was dropped on every frame and what stayed on
+  screen was the flat colour the game had cleared it to. RenderPearl was a blue screen from end to
+  end for this. Those buffers are opened now, on the strength of the program that writes them,
+  which is what the engine packs are tuned against does.
+
+  Two more things stood between that pack and its picture. It ships two of its lookup tables as
+  plain blocks of numbers rather than pictures, and the engine read a block of numbers only where
+  it was a three dimensional table, so the program reading them found nothing under the name and
+  was dropped; those are read now. And where the engine has to compare shadow depths in arithmetic
+  rather than on the sampler, it only knew the two plainest ways a shader asks for the comparison,
+  so a pack asking any other way did not compile at all: it now knows the forms that carry an
+  offset as well, the offset being how a pack samples the neighbourhood of a texel for a soft
+  edge, and it is carried through rather than dropped.
+
 - **A pack asking for a hard shadow edge gets one.** A shader pack can say that its shadow map is
   to be read without smoothing, and the engine listed those lines among the pack's settings and
   then bound the map smoothed anyway, so a pack written for a hard, stepped shadow came out soft.

--- a/NOTICE
+++ b/NOTICE
@@ -161,7 +161,12 @@ GNU Lesser General Public License version 3
   common/src/main/java/dev/vitrail/pack/target/TargetPlan.java folds a dimension's directives in the
   order of net.irisshaders.iris.shaderpack.programs.ProgramSet.locateDirectives, setup programs
   left out of it as they are there. The order the frame runs in, which the same file also carries,
-  is not that one and is not from Iris.
+  is not that one and is not from Iris. It also opens a colour target on the strength of a program
+  declaring the image name alone, which is what net.irisshaders.iris.samplers.IrisImages does at
+  line 25, calling net.irisshaders.iris.targets.RenderTargets.createIfUnsure, line 398. Which
+  families that set is bound to is read the same way, the terrain and the shadow programs among
+  them, net.irisshaders.iris.pipeline.IrisRenderingPipeline lines 391 and 572, with the shadow
+  composites left out of it, net.irisshaders.iris.shadows.ShadowCompositeRenderer line 306.
 
   common/src/main/java/dev/vitrail/pack/target/PackDirectives.java gathers the settings a pack declares
   about itself with the names, the defaults and the precedence of

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -193,15 +193,50 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 		//
 		// The level of detail is dropped, which is what a comparison sampler with no mipmaps would
 		// have done with it anyway: nothing ever fills a chain on the shadow map.
+		//
+		// An OFFSET is not dropped, and that is the difference between the two. A pack taps the
+		// neighbourhood of a texel through offsets, so an offset left out would take the same tap
+		// over and over and hand back a shadow with no filtering in it, which on screen looks
+		// exactly like one that has it. RenderPearl is the pack that asks: its shadow compute reads
+		// the map as textureLodOffset, a name the arithmetic road used to leave standing over a
+		// declaration it had already rewritten to an ordinary sampler, so the unit did not compile
+		// and the compute never ran.
+		//
+		// It is carried in the COORDINATE and not in a textureGatherOffset, which would be the
+		// natural spelling and asks for a feature nothing here requests: an offset that is a
+		// function parameter is not a constant expression, so that call lowers to an Offset operand
+		// and needs the ImageGatherExtended capability, which this device does not even enable.
+		// The weights are taken off the SHIFTED coordinate, so the arithmetic below is the same
+		// arithmetic at every offset, and at an offset of nought it is the plain gather this
+		// printed before down to the last operation.
+		//
+		// What it does not close is the disagreement this helper was born with: the texture unit
+		// picks its four texels off a coordinate it has quantised to its own subtexel bits, and the
+		// fract beside it is computed at full precision, so a coordinate sitting exactly on a texel
+		// boundary can be rounded the two ways. That is true of the offsetless form as it stands on
+		// dev and the offset neither widens it nor repairs it.
 		if (this.softRewrites > 0) {
-			lines.add("float " + GlslTranslator.SHADOW_COMPARE + "(sampler2D ofMap, vec3 ofAt) {"
-					+ " vec4 ofTests = step(vec4(ofAt.z), textureGather(ofMap, ofAt.xy, 0));"
-					+ " vec2 ofPart = fract(ofAt.xy * vec2(textureSize(ofMap, 0)) - 0.5);"
+			lines.add("float " + GlslTranslator.SHADOW_COMPARE
+					+ "(sampler2D ofMap, vec3 ofAt, ivec2 ofOffset) {"
+					+ " vec2 ofSize = vec2(textureSize(ofMap, 0));"
+					+ " vec2 ofUv = ofAt.xy + vec2(ofOffset) / ofSize;"
+					+ " vec4 ofTests = step(vec4(ofAt.z), textureGather(ofMap, ofUv, 0));"
+					+ " vec2 ofPart = fract(ofUv * ofSize - 0.5);"
 					+ " return mix(mix(ofTests.w, ofTests.z, ofPart.x),"
 					+ " mix(ofTests.x, ofTests.y, ofPart.x), ofPart.y); }");
+			lines.add("float " + GlslTranslator.SHADOW_COMPARE + "(sampler2D ofMap, vec3 ofAt) {"
+					+ " return " + GlslTranslator.SHADOW_COMPARE + "(ofMap, ofAt, ivec2(0)); }");
 			lines.add("float " + GlslTranslator.SHADOW_COMPARE
 					+ "(sampler2D ofMap, vec3 ofAt, float ofLod) {"
-					+ " return " + GlslTranslator.SHADOW_COMPARE + "(ofMap, ofAt); }");
+					+ " return " + GlslTranslator.SHADOW_COMPARE + "(ofMap, ofAt, ivec2(0)); }");
+			lines.add("float " + GlslTranslator.SHADOW_COMPARE
+					+ "(sampler2D ofMap, vec3 ofAt, float ofLod, ivec2 ofOffset) {"
+					+ " return " + GlslTranslator.SHADOW_COMPARE + "(ofMap, ofAt, ofOffset); }");
+			// The bias form of the offset lookup, which a fragment stage may write and which takes
+			// its two trailing arguments the other way round.
+			lines.add("float " + GlslTranslator.SHADOW_COMPARE
+					+ "(sampler2D ofMap, vec3 ofAt, ivec2 ofOffset, float ofBias) {"
+					+ " return " + GlslTranslator.SHADOW_COMPARE + "(ofMap, ofAt, ofOffset); }");
 		}
 
 		// One overload per shape the builtins take, and no driver sine anywhere in it. The turn

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -183,6 +183,17 @@ public final class GlslTranslator {
 	static final String SHADOW_COMPARE = "ofShadowCompare";
 
 	/**
+	 * The lookups the arithmetic road takes over, {@link #SHADOW_COMPARE} carrying an overload for
+	 * every shape each of them can be written in, the bias forms included.
+	 * <p>
+	 * A projective or a gathered comparison is not among them and is counted instead: what those
+	 * need is a different expression and not a different name, a projective one dividing before it
+	 * compares and a gather answering four results rather than one.
+	 */
+	private static final Set<String> COMPARABLE_LOOKUPS = Set.of("texture", "textureLod",
+			"textureOffset", "textureLodOffset");
+
+	/**
 	 * Whether every comparison goes back to the arithmetic of {@link #SHADOW_COMPARE} instead of
 	 * staying on the sampler. The hardware road cannot be watched from inside: a comparison bound
 	 * wrong does not fail, it hands back a fraction of the wrong thing, and the picture stays
@@ -2816,15 +2827,18 @@ public final class GlslTranslator {
 		}
 
 		String name = this.tokens.get(index).text();
-		if (!name.equals("texture") && !name.equals("textureLod")) {
+		if (!COMPARABLE_LOOKUPS.contains(name)) {
 			this.unwrappedShadowCalls++;
 
 			return true;
 		}
 
 		// The name alone: the arguments of texture(sampler, vec3) are the arguments the comparison
-		// takes, so nothing has to be found or balanced. textureLod carries a level this ignores,
-		// which is what a comparison sampler with no mipmaps would have done anyway.
+		// takes, so nothing has to be found or balanced, and the same holds of the other three
+		// shapes because the helper is written with an overload for each. A level is ignored, which
+		// is what a comparison sampler with no mipmaps would have done with it anyway; an OFFSET
+		// is not, and dropping one would turn a pack's neighbourhood of taps into the same tap
+		// taken over and over, which is a shadow with no filtering and looks like one that has it.
 		this.tokens.replace(index, SHADOW_COMPARE);
 		this.softRewrites++;
 

--- a/common/src/main/java/dev/vitrail/pack/model/TargetName.java
+++ b/common/src/main/java/dev/vitrail/pack/model/TargetName.java
@@ -26,6 +26,9 @@ public final class TargetName {
 
 	private static final String PREFIX = "colortex";
 
+	/** What the same target is called where a compute writes it rather than samples it. */
+	private static final String IMAGE_PREFIX = "colorimg";
+
 	/** By position: index 0 is {@code gcolor}, index 7 is {@code gaux4}, and nothing past that. */
 	private static final List<String> LEGACY = List.of(
 			"gcolor", "gdepth", "gnormal", "composite", "gaux1", "gaux2", "gaux3", "gaux4");
@@ -45,6 +48,30 @@ public final class TargetName {
 		}
 
 		String digits = name.substring(PREFIX.length());
+		if (digits.isEmpty() || digits.length() > 2 || !digits.chars().allMatch(Character::isDigit)) {
+			return OptionalInt.empty();
+		}
+
+		int index = Integer.parseInt(digits);
+
+		return index < MAX_TARGETS ? OptionalInt.of(index) : OptionalInt.empty();
+	}
+
+	/**
+	 * The same target under the name a compute STORES into, {@code colorimg7} answering with 7.
+	 * <p>
+	 * No alias answers here and that is the reference's own shape: Iris builds the set of image
+	 * names itself, one per target and none of the eight names from before the format was numbered
+	 * ({@code samplers/IrisImages.java:21}), so a pack writing {@code gaux4img} has written a name
+	 * nothing binds there either. The two digits and the ceiling are {@link #index}'s, so that one
+	 * spelling of a target's number cannot be read where the other is refused.
+	 */
+	public static OptionalInt imageIndex(String name) {
+		if (!name.startsWith(IMAGE_PREFIX)) {
+			return OptionalInt.empty();
+		}
+
+		String digits = name.substring(IMAGE_PREFIX.length());
 		if (digits.isEmpty() || digits.length() > 2 || !digits.chars().allMatch(Character::isDigit)) {
 			return OptionalInt.empty();
 		}

--- a/common/src/main/java/dev/vitrail/pack/program/ProgramSet.java
+++ b/common/src/main/java/dev/vitrail/pack/program/ProgramSet.java
@@ -125,6 +125,14 @@ public final class ProgramSet {
 				.toList();
 	}
 
+	/** Every compute entry point of one dimension, the stage no fragment walk reaches. */
+	public List<ProgramKey> computesOf(String place) {
+		return this.keys.stream()
+				.filter(key -> key.stage() == ProgramStage.COMPUTE)
+				.filter(key -> key.dimension().equals(place))
+				.toList();
+	}
+
 	/** The same keys, ordered by family under the caller's rank, then by slot, then by file. */
 	public static List<ProgramKey> sorted(List<ProgramKey> entries, ToIntFunction<String> rank) {
 		return entries.stream()

--- a/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/TargetPlan.java
@@ -85,6 +85,42 @@ public final class TargetPlan {
 			"^\\s*(?:layout\\s*\\([^)]*\\)\\s*)?uniform\\s+(?:layout\\s*\\([^)]*\\)\\s*)?"
 					+ "(?:(?:lowp|mediump|highp)\\s+)?([iu]?sampler\\w*)\\s+([^;]*);.*$");
 
+	/**
+	 * A layout or a memory qualifier, which an image declaration takes any number of.
+	 * <p>
+	 * {@code readonly} is deliberately not among them, and its absence is what keeps a name this
+	 * reads out of the targets a place is said to WRITE: an image the shader may only load from is
+	 * read, not stored into. A target that only such a declaration names is then allocated by
+	 * nothing, which is what happens today and what no pack of the corpus asks for: the four
+	 * readonly images the packs carry are Bliss's voxel volumes and none of them is a
+	 * {@code colorimgN}. The day one is, it wants the road a sampler takes and not this one.
+	 * <p>
+	 * A layout takes no space after it, the way the sampler pattern beside this allows: nothing of
+	 * the corpus writes {@code layout(rgba8)uniform}, and refusing it would be a rule about
+	 * whitespace rather than about GLSL.
+	 */
+	private static final String IMAGE_QUALIFIER =
+			"(?:layout\\s*\\([^)]*\\)\\s*|(?:coherent|volatile|restrict|writeonly)\\s+)";
+
+	/**
+	 * The same declaration for an IMAGE, which is how a program STORES into a colour target rather
+	 * than drawing into it. No draw buffer declares that and no directive of the pack names it, so
+	 * the declaration is the whole of what there is to read. It is the only thing a compute can
+	 * write a target through, and it is not a compute's alone: iterationT stores into
+	 * {@code colorimg0} from the fragment stage of its line program.
+	 * <p>
+	 * Where a sampler carries a precision qualifier an image carries memory qualifiers, any number
+	 * of them and in any order, and a pack writes them on EITHER side of the {@code uniform}, so
+	 * both sides are allowed for: RenderPearl writes
+	 * {@code uniform layout(rgba8) restrict writeonly image2D colorimg0} and Photon writes
+	 * {@code layout(rgba16f) writeonly uniform image2D colorimg4}. Measured rather than reasoned
+	 * about: of the ninety five image declarations the corpus carries this takes eighty nine, and
+	 * every one it leaves is meant to be left, two commented out and four of them read only.
+	 */
+	private static final Pattern IMAGE = Pattern.compile(
+			"^\\s*(?:" + IMAGE_QUALIFIER + ")*uniform\\s+(?:" + IMAGE_QUALIFIER
+					+ "|(?:lowp|mediump|highp)\\s+)*([iu]?image\\w*)\\s+([^;]*);.*$");
+
 	private static final String FINAL = "final";
 
 	/** What {@link #disabled()} says when the pack keeps a pass and {@code passes=} does not. */
@@ -245,6 +281,10 @@ public final class TargetPlan {
 		// program a compute hangs off, and it cannot know which those are before this has said so.
 		// Nothing here reads what the walk writes, so the two only ever ran in this order by habit.
 		computes(properties, options, defines, programs, draft);
+		// After the computes, whose kept list it reads so that a file this place never opens
+		// allocates nothing, and before the defaults, which stop asking their question the moment
+		// the first colour target is written.
+		stored(source, settings, programs, draft);
 		// After the computes, whose two lists it reads to leave out the files this place never
 		// opens. Nothing in the computes reads what this writes.
 		defaults(source, options, settings, properties, defines, programs, textures, images, draft);
@@ -379,6 +419,53 @@ public final class TargetPlan {
 	/** The ones of those the default sampler can stand on, which is where the target is decided. */
 	private static Set<String> picturesTo(PackTextures textures, String program) {
 		return TextureStage.of(program).map(textures::picturesTo).orElse(Set.of());
+	}
+
+	/**
+	 * Records the colour targets the COMPUTES of this place store into, the fragment stages having
+	 * answered for themselves inside {@link #read}.
+	 * <p>
+	 * A compute declares no draw buffer and no directive of the pack names what it writes, so the
+	 * image declaration is the whole of the evidence, and a target nothing else touches is
+	 * allocated on it alone. That is what the reference does, and where: Iris creates the render
+	 * target the moment a program declares the name
+	 * ({@code samplers/IrisImages.java:25} calling {@code targets/RenderTargets.java:398}).
+	 * <p>
+	 * Only the computes {@link #computes} kept, so a file the pack switched off or one past a gap
+	 * in its letters allocates nothing, both being files the reference never opens either. Their
+	 * samplers and their directives are deliberately NOT read: Iris folds neither, locating its
+	 * directives over the fragment stages and handing a compute the samplers of the pass it hangs
+	 * off, so a colortex a compute alone samples is not paid for there and is not paid for here.
+	 */
+	private static void stored(ShaderPackSource source, SettingSet settings, ProgramSet programs,
+			Draft draft) {
+		Set<String> kept = Set.copyOf(draft.computes);
+		IncludeExpander expander = new IncludeExpander(source, settings);
+		for (ProgramSet.ProgramKey key : programs.computesOf(draft.place)) {
+			// Shadow composites are held out for the reason the fragment walk holds them out, and
+			// the reference holds them out too: their image set is the shadow colours and the
+			// pack's own images, with no colorimg among them
+			// ({@code shadows/ShadowCompositeRenderer.java:306}).
+			if (ProgramNames.shadowComposite(key.name().family())
+					|| !kept.contains(stemOf(key.file(), draft.place))) {
+				continue;
+			}
+
+			Optional<Path> file = source.file(key.file());
+			if (file.isEmpty()) {
+				continue;
+			}
+
+			try {
+				// Recorded as written and nothing else. The schedule is built off the declared draw
+				// buffers, and a compute stores into the very half it samples rather than turning
+				// the target over, which TargetSchedule.passing carries: a name read here reaching
+				// the schedule would flip a target nothing flips.
+				draft.written.addAll(colourImages(expander.expand(file.get())));
+			} catch (IOException | RuntimeException e) {
+				draft.unreadable.add(key.file());
+			}
+		}
 	}
 
 	/**
@@ -758,6 +845,21 @@ public final class TargetPlan {
 				draft.written.addAll(writes);
 			}
 
+			// And what this program STORES into, which no draw buffer declares. Read for the
+			// geometry drawn from the light as well, and for the same reason the sampler scan below
+			// is: colorimgN names a colour target whichever end of the world the program is drawn
+			// from, where a draw buffer index does not. Iris binds this set from every place it
+			// builds a program, the terrain at IrisRenderingPipeline.java:391 and the gbuffers and
+			// the light's own geometry at :746, and the one place it does not is the shadow
+			// COMPOSITES, which this walk has already skipped above.
+			//
+			// What this ALLOCATES for, nothing here yet BINDS for: the image behind colorimgN is
+			// pushed for a compute and for nothing else, so iterationT's line program stores into
+			// an image no descriptor carries. That is a gap of its own, older than this, and the
+			// allocation is right whether or not it is closed: the reference opens the target on
+			// the declaration alone.
+			draft.written.addAll(colourImages(unit));
+
 			// A full screen program reads colortex0 under every name nothing else answers for, which
 			// is what SamplerPlan gives it and why Iris hands its default sampler the first colour
 			// target (samplers/IrisSamplers.java:93-95). Iris pays for that target when the binding
@@ -821,8 +923,35 @@ public final class TargetPlan {
 	private record Declaration(String name, String type) {
 	}
 
+	/** Every name declared as a sampler on a live line, whatever the sampler is for. */
+	private static List<Declaration> samplers(ExpandedUnit unit) {
+		return declared(unit, SAMPLER);
+	}
+
 	/**
-	 * Every name declared as a sampler on a live line, whatever the sampler is for.
+	 * The colour targets this unit writes as images, read off the same live lines under the same
+	 * rules. A compute is where most of them are, and not the only place: iterationT stores into
+	 * {@code colorimg0} and {@code colorimg5} from the fragment stage of its line program.
+	 * <p>
+	 * A target named here is allocated on that account alone, which is what the reference does:
+	 * Iris creates the render target behind an image name the moment a program declares it
+	 * ({@code samplers/IrisImages.java:25} calling {@code targets/RenderTargets.java:398}).
+	 * Without it a pack whose whole chain is computes has nowhere to put its picture: RenderPearl
+	 * ships no full screen pass at all, stores its scene into {@code colorimg0}, and that target
+	 * was neither drawn into by a fragment nor sampled by one, so nothing allocated it and the
+	 * compute holding the picture was dropped on every frame.
+	 */
+	private static Set<Integer> colourImages(ExpandedUnit unit) {
+		Set<Integer> indices = new TreeSet<>();
+		for (Declaration declaration : declared(unit, IMAGE)) {
+			TargetName.imageIndex(declaration.name()).ifPresent(indices::add);
+		}
+
+		return indices;
+	}
+
+	/**
+	 * Every name that pattern declares on a live line of the unit.
 	 * <p>
 	 * Live means both things a line can be crossed out by. The preprocessor is one, and the pack's
 	 * own comments are the other: Sildur's puts a whole block of declarations behind a {@code /*} in
@@ -833,7 +962,7 @@ public final class TargetPlan {
 	 * pattern wanting the declaration at the head of the line, so what has to be tracked is only
 	 * whether a block comment was already open when the line began.
 	 */
-	private static List<Declaration> samplers(ExpandedUnit unit) {
+	private static List<Declaration> declared(ExpandedUnit unit, Pattern pattern) {
 		List<Declaration> names = new ArrayList<>();
 		List<String> lines = unit.lines();
 		boolean commented = false;
@@ -845,7 +974,7 @@ public final class TargetPlan {
 				continue;
 			}
 
-			Matcher matcher = SAMPLER.matcher(lines.get(line));
+			Matcher matcher = pattern.matcher(lines.get(line));
 			if (!matcher.matches()) {
 				continue;
 			}

--- a/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/PackTextures.java
@@ -308,6 +308,16 @@ public final class PackTextures {
 			notes.add(path + " is a volume of " + raw.orElseThrow().pixelFormat() + " "
 					+ raw.orElseThrow().pixelType() + ", which is not laid out flat here, so " + sampler
 					+ " stays a sampler3D and no program declaring it can be built");
+		} else if (raw.filter(RawImage::serves).isPresent()) {
+			// The plain case, measured the same way and for the same reason. The declaration IS the
+			// size here, so there is nothing to work out: what is asked is only whether a device
+			// would take it.
+			RawImage image = RawImage.of(raw.orElseThrow());
+			if (!image.fits()) {
+				refused.add(new Refused(key, value, path + " is declared " + image.width() + "x"
+						+ image.height() + ", which is past what a texture can be", stage, sampler));
+				return;
+			}
 		}
 
 		supplied.add(texture);

--- a/common/src/main/java/dev/vitrail/pack/texture/RawImage.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/RawImage.java
@@ -1,0 +1,124 @@
+package dev.vitrail.pack.texture;
+
+import dev.vitrail.pack.model.PackTexture;
+import dev.vitrail.pack.model.PixelType;
+
+/**
+ * A blob the pack ships as a plain two dimensional texture, laid out as it will be uploaded.
+ * <p>
+ * This is the ordinary case and the atlas beside it is the exotic one: a pack writes
+ * {@code customTexture.areatex=tex/smaa_area.bin TEXTURE_2D RG8 160 560 RG UNSIGNED_BYTE} and
+ * means a texture of exactly that size, read at exactly those coordinates. Nothing is tiled and
+ * there is no gutter, because there is no neighbouring slice to bleed into: what a read past the
+ * edge answers is the sampler's own wrap, which is what a real two dimensional texture does.
+ * <p>
+ * All that is left is the widening {@link RawTexels} describes, four channels of the blob's own
+ * type. RenderPearl's two SMAA tables are the measured case: an {@code RG8} area table and an
+ * {@code R8} search table, both read as {@code .rg} and {@code .r}, and until they were served the
+ * compute that samples them found no image under the name and was dropped whole.
+ * <p>
+ * A shape that is not two dimensional stays out. A {@code TEXTURE_1D} would be a
+ * {@code sampler1D} and a {@code TEXTURE_RECTANGLE} a {@code sampler2DRect} indexed in texels
+ * rather than in zero to one, and neither is a thing this backend binds or this engine rewrites;
+ * no pack of the corpus declares either.
+ */
+public final class RawImage {
+
+	private final int width;
+	private final int height;
+	private final PixelType type;
+	private final int components;
+
+	private RawImage(int width, int height, PixelType type, int components) {
+		this.width = width;
+		this.height = height;
+		this.type = type;
+		this.components = components;
+	}
+
+	/**
+	 * The layout for that blob.
+	 *
+	 * @throws IllegalArgumentException if the blob is not one {@link #serves} says yes to, which the
+	 *                                  caller has to have asked first
+	 */
+	public static RawImage of(PackTexture.Raw raw) {
+		if (!serves(raw)) {
+			throw new IllegalArgumentException("A texture of " + raw.sizeX() + "x" + raw.sizeY()
+					+ " in " + raw.pixelFormat() + " " + raw.pixelType()
+					+ " is not one this uploads flat");
+		}
+
+		return new RawImage(raw.sizeX(), raw.sizeY(), raw.pixelType(),
+				raw.pixelFormat().components());
+	}
+
+	/** Whether a blob of that description is one this uploads: two dimensional, of a channel type it carries. */
+	public static boolean serves(PackTexture.Raw raw) {
+		return raw.shape() == PackTexture.Shape.TEXTURE_2D
+				&& raw.sizeX() > 0 && raw.sizeY() > 0
+				&& RawTexels.holds(raw.pixelType(), raw.pixelFormat());
+	}
+
+	/** Whether this is one a device could hold and this engine is willing to spend. */
+	public boolean fits() {
+		return RawTexels.fits(this.width, this.height, texelBytes());
+	}
+
+	/**
+	 * The texels, four channels of the blob's own type each, filled from the blob in the order the
+	 * file was written in, which is the order {@code glTexImage2D} consumes.
+	 *
+	 * @throws IllegalArgumentException if the blob is shorter than the texture, which is the one
+	 *                                  thing that would be filled in silently with zeroes
+	 */
+	public byte[] widen(byte[] blob) {
+		int in = this.components * channelBytes();
+		int texels = this.width * this.height;
+		if (blob.length < (long) texels * in) {
+			throw new IllegalArgumentException("A texture of " + this.width + "x" + this.height
+					+ " needs " + (long) texels * in + " bytes and this blob holds " + blob.length);
+		}
+
+		int out = texelBytes();
+		byte[] one = RawTexels.one(this.type);
+		byte[] image = new byte[texels * out];
+		for (int texel = 0; texel < texels; texel++) {
+			int to = texel * out;
+			System.arraycopy(blob, texel * in, image, to, in);
+			if (this.components <= RawTexels.ALPHA) {
+				System.arraycopy(one, 0, image, to + RawTexels.ALPHA * channelBytes(), one.length);
+			}
+		}
+
+		return image;
+	}
+
+	public int width() {
+		return this.width;
+	}
+
+	public int height() {
+		return this.height;
+	}
+
+	/** The blob's channel type, which the upload keeps. */
+	public PixelType type() {
+		return this.type;
+	}
+
+	/** How many channels the blob holds a texel, before it is widened to four. */
+	public int components() {
+		return this.components;
+	}
+
+	/** Bytes in one channel, the blob's own. */
+	public int channelBytes() {
+		return this.type.channelBytes();
+	}
+
+	/** Bytes in one texel once uploaded: four channels of the blob's type. */
+	public int texelBytes() {
+		return RawTexels.CHANNELS * channelBytes();
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/texture/RawTexels.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/RawTexels.java
@@ -1,0 +1,86 @@
+package dev.vitrail.pack.texture;
+
+import dev.vitrail.pack.model.PixelFormat;
+import dev.vitrail.pack.model.PixelType;
+
+import java.util.Set;
+
+/**
+ * What a texel of a blob the pack ships can be made of, and what it becomes once uploaded.
+ * <p>
+ * A blob is a file with no header: nothing in it says what it holds, and the declaration beside
+ * it is the whole of the description. This says which of those descriptions the engine can turn
+ * into a texture, and it is asked before anything reads a byte, by the volume that is laid out
+ * flat and by the plain image alike.
+ * <p>
+ * Whatever the blob holds, what goes up is four channels of the blob's own type: four is what
+ * the engine allocates for a texture of its own, and a byte a channel stays a byte while a half
+ * float stays a half float. A channel the blob has not got reads nought and a missing alpha
+ * reads one, which is what a texture short of channels answers under GL.
+ */
+public final class RawTexels {
+
+	/** Four channels a texel whatever the blob holds, the width the engine allocates. */
+	public static final int CHANNELS = 4;
+
+	/** The alpha channel, the one a blob short of channels is answered one for rather than nought. */
+	static final int ALPHA = 3;
+
+	/**
+	 * The channel types these lay out: unsigned bytes and shorts, and floats of both widths, the
+	 * types the corpus's blobs are made of. An integer format stays out, and that refusal is not a
+	 * matter of writing more: it is read through an integer sampler nothing here is written for.
+	 * <p>
+	 * A single float a channel goes up as the pack declared it, which is what Iris uploads and what
+	 * GL filters for it. Vulkan only PERMITS a device to filter a thirty two bit float format
+	 * linearly where it requires it of a half, so on a device that does not the sampler falls back
+	 * to nearest and says so, which costs the blend between two entries of a lookup table and
+	 * nothing else. Laying such a blob out in halves instead would keep the filtering and round
+	 * every value, and a table like that is read for its values.
+	 */
+	private static final Set<PixelType> TYPES = Set.of(PixelType.UNSIGNED_BYTE,
+			PixelType.UNSIGNED_SHORT, PixelType.HALF_FLOAT, PixelType.FLOAT);
+
+	/** The channel orders laid out as they come: a swapped order would have to be swapped back. */
+	private static final Set<PixelFormat> FORMATS = Set.of(PixelFormat.RED, PixelFormat.RG,
+			PixelFormat.RGB, PixelFormat.RGBA);
+
+	/**
+	 * What a blob is allowed to come out as, which is not what the declaration is allowed to say.
+	 * <p>
+	 * A blob is bounded by nothing but the file the pack ships and the declaration checked
+	 * against its length, and THIS is what bounds it: nothing downstream reads a blob refused
+	 * here. The sides are what a device takes and the total is what the memory is, counted in
+	 * bytes because a texel is four to sixteen of them: a hundred and twenty eight mebibytes at
+	 * the very most, which is a megabyte for the noise volumes of the corpus and thirty seven
+	 * for iterationT's atmosphere table.
+	 */
+	private static final int MAX_SIDE = 16384;
+
+	private static final long MAX_BYTES = 128L * 1024 * 1024;
+
+	private RawTexels() {
+	}
+
+	/** Whether a texel of that description is one these lay out, whatever shape the blob is. */
+	public static boolean holds(PixelType type, PixelFormat format) {
+		return TYPES.contains(type) && FORMATS.contains(format);
+	}
+
+	/** Whether a texture of that shape is one a device could hold and this engine is willing to spend. */
+	public static boolean fits(int width, int height, int texelBytes) {
+		return width <= MAX_SIDE && height <= MAX_SIDE
+				&& (long) width * height * texelBytes <= MAX_BYTES;
+	}
+
+	/** One, in the channel's own type and in the byte order the blob is in, which is the machine's. */
+	static byte[] one(PixelType type) {
+		return switch (type) {
+			case UNSIGNED_BYTE -> new byte[] {(byte) 0xFF};
+			case UNSIGNED_SHORT -> new byte[] {(byte) 0xFF, (byte) 0xFF};
+			case HALF_FLOAT -> new byte[] {0x00, 0x3C};
+			case FLOAT -> new byte[] {0x00, 0x00, (byte) 0x80, 0x3F};
+			default -> throw new IllegalStateException(type + " is not a type these lay out");
+		};
+	}
+}

--- a/common/src/main/java/dev/vitrail/pack/texture/VolumeAtlas.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/VolumeAtlas.java
@@ -1,10 +1,7 @@
 package dev.vitrail.pack.texture;
 
 import dev.vitrail.pack.model.PackTexture;
-import dev.vitrail.pack.model.PixelFormat;
 import dev.vitrail.pack.model.PixelType;
-
-import java.util.Set;
 
 /**
  * Where every texel of a volume ends up once the volume is laid out flat, decided once and read
@@ -41,49 +38,6 @@ public final class VolumeAtlas {
 
 	/** One texel on each side of every tile, holding the copy of what lies past the edge. */
 	public static final int GUTTER = 1;
-
-	/**
-	 * What the atlas is allowed to come out as, which is not what the volume is allowed to be.
-	 * <p>
-	 * A blob is bounded by nothing but the file the pack ships and the declaration checked against
-	 * its length, and THIS is what bounds it: nothing downstream reads a blob whose atlas was
-	 * refused here. The atlas is what the volume's texels are laid out AS, and one long axis lays
-	 * them out in a line. A megabyte declared as {@code 4096 1 2048} spreads to a hundred and
-	 * eighty eight thousand texels across, which no device will allocate and which nothing in the
-	 * file said. The sides are what a device takes and the total is what the memory is, counted in
-	 * bytes because a texel is four to sixteen of them: a hundred and twenty eight mebibytes at the
-	 * very most, which is a megabyte for the noise volumes of the corpus and thirty seven for
-	 * iterationT's atmosphere table.
-	 */
-	private static final int MAX_SIDE = 16384;
-
-	private static final long MAX_BYTES = 128L * 1024 * 1024;
-
-	/** Four channels a texel in the atlas whatever the blob holds, the width the engine allocates. */
-	private static final int CHANNELS = 4;
-
-	/** The alpha channel, the one a blob short of channels is answered one for rather than nought. */
-	private static final int ALPHA = 3;
-
-	/**
-	 * The channel types this lays out: unsigned bytes and shorts, and floats of both widths, the
-	 * types the corpus's noise volumes and iterationT's atmosphere table are made of. An integer
-	 * format stays out, and that refusal is not a matter of writing more: it is read through an
-	 * integer sampler the helper is not written for.
-	 * <p>
-	 * A single float a channel goes up as the pack declared it, which is what Iris uploads and what
-	 * GL filters for it. Vulkan only PERMITS a device to filter a thirty two bit float format
-	 * linearly where it requires it of a half, so on a device that does not the sampler falls back
-	 * to nearest and says so, which costs the blend between two entries of a lookup table and
-	 * nothing else. Laying such a blob out in halves instead would keep the filtering and round
-	 * every value, and a table like this one is read for its values.
-	 */
-	private static final Set<PixelType> TYPES = Set.of(PixelType.UNSIGNED_BYTE,
-			PixelType.UNSIGNED_SHORT, PixelType.HALF_FLOAT, PixelType.FLOAT);
-
-	/** The channel orders laid out as they come: a swapped order would have to be swapped back. */
-	private static final Set<PixelFormat> FORMATS = Set.of(PixelFormat.RED, PixelFormat.RG,
-			PixelFormat.RGB, PixelFormat.RGBA);
 
 	private final int width;
 	private final int height;
@@ -128,16 +82,19 @@ public final class VolumeAtlas {
 	public static boolean serves(PackTexture.Raw raw) {
 		return raw.shape() == PackTexture.Shape.TEXTURE_3D
 				&& raw.sizeX() > 0 && raw.sizeY() > 0 && raw.sizeZ() > 0
-				&& TYPES.contains(raw.pixelType()) && FORMATS.contains(raw.pixelFormat());
+				&& RawTexels.holds(raw.pixelType(), raw.pixelFormat());
 	}
 
 	/**
 	 * Whether this layout is one a device could hold and this engine is willing to spend. Asked
 	 * before a volume is served, because a layout that does not fit is one nothing can draw with.
+	 * <p>
+	 * The ATLAS is what is measured and not the volume, and the two are not the same question: a
+	 * megabyte declared as {@code 4096 1 2048} spreads to a hundred and eighty eight thousand
+	 * texels across, which no device will allocate and which nothing in the file said.
 	 */
 	public boolean fits() {
-		return atlasWidth() <= MAX_SIDE && atlasHeight() <= MAX_SIDE
-				&& (long) atlasWidth() * atlasHeight() * texelBytes() <= MAX_BYTES;
+		return RawTexels.fits(atlasWidth(), atlasHeight(), texelBytes());
 	}
 
 	/**
@@ -185,7 +142,7 @@ public final class VolumeAtlas {
 		}
 
 		int out = texelBytes();
-		byte[] one = one();
+		byte[] one = RawTexels.one(this.type);
 		byte[] atlas = new byte[atlasWidth() * atlasHeight() * out];
 		for (int z = 0; z < this.depth; z++) {
 			// From -1 to width inclusive: the two extra columns and rows are the gutter, and they
@@ -196,8 +153,8 @@ public final class VolumeAtlas {
 					int y = past(v, this.height);
 					int to = texel(u, v, z) * out;
 					System.arraycopy(blob, index(x, y, z) * in, atlas, to, in);
-					if (this.components <= ALPHA) {
-						System.arraycopy(one, 0, atlas, to + ALPHA * channelBytes(), one.length);
+					if (this.components <= RawTexels.ALPHA) {
+						System.arraycopy(one, 0, atlas, to + RawTexels.ALPHA * channelBytes(), one.length);
 					}
 				}
 			}
@@ -209,17 +166,6 @@ public final class VolumeAtlas {
 	/** The texel a coordinate one past the edge reads: the far edge when repeating, the edge itself when clamping. */
 	private int past(int at, int size) {
 		return this.clamp ? Math.clamp(at, 0, size - 1) : Math.floorMod(at, size);
-	}
-
-	/** One, in the channel's own type and in the byte order the blob is in, which is the machine's. */
-	private byte[] one() {
-		return switch (this.type) {
-			case UNSIGNED_BYTE -> new byte[] {(byte) 0xFF};
-			case UNSIGNED_SHORT -> new byte[] {(byte) 0xFF, (byte) 0xFF};
-			case HALF_FLOAT -> new byte[] {0x00, 0x3C};
-			case FLOAT -> new byte[] {0x00, 0x00, (byte) 0x80, 0x3F};
-			default -> throw new IllegalStateException(this.type + " is not a type this lays out");
-		};
 	}
 
 	/** How far apart two tiles start across, gutter included: 66 for a 64 wide volume. */
@@ -278,6 +224,6 @@ public final class VolumeAtlas {
 
 	/** Bytes in one texel of the atlas: four channels of the blob's type. */
 	public int texelBytes() {
-		return CHANNELS * channelBytes();
+		return RawTexels.CHANNELS * channelBytes();
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/PackImages.java
+++ b/common/src/main/java/dev/vitrail/render/PackImages.java
@@ -1,11 +1,13 @@
 package dev.vitrail.render;
 
 import dev.vitrail.pack.model.PackTexture;
+import dev.vitrail.pack.model.PixelType;
 import dev.vitrail.pack.model.TextureStage;
 import dev.vitrail.pack.source.ShaderPackSource;
 import dev.vitrail.pack.source.ShaderProperties;
 import dev.vitrail.pack.target.SamplerPlan;
 import dev.vitrail.pack.texture.PackTextures;
+import dev.vitrail.pack.texture.RawImage;
 import dev.vitrail.pack.texture.VolumeAtlas;
 import dev.vitrail.render.pbr.PbrAtlases;
 import dev.vitrail.uniform.NoiseTexture;
@@ -201,19 +203,35 @@ final class PackImages {
 				PackTexture.Raw raw = texture.raw().orElseThrow();
 
 				return new Image(texture, atlas.atlasWidth(), atlas.atlasHeight(),
-						atlas.spread(source.head(file.get(), raw.bytes())), format(atlas),
+						atlas.spread(source.head(file.get(), raw.bytes())), format(atlas.type()),
 						raw.sizeX() + "x" + raw.sizeY() + "x" + raw.sizeZ() + " laid out flat as "
 								+ atlas.atlasWidth() + "x" + atlas.atlasHeight());
+			}
+
+			// A blob that is a plain two dimensional texture goes up as it stands, its channels
+			// widened to the four the engine allocates. Read to the declared length for the reason
+			// the atlas is: the ceiling above this was written for a shader source.
+			PackTexture.Raw plain = texture.raw().filter(RawImage::serves).orElse(null);
+			if (plain != null) {
+				RawImage image = RawImage.of(plain);
+
+				return new Image(texture, image.width(), image.height(),
+						image.widen(source.head(file.get(), plain.bytes())), format(image.type()),
+						image.width() + "x" + image.height());
 			}
 
 			byte[] bytes = source.bytes(file.get());
 
 			// Any other blob means what its own format says it means, and nothing here turns one of
-			// those into an image. The corpus ships none; a pack that starts to has to be named
-			// rather than served something plausible.
+			// those into an image: a shape that is neither a volume nor a plain texture, or either
+			// of those in a channel type or order nothing lays out. A one dimensional blob and a
+			// rectangle are read through samplers this backend does not bind; the corpus ships
+			// neither.
 			if (!texture.png()) {
-				notes.add(texture.path() + " is a raw " + texture.raw().orElseThrow().shape()
-						+ ", which this engine only lays out flat for a volume, so "
+				PackTexture.Raw refused = texture.raw().orElseThrow();
+				notes.add(texture.path() + " is a raw " + refused.shape() + " of "
+						+ refused.pixelFormat() + " " + refused.pixelType()
+						+ ", which this engine does not lay out, so "
 						+ texture.sampler() + " reads one black pixel");
 
 				return null;
@@ -353,8 +371,8 @@ final class PackImages {
 	}
 
 	/**
-	 * What a flattened volume is allocated as: four channels of the blob's own type, so that the
-	 * bytes go up as the file holds them.
+	 * What a blob is allocated as, flattened volume and plain texture alike: four channels of its
+	 * own type, so that the bytes go up as the file holds them.
 	 * <p>
 	 * The channel type decides and the internal format the declaration names does not, which is a
 	 * divergence from GL where the two disagree: GL stores what the declaration says and converts
@@ -363,13 +381,13 @@ final class PackImages {
 	 * its bytes are in, so nothing draws differently for it today, and a pack that disagrees gets
 	 * its bytes unconverted rather than a conversion written for a case nothing exercises.
 	 */
-	private static GpuFormat format(VolumeAtlas atlas) {
-		return switch (atlas.type()) {
+	private static GpuFormat format(PixelType type) {
+		return switch (type) {
 			case UNSIGNED_BYTE -> GpuFormat.RGBA8_UNORM;
 			case UNSIGNED_SHORT -> GpuFormat.RGBA16_UNORM;
 			case HALF_FLOAT -> GpuFormat.RGBA16_FLOAT;
 			case FLOAT -> GpuFormat.RGBA32_FLOAT;
-			default -> throw new IllegalStateException(atlas.type() + " is not a type an atlas holds");
+			default -> throw new IllegalStateException(type + " is not a type a blob goes up in");
 		};
 	}
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -448,7 +448,9 @@ A short reference, if you are writing a pack or wondering why yours is treated d
   Mellow does with its noise and Photon with its atmosphere table. Since the backend refuses a
   declared three-dimensional sampler, the volume is laid flat onto a two-dimensional atlas and
   reads are rewritten to interpolate two slices, whether the volume repeats or clamps and whether
-  it holds unsigned bytes, unsigned shorts or half floats a channel.
+  it holds unsigned bytes, unsigned shorts or floats of either width a channel. A blob that is a
+  plain two-dimensional table, as RenderPearl's edge-blending tables are, is uploaded at the size
+  the declaration gives.
 - **A pack can ask for an unusual shadow buffer format.** Mellow asks for a single-channel one,
   which is why the shadow pipeline's colour state is built from the attachment rather than
   hardcoded.

--- a/docs/pack-format.md
+++ b/docs/pack-format.md
@@ -458,6 +458,16 @@ pixel type follows on the line. Two things take nothing: a key this cannot read 
 naming a file the pack does not ship, which the reference drops whole so that the name goes on
 meaning what it meant.
 
+**A two-dimensional blob is uploaded as it stands.** A pack may ship a lookup table as a block of
+numbers with no header rather than as a picture, and the declaration beside it is the whole of the
+description: RenderPearl's two edge-blending tables are one, an area table of two channels and a
+search table of one. Nothing is tiled and there is no margin, the coordinates being the ones the
+declaration gives; the channels are widened to the four the engine allocates, a channel the file has
+not got reading nought and a missing alpha reading one, which is what a texture short of channels
+answers. The file is read to the declared length, like a volume's. A blob declared one-dimensional or as a rectangle is
+not uploaded, the log saying so and the sampler reading one black pixel: those are read through
+samplers this backend does not bind, and no pack at hand declares either.
+
 **A three-dimensional volume is flattened onto a two-dimensional atlas**, its declaration rewritten
 under a forged name, and each read replaced by a helper that reads two slices and interpolates.
 What forces that is the data rather than the type: the blob is uploaded as one flat atlas of slices


### PR DESCRIPTION
## What changes

A pack whose picture is made by compute programs rather than by full screen passes now draws it. A
colour target was opened for what a program painted into or sampled and for nothing else, so a
target a program only STORES into as `colorimgN` was never opened: the dispatch found no image
behind the name, threw, and the program was dropped on every frame. RenderPearl ships no full
screen pass whatever, hands the screen its scene through `colorimg0`, and was a flat blue field end
to end because of it. Image declarations are now read off a program's own live lines, computes and
fragment stages alike, and the targets they name are allocated.

Two more things stood between that pack and its picture, and both are general. A raw blob was only
ever read where it was a three dimensional table, so a plain two dimensional one, which is what
that pack ships its two edge blending tables as, was refused by name and the compute reading them
dropped whole; such a blob now goes up at the size its declaration gives, its channels widened to
four with a missing channel reading nought and a missing alpha one. And where the shadow comparison
has to be made in arithmetic rather than on the sampler, only the two plainest spellings of the
lookup were rewritten onto the helper, so a unit reading the map any other way did not compile at
all: the forms carrying an offset are rewritten too, with the offset carried into the gather rather
than dropped, an offset being how a pack taps the neighbourhood of a texel.

## How it differs from the reference, and for what obstacle

It does not. Iris creates a render target the moment a program declares the image name
(`samplers/IrisImages.java:25` into `targets/RenderTargets.java:398`) and binds that set to the
terrain programs and the shadow ones alike (`pipeline/IrisRenderingPipeline.java:391` and `:572`),
the shadow composites alone being left out (`shadows/ShadowCompositeRenderer.java:306`); that is
the rule reproduced here, `NOTICE` carrying it. The shadow comparison in arithmetic is an existing
divergence this does not widen, and what changes is only which spellings of the lookup it covers.

## What proves it

- `gradlew build` green on every commit of the series, not the tip alone.
- The off-game harness over the 26 pack corpus, `dev` against this branch: the chain differs for
  RenderPearl and for no other pack, in none of its three dimensions, and both tables it writes
  are identical. 5980 translated units come out with the same compiler errors on both sides. The
  image declaration pattern was measured on the corpus too: it takes all 93 declarations the packs
  carry, and the two it leaves are commented out.
- One other pack of the corpus ships the same two blobs, Clarity, and every read of them sits
  behind its antialiasing setting, which is off in its own defaults. So it gains them for a player
  who turns that on and its picture at the defaults does not move.
- In the game, Fabric bench, RenderPearl v2.8.0-beta.4 on real terrain with the camera pinned:
  `colortex0` is allocated writable from a compute, its two blobs and its atmosphere table are
  served, and the load carries no refusal where it carried three. The screen went from one flat
  blue field to the terrain, the sky, the water and the shadows.

## What it leaves owing

The `setup` stage still has no moment in the frame, so a pack's setup compute does not run and the
log says so; that is a line of its own. RenderPearl's picture has not been compared against the
reference shot for shot, so it is not in the compatibility table yet.

What this opens a target for, nothing yet binds for outside a compute: the image behind
`colorimgN` is pushed for a compute descriptor and for no graphics program, so iterationT's line
program still stores into an image no descriptor carries. That gap is older than this and the
allocation is right either way, the reference opening the target on the declaration alone. Same
shape for the storage bit, which is asked of a compute's declarations only.

One line to check against `feat/shadow-map-mip-chain` if both land: that branch keeps the level a
pack wrote in `textureLod` and `textureLodOffset` instead of pinning it to nought, and the
comparison helper here ignores a level by design. No pack of the corpus asks for a mip chain and a
hardware comparison on the same image, so the two do not meet today.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one.
