### PR TITLE
fix(glsl): drop the debug names Metal reads as its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,22 @@ what the next one holds.
   being drawn. The test is now written only into the programs that expect it, which is where the
   engine the packs are tuned against writes it too.
 
+- **A pack no longer brings the game down on a Mac over a name it chose.** Apple hardware has no
+  driver of its own for the interface this engine draws through, so a translation layer rewrites
+  every shader into Metal's language, which is C++, and it carries over the names a pack gave its
+  own functions and variables. A pack that had named something `bias`, `length_squared` or `new`
+  then collided with words that language already owns, and Apple's compiler refused the whole pass:
+  the game came down at the moment the world was drawn, on a pipeline it could not compile. BSL,
+  Bliss and Photon all died there, on the version out today as much as on this one. The engine now
+  drops the names of everything outside a shader never asks for, which is where a pack names its
+  own working parts, and BSL draws. The names of what a pack exposes stay, its uniforms and its
+  textures, because the engine binds those by name; none of the packs tried collides there.
+
+  Bliss and Photon get past that and stop on a different Apple limit, which is not lifted here.
+  Metal offers sixteen slots for the textures one pass reads, and the engine hands it slot
+  numbers that run past the sixteenth even where a pass reads far fewer than sixteen. Reverie,
+  which never had a name to collide, is refused there too.
+
 - **A pack that paints its picture with compute shaders draws it.** A few packs do their whole
   post-processing in compute programs rather than in full screen passes, and store the finished
   frame into a colour buffer of their own. The engine only ever opened a colour buffer for what a

--- a/common/src/main/java/dev/vitrail/cache/ModuleCache.java
+++ b/common/src/main/java/dev/vitrail/cache/ModuleCache.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
 import dev.vitrail.glsl.LocalZeroes;
 import dev.vitrail.mixin.access.IntermediaryShaderModuleAccessor;
 import dev.vitrail.render.PackChain;
+import dev.vitrail.render.PackNames;
 import dev.vitrail.render.RawLocals;
 import dev.vitrail.render.ShaderDebugInfo;
 import dev.vitrail.Vitrail;
@@ -357,6 +358,7 @@ public final class ModuleCache {
 		feed(digest, RawLocals.cacheWord());
 		feed(digest, LocalZeroes.VERSION);
 		feed(digest, ShaderDebugInfo.cacheWord());
+		feed(digest, PackNames.cacheWord());
 		feed(digest, stage);
 		feed(digest, source);
 
@@ -656,6 +658,7 @@ public final class ModuleCache {
 			Vitrail.logger().info("Module cache off, so all {} units of this load were compiled and "
 					+ "reflected ({} since this launch)", misses, COMPILED_SINCE_LAUNCH.get());
 			RawLocals.say(misses);
+			PackNames.say(misses);
 
 			return;
 		}
@@ -673,9 +676,10 @@ public final class ModuleCache {
 					misses > named.size() ? "begin with" : "are", String.join(", ", named));
 		}
 
-		// At the same quiet moment and about the same compiles: what the pass did to the modules
+		// At the same quiet moment and about the same compiles: what the passes did to the modules
 		// this line counts as built.
 		RawLocals.say(misses);
+		PackNames.say(misses);
 	}
 
 	/** The directory, made and measured at the first unit of the run, or null when there is none. */

