### PR TITLE
fix(glsl): pin the level of a compared shadow read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,17 @@ what the next one holds.
   interface always allowed and this one does not require, keeps a single size and says so in the
   log.
 
+- **A shadow read through the hardware comparison names the copy it reads.** Where a pack asks the
+  card to compare shadow depths for it, which is how most of them read the map, the engine left the
+  choice of which copy of the map to read to the card, and a card works that out from how the
+  reading coordinate moves between neighbouring pixels. Inside a loop or a branch, where the pixels
+  beside one another may not be doing the same thing, that answer is undefined and the card may hand
+  back a copy nothing ever filled: on screen it shows as a shadow that flickers between frames from
+  a viewpoint that is not moving. Every other kind of read already named its copy for exactly that
+  reason, and these did not, though they are the reads a pack makes most, the four tap shadow filter
+  of both Complementary packs among them. They name it now, and a shader that names a copy itself
+  still gets the one it named.
+
 - **Smoke, flame and the other solid particles take the colour the pack meant them to.**
   The game draws its quad particles in two goes, the solid ones with the world and the
   see-through ones after the water, and only the second lot were reaching the pack's own

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -348,6 +348,22 @@ public final class GlslTranslator {
 	/** What the word sampler is followed by when the declaration asks for a comparison. */
 	private static final String SHADOW_SHAPE = "Shadow";
 
+	/**
+	 * The comparison shapes GLSL gives a lookup that names its level, and so the only ones a
+	 * compared read can be pinned on at all. Asked of glslangValidator and of shaderc, which answer
+	 * the same: {@code textureLod} and {@code textureLodOffset} take these three and refuse
+	 * {@code sampler2DArrayShadow}, {@code samplerCubeShadow} and {@code samplerCubeArrayShadow},
+	 * for which the language offers no explicit-level form to write.
+	 * <p>
+	 * Only the two-dimensional one can carry the shadow map. The names a declaration must introduce
+	 * for the binding to put a comparison sampler under it are the map's own, which are 2D, and
+	 * {@code SamplerTypes} refuses a one-dimensional sampler its pipeline whatever it reads. A read
+	 * through one of the three shapes left out keeps an implicit level, and no unit of the corpus
+	 * writes one.
+	 */
+	private static final Set<String> LEVELLED_SHADOW_SHAPES =
+			Set.of("1DShadow", "1DArrayShadow", "2DShadow");
+
 	/** The level {@link #pinLookupLevels} writes into a lookup, as GLSL text. */
 	private static final String BASE_LEVEL = "0.0";
 
@@ -2133,7 +2149,7 @@ public final class GlslTranslator {
 	}
 
 	private void rewriteIdentifiers() {
-		List<Integer> closings = new ArrayList<>();
+		List<Closing> closings = new ArrayList<>();
 		int[] lines = this.tokens.lineNumbers();
 
 		for (int index = 0; index < this.tokens.size(); index++) {
@@ -2240,8 +2256,18 @@ public final class GlslTranslator {
 					// The wrap adds an opening parenthesis, so it has to add a closing one too.
 					// Substituting the head alone is what left the prototype with eighty-six
 					// units ending in "unexpected SEMICOLON, expecting RIGHT_PAREN".
-					this.tokens.inject(index, "vec4(" + (compared ? SHADOW_COMPARE : shadow));
-					closings.add(close + 1);
+					//
+					// The wrap goes in as a token of its own and the NAME is replaced rather than
+					// fused into it, so that what stands there afterwards is the modern call this
+					// has become, readable by name like any other. It has to be: the level pinning
+					// matches names, and both Complementary packs write their four tap shadow
+					// filter in this spelling, so a fused head left every one of those taps on an
+					// implicit level. The two parentheses are raw text, which the bracket walks
+					// step over, reading operators only, so the call still opens and closes where
+					// it did.
+					closings.add(new Closing(index, "vec4(", directive));
+					this.tokens.replace(index, compared ? SHADOW_COMPARE : shadow);
+					closings.add(new Closing(close + 1, ")", null));
 					this.shadowCalls++;
 					continue;
 				}
@@ -2320,12 +2346,7 @@ public final class GlslTranslator {
 		// anything a later pass still has to know about a token is carried on the token, as
 		// Token#macroName is. A position kept across here would be read against somebody else's
 		// token, and the reading pass has no way to notice.
-		List<Closing> parentheses = new ArrayList<>(closings.size());
-		for (int at : closings) {
-			parentheses.add(new Closing(at, ")", null));
-		}
-
-		this.tokens.insertClosings(parentheses);
+		this.tokens.insertClosings(closings);
 	}
 
 	/**
@@ -2831,7 +2852,10 @@ public final class GlslTranslator {
 	 * spelling, so the lookup compiles to a depth-reference sample and the comparison is made by
 	 * the sampler the binding put under the name, {@code GL_COMPARE_REF_TO_TEXTURE} in the terms
 	 * Iris binds it in. The call is still counted and still answers true, because whatever road
-	 * makes the comparison, what comes back is a fraction of the light and not a depth.
+	 * makes the comparison, what comes back is a fraction of the light and not a depth. Its LEVEL
+	 * is another pass's: {@link #pinLookupLevels} reaches such a call like any other, the hardware
+	 * working the level out from the derivatives of the coordinate here as it does for an ordinary
+	 * read.
 	 * <p>
 	 * The arithmetic road exists because {@code GpuSampler} carries no comparison at all: two
 	 * address modes, two filters, an anisotropy and a maximum level of detail. Bound as an ordinary
@@ -2952,9 +2976,19 @@ public final class GlslTranslator {
 	 * unread, in a program drawn over the screen that asks for no chain at all, since every image
 	 * such a parameter could stand for is read at the base there. A parameter one call hands
 	 * something else, or one that some macro calls its function through, is left as it stood and
-	 * its lookups counted. A comparison sampler is left to {@link #rewriteShadowCompare}, a name
-	 * the pack made a macro of to the preprocessor, and a rectangle, buffer or multisample sampler
-	 * has no levelled lookup to pin.
+	 * its lookups counted. A name the pack made a macro of is left to the preprocessor, and a
+	 * rectangle, buffer or multisample sampler has no levelled lookup to pin.
+	 * <p>
+	 * <strong>A comparison read is pinned with the rest, and it is the one this pass was missing.</strong>
+	 * Where {@link #rewriteShadowCompare} sent the lookup to the arithmetic, there is nothing left
+	 * to pin: what it wrote gathers four texels, and a gather names no level. Where the comparison
+	 * stayed on the sampler the lookup compiles to a depth-reference sample, whose level the
+	 * hardware works out from the derivatives of the coordinate exactly as an ordinary read's, so it
+	 * is the same undefined read under a loop or a branch, and the shadow map is where a pack
+	 * computes its coordinate the most. The comparison sampler's own ceiling of nought is not the
+	 * answer to it: an equal ceiling on the ordinary samplers is what was measured not to hold, and
+	 * it is why this pass exists. {@link #LEVELLED_SHADOW_SHAPES} says which shapes can be written
+	 * that way at all.
 	 * <p>
 	 * A pack image laid over the name of a colour target is classified as the target in a geometry
 	 * program, since only the binding knows the difference, and is pinned with it; nothing fills a
@@ -3000,8 +3034,11 @@ public final class GlslTranslator {
 
 			String name = this.tokens.get(first).text();
 			int line = lines[index];
-			if (this.packMacros.contains(name) || comparisonAt(name, line)
-					|| hardwareComparisonAt(name, line)) {
+			// The arithmetic road only. What it left standing reads through a sampler this class
+			// has already declared ordinary, over a coordinate that still carries the reference to
+			// compare against, and no explicit-level form takes that pair. A comparison kept on the
+			// sampler is pinned like anything else below.
+			if (this.packMacros.contains(name) || comparisonAt(name, line)) {
 				continue;
 			}
 
@@ -3276,7 +3313,8 @@ public final class GlslTranslator {
 
 	/**
 	 * Whether a sampler declared so has a level to pin. A rectangle, a buffer and a multisample
-	 * image have one level and no lookup that takes one, and a comparison sampler is another pass's.
+	 * image have one level and no lookup that takes one, and a comparison sampler has one only in
+	 * the shapes {@link #LEVELLED_SHADOW_SHAPES} names.
 	 *
 	 * @param declaration the type alone, or the declaration {@link #liftUniforms} recorded, which
 	 *                    is the type followed by the name
@@ -3286,7 +3324,8 @@ public final class GlslTranslator {
 			String shape = SamplerTypes.shapeOf(word);
 			if (shape != null) {
 				return !shape.contains("Rect") && !shape.contains("Buffer") && !shape.contains("MS")
-						&& !shape.endsWith(SHADOW_SHAPE);
+						&& (!shape.endsWith(SHADOW_SHAPE)
+								|| LEVELLED_SHADOW_SHAPES.contains(shape));
 			}
 		}
 

--- a/common/src/main/java/dev/vitrail/render/ShadowCompare.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowCompare.java
@@ -208,12 +208,11 @@ public final class ShadowCompare {
 					// here would serve it, and it is not lifted, for two reasons that hold
 					// together. This is ONE object for the device's life, so it cannot follow a
 					// per-image directive, and no pack of the corpus asks for a chain and a
-					// comparison on the same image, so nothing would measure the change. And the
-					// ceiling is doing work nobody asked it for: a compared lookup is skipped by
-					// the level pinning outright, so its level is implicit, and this clamp is what
-					// keeps such a read on the base under the divergent flow this driver renders
-					// wrong. Lifting it belongs with the second comparison sampler, and with a
-					// pack to prove it on.
+					// comparison on the same image, so nothing would measure the change. What the
+					// ceiling is NOT is a defence against the implicit level a compared read used
+					// to keep: the translation pins those now, and an equal ceiling on the ordinary
+					// samplers is exactly what was measured not to hold. Lifting it belongs with
+					// the second comparison sampler, and with a pack to prove it on.
 					.minLod(0.0F)
 					.maxLod(0.0F);
 			LongBuffer handle = stack.mallocLong(1);

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -121,7 +121,14 @@ that drew it, so a read left on the base is the pinning's doing and not a missin
 gives a chain to the program that
 asked for it and to that program alone, where the reference keeps the mipmap filter on the target
 for the rest of the frame; that is an older divergence of the bindings, and the rewrite does not
-change what those later programs read.
+change what those later programs read. A read through a comparison sampler is pinned in the same
+move, wherever the comparison stayed on the sampler: the lookup then compiles to a depth-reference
+sample whose level the card works out from the derivatives exactly as an ordinary read's, and the
+shadow map is where a pack computes its coordinate the most. Where the comparison went to shader
+arithmetic instead there is nothing to pin, the gather it is written with naming no level at all.
+GLSL offers the explicit-level form on the one and two dimensional comparison shapes only, and the
+two dimensional one is the only shape the map can be carried on, so nothing a pack can bind is left
+out.
 
 **One uniform becomes a sampler, because its value never comes back from the card.**
 `centerDepthSmooth` is the depth at the middle of the screen, faded by the pack's own half-life,


### PR DESCRIPTION
## What changes

A shadow read made through a comparison sampler kept whatever level of detail the card worked out
from the derivatives. Under a loop or a branch that level is undefined in Vulkan, and it is exactly
where packs read their shadow map: the four-tap filter both Complementary packs write is a loop, and
across the corpus 302 such reads left an entry point with no level of their own. They are pinned now,
like every other read the translator pins, and the pinning is skipped only where the comparison went
to shader arithmetic, whose gather names no level to pin.

A second shape was in the way and is fixed with it. The legacy `shadow2D` call was rewritten into one
raw token carrying its wrapping parenthesis, which left the sampler's name unreadable to every pass
that matches on names, so the reads written that way stayed unpinned however the rest was handled.
The wrap is now a token of its own and the name stays readable.

## How it differs from the reference, and for what obstacle

It does not. The pinning is this engine's own answer to a rule the reference does not meet either,
undefined behaviour a driver is free to honour by luck, and it is the same shape as issue 264.

## What proves it

- `gradlew build` green, after the rebase onto `dev` and not before.
- A census taken on the SPIR-V the corpus compiles to rather than on its text, counting
  `OpImageSampleDrefImplicitLod` inside entry points: 302 before, 0 after, with 302
  `DrefExplicitLod` in their place, exactly conserved. The negative control on the pre-fix build
  returns 302 to the digit.
- The off-game harness over the whole corpus is identical before and after: 2771 units translated
  with the same failures at the same lines, 1147 varying pairs with none refused, and 2565 modules
  through shaderc and SPIRV-Cross with none refused, which is a second compiler accepting the pinned
  form in real pack code.
- In the game: Complementary Reimagined r5.9 on the frozen bench world, camera pinned, the mean of
  120 frames compared against two runs of `dev` in the same state. Two identical `dev` runs move
  17.6 percent of their pixels between themselves, the pack animating its foliage and its sky; this
  jar sits at 7.8 and 18.8 percent against those two runs, inside that floor from both sides, and
  its whole-screen mean matches `dev` to a tenth of a level.

## What it leaves owing

Sixteen implicit compared reads remain in Reverie's shared includes, unchanged before and after:
those units are never compiled as entry points, and that pack's real entry points carry none. And
the arithmetic road still reads the base level whatever the pack wrote, its gather naming no level,
which is a gap of the shadow bindings rather than of this rewrite.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
