### PR TITLE
fix(render): drop the game's per face brightness while a pack shades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,16 @@ what the next one holds.
 
 ### Fixed
 
+- **The world stops being shaded twice, and the sides and undersides of blocks come back to the
+  brightness the pack drew them at.** The game tints a block face by which of the six directions it
+  faces, out of a small table each dimension carries: in the overworld full strength on top, half
+  underneath and two values between on the sides, which is what gives an unshaded world its relief.
+  A pack works its own lighting out of the direction each surface faces, so that tint left underneath
+  darkened everything the pack had already shaded, each face by its own fixed amount and an
+  underside by half. It showed most where a pack lights a surface the game leaves dark, the plainest
+  of those being a canopy seen from below. A pack that wants the old behaviour writes
+  `oldLighting=true`, which the engine reads now.
+
 - **Leaves, grass and the item in hand come back on a pack that tests its own transparency.** A
   cutout draw needs the test that throws away the see-through parts of a texture, and the engine
   used to write that test into the shader itself whatever the shader was, reading the fourth channel

--- a/NOTICE
+++ b/NOTICE
@@ -992,6 +992,26 @@ Apache License, Version 2.0
   The question is asked of the spelling here and of the preprocessed text there, and the javadoc of
   GlslTranslator.planAlphaEpilogue says why and what that leaves standing.
 
+  common/src/main/java/dev/vitrail/render/FaceShading.java and the two mixins it governs take the
+  reference's rule about the game's own per face brightness: it is left out for every pack that
+  does not write oldLighting, which
+  net.irisshaders.iris.pipeline.IrisRenderingPipeline answers as !oldLighting at lines 1159 to 1160
+  with the directive defaulting to false at shaderpack/properties/PackDirectives.java:92, and it is
+  left out by handing the up direction to the per face table whatever face was asked about, which is
+  what net.irisshaders.iris.mixin.vertices.block_rendering.MixinClientLevel does at lines 16 to 23.
+  The fluid renderer carries the factor itself rather than reading that table, and the call taken
+  there is the one compat/sodium/mixin/MixinDefaultFluidRenderer takes at lines 24 to 32. Read on
+  the 26.2 branch on 10 September 2026. What is taken is the rule and not the code.
+
+  One condition is asked here that is not asked there, and it is a difference in what the two
+  engines can serve rather than a choice: the reference draws the world's chunks with the pack's own
+  programs in every case its pipeline exists for, while this engine has a road where it hands the
+  chunk passes back to the game's shader, which reads the factor out of the vertex colour and
+  expects to find it (render/TerrainDraw.java:179 raises and lowers that switch, and the vertex
+  colour it governs is described in docs/internals/terrain.md). So the brightness is left in
+  wherever that road is taken. What it costs the image is nothing on the road the reference has,
+  and on the road it has not it is the difference between a world the game shades and a flat one.
+
 AMD FidelityFX Super Resolution 1.0, https://github.com/GPUOpen-Effects/FidelityFX-FSR
 Copyright (c) 2021 Advanced Micro Devices, Inc.
 MIT License

