### PR TITLE
fix(glsl): seed a depth the pack redeclares and never writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,19 @@ what the next one holds.
 
 ### Fixed
 
+- **Grass, leaves and every other cut out block come back on RenderPearl.** A pack may tell the
+  driver, once, that it is going to write its own depth, either to say the value will only move one
+  way or to say it will not move at all. Saying it is enough to make the driver take the depth from
+  the shader rather than from the geometry, and a pack that says it without ever writing a value
+  leaves whatever happened to be lying around. Where the promise was that it would not move, that
+  costs nothing; where the promise was a direction, the reading came out at the far plane and the
+  block was thrown away as if something stood in front of it. RenderPearl drew its terrain, its sky
+  and its water and not one leaf or blade of grass because of it, its trees standing as bare trunks.
+  The depth is now filled in with the one the geometry produced before the pack's own code runs, so
+  a pack that writes its own still wins, and a pack that only made the promise gets what it
+  expected. Eight other packs write their depth on some branches and not others, and they stop
+  depending on what was left behind on the branches that do not.
+
 - **A pack that paints its picture with compute shaders draws it.** A few packs do their whole
   post-processing in compute programs rather than in full screen passes, and store the finished
   frame into a colour buffer of their own. The engine only ever opened a colour buffer for what a

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -44,7 +44,8 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 		boolean mainWrapped, boolean depthEpilogue, boolean terrainPrologue,
 		boolean distantPrologue, boolean entityWrapped, boolean linesWrapped,
 		boolean alphaEpilogue, boolean covers,
