### PR TITLE
feat(render): fill the shadow map's mip chain for a pack that asks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,8 +178,26 @@ what the next one holds.
   start. One pack of those at hand does say something: Pegasus asks for its shadow map to be read
   without smoothing, and now gets it, on a shadow test that steps hard enough for the change to sit
   on the edge of a shadow rather than across it. The same request on the shadow's colour buffer
-  stays ignored, as it is by the engine packs are tuned against, and asking for a mip chain under
-  the map is a separate line and still ignored too.
+  stays ignored, as it is by the engine packs are tuned against.
+
+- **A pack asking for a coarser copy of its shadow map gets one.** A shader pack can ask for the
+  shadow map to be kept at several sizes at once, each half the one above it, and then read the
+  size it wants: a soft, wide shadow is worked out from a small copy in one read where a sharp one
+  needs many. The engine kept one size, and a shader asking for any other was silently handed the
+  full one, so the estimate that decides how soft a shadow edge should be was made from the wrong
+  picture. The copies are now made, once at the end of the pass that draws the map, and a shader
+  that names the size it wants gets that size.
+
+  One pack of those at hand asks: iterationT, on the first of the map's two images, for the width
+  of its soft shadows. A pack that says nothing keeps one size and pays for nothing. A shader that
+  leaves the size to be worked out for it, rather than naming one, still reads the full map: that
+  is a separate limitation of this engine and it is unchanged. The same request on the shadow's
+  colour buffer stays ignored, and that is the reference's own behaviour rather than an omission:
+  it makes that copy and then reads the buffer through a setting that can never reach it.
+
+  A card that will not copy between two sizes of a depth image, which the reference's own graphics
+  interface always allowed and this one does not require, keeps a single size and says so in the
+  log.
 
 - **Smoke, flame and the other solid particles take the colour the pack meant them to.**
   The game draws its quad particles in two goes, the solid ones with the world and the

--- a/NOTICE
+++ b/NOTICE
@@ -54,6 +54,12 @@ GNU Lesser General Public License version 3
   where the format and clear directives do not. The colour half is parsed by Iris and then
   overruled at the bind, net.irisshaders.iris.samplers.IrisSamplers binding every shadowcolor
   through a LINEAR sampler object whatever the pack asked, so it is not honoured here either.
+  It takes the mipmap family from the same class in the same shape: generateShadowMipmap covers
+  both depth images, shadowtexMipmap is an alias for the first alone with no twin for the second,
+  shadowtexNMipmap names one image each, and the whole family folds in the order the declarations
+  are read so that the blanket name wins or loses on where it stands. The colour half of that
+  family is parsed there and overruled at the bind by the same LINEAR sampler object, so it is not
+  honoured here either.
 
   common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java reproduces the sampler aliasing
   rules of net.irisshaders.iris.samplers.IrisSamplers and of
@@ -190,6 +196,14 @@ GNU Lesser General Public License version 3
   whatever any program says, lines 73 and 75. What is not reused is when: the named ones are all
   built with the map rather than each at its first use, because the shadow programs of this engine
   are not all built before the first frame is drawn.