--- a/common/src/main/java/dev/vitrail/glsl/DebugNames.java
+++ b/common/src/main/java/dev/vitrail/glsl/DebugNames.java
@@ -1,0 +1,244 @@
+package dev.vitrail.glsl;
+
+import java.util.BitSet;
+
+/**
+ * Drops the debug names a module carries for everything that is not a resource, an input or an
+ * output, because on Apple hardware those names reach a C++ compiler that has its own meaning for
+ * some of them.
+ * <p>
+ * <strong>What it costs a pack to keep them.</strong> MoltenVK does not hand SPIR-V to Metal: it
+ * runs its own SPIRV-Cross and renders MSL, which is C++, and it takes the identifiers of that MSL
+ * from the module's {@code OpName} strings. A pack's own names then land in Metal's namespace, and
+ * Apple's compiler refuses the pipeline outright where one of them collides. Measured on an M4,
+ * macOS Tahoe 26.6.1, MoltenVK 1.4.2, over the nine packs swept there: Photon dies on
+ * {@code call to 'length_squared' is ambiguous}, its own helper against the one in Metal's standard
+ * library, and again on {@code invalid parameter name: 'new' is a keyword}; Bliss dies on
+ * {@code reference to 'bias' is ambiguous}, {@code metal::bias} being a type over there; BSL dies
+ * on {@code expected unqualified-id}. Three packs of the nine carried a colliding name, the same
+ * three carried it on the published 0.10.0-beta, so this has been shipping. Only BSL comes back
+ * on the names alone: Bliss and Photon carry a second refusal underneath, unrelated to any name,
+ * so they get past this pass and stop later.
+ * <p>
+ * <strong>Why dropping rather than renaming.</strong> A rename needs the list of what Metal
+ * reserves, which is a C++ keyword list plus a standard library that grows with every macOS, so a
+ * list is wrong the day after it is written. Dropping a name cannot collide with anything: the
+ * driver's SPIRV-Cross mints {@code _123} for whatever has none, and no compiler has a meaning for
+ * that. What is dropped is debug information, referenced by no instruction of the module.
+ * <p>
+ * <strong>What is KEPT, and why exactly this set.</strong> The names the game reads back are kept:
+ * every variable in a storage class the reflection walks, and the type behind each of them, arrays
+ * unwrapped, so that a uniform block's own name and its members' names survive. That type matters
+ * as much as the variable: SPIRV-Cross reports an empty name where the {@code OpName} sits on the
+ * block type rather than on the instance, which is the shape Complementary's
+ * {@code buffer blockDataBuffer { } blockDataSSBO} has, and the engine reads the type's name back
+ * for it ({@code render/ComputeShader.java:260-279}, the third fallback at the end of that
+ * method). A resource whose name went would come back empty from both, and {@code rebind} then
+ * throws rather than binding anything.
+ * <p>
+ * Everything else goes: functions, their parameters, module-scope globals a pack declares outside
+ * a block, locals, shared variables of a compute, and the plain structs a pack passes between its
+ * own functions. Not one of those is ever asked for by name from outside the module.
+ * <p>
+ * <strong>What it therefore does NOT cover.</strong> A pack that gives one of its UNIFORMS, its
+ * samplers or its stage interface a name Metal owns keeps that collision, the name being one the
+ * outside asks for. Nor does the kept set reach INSIDE a block: a struct a pack declares and then
+ * uses as a member of a kept block loses its own member names, only the block's own members being
+ * kept, and that is deliberate. What the reflection reads back of a block is the block and its
+ * members; the fields of a struct standing in one of those members are read by the module alone. What says the corpus has none of those is the sweep itself and not a reading:
+ * with this pass in, no pack of the nine is refused for a name any more, and the three that still
+ * fail, Bliss, Reverie and Photon, fail on Metal's sampler slots. That one is a NUMBERING and not
+ * a count: the refused stage names thirteen samplers while their binding numbers reach
+ * twenty-three, and Metal has sixteen slots. A rename here would be a second subject, and a
+ * harder one: it has to be carried through the binding side too, which keys on those very names.
+ * <p>
+ * <strong>It does not run when debug information was asked for.</strong> Somebody who set
+ * {@code -Dvitrail.shaderDebugInfo=true} wants to read the module, and a module full of
+ * {@code _123} is not readable; that state is already in the module cache's key, so the two never
+ * serve each other's blobs.
+ * <p>
+ * The pass is a pure function of the words, like {@link LocalZeroes}, and the buffer dance lives at
+ * the call site.
+ */
+public final class DebugNames {
+
+	/**
+	 * What the module cache hashes into its key for this pass: a change to what it drops changes
+	 * the bytes handed to the driver, and a blob built by the old rule must never be served under
+	 * the new one.
+	 */
+	public static final String VERSION = "names-1";
+
+	private static final int HEADER_WORDS = 5;
+
+	private static final int OP_NAME = 5;
+	private static final int OP_MEMBER_NAME = 6;
+	private static final int OP_TYPE_ARRAY = 28;
+	private static final int OP_TYPE_RUNTIME_ARRAY = 29;
+	private static final int OP_TYPE_POINTER = 32;
+	private static final int OP_VARIABLE = 59;
+
+	/**
+	 * The storage classes whose names are read from outside the module: uniforms, samplers and the
+	 * storage images a pack declares, all three {@code UniformConstant} or {@code Uniform} in what
+	 * glslang emits, the storage blocks ({@code StorageBuffer}), the push constants, and the stage
+	 * interface ({@code Input}, {@code Output}). {@code Image} is in the list for the sake of a
+	 * module that uses that class rather than because glslang writes one.
+	 * {@code Private}, {@code Function} and {@code Workgroup} are
+	 * deliberately absent: a pack's globals, its locals and a compute's shared variables are
+	 * nobody's business but the module's.
+	 */
+	private static final int[] KEPT_CLASSES = {0, 1, 2, 3, 9, 11, 12};
+
+	private DebugNames() {
+	}
+
+	/**
+	 * What one pass did to one module.
+	 *
+	 * @param words   the module, the same array when nothing was dropped
+	 * @param dropped how many name instructions went
+	 */
+	public record Result(int[] words, int dropped) {
+
+		public boolean changed() {
+			return this.dropped > 0;
+		}
+	}
+
+	/**
+	 * Walks the module three times: once to find the ids whose names are read from outside, once to
+	 * count what would go, and once to rebuild it without them. The first two are needed before
+	 * the third because the debug section, where the names sit, comes BEFORE the types and
+	 * variables it names, and because a module with nothing to drop must come back on its own array
+	 * rather than on a copy of itself: this runs on every module the engine compiles.
+	 * <p>
+	 * A module that cannot be walked as SPIR-V comes back untouched, and it is the driver's place
+	 * to refuse it. Past {@link LocalZeroes#readable}, an instruction that declares four words has
+	 * four words, so the operand reads below need no bound of their own.
+	 */
+	public static Result strip(int[] words) {
+		if (!LocalZeroes.readable(words)) {
+			return new Result(words, 0);
+		}
+
+		BitSet kept = keptIds(words);
+		int dropped = 0;
+		int keptWords = HEADER_WORDS;
+		for (int at = HEADER_WORDS; at < words.length; ) {
+			int length = words[at] >>> 16;
+			if (drops(words, at, kept)) {
+				dropped++;
+			} else {
+				keptWords += length;
+			}
+			at += length;
+		}
+
+		if (dropped == 0) {
+			return new Result(words, 0);
+		}
+
+		int[] out = new int[keptWords];
+		System.arraycopy(words, 0, out, 0, HEADER_WORDS);
+		int write = HEADER_WORDS;
+		for (int at = HEADER_WORDS; at < words.length; ) {
+			int length = words[at] >>> 16;
+			if (!drops(words, at, kept)) {
+				System.arraycopy(words, at, out, write, length);
+				write += length;
+			}
+			at += length;
+		}
+
+		return new Result(out, dropped);
+	}
+
+	/** Whether the instruction standing here is a name of something the outside never asks for. */
+	private static boolean drops(int[] words, int at, BitSet kept) {
+		int opcode = words[at] & 0xFFFF;
+		int length = words[at] >>> 16;
+		// A name is three words at least, the opcode, its target and one word of string. Shorter
+		// than that it is not one, whatever the opcode says, and it is kept: this pass drops what
+		// it has understood and never what it has not.
+		if (length < 3 || (opcode != OP_NAME && opcode != OP_MEMBER_NAME)) {
+			return false;
+		}
+
+		int target = words[at + 1];
+
+		return target >= 0 && !kept.get(target);
+	}
+
+	/**
+	 * The ids whose names survive: each variable of a kept storage class, and the type it points
+	 * at with its arrays unwrapped, which is where a block's member names hang.
+	 */
+	private static BitSet keptIds(int[] words) {
+		BitSet kept = new BitSet();
+		// Bound is the header's fourth word, so every id a well formed module uses fits under it.
+		// Clamped at BOTH ends rather than trusted. Every id costs at least the two words of the
+		// instruction that mints it, so a bound above the module's own length is not a bound, and
+		// sizing the tables from it would allocate whatever a broken header happened to ask for. A
+		// bound a module UNDERSTATES is left alone, and what that costs is written down rather than
+		// guarded: an id past the tables is not followed, so the type name of a block declared past
+		// the bound would go, and the module saying so is the broken one.
+		int[] pointee = new int[Math.min(Math.max(words[3], 1), words.length)];
+		int[] element = new int[pointee.length];
+		for (int at = HEADER_WORDS; at < words.length; ) {
+			int length = words[at] >>> 16;
+			int opcode = words[at] & 0xFFFF;
+			switch (opcode) {
+				case OP_TYPE_POINTER -> {
+					if (length >= 4 && inRange(words[at + 1], pointee)) {
+						pointee[words[at + 1]] = words[at + 3];
+					}
+				}
+				case OP_TYPE_ARRAY, OP_TYPE_RUNTIME_ARRAY -> {
+					if (length >= 3 && inRange(words[at + 1], element)) {
+						element[words[at + 1]] = words[at + 2];
+					}
+				}
+				case OP_VARIABLE -> {
+					if (length >= 4 && isKept(words[at + 3])) {
+						int id = words[at + 2];
+						if (id >= 0) {
+							kept.set(id);
+						}
+						int type = inRange(words[at + 1], pointee) ? pointee[words[at + 1]] : 0;
+						// An array of arrays of a block is the deepest thing GLSL declares, so two
+						// unwraps answer every real module. The loop allows eight and stops there
+						// rather than trusting a module not to point an array at itself.
+						for (int step = 0; step < 8 && type > 0; step++) {
+							kept.set(type);
+							int inner = inRange(type, element) ? element[type] : 0;
+							if (inner <= 0) {
+								break;
+							}
+							type = inner;
+						}
+					}
+				}
+				default -> {
+				}
+			}
+			at += length;
+		}
+
+		return kept;
+	}
+
+	private static boolean inRange(int id, int[] table) {
+		return id > 0 && id < table.length;
+	}
+
+	private static boolean isKept(int storageClass) {
+		for (int kept : KEPT_CLASSES) {
+			if (kept == storageClass) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/common/src/main/java/dev/vitrail/glsl/LocalZeroes.java
+++ b/common/src/main/java/dev/vitrail/glsl/LocalZeroes.java
@@ -149,7 +149,7 @@ public final class LocalZeroes {
 	 *         SPIR-V, a new one otherwise
 	 */
 	public static Result apply(int[] words) {
-		if (words.length < HEADER_WORDS || words[0] != MAGIC || !wellFormed(words)) {
+		if (!readable(words)) {
 			return new Result(words, 0, 0);
 		}
 
@@ -274,6 +274,16 @@ public final class LocalZeroes {
 		}
 
 		return new Result(out, zeroAt.size(), undefAt.size());
+	}
+
+	/**
+	 * Whether the words can be walked as SPIR-V at all: the magic number first, and every
+	 * instruction's word count keeping inside the module. Shared with {@link DebugNames}, which
+	 * walks the same words for its own reason and needs the same guarantee before it indexes an
+	 * operand: past this, an instruction that declares four words HAS four words.
+	 */
+	static boolean readable(int[] words) {
+		return words.length >= HEADER_WORDS && words[0] == MAGIC && wellFormed(words);
 	}
 
 	/** Whether every instruction's word count keeps inside the module. */

--- a/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/GlslCompilerMixin.java
@@ -13,6 +13,7 @@ import com.mojang.blaze3d.vulkan.glsl.ShaderCompileException;
 import dev.vitrail.cache.ModuleCache;
 import dev.vitrail.glsl.LoadClock;
 import dev.vitrail.render.GeometryStage;
+import dev.vitrail.render.PackNames;
 import dev.vitrail.render.RawLocals;
 import dev.vitrail.render.ShaderDebugInfo;
 import dev.vitrail.render.storage.StorageImages;
@@ -203,7 +204,15 @@ public abstract class GlslCompilerMixin {
 							+ "Lcom/mojang/blaze3d/vulkan/glsl/IntermediaryShaderModule;"))
 	private IntermediaryShaderModule vitrail$zeroLocals(String filename, ByteBuffer spirv,
 			Operation<IntermediaryShaderModule> original) {
-		return original.call(filename, RawLocals.patch(filename, spirv));
+		// Two passes over the same output, in this order and not either order. Neither depends on
+		// what the other did to the instructions, the zeroes going by opcode and storage class and
+		// the names by their target, but they are not independent of the HEADER: the zeroes raise
+		// the id bound when they mint ids, and the names pass sizes its tables from that bound, so
+		// each one has to read the bound of the module it is actually handed. Both run BEFORE the
+		// reflection, which has to read the module the driver will read. Each pass frees the buffer
+		// it replaces and neither refuses a module it failed to understand, so one buffer reaches
+		// the module and one only.
+		return original.call(filename, PackNames.patch(filename, RawLocals.patch(filename, spirv)));
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/render/PackNames.java
+++ b/common/src/main/java/dev/vitrail/render/PackNames.java
@@ -1,0 +1,96 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+import dev.vitrail.glsl.DebugNames;
+import org.lwjgl.system.MemoryUtil;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Runs {@link DebugNames} over the modules this engine compiles, so that a pack's own identifiers
+ * do not reach Apple's Metal compiler and collide with its namespace. {@link DebugNames} carries
+ * what it drops, what it keeps, and which of the packs that were dying were dying of this.
+ * <p>
+ * Placed exactly where {@link RawLocals} is placed, between shaderc and the reflection, and it
+ * follows the same rule about the buffer: whoever replaces a buffer frees the one they were handed,
+ * so the module ends up closing one buffer and one only.
+ * <p>
+ * Only this engine's own compiles. The game's shaders and Sodium's go through the same compiler and
+ * are left alone: they are written by people who can be told to rename a variable, and a name of
+ * theirs the game reads back is not this engine's business.
+ */
+public final class PackNames {
+
+	private static final AtomicLong WALKED = new AtomicLong();
+	private static final AtomicLong STRIPPED = new AtomicLong();
+	private static final AtomicLong NAMES = new AtomicLong();
+
+	private PackNames() {
+	}
+
+	/** The word the module cache's key carries, since what this drops changes the bytes. */
+	public static String cacheWord() {
+		return DebugNames.VERSION;
+	}
+
+	/**
+	 * The module the reflection should read: the one handed in, or one without the names of
+	 * anything the outside never asks for, in which case the one handed in has been freed.
+	 *
+	 * @param filename the debug name the compile was given, which says whose module it is
+	 * @param spirv    the compiler's output, native order, position at nought
+	 */
+	public static ByteBuffer patch(String filename, ByteBuffer spirv) {
+		// The same set of compiles RawLocals claims, asked of RawLocals rather than restated: two
+		// copies of that rule would answer differently the day one of them is widened.
+		if (ShaderDebugInfo.asked() || !RawLocals.ours(filename)) {
+			return spirv;
+		}
+
+		WALKED.incrementAndGet();
+		int[] words = new int[spirv.remaining() / 4];
+		spirv.duplicate().order(ByteOrder.nativeOrder()).asIntBuffer().get(words);
+		DebugNames.Result result = DebugNames.strip(words);
+		if (!result.changed()) {
+			return spirv;
+		}
+
+		ByteBuffer stripped = MemoryUtil.memCalloc(result.words().length * 4);
+		stripped.order(ByteOrder.nativeOrder()).asIntBuffer().put(result.words());
+		MemoryUtil.memFree(spirv);
+		STRIPPED.incrementAndGet();
+		NAMES.addAndGet(result.dropped());
+
+		return stripped;
+	}
+
+	/**
+	 * One line beside the module cache's, said in BOTH states: a load served whole from the store
+	 * was built under the state its blobs carry, and a reading taken on it has to be able to name
+	 * that state.
+	 *
+	 * @param compiled how many modules the compiler built this load
+	 */
+	public static void say(long compiled) {
+		long walked = WALKED.getAndSet(0L);
+		long stripped = STRIPPED.getAndSet(0L);
+		long names = NAMES.getAndSet(0L);
+		if (ShaderDebugInfo.asked()) {
+			Vitrail.logger().warn("Debug names LEFT IN every module, asked for by "
+					+ "-Dvitrail.shaderDebugInfo ({} modules built this load, none walked): a pack "
+					+ "identifier that collides with Metal's namespace refuses its pipeline on "
+					+ "Apple hardware, which is what dropping them prevents", compiled);
+
+			return;
+		}
+
+		Vitrail.logger().info("Debug names dropped off what the outside never asks for: {} names in "
+						+ "{} of the {} pack modules walked ({} modules built this load in all, the "
+						+ "rest served already stripped), which is the default. "
+						+ "-Dvitrail.shaderDebugInfo would leave them in, and this line is said "
+						+ "either way so that a reading can name the state it was taken under",
+				names, stripped, walked, compiled);
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/RawLocals.java
+++ b/common/src/main/java/dev/vitrail/render/RawLocals.java
@@ -30,9 +30,11 @@ import java.util.concurrent.atomic.AtomicLong;
  * module of one state under the key of the other, and serve it for as long as the key lives.
  * <p>
  * The pass runs between shaderc and the reflection, on the buffer the game copied the compiler's
- * output into, and hands the reflection a buffer of its own allocation when anything was changed:
- * the module frees whichever buffer it was built on, so the copy the game made is freed here in
- * that case and nothing is freed twice.
+ * output into, and hands on a buffer of its own allocation when anything was changed. The rule is
+ * that whoever replaces a buffer frees the one they were handed: the copy the game made is freed
+ * here in that case, and the buffer this pass hands on is freed in its turn by {@link PackNames}
+ * if that pass replaces it, or by the module it was built on if it gets that far. Nothing is
+ * freed twice and nothing is left behind.
  */
 public final class RawLocals {
 
@@ -129,7 +131,7 @@ public final class RawLocals {
 	 * {@code vitrail_sodium_pack_...}, and this engine's own {@code vitrail_...}), or the label
 	 * {@link PackCompute} gives a compute ({@code pack/<load>/...}).
 	 */
-	private static boolean ours(String filename) {
+	static boolean ours(String filename) {
 		return filename.startsWith(Vitrail.MOD_ID + "_") || filename.startsWith("pack/");
 	}
 

--- a/common/src/main/java/dev/vitrail/render/ShaderDebugInfo.java
+++ b/common/src/main/java/dev/vitrail/render/ShaderDebugInfo.java
@@ -23,6 +23,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * decide is the constructor, and the compiler there is the one the game, Sodium and this engine
  * all compile through.
  * <p>
+ * <strong>It decides the debug NAMES as well, since {@link PackNames} reads it.</strong> Off, the
+ * identifiers of everything outside a module never asks for are dropped from this engine's own
+ * modules, which is what keeps a pack's own words out of Metal's namespace on Apple hardware. On,
+ * they stay, because a module whose every function and variable is called {@code _123} is not the
+ * module somebody who asked for debug information meant to read.
+ * <p>
  * {@code -Dvitrail.shaderDebugInfo=true} asks for it back, and the two states keep two sets of
  * blobs: the switch changes the bytes a compile produces without changing the text it was handed,
  * so it goes into the module cache's key exactly as {@link RawLocals} does. Read once at start,


### PR DESCRIPTION
## What changes

Apple hardware has no Vulkan driver of its own: MoltenVK rewrites every shader into Metal's
language, which is C++, and it builds that language's identifiers out of the debug names carried in
the compiled module. A pack's own function, parameter and variable names therefore land in Metal's
namespace, and Apple's compiler refuses the whole pipeline where one of them collides: `bias` is a
type there, `length_squared` a standard library call, `new` a keyword. The engine now drops the
debug names of everything the outside never asks for, between the compiler and the reflection.

What keeps its name is what is read back BY name: every variable in a storage class the reflection
walks, and the type behind it with its arrays unwrapped, so a uniform block keeps its own name and
its members' and the binding remap is untouched. Functions, parameters, globals, locals, a
compute's shared variables and a pack's own structs lose theirs. Dropped rather than renamed: a
rename needs the list of what Metal reserves, a C++ keyword list plus a standard library that grows
with every macOS, and a name that is gone cannot collide with anything.
`-Dvitrail.shaderDebugInfo=true` leaves them in, and that state already keys the module cache.

## How it differs from the reference, and for what obstacle

It does not. Iris has no Vulkan road on macOS at all: its GLSL goes to Apple's OpenGL driver, which
compiles it as GLSL, where none of those words is reserved. Nothing here to align with.

## What proves it

- `gradlew clean build --no-build-cache` green.
- On an Apple M4 under MoltenVK 1.4.2, nine packs, one fresh launch each: six draw where five did.
  BSL comes back whole. Bliss and Photon get past the names and stop later, on Metal's sampler
  slots, which this branch does not touch. The five that already drew are unchanged.
- The same jar with the names left in, one property apart: Photon dies again on
  `call to 'length_squared' is ambiguous`, at the same pipeline. So the pass moved them, not the
  base.
- On the Windows Fabric bench, Photon and then Cursed Fog against a `dev` jar of the same tree: the
  seventeen lines naming which family is drawn by which program are identical word for word,
  uniform counts and sampler counts included, and so is the whole warning set on Cursed Fog. No
  pipeline refused on either jar. The picture as a sixty frame mean on the pinned real-terrain
  scene sits at 15.2 percent of pixels moved against a 13.8 floor taken with the jar held fixed,
  and the mean screen colour agrees to a tenth of a level.

## What it leaves owing

Three packs still refused on Apple, all three for one reason and none of it names: a stage whose
sampler bindings are numbered past Metal's sixteenth slot. Thirteen samplers wanted, indices
reaching twenty-three, the layout being built from every sampler a program DECLARES with the holes
numbered through. A batch of its own.

A pack naming one of its uniforms, its textures or its stage interface after something Metal owns
keeps that collision, those being the names the engine binds by. None of the nine does.

The off-game Metal gate still converts modules carrying their names, so it cannot see this pass,
and the pass has no gate of its own there. Both belong to the harness.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