--- a/common/src/main/java/dev/vitrail/mixin/CardinalLightingMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/CardinalLightingMixin.java
@@ -1,0 +1,40 @@
+package dev.vitrail.mixin;
+
+import dev.vitrail.render.FaceShading;
+
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.CardinalLighting;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+/**
+ * Hands the game's per face brightness the top face whatever face it was asked about, so what it
+ * gives back stops depending on which face it is, while a pack's own terrain program is drawing the
+ * chunks. Not a one: in the nether the top face is 0.9 like the bottom, and that stays the answer.
+ * <p>
+ * Why the shading has to go at all is in {@link FaceShading}: the pack shades from the normal it is
+ * handed, and the game's factor multiplied in beneath it shades the same surface twice. This is the
+ * reference's own gesture, {@code mixin/vertices/block_rendering/MixinClientLevel.java:16-23},
+ * against the same method.
+ * <p>
+ * <strong>The argument and not the return value</strong>, which is what keeps a pack's own
+ * {@code CardinalLighting} table honest: the record carries six numbers and the nether's differ from
+ * the overworld's, so forcing the answer to one would also throw away the dimension's own choice of
+ * what a top face is worth. Asking about the top face instead reads that table where it stands.
+ * <p>
+ * On the chunk build threads, several at a time, and it reads one volatile field. Nothing here
+ * orders the field against those builds, and nothing needs to: a section meshed on either answer is
+ * covered by the world being asked for again whenever the answer really moved, which is what
+ * {@link FaceShading} does. The one reader that is not a mesh is a block in flight, lit per frame,
+ * and it simply follows the field.
+ */
+@Mixin(CardinalLighting.class)
+public class CardinalLightingMixin {
+
+	@ModifyVariable(method = "byFace", at = @At("HEAD"), argsOnly = true, require = 1)
+	private Direction vitrail$topFaceWhileAPackShades(Direction face) {
+		return FaceShading.dropped() ? Direction.UP : face;
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/sodium/DefaultFluidRendererMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/sodium/DefaultFluidRendererMixin.java
@@ -2,6 +2,7 @@ package dev.vitrail.mixin.sodium;
 
 import dev.vitrail.sodium.TerrainVertex;
 import dev.vitrail.render.BlockStateIds;
+import dev.vitrail.render.FaceShading;
 import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.Vitrail;
 
@@ -108,6 +109,33 @@ public abstract class DefaultFluidRendererMixin {
 					+ "carries the packed id {}", table,
 					fluidBlock == null ? "nothing" : fluidBlock, this.vitrail$id);
 		}
+	}
+
+	/**
+	 * The fluid's side faces at full brightness while a pack shades the world, which is what
+	 * {@link FaceShading} does to every other face and for the same reason.
+	 * <p>
+	 * A fluid does not go through {@code CardinalLighting}: this renderer carries the factor itself
+	 * and hands it to {@code updateQuad}, so the mixin that answers for the blocks never sees it and
+	 * the water alone would keep a shading the pack applies again. The reference makes the same
+	 * change at the same call, {@code compat/sodium/mixin/MixinDefaultFluidRenderer.java:24-32},
+	 * and at that one alone of the three the method makes.
+	 */
+	@ModifyArg(
+			method = "render",
+			at = @At(value = "INVOKE",
+					target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/pipeline/"
+							+ "DefaultFluidRenderer;updateQuad(Lnet/caffeinemc/mods/sodium/client/"
+							+ "model/quad/ModelQuadViewMutable;Lnet/caffeinemc/mods/sodium/client/"
+							+ "world/LevelSlice;Lnet/minecraft/core/BlockPos;Lnet/caffeinemc/mods/"
+							+ "sodium/client/model/light/LightPipeline;Lnet/minecraft/core/Direction;"
+							+ "Lnet/caffeinemc/mods/sodium/client/model/quad/properties/"
+							+ "ModelQuadFacing;FLnet/caffeinemc/mods/sodium/client/model/color/"
+							+ "ColorProvider;Lnet/minecraft/world/level/material/FluidState;)V",
+					ordinal = 2),
+			require = 1)
+	private float vitrail$sideFaceAtFullBrightness(float brightness) {
+		return FaceShading.dropped() ? 1.0F : brightness;
 	}
 
 	/** The path taken when nothing sorts this quad, which is every fluid the pack draws opaquely. */