+
+  The same file takes the size of the depth pair's mip chain from lines 65 and 66 of that class,
+  the logarithm of the resolution in base two and floored, which stops one level short of a chain
+  running down to a single texel, and it takes it per image from that image's own directive. The
+  count is reproduced rather than worked out because a pack reading at or past the last level is
+  clamped to whatever that engine allocated. What is this project's own is the refusal: the chain
+  is not allocated at all where the device does not report both transfer bits on the depth format,
+  which the graphics interface Iris runs against always provided.
 
   common/src/main/java/dev/vitrail/render/storage/StorageBuffers.java keeps the rule that a
   bufferObject starts life at zero, which net.irisshaders.iris.gl.buffer.ShaderStorageBuffer

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -209,6 +209,33 @@ public final class GlslTranslator {
 	private static volatile boolean softCompareArmed;
 
 	/**
+	 * Whether the loaded pack asked for a mip chain on each depth image of its shadow map,
+	 * {@code shadowtex0} at nought and {@code shadowtex1} at one.
+	 * <p>
+	 * It decides one thing here and one only: whether a lookup that WROTE its own level on the map
+	 * keeps what it wrote, or has it overwritten with the base along with the undirected reads. A
+	 * directive of the pack and not of a program, folded over every fragment stage of the
+	 * dimension, which is why it arrives on a switch instead of off the unit in hand:
+	 * {@code colortexNMipmapEnabled} is a program's own word and is read from the text, where
+	 * {@code generateShadowMipmap} belongs to the pack and the unit that declares it need not be
+	 * the unit that reads at a level. iterationT is exactly that shape, declaring it in
+	 * {@code composite.fsh} and reading at a level inside an include.
+	 * <p>
+	 * Armed at every pack read, before a unit is translated, and false where nobody armed it, which
+	 * is every harness run: a tool measuring the text alone then sees the pinned form, which is the
+	 * translation of a pack that asked for no chain.
+	 * <p>
+	 * <strong>A pack read while another pack's families are still being warmed can hand them this
+	 * answer</strong>, the switch being one pair for the process. What bounds it is the second gate:
+	 * a lookup only reaches a level past nought if {@code ShadowTargets.depthMipmapped} also says
+	 * so, and that asks the map really bound, so the worst case is a written level clamped back to
+	 * the base by the sampler. The disk cache is not exposed to it at all, this pair being part of
+	 * {@link #emissionSwitches} and therefore of the key.
+	 */
+	private static volatile boolean shadowChainZero;
+	private static volatile boolean shadowChainOne;
+
+	/**
 	 * What a call to {@code sin} or {@code cos} becomes: a sine of this translation's own, and
 	 * never the driver's.
 	 * <p>
@@ -747,6 +774,16 @@ public final class GlslTranslator {
 		softCompareArmed = asked;
 	}
 
+	/**
+	 * Says which depth images of this pack's shadow map carry a chain, which is what lets a lookup
+	 * on them keep the level the pack wrote. Called once per pack read, from where the directives
+	 * were just folded, and before a unit is translated.
+	 */
+	public static void askShadowChains(boolean shadowtex0, boolean shadowtex1) {
+		shadowChainZero = shadowtex0;
+		shadowChainOne = shadowtex1;
+	}
+
 	private static boolean softCompare() {
 		return SOFT_COMPARE || softCompareArmed;
 	}
@@ -766,7 +803,8 @@ public final class GlslTranslator {
 	 */
 	public static String emissionSwitches() {
 		return (reduceTrig ? "trig-reduced" : "trig-driver")
-				+ (softCompare() ? " compare-in-shader" : " compare-on-sampler");
+				+ (softCompare() ? " compare-in-shader" : " compare-on-sampler")
+				+ " shadow-chain-" + (shadowChainZero ? '1' : '0') + (shadowChainOne ? '1' : '0');
 	}
 
 	private void rewrite() {
@@ -2904,8 +2942,10 @@ public final class GlslTranslator {
 	 * {@code colortexNMipmapEnabled} directives {@code TargetDirectives} reads; in a geometry
 	 * program, the names the engine serves out of a colour target, a depth, the noise or the shadow
 	 * map, and never the atlas or a material map, which carry chains and are read through them.
-	 * The shadow map's samplers are pinned with the rest, whatever mipmap directive the pack
-	 * wrote for them, because nothing of this engine fills a chain on the map. A sampler a
+	 * The shadow map's samplers are pinned with the rest, and one read of them is not: a lookup that
+	 * WROTE its own level on an image the pack asked for a chain on keeps what it wrote, which is
+	 * {@link #keepsWrittenLevel}. That is narrower than the exemption a colour target gets, and the
+	 * reason it has to be is in that method. A sampler a
 	 * function takes as a parameter has no name to classify, as {@link #countDepthLookup} says,
 	 * so its call sites are read instead: the parameter is pinned when every call of its function
 	 * hands it a sampler already pinned or a parameter already proven, and outright, call sites
@@ -2973,6 +3013,12 @@ public final class GlslTranslator {
 					continue;
 				}
 			} else if (!pinned.contains(name)) {
+				continue;
+			} else if (writesItsOwnLevel(token.text()) && keepsWrittenLevel(name)) {
+				// Inside this branch and not after it, so that it can only ever reach a name the
+				// FILE declares. A parameter spelled after one of the map's names is bound to
+				// whatever its call sites hand it, which may be a target with one level, and the
+				// name would say otherwise.
 				continue;
 			}
 
@@ -3128,10 +3174,13 @@ public final class GlslTranslator {
 	 * The samplers this program asks a chain for, under the names it declares them by: the targets
 	 * its {@code colortexNMipmapEnabled} directives name, whatever spelling the sampler took. Read
 	 * the way {@code TargetDirectives} reads them, on the live lines of this unit and the last
-	 * declaration winning. The shadow map's own mipmap directives are not read: Iris honours them
-	 * on the map's samplers and this engine fills no chain on the map, so its shadow lookups read
-	 * the base whatever the pack asked, pinned or not, and that is the older gap rather than this
-	 * pass's.
+	 * declaration winning.
+	 * <p>
+	 * The shadow map is NOT in here, whatever its own directives say, and that is deliberate: a
+	 * name in this set escapes the pin entirely, undirected reads included, which would hand the
+	 * map's lookups back the implicit level this pass exists to take away. What the map gets
+	 * instead is the narrower exemption {@link #keepsWrittenLevel} describes, and the two are not
+	 * interchangeable.
 	 */
 	private Set<String> chainedSamplers() {
 		Set<Integer> targets = new HashSet<>();
@@ -3163,10 +3212,60 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Whether a name is one the engine binds an image of its own under in every family and never
-	 * gives a chain to in a geometry program: a colour target, a depth of the world or of the far
-	 * terrain, the noise, or the shadow map's depth and colour, on which nothing of this engine
-	 * fills a chain in any family.
+	 * Whether this lookup already carries a level of its own, as opposed to one the hardware would
+	 * work out from the derivatives of its coordinate.
+	 * <p>
+	 * The two are not the same read at all, and this pass has only ever been about the second: the
+	 * defect it exists for is a level computed under divergent flow, and a literal or an expression
+	 * the pack wrote is computed by nobody.
+	 */
+	private static boolean writesItsOwnLevel(String lookup) {
+		return lookup.equals("textureLod") || lookup.equals("textureLodOffset");
+	}
+
+	/**
+	 * Whether a lookup that wrote its own level on this name keeps it.
+	 * <p>
+	 * The shadow map alone, and only where the pack asked for a chain on every image the name could
+	 * read. Pinning such a read was never about the driver: the pack handed a level and the pass
+	 * overwrote it with nought, which was the right answer only while the map carried one level.
+	 * With a chain under it, that rewrite is the engine deciding a pack's filter width for it, and
+	 * iterationT is the pack it decided for, asking for {@code log2(shadowMapResolution / 512)} and
+	 * being served the full size map.
+	 * <p>
+	 * Every image the name could read, and not the one it probably reads. {@code shadowtex0},
+	 * {@code shadowtex0HW} and {@code watershadow} are the first, {@code shadowtex1} and
+	 * {@code shadowtex1HW} the second: those five are fixed, whatever else the program declares.
+	 * The bare {@code shadow} is the one that moves, and it is the PROGRAM that moves it, being the
+	 * first image unless some stage also declares {@code watershadow} and the second when one does
+	 * ({@code samplers/IrisSamplers.java:145-152} on the 26.2 branch). This class sees one unit
+	 * where the binding folds the stages together, so the two can disagree about that one name: it
+	 * is admitted only where both images carry a chain, which is where the disagreement cannot
+	 * change the answer.
+	 * <p>
+	 * Undirected reads on those same names stay pinned, which is a divergence from Iris and the one
+	 * this pass already owed: there a mipmapped shadow sampler lets an ordinary {@code texture} call
+	 * pick its own level, and here it reads the base. Serving that would put the map back on the
+	 * exact read this driver renders wrong, so it waits for the day that defect is closed.
+	 */
+	private boolean keepsWrittenLevel(String name) {
+		if (SamplerPlan.classify(name) != SamplerPlan.Kind.SHADOW_DEPTH) {
+			return false;
+		}
+
+		if (name.equals("shadow")) {
+			return shadowChainZero && shadowChainOne;
+		}
+
+		return SamplerPlan.withoutTranslucents(name, false) ? shadowChainOne : shadowChainZero;
+	}
+
+	/**
+	 * Whether a name is one the engine binds an image of its own under in every family: a colour
+	 * target, a depth of the world or of the far terrain, the noise, or the shadow map's depth and
+	 * colour. It says the name is a candidate for pinning in a geometry program, and no more; a
+	 * colour target is taken back out by the caller's set of chained samplers, and one read of the
+	 * shadow map by {@link #keepsWrittenLevel}.
 	 */
 	private static boolean servedOutOfATarget(String name) {
 		return switch (SamplerPlan.classify(name)) {

--- a/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderMixin.java
@@ -171,7 +171,13 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 		}
 
 		int aspect = VulkanConst.formatAspectMask(texture.getFormat());
-		int filter = integer(texture) ? VK10.VK_FILTER_NEAREST : VK10.VK_FILTER_LINEAR;
+		// NEAREST on an integer format because there is nothing between two of its values, and
+		// NEAREST on a depth one because Vulkan says so outright: a blit whose source is a depth or
+		// stencil image must be filtered NEAREST (VUID-vkCmdBlitImage-srcImage-00232), the layers
+		// refusing the call rather than the driver approximating it. That is the whole chain of the
+		// shadow map, so the rule is not theoretical here.
+		boolean colour = (aspect & VK10.VK_IMAGE_ASPECT_COLOR_BIT) != 0;
+		int filter = colour && !integer(texture) ? VK10.VK_FILTER_LINEAR : VK10.VK_FILTER_NEAREST;
 		long vkImage = image.vkImage();
 		// The wide wait, when armed, stands where each transfer barrier would: a reporter whose
 		// image is still wrong with it on has then cleared the synchronisation of this road too,
@@ -282,9 +288,11 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 	 * only writes standing unsynchronised at this point are the blits themselves: the pass that
 	 * wrote the base has already closed on its own barrier, and that is also what ordered the
 	 * first blit's read. What can touch the chain next is a sampled read from any shader stage, a
-	 * pass writing the base again, or another transfer; the image is a colour target, so no depth
-	 * stage ever meets it. The wide wait never reaches here: while it is armed, the game's own
-	 * barrier already stands after the last blit.
+	 * pass writing the base again, or another transfer. The depth stages are named beside them
+	 * because the image is not always a colour target: the shadow map's depth pair carries a chain
+	 * wherever the pack asked for one, and the next frame's stage clears that base through a
+	 * load-op and draws the world into it. The wide wait never reaches here: while it is armed, the
+	 * game's own barrier already stands after the last blit.
 	 */
 	@Unique
 	private static void vitrail$chainTailBarrier(VkCommandBuffer commands, MemoryStack stack) {
@@ -296,11 +304,15 @@ public abstract class VulkanCommandEncoderMixin implements MipmapCommands {
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR
+						| KHRSynchronization2.VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR
+						| KHRSynchronization2.VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR
 						| KHRSynchronization2.VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR)
 				.dstAccessMask(KHRSynchronization2.VK_ACCESS_2_SHADER_SAMPLED_READ_BIT_KHR
 						| KHRSynchronization2.VK_ACCESS_2_SHADER_STORAGE_READ_BIT_KHR
 						| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT_KHR
 						| KHRSynchronization2.VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT_KHR
+						| KHRSynchronization2.VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT_KHR
 						| KHRSynchronization2.VK_ACCESS_2_TRANSFER_READ_BIT_KHR
 						| KHRSynchronization2.VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR);
 		VkDependencyInfo info = VkDependencyInfo.calloc(stack)

--- a/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
+++ b/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
@@ -89,7 +89,7 @@ public final class PackDirectives {
 	private final float shadowFarPlane;
 	private final float shadowIntervalSize;
 	private final Map<Integer, ShadowColour> shadowColours;
-	private final List<Boolean> shadowDepthNearest;
+	private final List<ShadowDepth> shadowDepths;
 
 	/**
 	 * What one {@code shadowcolor} buffer asks for: the format to allocate it in, whether the shadow
@@ -109,6 +109,17 @@ public final class PackDirectives {
 	 */
 	public record ShadowColour(TargetFormat.Resolution format, boolean clear,
 			TargetDirectives.Colour clearColour, boolean declaresClearColour) {
+	}
+
+	/**
+	 * What one depth image of the map asks for: how it is filtered, and whether it carries a mip
+	 * chain. {@code shadowtex0} at nought and {@code shadowtex1} at one, which is the pair Iris
+	 * carries ({@code shaderpack/properties/PackShadowDirectives.java:97}).
+	 * <p>
+	 * Both start false, which is where Iris starts too, and neither is the whole corpus: Pegasus
+	 * asks for NEAREST on both images and iterationT asks for a chain on nought.
+	 */
+	public record ShadowDepth(boolean nearest, boolean mipmap) {
 	}
 
 	private PackDirectives(Builder builder) {
@@ -131,7 +142,9 @@ public final class PackDirectives {
 		Map<Integer, ShadowColour> colours = new TreeMap<>();
 		builder.shadowColours.forEach((index, setting) -> colours.put(index, setting.build()));
 		this.shadowColours = Collections.unmodifiableMap(colours);
-		this.shadowDepthNearest = List.of(builder.depthNearest[0], builder.depthNearest[1]);
+		this.shadowDepths = List.of(
+				new ShadowDepth(builder.depthNearest[0], builder.depthMipmap[0]),
+				new ShadowDepth(builder.depthNearest[1], builder.depthMipmap[1]));
 	}
 
 	/** What a pack that declares nothing gets, which is what most of the corpus gets. */
@@ -314,25 +327,42 @@ public final class PackDirectives {
 	}
 
 	/**
-	 * Whether the pack asked for NEAREST on one of the two depth images of the map,
-	 * {@code shadowtex0} at nought and {@code shadowtex1} at one, which is the pair Iris carries
-	 * ({@code shaderpack/properties/PackShadowDirectives.java:184-198}).
+	 * How the pack asks for one of the two depth images of the map to be read back: the filter, and
+	 * whether it carries a mip chain. {@code shadowtex0} at nought and {@code shadowtex1} at one,
+	 * which is the pair Iris carries
+	 * ({@code shaderpack/properties/PackShadowDirectives.java:147-198}).
 	 * <p>
-	 * False is where both engines start, and it is not where the whole corpus stays: Pegasus asks
-	 * for NEAREST on both images. Several other packs carry the names too, set to false, or inside
-	 * a block comment, which is why the corpus is asked through the reader and never through a
-	 * grep: {@code .local/harness/ShadowSampling} answers it in one command.
+	 * Both false is where the two engines start, and it is not where the whole corpus stays:
+	 * Pegasus asks for NEAREST on both images, iterationT asks for a chain on nought. Several other
+	 * packs carry the names too, set to false, or inside a block comment, which is why the corpus
+	 * is asked through the reader and never through a grep:
+	 * {@code .local/harness/ShadowSampling} answers it in one command.
 	 * <p>
-	 * The colour buffers have the same family of names and it is deliberately not read, because
-	 * <strong>Iris parses those and then binds the buffer through a LINEAR sampler object
-	 * regardless</strong> ({@code samplers/IrisSamplers.java:156-176}, {@code GlSampler.LINEAR} on
-	 * every {@code shadowcolor} bind), and a GL sampler object overrules the texture's own
-	 * parameters. OptiFine does honour them, so honouring them here would be a divergence from the
-	 * engine packs are tuned against, on the one buffer where a pack blurs light across a penumbra.
+	 * The colour buffers have the same two families of names and neither is read, deliberately,
+	 * because <strong>Iris parses both and then binds every {@code shadowcolor} through
+	 * {@code GlSampler.LINEAR} regardless</strong> ({@code samplers/IrisSamplers.java:156-176}). A
+	 * GL sampler object overrules the texture's own parameters, and that one's minification filter
+	 * is plain {@code GL_LINEAR}, which selects the base level whatever level of detail a lookup
+	 * asks for: the chain Iris fills on those buffers ({@code shadows/ShadowRenderer.java:283-291})
+	 * is written and never read. So a pack reading {@code shadowcolor0} at a lod gets level nought
+	 * there, and serving it a coarser level here would be a divergence on the one buffer where a
+	 * pack blurs light across a penumbra. OptiFine does honour them, and that is not the engine
+	 * these packs are tuned against.
 	 */
+	public ShadowDepth shadowDepth(int index) {
+		return index >= 0 && index < this.shadowDepths.size()
+				? this.shadowDepths.get(index)
+				: new ShadowDepth(false, false);
+	}
+
+	/** Whether the pack asked for NEAREST on one depth image. See {@link #shadowDepth(int)}. */
 	public boolean shadowDepthNearest(int index) {
-		return index >= 0 && index < this.shadowDepthNearest.size()
-				&& this.shadowDepthNearest.get(index);
+		return shadowDepth(index).nearest();
+	}
+
+	/** Whether the pack asked for a mip chain on one depth image. See {@link #shadowDepth(int)}. */
+	public boolean shadowDepthMipmap(int index) {
+		return shadowDepth(index).mipmap();
 	}
 
 	public static final class Builder {
@@ -355,6 +385,7 @@ public final class PackDirectives {
 		private static final int SHADOW_DEPTHS = 2;
 
 		private final boolean[] depthNearest = new boolean[SHADOW_DEPTHS];
+		private final boolean[] depthMipmap = new boolean[SHADOW_DEPTHS];
 
 		private static final ShadowColour SHADOW_COLOUR_DEFAULT = new ShadowColour(
 				TargetFormat.defaultFormat(), true, new TargetDirectives.Colour(1.0F, 1.0F, 1.0F, 1.0F),
@@ -436,6 +467,20 @@ public final class PackDirectives {
 						asBool(directive, value -> this.depthNearest[0] = value);
 				case "shadowtex1Nearest", "shadow1MinMagNearest" ->
 						asBool(directive, value -> this.depthNearest[1] = value);
+				// Whether the map carries a chain, folded the same way and with the same shape of
+				// spellings: generateShadowMipmap covers both images at once where the per-image
+				// names cover one, and shadowtexMipmap is the older spelling of shadowtex0Mipmap
+				// with no shadowtex1 equivalent (PackShadowDirectives.java:147-168). The blanket
+				// name wins or loses on where it stands and not on being the blanket, which is
+				// Iris's own shape: it registers one consumer per name and walks the declarations
+				// in text order.
+				case "generateShadowMipmap" -> asBool(directive, value -> {
+					this.depthMipmap[0] = value;
+					this.depthMipmap[1] = value;
+				});
+				case "shadowtexMipmap", "shadowtex0Mipmap" ->
+						asBool(directive, value -> this.depthMipmap[0] = value);
+				case "shadowtex1Mipmap" -> asBool(directive, value -> this.depthMipmap[1] = value);
 				default -> shadowColour(directive);
 			}
 		}

--- a/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
+++ b/common/src/main/java/dev/vitrail/pack/target/PackDirectives.java
@@ -343,11 +343,15 @@ public final class PackDirectives {
 	 * {@code GlSampler.LINEAR} regardless</strong> ({@code samplers/IrisSamplers.java:156-176}). A
 	 * GL sampler object overrules the texture's own parameters, and that one's minification filter
 	 * is plain {@code GL_LINEAR}, which selects the base level whatever level of detail a lookup
-	 * asks for: the chain Iris fills on those buffers ({@code shadows/ShadowRenderer.java:283-291})
-	 * is written and never read. So a pack reading {@code shadowcolor0} at a lod gets level nought
-	 * there, and serving it a coarser level here would be a divergence on the one buffer where a
-	 * pack blurs light across a penumbra. OptiFine does honour them, and that is not the engine
-	 * these packs are tuned against.
+	 * asks for. Iris does still fill a chain on a shadow colour buffer, and on {@code shadowcolor0}
+	 * alone: it settles its samplers once, in the shadow renderer's constructor, and only the
+	 * buffers that exist by then are walked, the rest being built when a framebuffer or a sampler
+	 * first names them ({@code shadows/ShadowRenderer.java:238-244,280-293}, against
+	 * {@code shadows/ShadowRenderTargets.java:73,127}). Filled or not, none of it is reachable: a
+	 * pack reading {@code shadowcolor0} at a lod gets level nought there, and serving it a coarser
+	 * level here would be a divergence on the one buffer where a pack blurs light across a
+	 * penumbra. OptiFine does honour them, and that is not the engine these packs are tuned
+	 * against.
 	 */
 	public ShadowDepth shadowDepth(int index) {
 		return index >= 0 && index < this.shadowDepths.size()

--- a/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
+++ b/common/src/main/java/dev/vitrail/pack/target/SamplerPlan.java
@@ -770,8 +770,17 @@ public final class SamplerPlan {
 	 * would move {@code shadow} here and not there. No pack of the corpus writes the name at all.
 	 */
 	public boolean withoutTranslucents(String name) {
+		return withoutTranslucents(name, this.waterShadow);
+	}
+
+	/**
+	 * The same rule, for a caller that knows whether the program declares {@code watershadow} and
+	 * has no plan to ask. Written once here rather than twice, the translator asking it of a unit
+	 * it has just read the samplers of.
+	 */
+	public static boolean withoutTranslucents(String name, boolean waterShadow) {
 		return name.equals("shadowtex1") || name.equals("shadowtex1HW")
-				|| (this.waterShadow && name.equals("shadow"));
+				|| (waterShadow && name.equals("shadow"));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -373,7 +373,8 @@ final class ColorTargets {
 	 */
 	ColorTargets(TargetPlan plan, int noiseResolution, NoiseTexture.Image noiseImage,
 			PackImages packImages, ImageInformation.Reading storageImages, int shadowResolution,
-			List<PackDirectives.ShadowColour> shadowColours, List<Boolean> shadowDepthNearest) {
+			List<PackDirectives.ShadowColour> shadowColours,
+			List<PackDirectives.ShadowDepth> shadowDepths) {
 		this.plan = plan;
 		this.packImages = packImages;
 		this.storageImages = new StorageImages(storageImages);
@@ -389,7 +390,7 @@ final class ColorTargets {
 		// count, on the rule the colour targets themselves follow: a pack naming shadowcolor2 gets
 		// the image, a pack writing nought alone pays for nought alone. The ceiling those names were
 		// read against comes from the same place, being the pack's own declaration and not ours.
-		this.shadowMap = new ShadowTargets(shadowResolution, shadowColours, shadowDepthNearest,
+		this.shadowMap = new ShadowTargets(shadowResolution, shadowColours, shadowDepths,
 				plan.shadowAllocated(), plan.shadowCeiling());
 		this.doubled = Set.copyOf(plan.schedule().doubled());
 

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -1535,11 +1535,12 @@ final class GeometryProgram {
 
 		// The noise image tiles and everything else clamps, the same rule the chain follows.
 		//
-		// Never past level nought, even on a target that carries a chain, and this is not a gap left
-		// open. Nothing fills a chain for a geometry program, because the reduction opens render
-		// passes and a terrain pass draws inside the one Sodium opened, where no other can start; a
-		// sampler that let these reads climb would hand them levels nothing has written, which is
-		// undefined memory rather than a coarser image.
+		// A COLOUR TARGET is never read past level nought here, even where it carries a chain, and
+		// this is not a gap left open. Nothing fills such a chain for a geometry program: it is
+		// filled right before the full screen pass that reads it, and a terrain pass draws inside
+		// the one Sodium opened, where no transfer may be recorded. A sampler that let these reads
+		// climb would hand them levels nothing has written, which is undefined memory rather than a
+		// coarser image.
 		//
 		// Nothing asks for it either, and that was measured rather than assumed: across the eight
 		// packs there are fifty reads at a lod other than nought and not one of them is in a
@@ -1547,6 +1548,12 @@ final class GeometryProgram {
 		// Bliss on gaux1 the loudest, and none of those programs ever reads the target at a lod. So
 		// the directive is theirs to declare and dead on their side, and the cost of honouring it
 		// here would be a risk taken for nobody.
+		//
+		// The SHADOW MAP is the one exception, and it is one because of when its chain is filled:
+		// at the tail of the stage that drew the map, outside every pass, so it stands for the
+		// whole frame that reads it and a geometry program is inside that frame like anything else.
+		// The map itself answers, as it answers for the filter, so that the three roads that bind
+		// it read it one way.
 		SamplerPlan.Kind kind = one.binding.kind();
 		if (one.source != null && this.targets.packView(one.source.image()) != null) {
 			// A file of the pack's own is filtered and addressed as the pack asked, in the .mcmeta
@@ -1554,7 +1561,7 @@ final class GeometryProgram {
 			return PackPass.sampler(one.source.repeat(), one.source.filter(), false);
 		}
 
-		return PackPass.sampler(kind, filter(name), false);
+		return PackPass.sampler(kind, filter(name), mipmapped(name, kind));
 	}
 
 	/**
@@ -1754,7 +1761,9 @@ final class GeometryProgram {
 	 * the shadow programs writing over the world.
 	 */
 	private RenderPassDescriptor shadowDescriptor() {
-		GpuTextureView depth = this.shadow.depth();
+		// The one-level view and not the sampled one: a pack that asked for a chain gets a map of
+		// several levels, and Vulkan attaches exactly one.
+		GpuTextureView depth = this.shadow.depthAttachment();
 		if (depth == null) {
 			return null;
 		}
@@ -2391,6 +2400,16 @@ final class GeometryProgram {
 	/** A name answered per frame, an image or the far plane, which is not one nothing fills. */
 	private boolean readsTheDistantDepth(String sampler) {
 		return this.loaded.samplers().binding(sampler).kind() == SamplerPlan.Kind.DISTANT_DEPTH;
+	}
+
+	/**
+	 * Whether a lookup on this name may climb past level nought, which only the shadow map's depth
+	 * pair ever may here. The map answers, and it answers no while the pack asked for no chain or
+	 * while nothing has filled one.
+	 */
+	private boolean mipmapped(String sampler, SamplerPlan.Kind kind) {
+		return kind == SamplerPlan.Kind.SHADOW_DEPTH && this.targets.shadow()
+				.depthMipmapped(this.loaded.samplers().withoutTranslucents(sampler));
 	}
 
 	private FilterMode filter(String sampler) {

--- a/common/src/main/java/dev/vitrail/render/GpuFormats.java
+++ b/common/src/main/java/dev/vitrail/render/GpuFormats.java
@@ -121,6 +121,25 @@ final class GpuFormats {
 		return feature(format, VK10.VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT, true);
 	}
 
+	/**
+	 * Whether this device transfers a rectangle of that format into another of the same, at both
+	 * ends, which is what filling a mip chain by blit needs: every level past the base is read from
+	 * the level above it and written into itself.
+	 * <p>
+	 * Asked of the device because the specification requires neither bit of a DEPTH format, and
+	 * that is the format the shadow map is in. There is no runtime answer to fall back on: a
+	 * command buffer records what it is given and says nothing, so a chain allocated on a device
+	 * that cannot fill it would be read as a coarser image and hold whatever the driver left there.
+	 * The question is therefore asked before the memory is taken, and a device that says no gets a
+	 * map of one level, which is the map every pack had before there were chains.
+	 * <p>
+	 * No with no Vulkan device to ask, which is no device to blit on either.
+	 */
+	static boolean blitsBothWays(GpuFormat format) {
+		return feature(format, VK10.VK_FORMAT_FEATURE_BLIT_SRC_BIT, false)
+				&& feature(format, VK10.VK_FORMAT_FEATURE_BLIT_DST_BIT, false);
+	}
+
 	/** One bit of what this device does with that format, or {@code absent} with no device to ask. */
 	private static boolean feature(GpuFormat format, int bit, boolean absent) {
 		GpuDevice device = RenderSystem.tryGetDevice();

--- a/common/src/main/java/dev/vitrail/render/MipmapReduction.java
+++ b/common/src/main/java/dev/vitrail/render/MipmapReduction.java
@@ -4,9 +4,10 @@ import dev.vitrail.mixin.access.CommandEncoderAccessor;
 
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.CommandEncoderBackend;
+import com.mojang.blaze3d.textures.GpuTexture;
 
 /**
- * Fills the mip chain of a colour target. Nothing of the pack takes part.
+ * Fills the mip chain of a colour target, or of the shadow map. Nothing of the pack takes part.
  * <p>
  * It exists because the public encoder has no {@code generateMipmaps}. Iris pays one
  * {@code glGenerateMipmap} per chain; the Vulkan equivalent is a blit of each level into the next
@@ -18,8 +19,10 @@ import com.mojang.blaze3d.systems.CommandEncoderBackend;
  * wholesale the moment a jump moves that pixel from the ground to the sky. The same pack reads lods
  * for its depth of field and for the tiles of its bloom.
  * <p>
- * The blit uses the hardware linear filter, which is what {@code glGenerateMipmap} gave the packs,
- * and it floors the extent of every level, which is what lets a chain run to one texel on the
+ * The blit uses the hardware linear filter on a colour target, which is what
+ * {@code glGenerateMipmap} gave the packs, and the nearest one on the shadow map, Vulkan allowing
+ * no other where the source of a blit carries a depth aspect. It floors the extent of every level,
+ * which is what lets a chain run to one texel on the
  * longer side: a render pass per level was the road before it, and the game refuses a pass on a
  * level whose shorter side shifts to nought, so that road stopped a level short of OpenGL's chain
  * on every screen that is not as tall as it is wide.
@@ -43,15 +46,31 @@ final class MipmapReduction {
 			return false;
 		}
 
-		GeometryHold.flush(() -> "a mip chain being filled");
-		CommandEncoderBackend backend = ((CommandEncoderAccessor) encoder).vitrail$backend();
-		if (!(backend instanceof MipmapCommands commands)
-				|| !commands.vitrail$generateMipmaps(surface.texture())) {
+		if (!generate(encoder, surface.texture())) {
 			return false;
 		}
 
 		surface.chainWritten(true);
 
 		return true;
+	}
+
+	/**
+	 * The same over an image this engine holds directly, which is the shadow map: its depth pair is
+	 * not a colour target of a pack and carries its level count from its own directive.
+	 *
+	 * @return false when the chain could not be filled, in which case the levels hold whatever they
+	 *         held and the caller must keep its readers at the base
+	 */
+	static boolean generate(CommandEncoder encoder, GpuTexture texture) {
+		if (texture == null || texture.getMipLevels() <= 1) {
+			return false;
+		}
+
+		GeometryHold.flush(() -> "a mip chain being filled");
+		CommandEncoderBackend backend = ((CommandEncoderAccessor) encoder).vitrail$backend();
+
+		return backend instanceof MipmapCommands commands
+				&& commands.vitrail$generateMipmaps(texture);
 	}
 }

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -399,7 +399,7 @@ public final class PackChain {
 		// runs while the client is still starting up, off the render thread.
 		this.targets = new ColorTargets(chain.targets(), values.noiseResolution(),
 				values.noiseImage(), values.packImages(), values.storageImages(),
-				values.shadowResolution(), values.shadowColours(), values.shadowDepthNearest());
+				values.shadowResolution(), values.shadowColours(), values.shadowDepths());
 		this.seed = chain.chain().seed()
 				.filter(where -> this.targets.has(where.target()))
 				.map(where -> new SceneSeed(where, this.targets.format(where.target()),

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -616,7 +616,14 @@ final class PackCompute implements AutoCloseable {
 			default -> PackPass.customImageFilter(name);
 		};
 
-		return ((VulkanGpuSampler) PackPass.sampler(noise, filter, false)).vkSampler();
+		// The map's chain is the third road's half of one answer, asked of the map like the filter:
+		// it is filled at the tail of the stage that drew it and stands for the whole frame, so a
+		// compute reads it exactly as the pass it hangs off does. Nothing else a compute binds
+		// carries a chain a dispatch could safely climb.
+		boolean mipmaps = !noise && samplers.binding(name).kind() == SamplerPlan.Kind.SHADOW_DEPTH
+				&& targets.shadow().depthMipmapped(samplers.withoutTranslucents(name));
+
+		return ((VulkanGpuSampler) PackPass.sampler(noise, filter, mipmaps)).vkSampler();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackPass.java
+++ b/common/src/main/java/dev/vitrail/render/PackPass.java
@@ -731,8 +731,18 @@ final class PackPass {
 			// driver left there. Deciding this at the binding rather than when the pass was built
 			// is what makes the fall back real instead of announced: a chain nothing has written
 			// is read at level nought, which is the image the pack had before there were chains.
-			boolean mipmaps = surface != null && surface.chainWritten()
-					&& this.lodTargets.contains(binding.index());
+			//
+			// The shadow map's own chain is the other half of this, and it is asked of the map for
+			// the reason the filter is: a pack reading one image through two samplers is a
+			// difference nothing would ever explain. The narrowing above has no equivalent there,
+			// the map's chain being filled once at the tail of the stage that drew it and standing
+			// for the whole frame that follows, so there is no moment of a frame it could belong
+			// to instead.
+			boolean mipmaps = binding.kind() == SamplerPlan.Kind.SHADOW_DEPTH
+					? targets.shadow().depthMipmapped(
+							this.loaded.samplers().withoutTranslucents(binding.sampler()))
+					: surface != null && surface.chainWritten()
+							&& this.lodTargets.contains(binding.index());
 
 			// The noise image repeats and everything else clamps, which is Iris's choice and not a
 			// taste: a pack indexes noisetex with coordinates of its own, in texels and well past

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -1,5 +1,6 @@
 package dev.vitrail.render;
 
+import dev.vitrail.glsl.GlslTranslator;
 import dev.vitrail.pack.id.BlockIds;
 import dev.vitrail.pack.id.NameIds;
 import dev.vitrail.pack.option.OptionIndex;
@@ -131,6 +132,12 @@ public final class PackValues {
 		SettingSet settings = pack.settings();
 
 		values.state.directives(PackDirectives.read(source, settings, dimension));
+		// Here because it is the first moment the answer exists and the last one before a unit is
+		// translated: the map's chain is a directive of the PACK, folded over every fragment stage
+		// of the dimension, and what it decides in the translation is whether a shadowtex lookup
+		// keeps the level of detail the pack wrote or is pinned to the base with the rest.
+		GlslTranslator.askShadowChains(values.state.directives().shadowDepthMipmap(0),
+				values.state.directives().shadowDepthMipmap(1));
 		values.state.endFlashShadows(properties.endFlashShadows(settings.globalDefines(options)));
 		values.state.oldHandLight(properties.oldHandLight(settings.globalDefines(options)));
 		values.skyElements = properties.skyElements(settings.globalDefines(options));
@@ -529,13 +536,14 @@ public final class PackValues {
 	}
 
 	/**
-	 * Whether the pack asked for NEAREST on {@code shadowtex0} and on {@code shadowtex1}, in that
-	 * order. Beside {@link #shadowColours()} rather than inside it: the depth pair takes no format
-	 * and no clear colour, and the one thing a pack says about it is how it is read back.
+	 * How the pack asks for {@code shadowtex0} and {@code shadowtex1} to be read back, in that
+	 * order: the filter, and whether the image carries a mip chain. Beside {@link #shadowColours()}
+	 * rather than inside it: the depth pair takes no format and no clear colour, and the one thing
+	 * a pack says about it is how it is read back.
 	 */
-	public List<Boolean> shadowDepthNearest() {
-		return List.of(this.state.directives().shadowDepthNearest(0),
-				this.state.directives().shadowDepthNearest(1));
+	public List<PackDirectives.ShadowDepth> shadowDepths() {
+		return List.of(this.state.directives().shadowDepth(0),
+				this.state.directives().shadowDepth(1));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/ShadowCompare.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowCompare.java
@@ -49,9 +49,10 @@ import java.util.WeakHashMap;
  * against, and the map stores the forward window where nearer is smaller. Filtered, the hardware
  * compares each of the four texels and blends the RESULTS with the bilinear weights, which is
  * exactly the arithmetic the translation writes on its other road; the two roads answer the same
- * fraction. The level of detail is pinned to the base: nothing here ever fills a chain on the
- * shadow map, where Iris can mip it under {@code shadowtexMipmap}, and that gap is the map's and
- * not this sampler's.
+ * fraction. The level of detail is pinned to the base, and that is this sampler's own gap now that
+ * the map does carry a chain wherever a pack asks for one: Iris hands a compared read a mipmapped
+ * sampler under {@code shadowtexMipmap} and this one clamps. The line that sets it says why it is
+ * kept.
  * <p>
  * The registry is weak on the pipeline, because that is the lifetime being described: a pipeline
  * dropped on a pack change takes its entry with it, and a reload registers the new ones as they
@@ -200,8 +201,19 @@ public final class ShadowCompare {
 					.addressModeW(VK12.VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
 					.compareEnable(true)
 					.compareOp(VK12.VK_COMPARE_OP_LESS_OR_EQUAL)
-					// Level nought and no further, which is what a lookup's level of detail came
-					// to on the other road as well: nothing ever fills a chain on the shadow map.
+					// Level nought and no further, and that is now a KEPT gap rather than an
+					// absence: the map may carry a chain, and Iris hands a compared read a
+					// mipmapped sampler where the pack asked for one
+					// (ShadowRenderTargets.getSamplerFor, MIPPED_LINEAR_HW). Lifting the ceiling
+					// here would serve it, and it is not lifted, for two reasons that hold
+					// together. This is ONE object for the device's life, so it cannot follow a
+					// per-image directive, and no pack of the corpus asks for a chain and a
+					// comparison on the same image, so nothing would measure the change. And the
+					// ceiling is doing work nobody asked it for: a compared lookup is skipped by
+					// the level pinning outright, so its level is implicit, and this clamp is what
+					// keeps such a read on the base under the divergent flow this driver renders
+					// wrong. Lifting it belongs with the second comparison sampler, and with a
+					// pack to prove it on.
 					.minLod(0.0F)
 					.maxLod(0.0F);
 			LongBuffer handle = stack.mallocLong(1);

--- a/common/src/main/java/dev/vitrail/render/ShadowTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowTargets.java
@@ -5,7 +5,6 @@ import dev.vitrail.pack.target.TargetDirectives;
 import dev.vitrail.Vitrail;
 
 import com.mojang.blaze3d.GpuFormat;
-import com.mojang.blaze3d.pipeline.TextureTarget;
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderPassDescriptor;
@@ -13,6 +12,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuTexture;
 import com.mojang.blaze3d.textures.GpuTextureView;
+import net.minecraft.util.Mth;
 import org.joml.Vector4f;
 import org.joml.Vector4fc;
 
@@ -55,6 +55,14 @@ import java.util.TreeSet;
  * shadow bias and its texel coordinates from the number it declared, so a map allocated at any
  * other size is a picture computed against an image that does not exist.
  * <p>
+ * <strong>Every image here is allocated by this class, one call each, and they cannot part company
+ * on a size because they read the same field.</strong> The depth and the first colour were once one
+ * {@code TextureTarget}, which is what kept the two attachments of one render pass on one area;
+ * that class allocates every texture with a single level ({@code RenderTarget.createBuffers}, a
+ * hard coded 1) and so cannot express the chain a pack asks for on the depth. What it did for us
+ * was two textures, two views and a depth format, and that is what is written out here: the same
+ * usage word it passes, 15, and the same {@code GpuFormat.D32_FLOAT}.
+ * <p>
  * <strong>The map stores the forward window, nought at the near plane and one at the far one, and
  * that is a decision rather than an inheritance.</strong> The scene is drawn under a reversed Z the
  * translation undoes on the way out, but a {@code shadowtex} lookup is never wrapped: the pack
@@ -65,8 +73,8 @@ import java.util.TreeSet;
  * <p>
  * No caller ever holds a texture view, for the same reason {@link ColorTargets} hands none out: a
  * resize closes the views behind it and nothing on this backend notices a view that has outlived its
- * texture. The one view held here is the depth copy without the translucents, and it is safe because
- * this map is square at the resolution the pack asked for and is never resized.
+ * texture. The views held here are safe because this map is square at the resolution the pack asked
+ * for and is never resized.
  */
 final class ShadowTargets {
 
@@ -75,6 +83,21 @@ final class ShadowTargets {
 
 	/** Past this the pack is asking for more than any device here will give it. */
 	private static final int MAX_RESOLUTION = 16384;
+
+	/**
+	 * What the depth pair holds, which is the format {@code RenderTarget.createBuffers} gives a
+	 * target that asked for a depth, and the one Iris allocates the map in
+	 * ({@code shadows/ShadowRenderTargets.java:65-66}, the same {@code GpuFormat.D32_FLOAT}).
+	 */
+	private static final GpuFormat DEPTH_FORMAT = GpuFormat.D32_FLOAT;
+
+	/**
+	 * What the game asks for its own render targets, and what this class asks for every image it
+	 * allocates: sampled, drawn into, and copied both ways. The blit that fills a chain needs the
+	 * last two on one image, being a transfer from the level above into the level below.
+	 */
+	private static final int USAGE = GpuTexture.USAGE_COPY_DST | GpuTexture.USAGE_COPY_SRC
+			| GpuTexture.USAGE_TEXTURE_BINDING | GpuTexture.USAGE_RENDER_ATTACHMENT;
 
 	/**
 	 * The highest a {@code shadowcolor} name can go, which is what the arrays below are sized at and
@@ -97,12 +120,12 @@ final class ShadowTargets {
 	private final List<Vector4fc> clearColours;
 
 	/**
-	 * Whether the pack asked for NEAREST on each depth image, {@code shadowtex0} at nought and
-	 * {@code shadowtex1} at one. Kept here so that the three roads that bind the map ask one place:
-	 * a full screen pass, a geometry program and a compute reading one image through two filters is
-	 * a difference nothing would ever explain.
+	 * How the pack asks for each depth image to be read back, {@code shadowtex0} at nought and
+	 * {@code shadowtex1} at one: its filter, and whether it carries a chain. Kept here so that the
+	 * three roads that bind the map ask one place: a full screen pass, a geometry program and a
+	 * compute reading one image through two filters is a difference nothing would ever explain.
 	 */
-	private final List<Boolean> depthNearest;
+	private final List<PackDirectives.ShadowDepth> depths;
 
 	/**
 	 * How many of them this pack may reach, its own declaration deciding. Clamped to what the arrays
@@ -119,8 +142,7 @@ final class ShadowTargets {
 	 * Nought is in it whatever the pack names, and that is Iris rather than a floor of our own: it
 	 * builds the buffer at construction, for the framebuffer its depth copy is taken through
 	 * ({@code shadows/ShadowRenderTargets.java:73,75}), so the image exists before a program has
-	 * asked for anything. Here it is the colour attachment the depth shares a {@link TextureTarget}
-	 * with, so it exists for the same reason and cannot be left out of the clear.
+	 * asked for anything.
 	 */
 	private final List<Integer> live;
 
@@ -132,12 +154,8 @@ final class ShadowTargets {
 	 */
 	private final boolean[] unstarted = new boolean[MAX_COLOURS];
 
-	private TextureTarget target;
-
 	/**
-	 * Every colour past nought, which the depth cannot share a {@link TextureTarget} with: that class
-	 * carries one colour attachment and one depth, so the rest are images of their own, attached
-	 * beside it by whoever opens the pass.
+	 * The colour buffers of the place, one slot per name a pack may write.
 	 * <p>
 	 * <strong>The live ones are all made with the map, where Iris builds each one the first time a
 	 * framebuffer or a sampler names it</strong> ({@code shadows/ShadowRenderTargets.java:127,136}).
@@ -151,8 +169,22 @@ final class ShadowTargets {
 	 * from the programs would have to be answered by a pass already recording, where nothing may
 	 * allocate. The plan is read instead, and it read every fragment stage of the place before the
 	 * chain was built, which is why a pack that writes only nought pays for only nought.
+	 * <p>
+	 * None of them carries a chain, and the directives that ask for one are read by nobody: see
+	 * {@link PackDirectives#shadowDepth(int)} for what Iris does with those names.
 	 */
-	private final TargetSurface[] rest = new TargetSurface[MAX_COLOURS - 1];
+	private final TargetSurface[] colours = new TargetSurface[MAX_COLOURS];
+
+	/** The depth the world is drawn into, which the pack reads as {@code shadowtex0}. */
+	private GpuTexture depth;
+	private GpuTextureView depthView;
+
+	/**
+	 * Level nought of the depth alone, which is what a render pass takes: Vulkan attaches a view of
+	 * exactly one level, and the light draws into the base. The same object as {@link #depthView} on
+	 * a map with no chain, where the whole view is one level already.
+	 */
+	private GpuTextureView depthAttachment;
 
 	/**
 	 * The map as it stood before anything translucent was drawn into it, which the OptiFine model
@@ -163,6 +195,9 @@ final class ShadowTargets {
 	 * and let the translucent half carry on into the original. What a pack does with the pair is
 	 * compare them: a point occluded in nought and clear in one is behind something translucent, and
 	 * that is the whole test a coloured shadow rests on.
+	 * <p>
+	 * It takes its own chain from its own directive, the pack naming the two images apart, which is
+	 * Iris's shape as well ({@code shadows/ShadowRenderTargets.java:65-66}).
 	 */
 	private GpuTexture noTranslucents;
 	private GpuTextureView noTranslucentsView;
@@ -195,6 +230,22 @@ final class ShadowTargets {
 	 */
 	private boolean copied;
 
+	/**
+	 * Whether anything has written the levels past the base of each depth image since it was
+	 * allocated, {@code shadowtex0} at nought and {@code shadowtex1} at one.
+	 * <p>
+	 * The one thing that decides whether a lod read is safe, and it is the rule {@link TargetSurface}
+	 * follows for a colour target: a fresh image's levels hold whatever the driver left there, so a
+	 * sampler allowed to climb before the reduction has run once serves undefined memory rather than
+	 * a coarser image. The reduction is allowed to fail, a device refusing the blit on a depth
+	 * format, and then this stays down and every lookup reads the base, which is the map a pack got
+	 * before there were chains at all.
+	 * <p>
+	 * One flag per image and not one for the pair: the two are filled by two blits, and either may
+	 * be refused while the other went through.
+	 */
+	private final boolean[] chainWritten = new boolean[2];
+
 	private boolean broken;
 
 	/** Load-ops waiting for the first shadow pass of the frame, or a standalone encode if none opens. */
@@ -207,11 +258,11 @@ final class ShadowTargets {
 	 *                program declaring nothing is {@code {0, 1}} in there, which is the one way the
 	 *                pair reaches this class
 	 * @param ceiling how many the pack may reach, from {@code TargetPlan.shadowCeiling}
-	 * @param depthNearest whether the pack asked for NEAREST on {@code shadowtex0} and on
-	 *                {@code shadowtex1}, in that order
+	 * @param depths  how the pack asks for {@code shadowtex0} and {@code shadowtex1} to be read
+	 *                back, in that order
 	 */
 	ShadowTargets(int resolution, List<PackDirectives.ShadowColour> asked,
-			List<Boolean> depthNearest, Set<Integer> named, int ceiling) {
+			List<PackDirectives.ShadowDepth> depths, Set<Integer> named, int ceiling) {
 		// Clamped rather than refused: a directive that survived a setting nobody expanded can be
 		// any number at all, and a shadow map is not worth taking the pack down for.
 		this.resolution = Math.clamp(resolution, 1, MAX_RESOLUTION);
@@ -235,7 +286,7 @@ final class ShadowTargets {
 					one.format().alphaAdded() && !one.declaresClearColour() ? 1.0F : colour.a());
 		}).toList();
 
-		this.depthNearest = List.copyOf(depthNearest);
+		this.depths = List.copyOf(depths);
 		this.ceiling = Math.clamp(ceiling, 1, MAX_COLOURS);
 		SortedSet<Integer> live = new TreeSet<>(Set.of(0));
 		named.stream().filter(index -> index > 0 && index < this.ceiling).forEach(live::add);
@@ -255,11 +306,71 @@ final class ShadowTargets {
 	 *                            the translucents, which is the second of the pair
 	 */
 	FilterMode depthFilter(boolean withoutTranslucents) {
-		return this.depthNearest.get(withoutTranslucents ? 1 : 0)
+		return this.depths.get(withoutTranslucents ? 1 : 0).nearest()
 				? FilterMode.NEAREST
 				: FilterMode.LINEAR;
 	}
 
+	/**
+	 * Whether a lookup on one depth image may climb past level nought.
+	 * <p>
+	 * Two things at once, and both have to hold. The pack has to have asked for the chain, which is
+	 * {@code generateShadowMipmap} and its per-image spellings, and the chain has to have been
+	 * written since the image was allocated, which {@link #generateMipmaps} says. A sampler that
+	 * climbed on the strength of the directive alone would read undefined memory on the frames the
+	 * blit was refused, which is worse than the coarse level it was after.
+	 * <p>
+	 * The second question is asked of the image really bound and not of the name:
+	 * {@link #depthWithoutTranslucents} falls back to the live map while no copy stands for it, and
+	 * that image carries the OTHER directive's chain, or none.
+	 */
+	boolean depthMipmapped(boolean withoutTranslucents) {
+		if (!this.depths.get(withoutTranslucents ? 1 : 0).mipmap()) {
+			return false;
+		}
+
+		return this.chainWritten[withoutTranslucents && this.copied ? 1 : 0];
+	}
+
+	/**
+	 * How many levels one image of the pair carries: Iris's count, which is not the full chain.
+	 * <p>
+	 * {@code shadows/ShadowRenderTargets.java:65-66} allocates {@code log2(resolution)} levels, the
+	 * logarithm floored, where a chain running to one texel is one more. On a map of 1024 that is
+	 * ten levels and the last is two texels square, so a pack reading a lod of ten or past it is
+	 * clamped to that level there and would be handed a single averaged texel by a full chain. Iris
+	 * is what the packs are tuned against, so the count is Iris's; the colour targets of the screen
+	 * build the full chain instead ({@link TargetSurface#levelsFor}) because that is what
+	 * {@code glGenerateMipmap} gives them there.
+	 * <p>
+	 * <strong>And one level wherever the device will not fill the chain.</strong> The fill is a
+	 * blit, and Vulkan requires neither transfer bit of a depth format, where GL gave Iris
+	 * {@code glGenerateMipmap} on anything. A command buffer records what it is given without
+	 * answering, so there is no failure to catch afterwards: allocating the levels anyway would
+	 * hand a pack whatever the driver left in them under the name of a coarser map. Asked once,
+	 * before the memory is taken, and said in the log where the map's own line is.
+	 */
+	private int levels(int index) {
+		if (!this.depths.get(index).mipmap()) {
+			return 1;
+		}
+
+		if (!GpuFormats.blitsBothWays(DEPTH_FORMAT)) {
+			return 1;
+		}
+
+		return Math.max(1, Mth.log2(this.resolution));
+	}
+
+	/**
+	 * Whether the pack asked for a chain this device will not give it, which is the one case worth
+	 * a word of its own: everything else about the chain is either the pack's own silence or a
+	 * chain that works.
+	 */
+	private boolean chainRefused() {
+		return (this.depths.get(0).mipmap() || this.depths.get(1).mipmap())
+				&& !GpuFormats.blitsBothWays(DEPTH_FORMAT);
+	}
 
 	/**
 	 * Makes the map exist and empties it once. Must run on the render thread and outside any render
@@ -280,22 +391,21 @@ final class ShadowTargets {
 			return false;
 		}
 
-		if (this.target != null) {
+		if (this.depth != null) {
 			return true;
 		}
 
 		try {
-			// One object for the first colour and the depth, so that they cannot part company on a
-			// size: they are attachments of one render pass and one render pass has one area.
-			this.target = new TextureTarget("Vitrail shadow", this.resolution, this.resolution, true,
-					this.formats.get(0));
-			this.unstarted[0] = true;
-			for (int index : this.live) {
-				if (index == 0) {
-					continue;
-				}
+			int depthLevels = levels(0);
+			this.depth = RenderSystem.getDevice().createTexture(() -> "Vitrail shadow depth", USAGE,
+					DEPTH_FORMAT, this.resolution, this.resolution, 1, depthLevels);
+			this.depthView = RenderSystem.getDevice().createTextureView(this.depth);
+			this.depthAttachment = depthLevels > 1
+					? RenderSystem.getDevice().createTextureView(this.depth, 0, 1)
+					: this.depthView;
 
-				this.rest[index - 1] = new TargetSurface("Vitrail shadowcolor" + index,
+			for (int index : this.live) {
+				this.colours[index] = new TargetSurface("Vitrail shadowcolor" + index,
 						this.formats.get(index), false, this.resolution, this.resolution);
 				this.unstarted[index] = true;
 			}
@@ -371,7 +481,7 @@ final class ShadowTargets {
 
 	/** Standalone clears for whatever the pass about to open will not write. */
 	void flushPending(CommandEncoder encoder) {
-		if (this.target == null) {
+		if (this.depth == null) {
 			return;
 		}
 
@@ -399,7 +509,7 @@ final class ShadowTargets {
 		}
 
 		if (colours.isEmpty()) {
-			encoder.clearDepthTexture(this.target.getDepthTexture(), FAR);
+			encoder.clearDepthTexture(this.depth, FAR);
 			return;
 		}
 
@@ -409,7 +519,7 @@ final class ShadowTargets {
 		}
 
 		if (depth) {
-			descriptor.withDepthAttachment(this.target.getDepthTextureView(), OptionalDouble.of(FAR));
+			descriptor.withDepthAttachment(this.depthAttachment, OptionalDouble.of(FAR));
 		}
 
 		descriptor.withRenderArea(new RenderPass.RenderArea(0, 0, this.resolution, this.resolution));
@@ -423,22 +533,19 @@ final class ShadowTargets {
 			this.pendingColour[index] = null;
 		}
 
-		if (this.target == null) {
+		if (this.depth == null) {
 			return;
 		}
 
+		// The chain stops standing for the map the moment the map is emptied, exactly as the copy
+		// beside it does: what the levels hold is an average of a picture this call is throwing
+		// away, and a lookup climbing to one would read the last frame's world under this frame's
+		// base. The tail of the stage fills them again before anything reads them.
+		this.chainWritten[0] = false;
+		this.chainWritten[1] = false;
 		this.pendingDepth = true;
-		if (wanted(0)) {
-			this.pendingColour[0] = this.clearColours.get(0);
-		}
-
 		for (int index : this.live) {
-			if (index == 0) {
-				continue;
-			}
-
-			TargetSurface surface = this.rest[index - 1];
-			if (surface != null && wanted(index)) {
+			if (this.colours[index] != null && wanted(index)) {
 				this.pendingColour[index] = this.clearColours.get(index);
 			}
 		}
@@ -469,6 +576,23 @@ final class ShadowTargets {
 					.append(this.asked.get(index).clear() ? "" : ", which the pack keeps between frames");
 		}
 
+		int zero = levels(0);
+		int one = levels(1);
+		if (zero > 1 || one > 1) {
+			// What each NAME is read at rather than what each image holds: the copy shadowtex1 is
+			// read through is allocated the first time the stage takes it, and a pack no program of
+			// which names it never has one at all.
+			text.append(", and the pack asks for a chain the light fills every frame, ")
+					.append(zero).append(" levels where it reads shadowtex0 and ")
+					.append(one).append(" where it reads shadowtex1");
+		} else if (chainRefused()) {
+			// Said where the map's own line is, because it is the map that is smaller than the pack
+			// asked for: a chain nobody can fill would be read as a coarser image and hold whatever
+			// the driver left in it, so the map keeps one level and every lookup reads the base.
+			text.append(", and the pack asks for a chain this device will not fill on a depth "
+					+ "format, so the map carries one level and every lookup reads it");
+		}
+
 		return text.toString();
 	}
 
@@ -478,23 +602,53 @@ final class ShadowTargets {
 	 * the render thread and outside any render pass.
 	 */
 	void copyWithoutTranslucents(CommandEncoder encoder) {
-		GpuTexture depth = this.target == null ? null : this.target.getDepthTexture();
-		if (depth == null || this.broken) {
+		if (this.depth == null || this.broken) {
 			return;
 		}
 
 		if (this.noTranslucents == null) {
 			// The source's own format rather than an assumed one, the same rule the world's depth
 			// copy follows: a copy whose format differs from its source is refused outright.
+			// Three usages and not the four the map itself takes: nothing ever draws into this
+			// image, it is written by the copy alone. COPY_SRC is here for the chain, a blit
+			// reading the level above the one it writes.
 			this.noTranslucents = RenderSystem.getDevice().createTexture(() -> "Vitrail shadowtex1",
-					GpuTexture.USAGE_COPY_DST | GpuTexture.USAGE_TEXTURE_BINDING, depth.getFormat(),
-					this.resolution, this.resolution, 1, 1);
+					GpuTexture.USAGE_COPY_DST | GpuTexture.USAGE_COPY_SRC
+							| GpuTexture.USAGE_TEXTURE_BINDING,
+					this.depth.getFormat(), this.resolution, this.resolution, 1,
+					levels(1));
 			this.noTranslucentsView = RenderSystem.getDevice().createTextureView(this.noTranslucents);
 		}
 
-		encoder.copyTextureToTexture(depth, this.noTranslucents, 0, 0, 0, 0, 0, this.resolution,
+		encoder.copyTextureToTexture(this.depth, this.noTranslucents, 0, 0, 0, 0, 0, this.resolution,
 				this.resolution);
 		this.copied = true;
+	}
+
+	/**
+	 * Fills the levels past the base of both depth images, which the stage invokes at its tail, once
+	 * everything the map holds is in it. Must run outside any render pass.
+	 * <p>
+	 * Where Iris puts it, and for the same reason: it generates the chain after the translucent
+	 * group and before it restores the player's viewport
+	 * ({@code shadows/ShadowRenderer.java:613-615}), so what the levels average is the finished map
+	 * and never a half drawn one. Every frame and not once, because every frame writes the base
+	 * again, whether by drawing the world into it or by putting the store back.
+	 * <p>
+	 * Silent and harmless on a pack that asked for no chain, which is all of the corpus but one: the
+	 * images then carry a single level and the reduction has nothing to do.
+	 */
+	void generateMipmaps(CommandEncoder encoder) {
+		if (this.depth == null || this.broken) {
+			return;
+		}
+
+		this.chainWritten[0] = MipmapReduction.generate(encoder, this.depth);
+		// Its own chain over its own base, which the copy has just written. Left out, the levels of
+		// shadowtex1 would hold the average of whatever the last fill saw, which is a frame of the
+		// world older than the base under them.
+		this.chainWritten[1] = this.noTranslucents != null
+				&& MipmapReduction.generate(encoder, this.noTranslucents);
 	}
 
 	/**
@@ -505,16 +659,15 @@ final class ShadowTargets {
 	 * because a frame that restores half of them draws this frame's movers over last frame's colour.
 	 */
 	void keep(CommandEncoder encoder) {
-		GpuTexture depth = this.target == null ? null : this.target.getDepthTexture();
-		if (depth == null || this.broken || !copyable(depth)) {
+		if (this.depth == null || this.broken || !copyable(this.depth)) {
 			return;
 		}
 
 		if (this.keptDepth == null) {
-			this.keptDepth = store("Vitrail kept shadow depth", depth.getFormat());
+			this.keptDepth = store("Vitrail kept shadow depth", this.depth.getFormat());
 		}
 
-		encoder.copyTextureToTexture(depth, this.keptDepth, 0, 0, 0, 0, 0, this.resolution,
+		encoder.copyTextureToTexture(this.depth, this.keptDepth, 0, 0, 0, 0, 0, this.resolution,
 				this.resolution);
 		for (int index : this.live) {
 			GpuTexture colour = colourTexture(index);
@@ -548,12 +701,11 @@ final class ShadowTargets {
 	 * @return whether there was anything to put back
 	 */
 	boolean restore(CommandEncoder encoder) {
-		GpuTexture depth = this.target == null ? null : this.target.getDepthTexture();
-		if (!this.kept || depth == null || this.broken || this.keptDepth == null) {
+		if (!this.kept || this.depth == null || this.broken || this.keptDepth == null) {
 			return false;
 		}
 
-		encoder.copyTextureToTexture(this.keptDepth, depth, 0, 0, 0, 0, 0, this.resolution,
+		encoder.copyTextureToTexture(this.keptDepth, this.depth, 0, 0, 0, 0, 0, this.resolution,
 				this.resolution);
 		for (int index : this.live) {
 			GpuTexture colour = colourTexture(index);
@@ -564,6 +716,10 @@ final class ShadowTargets {
 		}
 
 		this.copied = false;
+		// The store holds level nought alone, so a restore leaves the levels above it standing for
+		// a map that is no longer under them. The tail of the stage fills them again.
+		this.chainWritten[0] = false;
+		this.chainWritten[1] = false;
 		if (!this.saidRestored) {
 			this.saidRestored = true;
 			Vitrail.logger().info("Shadow map put back from the store, so this frame draws only "
@@ -590,11 +746,7 @@ final class ShadowTargets {
 	}
 
 	private GpuTexture colourTexture(int index) {
-		if (index == 0) {
-			return this.target == null ? null : this.target.getColorTexture();
-		}
-
-		TargetSurface surface = this.rest[index - 1];
+		TargetSurface surface = this.colours[index];
 
 		return surface == null ? null : surface.texture();
 	}
@@ -620,7 +772,15 @@ final class ShadowTargets {
 
 	/** The depth with everything in it, which the pack reads as {@code shadowtex0}. */
 	GpuTextureView depth() {
-		return this.target == null ? null : this.target.getDepthTextureView();
+		return this.depthView;
+	}
+
+	/**
+	 * The same image as one level, which is what a render pass attaches. Never handed to a sampler:
+	 * a lookup at a lod on this view would be clamped to the base whatever the pack asked for.
+	 */
+	GpuTextureView depthAttachment() {
+		return this.depthAttachment;
 	}
 
 	/**
@@ -647,11 +807,7 @@ final class ShadowTargets {
 			return null;
 		}
 
-		if (index == 0) {
-			return this.target == null ? null : this.target.getColorTextureView();
-		}
-
-		TargetSurface surface = this.rest[index - 1];
+		TargetSurface surface = this.colours[index];
 
 		return surface == null ? null : surface.view();
 	}
@@ -681,15 +837,30 @@ final class ShadowTargets {
 
 	void release() {
 		this.copied = false;
-		if (this.target != null) {
-			this.target.destroyBuffers();
-			this.target = null;
+		this.chainWritten[0] = false;
+		this.chainWritten[1] = false;
+		// The one-level view first, and only where it is an object of its own: on a map with no
+		// chain it IS the whole view, and closing it twice closes a handle somebody else may still
+		// hold under the other name.
+		if (this.depthAttachment != null && this.depthAttachment != this.depthView) {
+			this.depthAttachment.close();
 		}
 
-		for (int index = 1; index < MAX_COLOURS; index++) {
-			if (this.rest[index - 1] != null) {
-				this.rest[index - 1].close();
-				this.rest[index - 1] = null;
+		this.depthAttachment = null;
+		if (this.depthView != null) {
+			this.depthView.close();
+			this.depthView = null;
+		}
+
+		if (this.depth != null) {
+			this.depth.close();
+			this.depth = null;
+		}
+
+		for (int index = 0; index < MAX_COLOURS; index++) {
+			if (this.colours[index] != null) {
+				this.colours[index].close();
+				this.colours[index] = null;
 			}
 		}
 

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -537,6 +537,22 @@ public final class TerrainDraw {
 	}
 
 	/**
+	 * Fills the mip chain of the map, which the caller invokes at the tail of the stage, once
+	 * everything the map holds is in it. Outside any render pass, which that seam is.
+	 * <p>
+	 * Where Iris puts it ({@code shadows/ShadowRenderer.java:613-615}), and it costs nothing on a
+	 * pack that asked for no chain, which is all of this corpus but one: the map then carries a
+	 * single level and there is nothing to fill.
+	 */
+	public static void mipShadowMap() {
+		TerrainDraw self = PackChain.terrain();
+		GpuDevice device = RenderSystem.tryGetDevice();
+		if (self != null && device != null) {
+			self.targets.shadow().generateMipmaps(device.createCommandEncoder());
+		}
+	}
+
+	/**
 	 * Opens the end-of-frame shadow stage: makes the map exist, empties it, and settles that its
 	 * three programs will really be served, once and before any group is drawn into it. Must run
 	 * outside any render pass, which the end of the frame is.

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -389,6 +389,11 @@ public final class ShadowTerrain {
 			TerrainDraw.shadowPass(() -> renderer.drawChunkLayer(ChunkSectionLayerGroup.TRANSLUCENT,
 					matrices, camera.x, camera.y, camera.z, sampler));
 		}
+
+		// And the chain last of all, on a map nothing else will write this frame, which is where
+		// Iris fills it too (shadows/ShadowRenderer.java:613-615). After the copy and not before:
+		// shadowtex1 takes its own chain over the base the copy just wrote.
+		TerrainDraw.mipShadowMap();
 	}
 
 	/** Every section a walk kept, which is what says how tight the shape it measured against was. */

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -463,8 +463,9 @@ A short reference, if you are writing a pack or wondering why yours is treated d
   reference does, the log naming the program it happened to. **Of those, only the ones some program
   of the place writes or samples are allocated**, so a pack whose light never names `shadowcolor1`
   is not charged an image at the shadow map's own resolution for it.
-  `shadowcolor0` stands whatever the pack writes, being the attachment the map's depth shares an
-  object with. **Where a program names none, or names more buffers than it writes outputs, it is
+  `shadowcolor0` stands whatever the pack writes, which is the reference's own floor: it builds
+  that buffer before a program has asked for anything, for the framebuffer its depth copy is taken
+  through. **Where a program names none, or names more buffers than it writes outputs, it is
   given only as many as it writes**: a buffer short of the reference. That is deliberate: Vulkan
   leaves an attachment no fragment writes undefined for the whole draw, where the GL these packs
   were written against leaves it standing, and what a pack reads out of an untouched shadow buffer

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -128,6 +128,37 @@ Coloured light through stained glass does not rest on that swap. It rests on the
 shadow colour buffer: a point occluded in one image and clear in the other has something translucent
 between it and the light, and the tint comes from the colour buffer.
 
+### A pack may ask for coarser copies of the map
+
+`generateShadowMipmap` asks for a mip chain on both depth images at once, `shadowtex0Mipmap` and
+`shadowtex1Mipmap` for one each, and the older `shadowtexMipmap` is the first of those under
+another name. A pack that reads its map at a level of detail of its own is estimating something
+over an area rather than at a point: how wide a penumbra should be, at the cost of one read instead
+of many.
+
+Each image takes its own chain, sized as the reference sizes it, and the chain is filled once per
+frame at the tail of the stage that drew the map, after the copy the second name reads. It has to be
+refilled every frame because every frame writes the base again, by drawing the world into it or by
+putting the reuse store back, and a level standing over a base it no longer averages is an older
+frame's world.
+
+Two things gate a lookup that climbs, and both must hold: the pack asked, and the fill went through.
+A device that refuses the transfer leaves the levels holding whatever it left there, so the engine
+keeps every read on the base rather than serving undefined memory as a coarser image. The same two
+questions decide on all three roads that bind the map, the full screen passes, the world's own
+programs and the compute passes, which is why they ask the map itself.
+
+The shadow colour buffers carry the same family of names and it is read by nobody. The reference
+parses them, fills a chain on the first buffer, and then binds every `shadowcolor` through a sampler
+whose minification setting can only ever return the base level, so a pack reading one at a level of
+detail gets the full-size image there. Serving a coarser one here would diverge on the buffer that
+carries the light which came through stained glass.
+
+A lookup that leaves the level to be worked out from the derivatives of its coordinate reads the
+base whatever the pack asked, where the reference lets it pick a level. That is the older
+divergence: a level computed that way under a branch or a loop comes back wrong on this hardware,
+so those reads are held to the base and only a level the pack wrote out is honoured.
+
 ### What goes into the map is decided in its own namespace
 
 The directives that describe shadow colour buffers (their format, whether they are cleared, and to


### PR DESCRIPTION
## What changes

A pack can ask for its shadow map to be kept at several sizes at once, each half the one above, and
then read the size it wants: a soft wide shadow is worked out from a small copy in one read where a
sharp one needs many. The engine kept a single size and handed the full map back for any level a
shader asked for, so the estimate that decides how soft an edge should be was made from the wrong
picture. The four directives that ask for this are read now, the copies are allocated and filled
once at the tail of the pass that drew the map, so what they average is the finished map and never
a half drawn one, and a lookup that names its own level keeps it instead of being pinned to the
base.

The depth image and the first colour buffer shared one target whose textures are allocated with a
single level, which is what made a chain impossible; they are allocated here instead, at the same
usage and the same format, and the colour buffers all become surfaces of the same kind. The levels
are only taken where the device will fill them, asked before the memory rather than after: filling
one is a blit, Vulkan requires neither transfer bit of a depth format, and a device that says no
gets one level and a line saying so, where taking them anyway would serve whatever the driver left
in them as a coarser map.

## How it differs from the reference, and for what obstacle

It does not. The level count is the reference's, log2 of the resolution floored, one short of a
chain running to a single texel, so a pack reading at or past the last level is clamped exactly
where those packs are tuned. What stays divergent is older and untouched here: a lookup that does
NOT name a level is still pinned to the base, because a level computed from the derivatives of a
coordinate under divergent flow is what this driver renders wrong. That pin used to overwrite the
level a pack had written as well; it no longer does, on an image the pack asked a chain for.

## What proves it

- `gradlew build` green on every commit of the series, not the tip alone.
- The off-game harness over the whole corpus, which is where the directive reading was measured:
  one pack asks for the chain and one asks for the nearest filter, and the reader is itself checked
  against five one-program packs whose fold is known.
- In the game, Fabric bench, frozen world with the camera pinned, on the one pack of the corpus
  that asks: iterationT declares the chain on the first depth image and not the second, and the
  load says the light fills 11 levels on `shadowtex0` and 1 on `shadowtex1`, which is that
  declaration exactly. The picture moves 2.20 mean and 4.27 percent of its pixels against `dev`
  captured in the same session, where the pack's own floor, one jar twice, is 3.59 and 7.50: inside
  its own noise, and only in the cells whose foliage and plume never stop moving.

## What it leaves owing

One line to check if the arithmetic shadow comparison widens again: a pack asking for a chain AND a
hardware comparison on the same image would send its levelled lookup through a gather that takes no
level, and lose the one this keeps. No pack of the corpus asks for both, so it is latent.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one.
