### PR TITLE
fix(render): bind the samplers a module reaches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,10 +183,22 @@ what the next one holds.
   own working parts, and BSL draws. The names of what a pack exposes stay, its uniforms and its
   textures, because the engine binds those by name; none of the packs tried collides there.
 
-  Bliss and Photon get past that and stop on a different Apple limit, which is not lifted here.
-  Metal offers sixteen slots for the textures one pass reads, and the engine hands it slot
-  numbers that run past the sixteenth even where a pass reads far fewer than sixteen. Reverie,
-  which never had a name to collide, is refused there too.
+  Bliss and Photon got past that and stopped on a different Apple limit, the one below.
+
+- **A pack that declares more textures than a pass reads draws on a Mac.** Apple offers one pass
+  sixteen slots for the textures it reads, and numbers them off the whole list of textures the
+  engine hands that pass rather than off the ones its shaders touch. A pack usually declares every
+  texture it owns in one file all its programs include, so a pass reading thirteen of them was
+  handed a list of forty-eight and given slot numbers running past the sixteenth: Apple's compiler
+  refused it and the game came down as the world was drawn, on a pass wanting three fewer slots
+  than the hardware has. The engine now numbers a pass off the textures its two shader stages read
+  between them, which is the count that has to fit, so the numbering is dense and anything under
+  sixteen gets in. Bliss and Photon draw.
+
+  Reverie has two passes whose stages read seventeen and eighteen textures between them, more than
+  Apple's hardware holds however they are numbered, and those two stay refused. Everywhere else this
+  is invisible: the same textures are bound as before and the same ones are read, and what changes
+  is only which of them the pass is given a numbered slot for.
 
 - **A pack that paints its picture with compute shaders draws it.** A few packs do their whole
   post-processing in compute programs rather than in full screen passes, and store the finished

--- a/common/src/main/java/dev/vitrail/cache/ModuleCache.java
+++ b/common/src/main/java/dev/vitrail/cache/ModuleCache.java
@@ -6,6 +6,7 @@ import dev.vitrail.mixin.access.IntermediaryShaderModuleAccessor;
 import dev.vitrail.render.PackChain;
 import dev.vitrail.render.PackNames;
 import dev.vitrail.render.RawLocals;
+import dev.vitrail.render.SamplerReach;
 import dev.vitrail.render.ShaderDebugInfo;
 import dev.vitrail.Vitrail;
 
@@ -359,6 +360,7 @@ public final class ModuleCache {
 		feed(digest, LocalZeroes.VERSION);
 		feed(digest, ShaderDebugInfo.cacheWord());
 		feed(digest, PackNames.cacheWord());
+		feed(digest, SamplerReach.cacheWord());
 		feed(digest, stage);
 		feed(digest, source);
 
@@ -659,6 +661,7 @@ public final class ModuleCache {
 					+ "reflected ({} since this launch)", misses, COMPILED_SINCE_LAUNCH.get());
 			RawLocals.say(misses);
 			PackNames.say(misses);
+			SamplerReach.say(misses);
 
 			return;
 		}
