### PR TITLE
docs: say what the shadow reuse really keeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ what the next one holds.
   detail comes from the frames themselves and a low scale settles instead of shimmering.
 
   It is off until you turn it on, and the checkbox is greyed out at a render scale of 100 percent,
-  where there is nothing to rebuild. It costs two more passes and three more images, about 32 MiB of
+  where there is nothing to rebuild. It costs two more passes and three more images, about 40 MiB of
   them at 1920x1080. Things that move on their own keep a faint trail, because the match is worked
   out from the camera and not from what each object did.
 
@@ -92,6 +92,16 @@ what the next one holds.
 - **Compute passes are announced as a capability.** They have been running for a while, so a pack
   that says it cannot draw without them was being refused for something it would have got. Clarity
   and Noble now load.
+
+  Three more things stood between those two packs and their picture, and none of them was ever
+  visible in a released version, since neither pack loaded at all. Clarity spells the matrix that
+  places a texture under a plain name rather than the old fixed function one, and nothing here
+  answered that spelling, so every corner of the sun and of the moon was handed the same texture
+  coordinate and both came out as flat squares of a single colour; it also lost two passes to a
+  setting compared against a number with a decimal point, which the entry below describes. Noble
+  names, in the shader itself, the format of the image that shader writes to, and that word was
+  being dropped as the declaration was moved to where this backend wants it, so the pass never
+  built and nothing wrote its screen space reflections.
 
 - **The pack is told what you are holding.** A shader recognises an item by the number the pack
   gives it in its own table, and nothing was looking your hands up in that table, so whatever you
@@ -327,18 +337,6 @@ what the next one holds.
   in one and everything that lights its world reads what that leaves behind, so its diffuse
   lighting, its shadows, its gbuffers and its fog all went dark at once.
 
-- **A pass that writes into an image no longer goes missing.** A pack can name, in the shader
-  itself, the format of the image that shader writes to, and that word was being dropped as the
-  declaration was moved to where this backend wants it. What was left is a declaration the compiler
-  refuses, so the pass never built and the frame went on without it. Noble is the pack this showed
-  on, where nothing wrote its screen space reflections.
-
-- **The sun and the moon carry their texture again on a pack written for the core profile.** Such a
-  pack spells the matrix that places a texture under a plain name rather than the old fixed function
-  one, and nothing here answered that spelling, so every corner of the sun and of the moon was handed
-  the same texture coordinate and both came out as flat squares of a single colour. Clarity is the
-  pack this showed on, in the program that draws them.
-
 - **E-LITE's clouds follow the hour of the day again.** A pack may declare a value of its own under
   either of two keywords, and only one of them was reaching the shaders. E-LITE writes the hour of
   the day under the other one and its sky reads it, so it arrived as nought: the count of days was
@@ -371,8 +369,7 @@ what the next one holds.
   packs write conditions like "if the motion blur is above 0.0" or "if the falloff equals 1", with
   the setting itself holding 0.5 or 1.0. Those were read as whole numbers, so a half became nought
   and the branch was decided the wrong way, and the line was then refused outright besides. Pegasus
-  was losing its terrain, its water, its entities and its particles to one of them, and Clarity two
-  of its passes.
+  was losing its terrain, its water, its entities and its particles to one of them.
 
 - **The extensions a pack asks for are no longer dropped.** A pack using half precision types
   guarded them on the extension being available and shipped a fallback for when it is not; the line