--- a/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
+++ b/common/src/main/java/dev/vitrail/pack/source/ShaderProperties.java
@@ -133,6 +133,11 @@ public final class ShaderProperties {
 	// eleven packs of the corpus write it, all seven write false, and none writes true, so a flat
 	// default would have an off hand torch answering for seven main hands that asked it not to.
 	private static final Pattern OLD_HAND_LIGHT = Pattern.compile("^\\s*oldHandLight\\s*=\\s*(.*)$");
+	// Whether the game's own per face brightness stays in the chunk mesh. Read on the live
+	// lines and on separateAo's rule, and the default is off, which is the reference's
+	// (shaderpack/properties/PackDirectives.java:92, getOldLighting().orElse(false)): a pack
+	// shades from the normal it is handed, so the game's factor underneath it shades twice.
+	private static final Pattern OLD_LIGHTING = Pattern.compile("^\\s*oldLighting\\s*=\\s*(.*)$");
 	private static final Pattern SIZE_BUFFER = Pattern.compile("^\\s*size\\.buffer\\.([^=\\s.]+)\\s*=\\s*(.*)$");
 	private static final Pattern SKY_ELEMENT = Pattern.compile("^\\s*(sun|moon|stars|sky)\\s*=\\s*(.*)$");
 	// The fifth word of that family, kept apart because it is the one that takes neither a yes nor a
@@ -423,6 +428,11 @@ public final class ShaderProperties {
 		// And on that rule too, for that reason: a word this cannot read is what puts the answer back
 		// to the default, so the line is read whether the word is one of the four or not.
 		if (OLD_HAND_LIGHT.matcher(line).matches()) {
+			return;
+		}
+
+		// The same rule again, and the same reason.
+		if (OLD_LIGHTING.matcher(line).matches()) {
 			return;
 		}
 
@@ -1445,6 +1455,32 @@ public final class ShaderProperties {
 		}
 
 		return asked == null || asked;
+	}
+
+	/**
+	 * Whether the pack asks for the game's own per face brightness to stay in the chunk mesh, which
+	 * is what {@code oldLighting} means and what almost no pack wants.
+	 * <p>
+	 * <strong>The default is off, and it is the reference's</strong>
+	 * ({@code shaderpack/properties/PackDirectives.java:92},
+	 * {@code getOldLighting().orElse(false)}). A pack computes its own directional shading from the
+	 * normal it is handed, so the game's fixed factor multiplied in beneath it shades the same
+	 * surface twice: the top of the world is unharmed, its factor being one, and every other face
+	 * comes out darker than the pack drew it. What the directive buys back is the old behaviour for
+	 * a pack written to expect it.
+	 * <p>
+	 * Read through {@link #live} and answered like {@link #separateAo}, whose note carries why the
+	 * last live line decides even when it carries a word this cannot read.
+	 *
+	 * @param defines the pack's settings, which decide which lines of the file are alive at all
+	 */
+	public boolean oldLighting(Map<String, String> defines) {
+		Boolean asked = null;
+		for (Matcher line : live(OLD_LIGHTING, defines)) {
+			asked = truth(line.group(1).trim());
+		}
+
+		return Boolean.TRUE.equals(asked);
 	}
 
 	/** Each profile's unexpanded body, in the order the pack declares them. */

--- a/common/src/main/java/dev/vitrail/render/FaceShading.java
+++ b/common/src/main/java/dev/vitrail/render/FaceShading.java
@@ -1,0 +1,141 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+
+import net.minecraft.client.Minecraft;
+
+/**
+ * Whether the game's own per face brightness is left out of the chunk mesh, which it is for every
+ * pack that does not ask for the old lighting back.
+ * <p>
+ * The game tints the colour of every block face by the way it points, out of a table of six numbers
+ * the dimension carries ({@code CardinalLighting}): in the overworld a one on top, a half
+ * underneath and 0.8 and 0.6 on the sides. A pack computes its own directional shading from the
+ * normal it is handed, so leaving the game's in means the surface is shaded twice, and only a face
+ * whose factor is already the top one comes out where the pack drew it.
+ * <p>
+ * Measured on the frozen world, RenderPearl against the reference: the ground at the camera's feet
+ * matched to a level and the sky to half a level, while the canopy above them came out about twenty
+ * levels darker. <strong>What named the cause is the shape of that gap and not its size</strong>:
+ * the per pixel ratio over the canopy does not spread around one value, it piles up near 0.56 and
+ * 0.72 with a tail at one. Those are not the table's numbers to the digit, a leaf being blended
+ * against what stands behind it, but a term belonging to the surface rather than to the quad, an
+ * occlusion or a shadow tap or a texture read, could not pile up at a few values at all.
+ * <p>
+ * The reference does the same thing and reads the same directive:
+ * {@code pipeline/IrisRenderingPipeline.java:1159-1160} answers {@code !oldLighting} and
+ * {@code mixin/vertices/block_rendering/MixinClientLevel.java:16-23} applies it by handing
+ * {@code CardinalLighting.byFace} the up direction whatever face it was asked about. The default is
+ * off there too, {@code shaderpack/properties/PackDirectives.java:92}.
+ * <p>
+ * <strong>Handing over the up direction is not the same as handing over a one</strong>, and the
+ * difference is the nether: its table gives 0.9 to the top as well as to the bottom, so what a face
+ * is worth there stays the dimension's own answer and only stops depending on which face it is.
+ * <p>
+ * <strong>It follows the terrain switch as well as the pack</strong>, which the reference has no
+ * reason to do: where a pack's own terrain program is not served, the chunks are drawn by the
+ * game's own shader, and that shader expects the brightness to be there. Taking it away then would
+ * flatten a world nothing else is shading.
+ * <p>
+ * <strong>What the table reaches was read rather than assumed, and in BOTH jars</strong>, which
+ * matters because the half that decides here is not the game's. In the game,
+ * {@code CardinalLighting.byFace} is called from {@code BlockModelLighter} alone, reached from
+ * {@code SectionCompiler} and from {@code ModelBlockRenderer}, and that second one outside the mesh
+ * only from {@code MovingBlockFeatureRenderer}. In Sodium, which is what really meshes the chunks
+ * here, it is called from {@code FlatLightPipeline} and {@code SmoothLightPipeline}. The mixin sits
+ * on the table itself rather than on any of its callers, so every one of them is covered whichever
+ * renderer is building.
+ * <p>
+ * Two consequences worth keeping. A block entity and a block held in the hand never go through the
+ * table at all, so nothing here touches them. And a block in flight, the falling one and the one a
+ * piston carries, is lit through it PER FRAME rather than out of a mesh, so that one follows the
+ * answer the instant it moves, with no rebuild in it.
+ * <p>
+ * <strong>For everything else the number is baked into the mesh</strong>, so a change here is worth
+ * a rebuilt world, through the same door {@link BlockStateIds} uses and for the same reason: the
+ * sections standing at this instant carry the other answer, and nothing else would ever reach them.
+ */
+public final class FaceShading {
+
+	/**
+	 * Read on every chunk build thread and written on the render thread and on the pack load worker,
+	 * hence volatile; a face is asked about once per quad, so the read has to stay a field read and
+	 * nothing more.
+	 * <p>
+	 * A build already running when this moves reads whichever value it happens to see, and that is
+	 * why the move asks for the whole world again rather than trusting the timing.
+	 */
+	private static volatile boolean dropped;
+
+	private FaceShading() {
+	}
+
+	/** Whether the game's per face brightness is to be left out of what a chunk mesh carries. */
+	public static boolean dropped() {
+		return dropped;
+	}
+
+	/**
+	 * What the pack asked for, taken with its other directives.
+	 *
+	 * @param oldLighting whether the pack wrote {@code oldLighting=true}, which is it asking for the
+	 *                    game's own per face brightness to be left in
+	 */
+	public static void install(boolean oldLighting) {
+		follow(!oldLighting && TerrainDraw.asked(), true);
+	}
+
+	/**
+	 * The game's own brightness back.
+	 * <p>
+	 * Asked from the five places a chain or the terrain family stops, which is what covers every road
+	 * that ends with the game's shader drawing the chunks: {@code PackChain.stop} for the three
+	 * refusals at load, {@code PackChain.putAway} for the thirteen the frame can take,
+	 * {@link TerrainDraw#wanted(boolean)} for every road that switches the family off, and the two
+	 * places {@link TerrainDraw} lowers that same field directly, one after a failed read and one
+	 * after a failed prepare. All of them leave
+	 * the mesh where it stands and hand the pass back, so the world would otherwise be drawn by a
+	 * shader that expects the factor, out of a mesh built without it.
+	 * <p>
+	 * More than one can fire for a single event, which is why this is written to be idempotent and
+	 * why a call that moves nothing says nothing: the guard in {@code follow} is the whole of what
+	 * makes the second call free.
+	 */
+	public static void none() {
+		follow(false, false);
+	}
+
+	/**
+	 * The state, said in both directions.
+	 * <p>
+	 * A switch that logs only when it is armed makes a morning of before and after readings
+	 * unusable, because a silent log reads the same as a pack the engine never reached. So the load
+	 * says its answer whichever way it falls, which is what {@code said} is for, while the roads that
+	 * put the brightness back say nothing unless they really moved it: several of them can fire for
+	 * one event, and a line printed four times for one refusal is its own kind of unreadable.
+	 */
+	private static void follow(boolean asked, boolean said) {
+		if (said) {
+			Vitrail.logger().info("The game's own per face brightness is {} the chunk mesh",
+					asked ? "left out of" : "in");
+		}
+
+		if (dropped == asked) {
+			return;
+		}
+
+		if (!said) {
+			Vitrail.logger().info("The game's own per face brightness is in the chunk mesh again, "
+					+ "the pack's own terrain program having stopped drawing the chunks");
+		}
+
+		dropped = asked;
+		Minecraft minecraft = Minecraft.getInstance();
+		if (minecraft == null || minecraft.level == null) {
+			return;
+		}
+
+		Vitrail.logger().info("The sections carry it, so they are all built again");
+		minecraft.levelExtractor.allChanged();
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -167,6 +167,11 @@ public final class PackChain {
 	/** Stops the frame drawing the pack; the reason is {@link PackChoice}'s to say. */
 	static void stop() {
 		disabled = true;
+		// The mesh is not taken down here and the pass goes back to the game's own shader, which
+		// expects the game's per face brightness to be in the vertex colour. Said here rather than
+		// at each of the three roads into this method, so a fourth cannot forget it. This is the
+		// LOAD's road only; putAway is the frame's, and says the same thing for the same reason.
+		FaceShading.none();
 	}
 
 	static boolean stopped() {
@@ -649,6 +654,12 @@ public final class PackChain {
 		}
 
 		disabled = true;
+		// The frame's own road out, and the thirteen sites that reach it are why this is said here
+		// rather than beside each of them. The mesh stands and the game's shader takes the chunk
+		// passes back, so the per face brightness it reads out of the vertex colour has to be there.
+		// Fired from inside a frame on purpose: allChanged raises a flag the next extract consumes
+		// rather than tearing sections down under the frame that asked.
+		FaceShading.none();
 		PackChoice.error(this.chain.packName() + " is not drawn at all: " + why);
 		Vitrail.logger().error("{} is put away rather than drawn by halves, because {}",
 				this.chain.packName(), why);

--- a/common/src/main/java/dev/vitrail/render/PackValues.java
+++ b/common/src/main/java/dev/vitrail/render/PackValues.java
@@ -160,6 +160,7 @@ public final class PackValues {
 		// Read against the same settings as everything above, which is not a formality: BSL wraps
 		// all its declarations in one conditional and keeps a fifth of them under the #else, so a
 		// reading with an empty table measures a different pack.
+		FaceShading.install(properties.oldLighting(settings.globalDefines(options)));
 		BlockStateIds.install(BlockIds.read(source, settings.globalDefines(options)));
 		PackNameIds.install(
 				NameIds.read(source, settings.globalDefines(options), NameIds.Kind.ENTITY),

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -167,11 +167,22 @@ public final class TerrainDraw {
 	 * {@code LevelRenderer.invalidateCompiledGeometry}, where Sodium builds its chunk renderer again
 	 * from nothing, and that is where the format is taken.
 	 * <p>
-	 * <strong>Asking is all this does</strong>, and it is what makes the one place that writes the
-	 * field directly safe: a terrain program that threw stops being offered at once, without a
-	 * rebuilt world, and the mesh goes on carrying what it carried until something else rebuilds it.
-	 * The format cannot fall out of step with a living builder that way, because it is not this field
-	 * that the format follows but the reading taken at the rebuild.
+	 * <strong>Asking is all this does</strong>, and it is what makes the two places that write the
+	 * field directly safe: a terrain program that threw stops being offered at once, and the mesh
+	 * goes on carrying what it carried until something else rebuilds it. The format cannot fall out
+	 * of step with a living builder that way, because it is not this field that the format follows
+	 * but the reading taken at the rebuild.
+	 * <p>
+	 * <strong>Those two places CAN ask for a rebuilt world now, and for something else</strong>: they
+	 * call {@link FaceShading#none()} beside the write, because the pass they are handing back is
+	 * about to be drawn by the game's own shader, which reads the game's per face brightness out of
+	 * the vertex colour and would find a mesh built without it. Only when that answer really moves,
+	 * so a pack that never had it dropped asks for nothing. It is a rebuild for the COLOUR and not
+	 * for the format, and it goes through the same deferred door as every other one here, so nothing
+	 * is torn down inside the frame that asked. What it does mean is that the format is taken again
+	 * at that rebuild, out of {@link #carries} as it stands, which on these two roads is still the
+	 * pack's own list: the mesh comes back as wide as it was, which is the state the paragraph above
+	 * describes and not a new one.
 	 * <p>
 	 * Silent before a world is joined, where nothing has been meshed and the first reading answers
 	 * itself.
@@ -182,6 +193,10 @@ public final class TerrainDraw {
 			// flag standing with no chain behind it, and the elements are the half of the answer the
 			// mesh really reads.
 			carries(List.of());
+			// And the game's own per face brightness with them, for the same reason and on the same
+			// terms: the chunk passes are going back to the game's shader, which reads that factor
+			// out of the vertex colour. Said here rather than at each caller that lowers this.
+			FaceShading.none();
 		}
 
 		if (wanted == asked) {
@@ -249,6 +264,9 @@ public final class TerrainDraw {
 					.anyMatch(PackProgram.Loaded::voxelises);
 		} catch (IOException | RuntimeException e) {
 			wanted = false;
+			// And with it the game's own per face brightness, which the shader about to draw this
+			// mesh expects to find in the vertex colour.
+			FaceShading.none();
 			Vitrail.logger().error("Could not read the terrain programs of "
 					+ this.packPath.getFileName() + ", so the world keeps the game's own shader", e);
 		}
@@ -856,6 +874,8 @@ public final class TerrainDraw {
 			return draw.prepare(drawn, format, atlas);
 		} catch (RuntimeException e) {
 			wanted = false;
+			// The same as at the read above: the mesh is about to be drawn by the game's shader.
+			FaceShading.none();
 			Vitrail.logger().error("Vitrail stopped drawing the terrain after an error", e);
 
 			return null;

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -16,6 +16,7 @@
 		"sodium.BlockRendererMixin",
 		"BufferBuilderMixin",
 		"access.ByteBufferBuilderAccessor",
+		"CardinalLightingMixin",
 		"sodium.ChunkMeshFormatsMixin",
 		"sodium.ChunkVertexMixin",
 		"ClientLevelMixin",

--- a/docs/internals/terrain.md
+++ b/docs/internals/terrain.md
@@ -71,10 +71,29 @@ index. Four elements. Several of the things a pack asks for are already inside t
 knowing before writing any shader glue.
 
 **The colour already contains lighting.** The encoder multiplies the block tint by ambient occlusion
-before writing it, and face shading is baked in the same way. Two consequences: no translated
-program will ever produce "flat unlit albedo" as long as vertex colour comes from there, and "the
-sides are darker than the tops" is true before any normal exists and therefore proves nothing about
-one. Any test of a normal has to be an A/B on the same scene from the same camera.
+before writing it, so no translated program will ever produce "flat unlit albedo" as long as vertex
+colour comes from there. Any test of a normal has to be an A/B on the same scene from the same
+camera all the same, since the occlusion alone already darkens a corner.
+
+**What is NOT in it any more is the game's own per face brightness.** The game tints a face by which
+of the six directions it faces, out of a table the dimension carries: the overworld's is one on top,
+a half underneath and 0.8 and 0.6 on the sides. A pack works its own directional shading out of the
+normal it is handed, so the factor left underneath shades the same surface twice, and in the
+overworld only the tops escape, their factor being one. So while a pack's own terrain program draws
+the chunks, that table is asked about the top face whatever face is really being built, which is the
+reference's own gesture and the reference's own default; a pack that wants the old behaviour writes
+`oldLighting=true`.
+
+**Asking about the top face is not the same as writing a one**, and the nether is where the two part:
+its table gives 0.9 to the top as much as to the bottom, so a face there is still worth what the
+dimension says and only stops depending on which face it is. Two consequences worth keeping: "the
+sides are darker than the tops" is now a statement about the pack and not about the mesh, and the
+factor is baked into the vertex, so the answer moving is worth a rebuilt world exactly as the block
+id table is. Every road that hands the chunk passes back to the game's own shader puts it back for
+that reason: a pack refused at load, a chain put away mid-frame, and a terrain program that threw at
+either end. And the mesh is not quite all of it, which is worth knowing before reading a capture: a
+block in flight, the falling one and the one a piston carries, is lit through the same table per
+frame rather than out of a section, so it follows the answer with no rebuild in between.
 
 **Unless the pack asked for the two apart.** `separateAo=true` in `shaders.properties` says the pack
 wants the occlusion where it can see it: the tint reaches the program undivided and the coefficient


### PR DESCRIPTION
## What changes

The world stops being shaded twice. The game tints a block face by which of the six directions it
faces, out of a table each dimension carries, and a pack works its own directional shading out of
the normal it is handed: the game's factor left underneath darkened everything the pack had already
shaded, each face by its own fixed amount and an underside by half, while tops came out right. It is
left out now for any pack that does not write `oldLighting`, which is read for the first time. Where
the chunk passes go back to the game's own shader, which reads that factor out of the vertex colour,
it is put back.

## How it differs from the reference, and for what obstacle

It removes a divergence and adds one condition. What is taken is the reference's rule and its
default: `pipeline/IrisRenderingPipeline.java:1159-1160` answers `!oldLighting`,
`mixin/vertices/block_rendering/MixinClientLevel.java:16-23` applies it by handing the up direction
to the per face table whatever face was asked about, and
`shaderpack/properties/PackDirectives.java:92` defaults the directive to false. Fluids carry the
factor themselves instead of reading that table, and the call taken is the one
`compat/sodium/mixin/MixinDefaultFluidRenderer.java:24-32` takes.

The condition is that the pack's own terrain program has to be serving the chunks. The reference has
no case where it is not; this engine does, `render/TerrainDraw.java:190` raising and lowering that
switch, and on that road the game's shader draws the mesh and expects the factor to be in the vertex
colour. What it costs the image is nothing where the reference has a road, and on the road it has
not it is the difference between a world the game shades and a flat one.

## What proves it

- `gradlew build` green, after the rebase.
- In the game, Fabric bench, world `frozen real`, RenderPearl v2.8.0-beta.4, both benches on the
  same mod set jar for jar: the pack goes from 7.16 mean and 17.10 percent of pixels moved against
  the reference to **2.38 and 5.04**, where the floors of that run are 1.76 and 4.14 here and 1.84
  and 4.54 there. On the canopy band the multiplier goes from 0.926 to 0.999, with the same jar
  captured twice at 1.001, and the per pixel ratio there from a median of 0.674 spread between 0.41
  and 1.0 to a median of 0.999 between 0.974 and 1.020. Spooklementary, captured beside it, stays
  under the floor on both jars.
- The table's callers were read in both jars rather than assumed: in the game only
  `BlockModelLighter`, and in Sodium `FlatLightPipeline` and `SmoothLightPipeline`. Of the three
  calls the fluid renderer makes, the first two pass a constant one and only the third carries a
  factor, which is why that one is taken.

## What it leaves owing

A block in flight, the falling one and the one a piston carries, is lit through the same table per
frame rather than out of a mesh, so it follows the answer with no rebuild between: correct, but it
is the one reader this branch does not put through a rebuilt world, and a capture taken during a
change would catch it mid-way.

The picture was read on one pack against the reference and one static pack beside it, not on the
whole corpus. Every pack that shades from the normal gains the same correction by construction, and
the packs measured at the time all showed the same canopy ratio, but the corpus figure is not
retaken here.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`.
- [x] Every place that states a fact this branch changed now states the new one: `docs/internals/terrain.md` said face shading was baked into the vertex colour, and `NOTICE` carries the rule taken from the reference.
