### PR TITLE
fix(glsl): test the alpha only on a legacy first output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,18 @@ what the next one holds.
 
 ### Fixed
 
+- **Leaves, grass and the item in hand come back on a pack that tests its own transparency.** A
+  cutout draw needs the test that throws away the see-through parts of a texture, and the engine
+  used to write that test into the shader itself whatever the shader was, reading the fourth channel
+  of the first buffer the program fills. Filling that buffer the way shaders did before they could
+  name their own outputs came with the test built into the hardware, so a program written that way
+  is written expecting it. A program that names the buffer itself is not: it puts what it likes in
+  that channel, a light level as readily as a transparency, and does its own test with the threshold
+  the engine hands it. Testing the channel anyway threw away every leaf, every blade of grass and
+  the item in hand of RenderPearl, on a ground still carrying the shadow of a canopy that was not
+  being drawn. The test is now written only into the programs that expect it, which is where the
+  engine the packs are tuned against writes it too.
+
 - **A pack that paints its picture with compute shaders draws it.** A few packs do their whole
   post-processing in compute programs rather than in full screen passes, and store the finished
   frame into a colour buffer of their own. The engine only ever opened a colour buffer for what a

--- a/NOTICE
+++ b/NOTICE
@@ -982,6 +982,16 @@ Apache License, Version 2.0
   with a depth layout, and a use above that redeclaration is refused by the compiler. The wrapper
   itself, and what it writes, are this engine's.
 
+  common/src/main/java/dev/vitrail/glsl/GlslTranslator.java writes the pass's alpha test into a
+  fragment stage only where that stage reaches draw buffer nought through gl_FragColor or
+  gl_FragData[0] at a literal subscript, which is the condition
+  net.irisshaders.iris.pipeline.transform.transformer.CommonTransformer puts on its own injection,
+  line 280 with gl_FragColor renamed onto gl_FragData[0] at line 239, read on the 26.2 branch on
+  10 September 2026. What is taken is the rule and not the code: a pack that declares its own first
+  output is left to test itself against alphaTestRef, and packs are written expecting exactly that.
+  The question is asked of the spelling here and of the preprocessed text there, and the javadoc of
+  GlslTranslator.planAlphaEpilogue says why and what that leaves standing.
+
 AMD FidelityFX Super Resolution 1.0, https://github.com/GPUOpen-Effects/FidelityFX-FSR
 Copyright (c) 2021 Advanced Micro Devices, Inc.
 MIT License

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -562,6 +562,17 @@ public final class GlslTranslator {
 	private boolean mainWrapped;
 
 	private int maxFragmentOutput = -1;
+
+	/**
+	 * Whether this fragment stage writes draw buffer nought the way the fixed function pipeline
+	 * did, which is {@code gl_FragColor} or {@code gl_FragData[0]} at a literal subscript.
+	 * <p>
+	 * Counted from every branch, taken or not, for the reason {@link #rewriteFragmentOutputs}
+	 * measured about the count beside it. It is what decides whether the pass's alpha test is
+	 * written in at all, and {@link #planAlphaEpilogue} says why.
+	 */
+	private boolean legacySlotZero;
+
 	private boolean ordered;
 	private int dynamicFragData;
 	private int shadowCalls;
@@ -3758,10 +3769,12 @@ public final class GlslTranslator {
 			this.tokens.blank(number);
 			this.tokens.blank(this.tokens.significantAfter(number));
 			this.maxFragmentOutput = Math.max(this.maxFragmentOutput, slot);
+			this.legacySlotZero |= slot == 0;
 		}
 
 		if (fragColor) {
 			this.maxFragmentOutput = Math.max(this.maxFragmentOutput, 0);
+			this.legacySlotZero = true;
 		}
 	}
 