--- a/common/src/main/java/dev/vitrail/pack/texture/VolumeAtlas.java
+++ b/common/src/main/java/dev/vitrail/pack/texture/VolumeAtlas.java
@@ -90,8 +90,8 @@ public final class VolumeAtlas {
 	 * before a volume is served, because a layout that does not fit is one nothing can draw with.
 	 * <p>
 	 * The ATLAS is what is measured and not the volume, and the two are not the same question: a
-	 * megabyte declared as {@code 4096 1 2048} spreads to a hundred and eighty eight thousand
-	 * texels across, which no device will allocate and which nothing in the file said.
+	 * volume declared as {@code 4096 1 2048} spreads to a hundred and eighty eight thousand texels
+	 * across, which no device will allocate and which nothing in the file said.
 	 */
 	public boolean fits() {
 		return RawTexels.fits(atlasWidth(), atlasHeight(), texelBytes());

--- a/common/src/main/java/dev/vitrail/render/GeometryStage.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryStage.java
@@ -41,8 +41,8 @@ import java.util.WeakHashMap;
  * flag up for the length of that one call, which {@code GlslCompilerMixin} reads through
  * {@link #compiling} to ask shaderc for kind 3 and to key the module cache under this stage rather
  * than under the vertex one. What that road then does to the unit, the compiler's own two defines,
- * the debug information {@code rebind} needs, the local zeroes and the cache itself, it does for
- * this stage as it does for the two others. The pipeline's own defines are laid on here, which is
+ * the debug information the compiler was or was not asked for, the local zeroes and the cache
+ * itself, it does for this stage as it does for the two others. The pipeline's own defines are laid on here, which is
  * what {@code GeometryProgram} does for the vertex and fragment stages it compiles itself.</li>
  * <li>{@code GlslCompiler.compile} builds the bind group out of two modules and pairs them by
  * name. The third module joins the same group and is rebound between the two: the vertex stage's

--- a/common/src/main/java/dev/vitrail/render/ParticleDraw.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleDraw.java
@@ -623,14 +623,14 @@ public final class ParticleDraw extends FamilyDraw {
 	 * Null is a refusal, and there is one left for both halves alike: a place whose targets are not
 	 * the size of the screen, one render pass having one render area.
 	 * <p>
-	 * <strong>The opaque half used to refuse two more and no longer does, because the coverage mask
-	 * took their reason away.</strong> Both rested on the same premise, that its first output had no
-	 * road into the pack's picture but the scene seed: one refused a place where the seed is off, the
-	 * other a place where the seed paints a target the program does not write first. With the mask
-	 * the half owns draw buffer nought outright and writes the pack's own target, which is what Iris
-	 * does with it and what {@link ParticleProgram} sets out. Kept, they would hand a half back for a
-	 * road it no longer travels; Bliss was the corpus case, its {@code gbuffers_textured_lit} writing
-	 * colortex2 first where the seed paints colortex1.
+	 * <strong>Two further refusals would look reasonable on the opaque half and are wrong, the
+	 * coverage mask taking their reason away.</strong> Both rest on the premise that its first output
+	 * has no road into the pack's picture but the scene seed: one would refuse a place where the seed
+	 * is off, the other a place where the seed paints a target the program does not write first. With
+	 * the mask the half owns draw buffer nought outright and writes the pack's own target, which is
+	 * what Iris does with it and what {@link ParticleProgram} sets out. Either would hand a half back
+	 * for a road it does not travel; Bliss is the corpus case, its {@code gbuffers_textured_lit}
+	 * writing colortex2 first where the seed paints colortex1.
 	 */
 	private List<ChainPlan.Attachment> writes(Element element, PackProgram.Loaded loaded) {
 		String servedBy = loaded.path().substring(loaded.path().lastIndexOf('/') + 1);

--- a/common/src/main/java/dev/vitrail/render/ParticleProgram.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleProgram.java
@@ -109,9 +109,8 @@ final class ParticleProgram extends FamilyProgram {
 				// none: the seed has run long before it draws, and it owns draw buffer nought on the
 				// strength of its side alone.
 				//
-				// claimed: no sibling marks these pixels for them. The opaque half is drawn with
-				// RenderPipelines.OPAQUE_PARTICLE, which blends nothing, so the question does not
-				// arise there either.
+				// The opaque half is drawn with RenderPipelines.OPAQUE_PARTICLE, which blends
+				// nothing, so no sibling has to mark these pixels for it either.
 				!element.afterDeferred(), false, element.afterDeferred(),
 				game.getPrimitiveTopology(), game.isCull(),
 				game.getDepthStencilState(), element.stage(),

--- a/common/src/main/resources/assets/vitrail/lang/en_us.json
+++ b/common/src/main/resources/assets/vitrail/lang/en_us.json
@@ -16,7 +16,7 @@
 	"options.vitrail.temporal_fold": "Temporal Fold",
 	"options.vitrail.temporal_fold_tooltip": "Folds several upscaled frames into one, so a lower Render Scale keeps more detail.\nDistant leaves and fences stop crawling. Things that move keep a faint trail.\nNeeds a Render Scale under 100%.\nApplies at the next frame. No pack reload.",
 	"options.vitrail.shadow_amortisation": "Shadow Reuse",
-	"options.vitrail.shadow_amortisation_tooltip": "How many frames the shadow map is kept before it is drawn again.\nHigher is faster: drawing it is the most expensive pass of the frame.\nShadows of things that MOVE are that many frames late.\nApplies at the next frame. No pack reload.",
+	"options.vitrail.shadow_amortisation_tooltip": "How many frames the shadow map is kept before it is drawn again.\nHigher is faster: drawing it is the most expensive pass of the frame.\nOnly the GROUND ages: a block you place or break keeps its old shadow that long.\nApplies at the next frame. No pack reload.",
 	"options.vitrail.shadow_amortisation_off": "Off",
 	"options.vitrail.shadow_amortisation_frame": "%s frame",
 	"options.vitrail.shadow_amortisation_frames": "%s frames",

--- a/common/src/main/resources/assets/vitrail/lang/fr_fr.json
+++ b/common/src/main/resources/assets/vitrail/lang/fr_fr.json
@@ -16,7 +16,7 @@
 	"options.vitrail.temporal_fold": "Fusion temporelle",
 	"options.vitrail.temporal_fold_tooltip": "Fusionne plusieurs images agrandies en une seule, pour qu'une échelle de rendu plus basse garde plus de détail.\nLes feuillages et les barrières au loin arrêtent de grouiller. Ce qui bouge laisse une légère traînée.\nDemande une échelle de rendu sous 100 %.\nS'applique à la frame suivante. Pas de rechargement du pack.",
 	"options.vitrail.shadow_amortisation": "Réutilisation des ombres",
-	"options.vitrail.shadow_amortisation_tooltip": "Combien de frames la carte d'ombre est gardée avant d'être redessinée.\nPlus haut, plus rapide : la dessiner est la passe la plus chère de la frame.\nLes ombres de ce qui BOUGE ont ce nombre de frames de retard.\nS'applique à la frame suivante. Pas de rechargement du pack.",
+	"options.vitrail.shadow_amortisation_tooltip": "Combien de frames la carte d'ombre est gardée avant d'être redessinée.\nPlus haut, plus rapide : la dessiner est la passe la plus chère de la frame.\nSeul le SOL vieillit : un bloc posé ou cassé garde son ancienne ombre aussi longtemps.\nS'applique à la frame suivante. Pas de rechargement du pack.",
 	"options.vitrail.shadow_amortisation_off": "Désactivée",
 	"options.vitrail.shadow_amortisation_frame": "%s frame",
 	"options.vitrail.shadow_amortisation_frames": "%s frames",

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -371,9 +371,10 @@ road, the one every opaque piece of the world takes: it writes the mask.
 
 **The hand was the last piece that could have taken the mask and did not**, and what had kept it
 there was the flag the mask used to be. It is not the last piece drawn before the seed making the
-trip through the game's target, and the difference is worth keeping: the opaque particles never ask
-for a mask at all, so the seed carries them in by design, and so does anything whose fragment stage
-the translation could not place a mask in. The hand is drawn with its clip depth squeezed into the
+trip through the game's target, and the difference is worth keeping: the seed carries in anything
+whose fragment stage the translation could not place a mask in. The opaque particles are no longer
+of that number, their half writing the mask and owning the draw buffers the pack declares, and the
+translucent half owes none for the reason every after-deferred pass owes none. The hand is drawn with its clip depth squeezed into the
 middle eighth of the range, which is not the depth of anything it stands in front of, so against a
 flag the cut asked whether the depth had moved closer since a copy taken before the game's features
 and every hand pixel answered yes. Against a depth it asks nothing of the sort: the mask is filled

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -243,7 +243,8 @@ and the walk is widened around the facade at three points. The reflected entry l
 storage images and blocks it never enumerates, the layout emits a storage type for those names
 instead of a combined sampler or a uniform buffer, and the descriptor written at bind time carries
 the VMA handle and the three-dimensional view. `IRIS_FEATURE_CUSTOM_IMAGES` is posed on that road
-being open, and it is the only capability define this engine poses today.
+being open, one of the capability defines the engine poses; `EngineDefines` names the others and
+says which condition each one waits on.
 
 The Vulkan backend behind that facade already has the rest. The device object hands out the
 `VkDevice`, the VMA allocator, and a graphics queue created with both the graphics and compute

--- a/docs/sky-and-shadows.md
+++ b/docs/sky-and-shadows.md
@@ -284,9 +284,11 @@ implementation, and it is the first thing to suspect for any shadow artefact.
 
 **Shadow Reuse makes that lag settable, and the walk stops being one per frame.** The map holds a
 world that does not move between two frames of a player standing still, so it is kept for as many
-further frames as the setting says and the walk is skipped on those. The lag on anything that MOVES
-becomes one plus that number, which is the first thing to suspect before the paragraph above once
-the setting is off nought, and it is what the setting's small ceiling is for. What keeps the reuse
+further frames as the setting says and the walk is skipped on those. What is kept is the OPAQUE
+world alone: every caster that moves is drawn into the restored map on every frame, so a mob, a
+boat and the player's own shadow are exact whatever the interval, and what ages is the ground, a
+block placed or broken keeping the shadow it had until the map is drawn again. That is what the
+setting's small ceiling is for. What keeps the reuse
 honest is that the published shadow pair is anchored on the frame that really drew rather than
 shifted every frame: a pass sampling the map transforms with the matrix that map was built with,
 whatever its age, so nothing slides. At nought the anchor moves every frame and this whole

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -115,9 +115,10 @@ rewrite is by the name of the sampler, and a sampler a function takes as a param
 the depth conversion below describes, is read through its call sites instead: the parameter is
 pinned when every call hands it a sampler already pinned or a parameter already proven, outright in
 a full screen program that asks for no chain at all, and its lookups are counted and left otherwise,
-a function some macro calls included. The shadow map's samplers are pinned with the rest, since
-nothing here fills a chain on the map whatever mipmap directive the pack wrote, which is an older
-gap of the shadow bindings and not of this rewrite. The engine gives a chain to the program that
+a function some macro calls included. The shadow map's samplers are pinned with the rest, and the
+map does carry the chain a pack asks for since the depth pair fills one at the tail of the stage
+that drew it, so a read left on the base is the pinning's doing and not a missing chain. The engine
+gives a chain to the program that
 asked for it and to that program alone, where the reference keeps the mipmap filter on the target
 for the rest of the frame; that is an older divergence of the bindings, and the rewrite does not
 change what those later programs read.


### PR DESCRIPTION
## What changes

Shadow Reuse told the player the wrong thing. Its tooltip, in English and in French, said that
shadows of things that move are as many frames late as the interval says, and the shadow page said
the same. They are not late at all: only the opaque world is kept, and every caster that moves is
drawn into the restored map on every frame. What ages is the ground, so a block placed or broken
keeps the shadow it had until the map is drawn again, and that is what both now say.

Four pages had gone stale under the batches of this cycle and now match the code: the shadow map
does carry the mipmap chain a pack asks for, the opaque particles do write the coverage mask
instead of arriving through the scene seed, the engine poses more than one capability define, and
the binding remap does not need shaderc's debug information, patching SPIR-V by a name that
survives the option. The temporal fold's three images come to about forty megabytes at 1920x1080
rather than thirty two, two of the three being four channels of half floats. The fixes that let
Clarity and Noble load at all are filed under the entry that says they load, since no published
version carried the defects they describe.

## How it differs from the reference, and for what obstacle

It does not. Nothing here changes what the engine draws or how it is bound; the only Java hunks are
comments and javadoc.

## What proves it

- `gradlew build` green, which is also what refuses a BOM and typographic punctuation here.
- Each corrected sentence was read against the code that contradicts it: the reuse against
  `ShadowAmortisation`, `ShadowTargets` and `ShadowTerrain`, the chain against `ShadowTargets`, the
  particles against `ParticleProgram`, the defines against `EngineDefines`, the debug information
  against `ShaderDebugInfo` and the corpus that loads and draws without it.
- In the game: the bench at the title screen, engine page, the Shadow Reuse tooltip read in both
  languages.

## What it leaves owing

Nothing of its own. Thirteen of the fifteen language files carry no Shadow Reuse tooltip yet and
fall back to English, which is where they stood before this branch.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