-		boolean wrapsFragment, boolean ordered, boolean namesFragDepth, boolean makesOverlayColour) {
+		boolean ordered, boolean ordersInWrapper, boolean namesFragDepth,
+		boolean makesOverlayColour) {
 
 	private static final String VERSION = "#version 460 core";
 
@@ -475,8 +476,13 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 				+ (this.distantPrologue ? DistantVertex.PROLOGUE + "(); " : "")
 				+ overlayPrologue()
 				+ identifierPrologue(varyings)
-				+ (wrapsFragment() ? GlslTranslator.ORDER_OUTPUTS + "(); " : "")
-				+ coveragePrologue()
+				// Its own question, and neither of the two it looks like: not whether the function
+				// exists, since a stage declaring no output at all is wrapped for the depth seed with
+				// nothing to order, and not whether the body is wrapped, since a stage wrapped later
+				// for its splits already carries the call inside its own main.
+				// GlslTranslator.ordersInWrapper holds both halves.
+				+ (this.ordersInWrapper ? GlslTranslator.ORDER_OUTPUTS + "(); " : "")
+				+ fragDepthPrologue()
 				+ owedPrologue()
 				+ this.splits.matrixPrologue()
 				+ this.splits.structPrologue()
@@ -531,16 +537,23 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 	 * Gives {@code gl_FragDepth} the value the hardware would have written, before the pack's own
 	 * body runs and can write another.
 	 * <p>
-	 * <strong>Only where the mask is written and the stage names the builtin</strong>, and both
-	 * halves are paid for. A stage that names it may still leave it alone on the branch that runs -
-	 * Bliss writes it under {@code POM} and nowhere else ({@code dimensions/all_solid.fsh:359,394})
-	 * - and reading a builtin the stage never wrote is undefined, so the mask would carry whatever
-	 * the driver left there. Writing it costs the early depth test, which is why a stage that never
-	 * names it is left alone: it would pay that for a value the line below can read off
-	 * {@code gl_FragCoord} instead.
+	 * <strong>Wherever the stage names the builtin at all</strong>, because naming it is what puts
+	 * it in the entry point's interface and that alone replaces the depth: the attachment then
+	 * receives the variable, whether or not anything ever assigned it.
+	 * {@link GlslTranslator#planFragDepth} carries what an unassigned one does to the picture in
+	 * this engine's reversed volume, and why a pack that only redeclares the builtin for a layout
+	 * hint is the case that matters.
+	 * <p>
+	 * The mask reads the same variable and is the second thing this covers. A stage may name the
+	 * builtin and still leave it alone on the branch that runs, Bliss writing it under {@code POM}
+	 * and nowhere else ({@code dimensions/all_solid.fsh:359,394}), so without the seed the mask
+	 * would carry whatever the driver left there.
+	 * <p>
+	 * A stage that never names it is left alone, and pays nothing: no name means no depth
+	 * replacement, the early depth test is kept, and the mask reads {@code gl_FragCoord} instead.
 	 */
-	private String coveragePrologue() {
-		return this.covers && this.namesFragDepth ? "gl_FragDepth = gl_FragCoord.z; " : "";
+	private String fragDepthPrologue() {
+		return this.namesFragDepth ? "gl_FragDepth = gl_FragCoord.z; " : "";
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -520,6 +520,9 @@ public final class GlslTranslator {
 
 	private int maxFragmentOutput = -1;
 	private boolean ordered;
+
+	/** Whether the ascending call went into the pack's own main rather than being left to a wrapper. */
+	private boolean orderInjected;
 	private int dynamicFragData;
 	private int shadowCalls;
 	private int unwrappedShadowCalls;
@@ -612,6 +615,13 @@ public final class GlslTranslator {
 	 * where the surface was before the parallax moved it.
 	 */
 	private boolean namesFragDepth;
+
+	/**
+	 * Whether the wrapper gives {@code gl_FragDepth} the interpolated depth before the pack's body
+	 * runs. {@link #planFragDepth} says when it cannot, which is when there is no {@code main} to
+	 * wrap.
+	 */
+	private boolean seedsFragDepth;
 
 	/** Where the fragment stage's own {@code main} stands, once the alpha test has claimed it. */
 	private int packMainName = -1;
@@ -819,6 +829,9 @@ public final class GlslTranslator {
 		// answer rather than each asking again.
 		planAlphaEpilogue();
 		planCoverage();
+		// After convertDepth, which is where namesFragDepth is settled, and beside the other two
+		// reasons a fragment body is wrapped rather than anywhere else: all three share the wrapper.
+		planFragDepth();
 		// Before the ascending call goes in, and that is the whole point: the call replaces the
 		// opening brace of main with text of ours, which is no longer an operator, so a brace
 		// counter run afterwards would walk past main without opening it and close one brace too
@@ -3809,7 +3822,22 @@ public final class GlslTranslator {
 		if (brace >= 0) {
 			this.tokens.inject(brace, "{ " + ORDER_OUTPUTS + "();");
 			this.ordered = true;
+			this.orderInjected = true;
 		}
+	}
+
+	/**
+	 * Whether the WRAPPER is the one that has to call the ascending function.
+	 * <p>
+	 * Not the same question as whether the body is wrapped, and the difference is a stage this pass
+	 * left alone that {@link #wrapMainForSplits} wraps afterwards: the call is already inside the
+	 * pack's own main by then, and the wrapper would make it a second time. Not the same question as
+	 * whether the function exists either, since a stage declaring no fragment output at all is
+	 * wrapped for the depth seed with nothing to order, and the call would name a function nobody
+	 * wrote.
+	 */
+	private boolean ordersInWrapper() {
+		return this.ordered && !this.orderInjected;
 	}
 
 	/**
@@ -3874,9 +3902,59 @@ public final class GlslTranslator {
 		this.covers = this.packMainName >= 0;
 	}
 
-	/** Whether the fragment stage's own {@code main} is wrapped, by the alpha test or by the mask. */
+	/**
+	 * Decides that the wrapper seeds {@code gl_FragDepth}, which is what stops a stage naming the
+	 * builtin from writing the depth attachment with a value nobody set.
+	 * <p>
+	 * <strong>Declaring the builtin is enough to replace the depth, writing to it is not
+	 * required.</strong> A fragment entry point whose interface carries {@code FragDepth} performs
+	 * depth replacement, so the attachment receives whatever that variable holds, and a stage that
+	 * only redeclares it to hand the driver a layout hint has never put anything in it. What the
+	 * hint then says decides whether that costs the picture: {@code depth_unchanged} promises the
+	 * value equals the one the rasteriser produced, so an implementation is free to use that one and
+	 * the unwritten variable never reaches the attachment, while {@code depth_greater} promises only
+	 * a direction and the variable's own value is what lands.
+	 * <p>
+	 * <strong>And the direction is read in the volume this engine rasterises in, not the one the
+	 * pack was written for.</strong> Far is nought here and the test is greater than
+	 * ({@code render/ColorTargets.java:115}, {@code render/DistantProgram.java:81-88}), so an
+	 * unwritten depth that comes out as nought is the far plane and fails against anything already
+	 * drawn; under the reference's zero to one volume and its less than test the same nought is the
+	 * near plane and passes everything, which is why a pack doing this draws there and vanishes
+	 * here. RenderPearl redeclares it on every terrain stage and writes it nowhere in the pack, so
+	 * its cutout geometry, every leaf and every blade of grass, was thrown away by the depth test
+	 * while its solid terrain, which takes the {@code depth_unchanged} branch, drew.
+	 * <p>
+	 * The seed is the interpolated depth, which satisfies both hints and is what the pack expects to
+	 * be there, and the pack's own writes still land after it. The early depth test is already lost
+	 * to the redeclaration itself, so this costs nothing a stage naming the builtin was not paying.
+	 * <p>
+	 * Asked of {@link #namesFragDepth}, which answers for a dead branch too, so a stage naming the
+	 * builtin only where the preprocessor took the other road is seeded and loses its early depth
+	 * test for nothing. That is the bias {@link #convertDepth} already chose and for the same
+	 * reason: over counting costs the test, under counting costs a picture. What is written is the
+	 * depth the rasteriser produced either way, so no such stage draws differently, and the corpus
+	 * carries none of them.
+	 */
+	private void planFragDepth() {
+		if (this.stage != ProgramStage.FRAGMENT || !this.namesFragDepth) {
+			return;
+		}
+
+		// The same wrapper and the same name as the alpha test and the mask, whichever asked first.
+		if (this.packMainName < 0) {
+			this.packMainName = mainName();
+		}
+
+		this.seedsFragDepth = this.packMainName >= 0;
+	}
+
+	/**
+	 * Whether the fragment stage's own {@code main} is wrapped, by the alpha test, by the mask, or
+	 * by the depth seed.
+	 */
 	private boolean wrapsFragment() {
-		return this.alphaEpilogue || this.covers;
+		return this.alphaEpilogue || this.covers || this.seedsFragDepth;
 	}
 
 	/**
@@ -5363,7 +5441,7 @@ public final class GlslTranslator {
 				this.gameModelView, this.softRewrites, this.trigCalls, this.hashCalls,
 				this.mainWrapped, this.depthEpilogue, this.terrainPrologue, this.distantPrologue,
 				this.entityWrapped, this.linesWrapped, this.alphaEpilogue, this.covers,
-				wrapsFragment(), this.ordered, this.namesFragDepth, this.makesOverlayColour);
+				this.ordered, ordersInWrapper(), this.namesFragDepth, this.makesOverlayColour);
 	}
 
 	/**

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -97,6 +97,19 @@ to a function, or written with a compound assignment, cannot be rewritten where 
 are counted rather than guessed at. What the translator never rewrites at all is a **lookup through
 a sampler**. Those are served by converting the *image* instead, once, when the depth is taken.
 
+**A stage that names the output depth is given one, whether or not it writes one.** Naming
+`gl_FragDepth` puts it in the fragment entry point's interface, and that alone is what makes the
+hardware take the depth from the shader rather than from the geometry: writing to it is not
+required. A pack may name it and never write it, redeclaring it only to hand the driver a layout
+hint such as `layout(depth_greater)`, and the attachment then receives a variable nothing set.
+`depth_unchanged` hides that, since it promises the value equals the interpolated one and an
+implementation may use that instead; a directional hint does not, and here the unset value lands.
+Read in reversed Z it is the far plane rather than the near one, so the whole pass is thrown away
+where the same pack draws under the convention it was written for. So the wrapper assigns the
+interpolated depth before the pack's body runs, wherever the stage names the builtin. A pack's own
+write still lands after it, and the early depth test was already gone the moment the name entered
+the interface.
+
 **A lookup through a sampler bound without a mip chain is pinned to the base level.**
 `texture(s, uv)` becomes `textureLod(s, uv, 0.0)`, a level the pack wrote out becomes nought, and a
 bias or a pair of derivatives, which only ever chose a level, is dropped. The reference binds the


### PR DESCRIPTION
## What changes

A pack that tells the driver it will write its own depth, and then never writes one, no longer
loses the geometry of that pass. Naming `gl_FragDepth` is what puts it in the fragment entry
point's interface, and that alone makes the hardware take the depth from the shader rather than
from the geometry: an assignment is not required. A pack may name it only to hand over a layout
hint, and the attachment then gets a variable nothing ever set. Where the hint is `depth_unchanged`
that is invisible, since it promises the value equals the interpolated one and an implementation
may use that one instead. Where the hint is directional the unset value is what lands, and in the
reversed volume this engine rasterises in it reads as the far plane, so every fragment fails
against what was already drawn. The wrapper now assigns the interpolated depth before the pack's
body runs, wherever the stage names the builtin, and a pack's own write still lands after it.

RenderPearl redeclares the builtin on every terrain stage, directional on the branch that alpha
tests and unchanged on the branch that does not, and writes it nowhere. Its solid terrain drew and
every cut out block was thrown away: no grass, no leaves, trees as bare trunks, no held item.

## How it differs from the reference, and for what obstacle

It writes a statement the reference does not. Iris wraps a pack's main at the same place
(`pipeline/transform/transformer/VanillaTransformer.java:200-223`) and puts nothing in front of the
body for this, `gl_FragDepth` appearing nowhere in its tree: on its target the same unset depth is
harmless, the volume being zero to one under a less than test, so the value reads as the near plane
and passes. Here the volume is reversed, far at nought under a greater than test
(`render/ColorTargets.java:115`, `render/DistantProgram.java:81-88`). The divergence costs the
image nothing, the seed being the depth the rasteriser produced, which satisfies every layout hint
a pack can declare.

## What proves it

- `gradlew build` green.
- The off-game harness over the 26 pack corpus, `dev` against this branch: 5980 units translated,
  the compile table identical pack by pack with the same error lists, so no pack loses a program.
- The emitted modules, disassembled. RenderPearl's cutout carries `DepthGreater` with no store to
  the builtin on `dev`, and `DepthReplacing` plus `DepthGreater` with one store here. 312 units
  across nine packs gain the assignment, 273 of them a wrapper; only RenderPearl declares a depth
  layout at all, which is why it is the only pack whose picture moves.
- In the game: not yet, and that is what this request waits on.

## What it leaves owing

The seed is decided on whether the stage names the builtin anywhere, dead branch included, so a
stage naming it only where the preprocessor took the other road pays an early depth test for
nothing. That is the bias the depth conversion already chose, for the same reason, and the
rasteriser's own depth is what gets written either way. No pack of the corpus is in that case.

The same cutout opens with a subgroup vote over the alpha test result, taken before the real per
fragment discard below it. It compiles and it is not what emptied the pass, but the engine's own
preprocessor reads the subgroup extension macros as undefined where the compiler defines them, so
the live lines it collects can come from a branch the compiler did not take. A line of its own.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one.