@@ -3959,16 +3972,50 @@ public final class GlslTranslator {
 	 * is done by wrapping, for the reasons {@link #wrapMain} gives about closing braces, and the
 	 * wrapper then makes both calls.
 	 * <p>
-	 * Three things have to hold and none of them is a formality. The stage has to declare an output
-	 * nought, since that is the one the fixed function pipeline tested and the only one a pack can
-	 * mean; that output has to be a {@code vec4}, or it has no alpha to read; and {@code main} has
-	 * to be findable, since a stage whose {@code main} is not is a stage nothing can be appended to.
-	 * Nothing in the corpus fails any of the three, and a program that does keeps its picture and
+	 * <strong>The test is only written into a stage that writes draw buffer nought the way the
+	 * fixed function pipeline did</strong>, {@code gl_FragColor} or {@code gl_FragData[0]} at a
+	 * literal subscript. Iris asks the same before it injects anything, and it asks it in one
+	 * place: {@code pipeline/transform/transformer/CommonTransformer.java:280} on
+	 * {@code origin/26.2} wants the index nought of {@code gl_FragData} to have been rewritten,
+	 * {@code gl_FragColor} having been renamed onto it at {@code :239}. Its core profile
+	 * transformers never call that method at all, and the flag beside the condition is passed true
+	 * by the roads that must not inject whatever a stage writes, the composites and the compute
+	 * ones; the road a pack's geometry takes passes it false.
+	 * <p>
+	 * A pack that declares its own {@code layout(location = 0) out} is saying that slot holds
+	 * whatever it packed there, and the reference leaves it to test itself against
+	 * {@code alphaTestRef}, which it serves under that name and under {@code iris_currentAlphaTest}
+	 * both ({@code uniforms/IrisInternalUniforms.java:41,45}), renaming a pack's use of the first
+	 * only on its core profile roads.
+	 * <p>
+	 * <strong>Writing one in anyway is not a harmless extra.</strong> RenderPearl's cutout terrain
+	 * puts the block light level in the alpha of its draw buffer nought,
+	 * {@code colortex1 = f16vec4(linear(color.rgb), block_light)}, and an injected
+	 * {@code if (!(colortex1.a > 0.5)) { discard; }} then threw away every cutout fragment of the
+	 * world: no leaves, no grass, no held item, on a ground still carrying the canopy's shadow. The
+	 * alpha of a self declared slot nought is not an alpha, it is whatever the pack packed there.
+	 * <p>
+	 * <strong>The question is asked of the spelling and not of the live branches</strong>, which
+	 * differs from the reference and is deliberate: Iris preprocesses the file before its
+	 * transformer sees it, this translator leaves every {@code #if} standing so the game's compiler
+	 * re-evaluates the engine symbols, and the branch the expander read as dead is one the compiler
+	 * may read as live. {@link #rewriteFragmentOutputs} measured what asking for liveness costs on
+	 * exactly this token. What it leaves standing is a pack whose only legacy write to slot nought
+	 * sits on a dead branch beside a live declaration of its own, the shape {@link #liftOutput}
+	 * describes: that one would be given a test on its own output. No pack of the corpus writes it,
+	 * and withholding a discard from a program that really writes the builtin is the worse of the
+	 * two, a leaf drawn as a cube.
+	 * <p>
+	 * Two more things have to hold. Where the pack has ALSO declared slot nought for itself, that
+	 * declaration owns the name the test would read, so it has to be a {@code vec4} or there is no
+	 * alpha there to read; and {@code main} has to be findable, since a stage whose {@code main} is
+	 * not is a stage nothing can be appended to. A program that fails either keeps its picture and
 	 * loses its discard, which {@link TranslatedUnit.Notes#alphaEpilogue} reports rather than hides.
 	 */
 	private void planAlphaEpilogue() {
-		if (this.stage != ProgramStage.FRAGMENT || !this.alphaTest.tests()
-				|| this.maxFragmentOutput < 0) {
+		// No test for maxFragmentOutput here, unlike planCoverage: neither road can raise the flag
+		// without that count having been raised too, the gl_FragColor one at the end of its walk.
+		if (this.stage != ProgramStage.FRAGMENT || !this.alphaTest.tests() || !this.legacySlotZero) {
 			return;
 		}
 

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -323,6 +323,16 @@ implementation's value for that pass, or a line in the pack's properties file na
 that serves it, which wins over it. That second one is why a pack shipping a single
 `gbuffers_terrain` for both the solid and the cutout pass moves both of them with one override.
 
+That test is written into the shader, and only into a fragment stage that writes its first draw
+buffer the way the fixed function pipeline did, through `gl_FragColor` or `gl_FragData[0]` at a
+subscript written out as a number. A pack that declares `layout(location = 0) out` for itself gets
+none, and is left to test itself against the `alphaTestRef` value the engine hands it, which is what
+the reference leaves it to do as well. The reason is that the alpha of a self declared first output
+is not an alpha at all: it is whatever the pack chose to pack there, a light level or a material
+word as easily as a coverage. Testing it discards geometry on a value that means nothing, and the
+symptom is a world with its solid blocks and none of its leaves, grass or held item, on a ground
+still carrying the shadow those leaves cast.
+
 There is a practical corollary for anyone choosing a witness block for a test: a block drawn in the
 cutout pass never reaches a program that has only been substituted on the solid pass. Foliage is
 cutout. Picking a leaf block to prove that block ids arrive is a test of nothing, and it looks like a


### PR DESCRIPTION
## What changes

A geometry pass whose alpha test asks for a discard had that discard written into every fragment
stage that declared a first draw buffer of type `vec4`, whoever had declared it. It is now written
only where the stage reaches that buffer the way the fixed function pipeline did, through
`gl_FragColor` or `gl_FragData[0]` at a literal subscript. A pack that declares its own
`layout(location = 0) out` puts whatever it likes in that slot's fourth channel and does its own
test against `alphaTestRef`. RenderPearl puts the block light level there, so the injected
`if (!(colortex1.a > 0.5)) { discard; }` threw away every cutout fragment of the world: no leaves,
no grass, no held item, on a ground still carrying the shadow of a canopy nothing was drawing.

## How it differs from the reference, and for what obstacle

It does not. This removes a divergence. Iris asks the same question in one place,
`pipeline/transform/transformer/CommonTransformer.java:280` on `origin/26.2`, with `gl_FragColor`
renamed onto `gl_FragData[0]` at `:239`; its core profile transformers never reach that method, and
it serves `alphaTestRef` under that name to a pack that tests itself,
`uniforms/IrisInternalUniforms.java:45`. The rule is now in `NOTICE`.

The question is asked here of the spelling and there of the preprocessed text, because this
translator leaves every `#if` standing so the game's compiler re-evaluates the engine symbols. That
is the same answer the output count beside it already gives, and for the reason measured there: a
branch read as dead here is one the compiler may read as live, and withholding a discard from a
program that really writes the builtin draws a leaf as a cube.

## What proves it

- `gradlew build` green.
- `harness/Terrain` over the bench corpus, both colour contracts, emitted GLSL compared file by
  file against `dev`: 8 files of 640 differ, the four passes of Mellow and Clarity whose first draw
  buffer is their own declaration and which carry their own test. `harness/Entities` the same way,
  1058 files, none differ; `Crumbling`, `Lines`, `Text` and `Geometry` tables unchanged.
- The same run carries both controls: Sildur's shadow cutout writes `gl_FragData[0]` and keeps its
  test to the character, Mellow's cutout declares its own slot and loses it.
- In the game, Fabric bench, world `frozen real`, RenderPearl v2.8.0-beta.4, same camera: on `dev`
  bare trunks, no grass, no held item; on this branch the foliage, the grass and the held item are
  drawn. Mellow, whose cutout loses its injected test here, keeps the silhouettes it had on `dev`.

## What it leaves owing

RenderPearl's picture has still never been read against Iris with its foliage in it: the campaign
figure that made it the worst pack of the run was taken while all of it was being discarded, and it
has to be retaken before anything else about that pack is believed.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one.