@@ -680,6 +683,7 @@ public final class ModuleCache {
 		// this line counts as built.
 		RawLocals.say(misses);
 		PackNames.say(misses);
+		SamplerReach.say(misses);
 	}
 
 	/** The directory, made and measured at the first unit of the run, or null when there is none. */

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -4781,7 +4781,8 @@ public final class GlslTranslator {
 	/**
 	 * Moves every plain uniform into one block, because Vulkan takes no other kind. Samplers stay
 	 * opaque and loose, but their declarations leave the body the same way: the header writes them
-	 * in the order the program handed over, sampled names first, so MoltenVK numbers those first.
+	 * in the order the program handed over, sampled names first. What that order buys, and what it
+	 * no longer decides, is on {@code ProgramTranslator.sampledFirst}.
 	 * <p>
 	 * Brace depth is not consulted. A uniform is only legal at file scope, {@code uniform} is a
 	 * reserved word so it can be nothing else, and a pack that opens a brace in one branch of an

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -489,6 +489,15 @@ public final class ProgramTranslator {
 	 * Names a stage samples first, unused declarations after, so both the bind group and the
 	 * shader text meet the used names first. The compiler assigns bindings in the order it first
 	 * meets a name, and MoltenVK turns that into a Metal sampler that only accepts 0 through 15.
+	 * <p>
+	 * This is no longer what decides whether a pack fits under those sixteen, and it was never
+	 * enough on its own: what counts as sampled here is read off the translated TEXT, where every
+	 * {@code #if} is still standing, so a name read in a branch the game's compiler will drop
+	 * counts as sampled and takes a place at the front. Measured over the corpus that keeps about
+	 * three times too many. {@code render/SamplerReach} answers the same question on the compiled
+	 * module, where the branches are settled, and the layout is built from that. What this is still
+	 * for is the two roads where that answer is not there: a module SPIRV-Cross would not read
+	 * twice, and {@code -Dvitrail.declaredSamplers}.
 	 */
 	private static List<TranslatedUnit.Uniform> sampledFirst(
 			Map<String, TranslatedUnit.Uniform> samplers,

--- a/common/src/main/java/dev/vitrail/mixin/IntermediaryShaderModuleMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/IntermediaryShaderModuleMixin.java
@@ -4,6 +4,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
 import dev.vitrail.render.ComputeShader;
+import dev.vitrail.render.SamplerReach;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Coerce;
@@ -14,7 +15,8 @@ import java.nio.ByteBuffer;
 
 /**
  * Lists SPIR-V storage images and storage buffers beside the resources the game asks SPIRV-Cross
- * for, and lets a 3D image through {@code rebind}.
+ * for, drops the sampled images the entry point never reaches, and lets a 3D image through
+ * {@code rebind}.
  * <p>
  * Type 6 is a storage image. Type 2 is a storage buffer. Type 7 is a sampled image.
  * {@code createFromSpirv} walks 1 and 7 and leaves 2 and 6 on the bindings shaderc assigned.
@@ -24,9 +26,17 @@ import java.nio.ByteBuffer;
 @Mixin(IntermediaryShaderModule.class)
 public abstract class IntermediaryShaderModuleMixin {
 
+	/**
+	 * The narrowing goes first and the two appends after, though the order does not decide the
+	 * result: what {@link SamplerReach} drops is named by the reflection as a sampled image, and a
+	 * storage image the appends put in the same list never was one. Read in that order all the
+	 * same, because that is the order the list is meant to be understood in, the module's own
+	 * resources and then what this engine adds to them.
+	 */
 	@Inject(method = "createFromSpirv", at = @At("RETURN"), require = 1)
 	private static void vitrail$storageImages(String filename, ByteBuffer spirv,
 			CallbackInfoReturnable<IntermediaryShaderModule> callback) {
+		SamplerReach.narrow(filename, callback.getReturnValue());
 		ComputeShader.appendStorageImages(callback.getReturnValue());
 		ComputeShader.appendStorageBuffers(callback.getReturnValue());
 	}

--- a/common/src/main/java/dev/vitrail/render/ComputeShader.java
+++ b/common/src/main/java/dev/vitrail/render/ComputeShader.java
@@ -294,6 +294,18 @@ public final class ComputeShader {
 		}
 	}
 
+	/**
+	 * The name on one of the sampler records this package holds in raw lists, for
+	 * {@link SamplerReach}, which is the other reader inside {@code render}. Here rather than looked
+	 * up again there because this class already holds the handle and its initialiser already fails
+	 * loudly if the record moves. {@code cache/ModuleCache} keeps a third lookup of its own, and
+	 * deliberately: it has to survive a game that no longer carries the record at all, so its
+	 * handles are nullable where these are not.
+	 */
+	static String samplerName(Object sampler) {
+		return nameOf(sampler, SAMPLER_NAME);
+	}
+
 	private static String nameOf(Object record, Method accessor) {
 		try {
 			return (String) accessor.invoke(record);

--- a/common/src/main/java/dev/vitrail/render/SamplerReach.java
+++ b/common/src/main/java/dev/vitrail/render/SamplerReach.java
@@ -1,0 +1,255 @@
+package dev.vitrail.render;
+
+import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
+import dev.vitrail.Vitrail;
+import dev.vitrail.mixin.access.IntermediaryShaderModuleAccessor;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.util.spvc.Spvc;
+import org.lwjgl.util.spvc.SpvcReflectedResource;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Keeps out of a module's reflected sampler list every sampled image its entry point never
+ * touches, so the layout built from that list carries a binding for the samplers the shader
+ * really reads and for no others.
+ * <p>
+ * <strong>What this is for.</strong> The bind group layout of a pipeline is built by the game out
+ * of the modules themselves: {@code GlslCompiler.compile} walks the vertex stage's samplers, then
+ * the fragment stage's, and every name it has not already seen becomes an entry. The entry's INDEX
+ * in that list is the Vulkan binding the module is then rebound onto. On desktop drivers a binding
+ * number is a name and nothing more, and the numbering can be as sparse as it likes. On Apple it is
+ * not: MoltenVK hands each descriptor of a set a Metal slot counted off its place among the
+ * descriptors of its own kind, and Metal has sixteen sampler slots. So a stage that reads thirteen
+ * samplers out of a layout carrying forty-eight is given indices running past sixteen and the
+ * pipeline is refused, for a shader wanting three slots fewer than the hardware has.
+ * <p>
+ * <strong>Why the list held more than the shader reads.</strong> A pack's programs are a handful of
+ * files over a shared include, and that include declares every sampler any of them might want. The
+ * reflection the game asks SPIRV-Cross for is {@code spvc_compiler_create_shader_resources}, which
+ * lists the resources of the MODULE, and shaderc is run at optimisation level nought, so a
+ * declaration nothing samples survives into the SPIR-V and into that list. Measured over the corpus
+ * the gap is wide: the worst module declares forty-eight sampled images and reaches seventeen.
+ * <p>
+ * <strong>Why the reached set is exact and the text is not.</strong> The one other place the
+ * question could be asked is the translated GLSL, and the answer there is not safe: this engine
+ * leaves every {@code #if} standing for the game's compiler to evaluate
+ * ({@code glsl/GlslTranslator.java:87-92}), so the text carries the declarations and the reads of
+ * branches that will be dropped, and a name can only be called unused when it appears nowhere at
+ * all. That criterion over-keeps by about a factor of three. The module is past the preprocessor
+ * and past the dead branches, and what it says is what the driver will see.
+ * <p>
+ * <strong>What a dropped sampler leaves behind, said in full because it looks worse than it is.</strong>
+ * Its {@code OpVariable} stays in the module holding whatever binding shaderc assigned it, since
+ * {@code rebind} only rewrites the names the entry list carries. So the module ends up with two
+ * variables ALIASED on one binding whenever that stale number lands on a live entry's index, which
+ * over a dense layout it usually does. What makes that harmless is not the numbering, it is that
+ * Vulkan asks a pipeline layout to cover the descriptors a shader STATICALLY USES and nothing here
+ * uses the dropped one: SPIRV-Cross's active set is that same static reach, and both aliases are
+ * sampled images, so nothing is read through the wrong type either. It does not reach Apple's
+ * compiler at all, that backend writing only the active set into the Metal source, which is read
+ * off the MSL a refusal quoted rather than deduced: the stage Metal turned down named thirteen
+ * samplers in {@code main0} out of the forty-eight its module declares. And the aliasing is not
+ * argued from the specification alone: a launch under the Khronos validation layer reports the same
+ * rules broken as the build before this one and not one rule more, none of them about a descriptor.
+ * <p>
+ * This engine also goes on binding every DECLARED name at draw time, and that is left alone
+ * deliberately. It costs nothing: the descriptor writes walk the layout's entries, so a texture
+ * bound under a name no entry carries is never looked up.
+ * <p>
+ * <strong>Only this engine's own compiles</strong>, on the same rule as {@link RawLocals} and
+ * {@link PackNames} and asked of the first of them: the game's shaders and Sodium's go through the
+ * same compiler and are left alone. A storage image is never dropped whatever it reaches, because
+ * the list it is dropped from is the one {@link ComputeShader} appends storage images to and only
+ * names the reflection gave as sampled images are candidates.
+ * <p>
+ * {@code -Dvitrail.declaredSamplers=true} puts the whole declared list back, which is what every
+ * layout carried before this existed. It is the A/B this pass is measured with, one jar and two
+ * launches, and like the other two switches over the same bytes it goes into the module cache's
+ * key: the two states reflect the same text into different tables, so a blob built under one must
+ * never be served under the other.
+ */
+public final class SamplerReach {
+
+	/** {@code SPVC_RESOURCE_TYPE_SAMPLED_IMAGE}, the type the game's own sampler list comes from. */
+	private static final int SAMPLED_IMAGE = Spvc.SPVC_RESOURCE_TYPE_SAMPLED_IMAGE;
+
+	private static final boolean DECLARED = Boolean.getBoolean("vitrail.declaredSamplers");
+
+	private static final AtomicLong WALKED = new AtomicLong();
+	private static final AtomicLong NARROWED = new AtomicLong();
+	private static final AtomicLong DROPPED = new AtomicLong();
+
+	private SamplerReach() {
+	}
+
+	/** The word the module cache's key carries, since the state decides the tables it stores. */
+	public static String cacheWord() {
+		return DECLARED ? "declared-samplers" : "reached-samplers";
+	}
+
+	/**
+	 * Drops from the module's sampler list every sampled image the entry point does not reach.
+	 * Called on the module the reflection has just built, before anything has read its tables.
+	 *
+	 * @param filename the debug name the compile was given, which says whose module it is
+	 * @param module   the module to narrow, whose lists are the ones the reflection filled
+	 */
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public static void narrow(String filename, IntermediaryShaderModule module) {
+		if (DECLARED || module == null || module.spirv() == null || !RawLocals.ours(filename)) {
+			return;
+		}
+
+		WALKED.incrementAndGet();
+		Set<String> unreached = unreached(module.spirv());
+		if (unreached.isEmpty()) {
+			return;
+		}
+
+		List samplers = ((IntermediaryShaderModuleAccessor) (Object) module).vitrail$samplers();
+		int before = samplers.size();
+		try {
+			// By NAME and not by rank. The two readings list the module's resources in the same
+			// order today, but a rank is only right for as long as that holds and for as long as
+			// nothing has been appended to the list in between, where a name is right either way.
+			samplers.removeIf(sampler -> unreached.contains(ComputeShader.samplerName(sampler)));
+		} catch (RuntimeException e) {
+			// A narrowing is not worth a pack. Reading that name is reflection over a record of
+			// the game's: not over a shape this build never found, which ComputeShader's own
+			// initialiser refuses long before anything compiles, but the invoke can still throw,
+			// and thrown from here it would come out of the compiler's own method and take every
+			// pack on the machine down rather than cost one layout its density. Said at WARN,
+			// because a load that lost this quietly is a load whose Apple refusals come back with
+			// nothing in the log to explain them.
+			Vitrail.logger().warn("Could not read a module's sampler names, so its layout keeps a "
+					+ "binding for every declared sampler: a pack over Metal's sixteen slots is "
+					+ "refused on Apple hardware again", e);
+
+			return;
+		}
+
+		int gone = before - samplers.size();
+		if (gone > 0) {
+			NARROWED.incrementAndGet();
+			DROPPED.addAndGet(gone);
+		}
+	}
+
+	/**
+	 * One line beside the module cache's, said in BOTH states: a load served whole from the store
+	 * was built under the state its blobs carry, and a reading taken on it has to be able to name
+	 * that state.
+	 *
+	 * @param compiled how many modules the compiler built this load
+	 */
+	public static void say(long compiled) {
+		long walked = WALKED.getAndSet(0L);
+		long narrowed = NARROWED.getAndSet(0L);
+		long dropped = DROPPED.getAndSet(0L);
+		if (DECLARED) {
+			Vitrail.logger().warn("Every DECLARED sampler given a binding, asked for by "
+					+ "-Dvitrail.declaredSamplers ({} modules built this load, none walked): a pack "
+					+ "whose shared include declares more samplers than a stage reads is numbered "
+					+ "past Metal's sixteen slots and refused on Apple hardware", compiled);
+
+			return;
+		}
+
+		Vitrail.logger().info("Samplers bound from what a module reaches: {} dropped across {} of "
+						+ "the {} pack modules walked ({} modules built this load in all, the "
+						+ "game's and Sodium's among them)", dropped, narrowed, walked, compiled);
+	}
+
+	/**
+	 * The sampled images the module declares and never reaches.
+	 * <p>
+	 * Two readings of one module through one compiler: the resource list the game itself asks for,
+	 * then the same list restricted to the entry point's active interface variables. The second is
+	 * the module's static reach, which is what Vulkan means by a descriptor a shader uses and what
+	 * SPIRV-Cross carries into the shader it writes.
+	 * <p>
+	 * A failure at any step returns nothing to drop, so a module this cannot read keeps the layout
+	 * it would have had, which is the layout of every build before this one. Silently, and on
+	 * purpose: there is nothing to say about a module the reflection would not read twice that the
+	 * refusal it may earn on Apple will not say better.
+	 */
+	private static Set<String> unreached(ByteBuffer spirv) {
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			PointerBuffer pointer = stack.callocPointer(1);
+			if (Spvc.spvc_context_create(pointer) != 0) {
+				return Set.of();
+			}
+
+			long context = pointer.get(0);
+			try {
+				if (Spvc.spvc_context_parse_spirv(context, spirv.asIntBuffer(),
+						spirv.remaining() / 4, pointer) != 0) {
+					return Set.of();
+				}
+
+				long ir = pointer.get(0);
+				if (Spvc.spvc_context_create_compiler(context, 0, ir, 1, pointer) != 0) {
+					return Set.of();
+				}
+
+				long compiler = pointer.get(0);
+				if (Spvc.spvc_compiler_create_shader_resources(compiler, pointer) != 0) {
+					return Set.of();
+				}
+
+				List<String> declared = sampledImages(stack, pointer.get(0));
+				if (declared.isEmpty()) {
+					return Set.of();
+				}
+
+				if (Spvc.spvc_compiler_get_active_interface_variables(compiler, pointer) != 0) {
+					return Set.of();
+				}
+
+				long active = pointer.get(0);
+				if (Spvc.spvc_compiler_create_shader_resources_for_active_variables(compiler,
+						pointer, active) != 0) {
+					return Set.of();
+				}
+
+				Set<String> unreached = new HashSet<>(declared);
+				unreached.removeAll(sampledImages(stack, pointer.get(0)));
+
+				return unreached;
+			} finally {
+				Spvc.spvc_context_destroy(context);
+			}
+		}
+	}
+
+	private static List<String> sampledImages(MemoryStack stack, long resources) {
+		PointerBuffer list = stack.callocPointer(1);
+		PointerBuffer count = stack.callocPointer(1);
+		if (Spvc.spvc_resources_get_resource_list_for_type(resources, SAMPLED_IMAGE, list,
+				count) != 0) {
+			return List.of();
+		}
+
+		int found = (int) count.get(0);
+		if (found == 0) {
+			return List.of();
+		}
+
+		List<String> names = new ArrayList<>(found);
+		SpvcReflectedResource.Buffer reflected = SpvcReflectedResource.create(list.get(0), found);
+		for (int index = 0; index < found; index++) {
+			// The same string the game's own reflection puts on the record, taken from the same
+			// call, so the two spellings of one resource cannot differ.
+			names.add(reflected.get(index).nameString());
+		}
+
+		return names;
+	}
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -21,7 +21,7 @@ quietly stale.
 | Mellow v3.3 | Drawn, and it exercises two more of them: it ships a three-dimensional volume as a raw blob, and it asks for a single-channel shadow buffer. |
 | Photon v1.3b | Drawn, at default settings. It exercises a clamped volume of half floats as its atmosphere table, reads its volumes through macros standing for the sampler's name, and lays a volume over the name of a colour target that the same stage also reads as a plain `sampler2D`. Not yet compared against the reference shot for shot. |
 | Body Camera v1.6.1 | Drawn. It is one of the packs that branches on the star flag in the sky, so it is worth reading [the sky goes flat](#the-sky-goes-flat) alongside. |
-| Reverie Beta v0.9 | Drawn, at its shipped profile. It is the pack that exercises the storage buffers hardest: its exposure is an average brightness that a compute writes into one and every later pass reads back, and a compute of its cloud pass reads the depth. It declares the uniforms of the Voxy mod beside those of Distant Horizons and reads them only under a `VOXY` define that mod sets and nothing here does, so the seven `vx` names the log reports as zeros are handed as zeros by Iris too without that mod, and the misspelt `previouscameraPositionFract` beside them is read by no program of the pack. Not yet compared against the reference shot for shot. |
+| Reverie Beta v0.9 | Drawn, at its shipped profile. It is the pack that exercises the storage buffers hardest: its exposure is an average brightness that a compute writes into one and every later pass reads back, and a compute of its cloud pass reads the depth. It declares the uniforms of the Voxy mod beside those of Distant Horizons and reads them only under a `VOXY` define that mod sets and nothing here does, so the seven `vx` names the log reports as zeros are handed as zeros by Iris too without that mod, and the misspelt `previouscameraPositionFract` beside them is read by no program of the pack. Two of its passes read more textures at once than Apple's hardware has slots for, so it is the one pack of these that does not draw on a Mac; [the pack was refused](#the-pack-was-refused) says why that one is a real count. Not yet compared against the reference shot for shot. |
 
 Start from what you are seeing. Each symptom below names its cause, and says how to confirm it
 rather than guess.
@@ -82,6 +82,17 @@ a pack refused here is not for that reason refused there.
 Iris refuses a required flag only when the name is unknown to it or the hardware cannot serve
 it, and it has built every one of the ones Reverie asks for: some outright, some wherever the
 driver supports them.
+
+**On a Mac, a pass that reads more than sixteen textures at once takes the pack with it.** Apple
+gives one pass sixteen slots for the textures it reads, and no setting or numbering raises that. The
+engine numbers a pass off the textures its two shader stages actually read between them, which is as
+tight as the numbering can be made, so what is left over that line is a genuine count rather than an
+accounting artefact. Two of Reverie's passes read seventeen and eighteen textures between their
+stages, so on Apple hardware they are refused and the pack comes down with them, with Apple's own
+message in the log: `'sampler' attribute parameter is out of bounds: must be between 0 and 15`. The
+same two passes draw on a desktop card, the cap being Apple's. What would lift it is Metal's
+argument buffers, a stage handed one table of resources instead of one slot each, and nothing here
+asks for that today. Every other pack measured stays under the line, one of them exactly on it.
 
 **A full-screen pass that fails to compile takes the whole pack with it**, and the log names the
 program. One shape of that was a `const` whose initialiser Vulkan will not take as a constant,

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -206,13 +206,21 @@ Over-declaring is therefore free and under-declaring fails at compile time, whic
 direction is a generous layout. That is what makes it practical to serve a large uniform surface
 without declaring it pipeline by pipeline.
 
-**MoltenVK is the exception that makes the order of those declarations load-bearing.** Metal numbers
-a sampler by the binding the compiler assigned from the order it first met the name, not by how
-many the shader actually samples, and it only accepts 0 through 15. A shader that declares twenty
-unused names ahead of the one texture the body reads still hands that texture binding 17, and the
-pipeline is refused. The translator therefore writes the names a program samples first in the
-header, unused declarations after. A program that samples more than sixteen textures is still
-refused there: that is Metal's own cap, the same one Iris documented for macOS.
+**MoltenVK is the exception that makes over-declaring cost something.** Metal accepts sampler
+indices 0 through 15 only, and MoltenVK counts a descriptor's Metal index off its place among the
+descriptors of its kind in the set's layout. That layout is built from the modules themselves:
+`GlslCompiler.compile` walks each stage's reflected sampler list and the INDEX of an entry becomes
+the Vulkan binding the module is rebound onto, whatever number shaderc had assigned. So a program
+whose shared include declares forty-eight samplers used to hand a body that reads thirteen of them
+indices running past the sixteenth, and the pipeline was refused for wanting three slots fewer than
+the hardware has.
+
+`render/SamplerReach` closes that: it drops from a module's reflected sampler list every sampled
+image the entry point does not reach, so the layout is dense and a program under sixteen fits. Over
+a program's two stages TOGETHER, since one layout serves both. A program whose stages read more than
+sixteen between them is still refused there, and that is Metal's own cap, the same one Iris
+documented for macOS. The translator still writes sampled names first in the header, which no longer
+decides the cap and is described where it lives.
 
 The asymmetry does not extend to the draw. A sampler that is declared and used, but not bound when
 the draw happens, throws, so the layout can be generous while the binding cannot be sloppy.

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -161,10 +161,12 @@ mass overlapping-location errors. The game's compiler switches on the options th
 uniforms and auto-map locations, and that is exactly what makes emitting nothing work: they are not
 inert here, they are what assigns what the emitter deliberately leaves unassigned.
 
-Those assigned numbers follow the order the compiler first meets each name in the shader. Unused
-sampler declarations still consume a number if they sit in front of a used one, which on MoltenVK
-is a Metal sampler index above 15 and a refused pipeline. Sampled names are therefore declared
-first in the header, unused after; see [the graphics API](internals/game-graphics-api.md).
+Those assigned numbers follow the order the compiler first meets each name in the shader, and the
+game then renumbers every sampler over the layout it builds from the modules. A sampler a program
+declares and never reads used to take a place in that layout, which on MoltenVK is a Metal sampler
+index that can land above 15 and refuse the pipeline; the layout is built from what a module
+actually reaches now. Sampled names are still declared first in the header, which no longer decides
+that; see [the graphics API](internals/game-graphics-api.md).
 
 The exception is fragment outputs, which keep their explicit location, because their **order** is
 the only thing that says which write lands on which attachment.


### PR DESCRIPTION
## What changes

The game builds a pipeline's descriptor set layout out of the shader modules themselves, and the
index of an entry in that list becomes the Vulkan binding the module is rebound onto. The reflection
behind it lists the resources of the MODULE, so a sampler a pack's shared include declares and this
program never touches takes a binding all the same. On a desktop driver that number is a name. On
Apple it is a slot: MoltenVK counts a descriptor's Metal index off its place among the descriptors of
its kind, Metal has sixteen sampler slots, and a stage reading thirteen samplers out of a module
declaring forty-eight was handed indices running to twenty-three and refused. `SamplerReach` reads
such a module a second time and drops from its sampler list every sampled image the entry point does
not reach, which is the set SPIRV-Cross carries into the shader it writes, so the numbering is dense
and any program under sixteen fits. Only this engine's own compiles are touched, on the test
`RawLocals` and `PackNames` already use; `-Dvitrail.declaredSamplers` puts the declared list back and
joins the module cache's key.

## How it differs from the reference, and for what obstacle

It does not. Iris runs on OpenGL, where a sampler is bound to a texture unit rather than numbered
into a descriptor set layout, so the question does not arise there and the cap it documented for
macOS is the same hardware cap named here.

## What proves it

- `gradlew clean build --no-build-cache` green.
- **On a rented Apple Silicon Mac the corpus goes from six packs drawing to eight.** Same machine,
  same nine packs, same world, one fresh launch each: Bliss and Photon draw where Apple's compiler
  refused them with `'sampler' attribute parameter is out of bounds: must be between 0 and 15`, and
  none of the six that already drew moved. Reverie's refusal moved from `world0/deferred` to
  `world0/deferred2`, the program measured at seventeen samplers reached, so the holes are gone and
  what is left is a real count.
- **On the Windows Fabric bench nothing moved.** Photon, real terrain with the camera pinned and the
  clock frozen, against a `dev` jar of the same base: the seventeen lines naming which family is
  drawn by which program are identical word for word, sampler and uniform counts included, and no
  pipeline is refused either side. The sixty frame mean sits inside what two means of one jar move
  in one run, and its mean screen colour inside three readings of the other jar.
- **Under the Khronos validation layer the same rules break as before and not one more**, none about
  a descriptor: that is what says the variable a dropped sampler leaves behind, holding a binding no
  descriptor answers, is dead weight rather than a live aliasing.

## What it leaves owing

Reverie keeps two programs over the cap, `world0/composite4` at eighteen reached and
`world0/deferred2` at seventeen, and no numbering reaches those: the way past them is Metal's
argument buffers, a stage handed one table of resources instead of a slot each. Photon sits exactly
at sixteen, so it has no margin.

`ProgramTranslator.sampledFirst` stays, answering the same question on the text where every
conditional is still standing, so it keeps about three times too many. It no longer decides the cap
and its javadoc says so rather than claiming it.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
