### PR TITLE
fix(render): end an idle geometry hold before a transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,13 @@ what the next one holds.
 
 ### Fixed
 
+- **Water no longer loses whole patches of its surface on a Mac.** On Apple Silicon a lake could show
+  its bed through rectangles where the surface was not drawn, coming and going as the view moved.
+  The engine keeps one drawing pass open across the world's geometry when it can, and the hand
+  wrote its own data to the graphics card inside that pass right after the water had been drawn in
+  it, which Vulkan does not allow; on a Mac that write cost the water already drawn. The pass is now
+  closed before any such write, unless something is still drawing into it.
+
 - **The world stops being shaded twice, and the sides and undersides of blocks come back to the
   brightness the pack drew them at.** The game tints a block face by which of the six directions it
   faces, out of a small table each dimension carries: in the overworld full strength on top, half

--- a/common/src/main/java/dev/vitrail/mixin/CommandEncoderMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/CommandEncoderMixin.java
@@ -23,7 +23,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * A geometry hold must end before any of those: a copy or a clear cannot be recorded inside a
  * pass, and a composite that samples what geometry just wrote has to see the store. Leftover
  * Immediate draws and Distant Horizons' GenericObjectRenderer that write the same images are
- * the exception: they keep the hold, the way Iris leaves the default framebuffer bound.
+ * the exception: they keep the hold, the way Iris leaves the default framebuffer bound. A buffer
+ * or texture transfer ends it too, unless a family is still drawing into it.
  */
 @Mixin(CommandEncoder.class)
 public abstract class CommandEncoderMixin {
@@ -99,5 +100,36 @@ public abstract class CommandEncoderMixin {
 	private void vitrail$copyTexture(CallbackInfo ci) {
 		GeometryHold.flush(() -> "a texture copy");
 		PassTimings.censusCopy();
+	}
+
+	/**
+	 * Ends a hold nothing is drawing into before a buffer or texture transfer is recorded.
+	 * <p>
+	 * Every {@code createCommandEncoder()} is a new facade over the one Vulkan encoder, so the
+	 * facade's own refusal of a transfer inside a pass only sees the passes that same instance
+	 * opened. A transfer asked for through any other instance went straight into the pass the hold
+	 * kept open: the hand's projection block and its vertex upload into the pass of whichever family
+	 * drew last, the translucent terrain included. Vulkan forbids a transfer
+	 * inside a render pass, so what a driver makes of one is its own affair and differs between them.
+	 * <p>
+	 * The two-argument {@code writeToTexture} hands over to the six-argument one and is not listed;
+	 * both read backs are, the short one checking for a pass of its own, and ending a hold twice is
+	 * ending it once.
+	 */
+	@Inject(method = {
+			"writeToBuffer(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Ljava/nio/ByteBuffer;)V",
+			"copyToBuffer(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Lcom/mojang/blaze3d/buffers/GpuBufferSlice;)V",
+			"writeToTexture(Lcom/mojang/blaze3d/textures/GpuTexture;Lcom/mojang/blaze3d/platform/NativeImage;"
+					+ "IIII)V",
+			"writeToTexture(Lcom/mojang/blaze3d/textures/GpuTexture;Ljava/nio/ByteBuffer;IIIIII)V",
+			"copyBufferToTexture(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;IIII"
+					+ "Lcom/mojang/blaze3d/textures/GpuTexture;IIIIII)V",
+			"copyTextureToBuffer(Lcom/mojang/blaze3d/textures/GpuTexture;Lcom/mojang/blaze3d/buffers/GpuBuffer;"
+					+ "JLjava/lang/Runnable;I)V",
+			"copyTextureToBuffer(Lcom/mojang/blaze3d/textures/GpuTexture;Lcom/mojang/blaze3d/buffers/GpuBuffer;"
+					+ "JLjava/lang/Runnable;IIIII)V"},
+			at = @At("HEAD"), require = 7)
+	private void vitrail$transfer(CallbackInfo ci) {
+		GeometryHold.flushIdle(() -> "a buffer or texture transfer");
 	}
 }

--- a/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderTransferMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderTransferMixin.java
@@ -1,0 +1,100 @@
+package dev.vitrail.mixin;
+
+import dev.vitrail.render.timing.TransferProbe;
+
+import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
+import com.mojang.blaze3d.vulkan.VulkanRenderPass;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.Supplier;
+
+/**
+ * Feeds {@link TransferProbe} from the one Vulkan encoder every {@code CommandEncoder} shares, which
+ * is the only place that knows whether a pass is open whoever asked.
+ * <p>
+ * One injection per call rather than a name matching several overloads: the five-argument
+ * {@code copyTextureToBuffer} hands over to the nine-argument one, and counting both would count one
+ * copy twice.
+ */
+@Mixin(VulkanCommandEncoder.class)
+public abstract class VulkanCommandEncoderTransferMixin {
+
+	@Shadow
+	private VulkanRenderPass currentRenderPass;
+
+	@Unique
+	private Supplier<String> vitrail$open() {
+		return this.currentRenderPass == null ? null : this.currentRenderPass.getLabel();
+	}
+
+	@Inject(method = "writeToBuffer(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;Ljava/nio/ByteBuffer;)V",
+			at = @At("HEAD"))
+	private void vitrail$writeToBuffer(CallbackInfo ci) {
+		TransferProbe.seen("writeToBuffer", vitrail$open());
+	}
+
+	@Inject(method = "copyToBuffer(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;"
+			+ "Lcom/mojang/blaze3d/buffers/GpuBufferSlice;)V", at = @At("HEAD"))
+	private void vitrail$copyToBuffer(CallbackInfo ci) {
+		TransferProbe.seen("copyToBuffer", vitrail$open());
+	}
+
+	@Inject(method = "writeToTexture(Lcom/mojang/blaze3d/textures/GpuTexture;Ljava/nio/ByteBuffer;IIIIII)V",
+			at = @At("HEAD"))
+	private void vitrail$writeToTexture(CallbackInfo ci) {
+		TransferProbe.seen("writeToTexture", vitrail$open());
+	}
+
+	@Inject(method = "copyBufferToTexture(Lcom/mojang/blaze3d/buffers/GpuBufferSlice;IIII"
+			+ "Lcom/mojang/blaze3d/textures/GpuTexture;IIIIII)V", at = @At("HEAD"))
+	private void vitrail$copyBufferToTexture(CallbackInfo ci) {
+		TransferProbe.seen("copyBufferToTexture", vitrail$open());
+	}
+
+	@Inject(method = "copyTextureToBuffer(Lcom/mojang/blaze3d/textures/GpuTexture;"
+			+ "Lcom/mojang/blaze3d/buffers/GpuBuffer;JLjava/lang/Runnable;IIIII)V", at = @At("HEAD"))
+	private void vitrail$copyTextureToBuffer(CallbackInfo ci) {
+		TransferProbe.seen("copyTextureToBuffer", vitrail$open());
+	}
+
+	@Inject(method = "copyTextureToTexture(Lcom/mojang/blaze3d/textures/GpuTexture;"
+			+ "Lcom/mojang/blaze3d/textures/GpuTexture;IIIIIII)V", at = @At("HEAD"))
+	private void vitrail$copyTextureToTexture(CallbackInfo ci) {
+		TransferProbe.seen("copyTextureToTexture", vitrail$open());
+	}
+
+	@Inject(method = "clearColorTexture(Lcom/mojang/blaze3d/textures/GpuTexture;Lorg/joml/Vector4fc;)V",
+			at = @At("HEAD"))
+	private void vitrail$clearColorTexture(CallbackInfo ci) {
+		TransferProbe.seen("clearColorTexture", vitrail$open());
+	}
+
+	@Inject(method = "clearDepthTexture(Lcom/mojang/blaze3d/textures/GpuTexture;D)V", at = @At("HEAD"))
+	private void vitrail$clearDepthTexture(CallbackInfo ci) {
+		TransferProbe.seen("clearDepthTexture", vitrail$open());
+	}
+
+	@Inject(method = "clearColorAndDepthTextures(Lcom/mojang/blaze3d/textures/GpuTexture;"
+			+ "Lorg/joml/Vector4fc;Lcom/mojang/blaze3d/textures/GpuTexture;D)V", at = @At("HEAD"))
+	private void vitrail$clearColorAndDepthTextures(CallbackInfo ci) {
+		TransferProbe.seen("clearColorAndDepthTextures", vitrail$open());
+	}
+
+	@Inject(method = "clearColorAndDepthTextures(Lcom/mojang/blaze3d/textures/GpuTexture;"
+			+ "Lorg/joml/Vector4fc;Lcom/mojang/blaze3d/textures/GpuTexture;DIIII)V", at = @At("HEAD"))
+	private void vitrail$clearColorAndDepthRegion(CallbackInfo ci) {
+		TransferProbe.seen("clearColorAndDepthTextures (region)", vitrail$open());
+	}
+
+	@Inject(method = "createRenderPass(Lcom/mojang/blaze3d/systems/RenderPassDescriptor;)"
+			+ "Lcom/mojang/blaze3d/systems/RenderPassBackend;", at = @At("HEAD"))
+	private void vitrail$createRenderPass(CallbackInfoReturnable<?> cir) {
+		TransferProbe.seen("createRenderPass", vitrail$open());
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/GeometryHold.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryHold.java
@@ -25,8 +25,9 @@ import java.util.function.Supplier;
  * <p>
  * A later pass that samples what the last one wrote, or that names different attachments, or that
  * is a composite, a copy or a clear, ends the hold first. The encoder mixin is that door: every
- * foreign {@code createRenderPass}, copy or clear flushes. This class's own open is the exception,
- * so a matching geometry program does not flush itself.
+ * foreign {@code createRenderPass}, copy or clear flushes, and so does a buffer or texture transfer
+ * while no family is drawing into the pass ({@link #flushIdle}). This class's own open is the
+ * exception, so a matching geometry program does not flush itself.
  */
 public final class GeometryHold {
 
@@ -48,6 +49,13 @@ public final class GeometryHold {
 	private static int areaW;
 	private static int areaH;
 	private static boolean opening;
+
+	/**
+	 * True from the moment a family is handed the pass until that family closes it: the pass is being
+	 * drawn into rather than merely kept. {@link #flushIdle} reads it, a transfer asked for in the
+	 * middle of a family's own draws being one the hold must not end under that family.
+	 */
+	private static boolean drawing;
 
 	/**
 	 * What ended the hold, kept for the next open to report.
@@ -74,6 +82,7 @@ public final class GeometryHold {
 		int fit = fit(descriptor);
 		if (fit == JOINS) {
 			resetArea(current);
+			drawing = true;
 
 			return current;
 		}
@@ -92,6 +101,7 @@ public final class GeometryHold {
 		try {
 			current = encoder.createRenderPass(descriptor);
 			remember(descriptor);
+			drawing = true;
 
 			return current;
 		} finally {
@@ -104,7 +114,12 @@ public final class GeometryHold {
 	 * close in a try-with-resources; cancelling that close is what keeps the backend pass alive.
 	 */
 	public static boolean keep(RenderPass pass) {
-		return pass == current;
+		boolean held = pass == current;
+		if (held) {
+			drawing = false;
+		}
+
+		return held;
 	}
 
 	/**
@@ -132,6 +147,7 @@ public final class GeometryHold {
 		}
 
 		resetArea(current);
+		drawing = true;
 
 		return current;
 	}
@@ -152,10 +168,28 @@ public final class GeometryHold {
 		}
 
 		current = null;
+		drawing = false;
 		colours = null;
 		depth = null;
 		if (pass != null) {
 			pass.close();
+		}
+	}
+
+	/**
+	 * Ends the hold before a buffer or texture transfer is recorded, unless a family is drawing
+	 * into it.
+	 * <p>
+	 * Between two families the pass is only kept, and a transfer recorded then lands inside it,
+	 * which Vulkan forbids. While a family is drawing it is that family's pass: closing it would
+	 * leave the family drawing into a closed pass, so a transfer arriving there is not this hold's
+	 * to end.
+	 *
+	 * @param cause what the census reports against the pass that opens next
+	 */
+	public static void flushIdle(Supplier<String> cause) {
+		if (!drawing) {
+			flush(cause);
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/render/timing/TransferProbe.java
+++ b/common/src/main/java/dev/vitrail/render/timing/TransferProbe.java
@@ -1,0 +1,129 @@
+package dev.vitrail.render.timing;
+
+import dev.vitrail.Vitrail;
+
+import net.minecraft.client.Minecraft;
+
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Names the buffer and texture transfers, colour and depth clears and pass openings recorded into
+ * the frame's command buffer while a render pass is already open on it.
+ * <p>
+ * The game refuses a copy inside a pass on the {@code CommandEncoder} it hands out, but it hands
+ * out a new one on every {@code createCommandEncoder()} over the one Vulkan encoder, so the refusal
+ * only sees the passes that same instance opened. A copy asked for through any other instance goes
+ * straight into whatever pass is recording. Vulkan forbids a copy, a clear or a barrier there, and
+ * what a driver makes of one differs between drivers. Which calls land where is not something
+ * reading settles, so this says it.
+ * <p>
+ * A file {@code vitrail/transfer-in-pass} in the game directory, or
+ * {@code -Dvitrail.transferInPass=true}. Each distinct call, pass and caller is said the first time
+ * it is seen; the running counts follow, at most every ten seconds, for as long as such calls keep
+ * arriving. Asked once and the answer kept.
+ */
+public final class TransferProbe {
+
+	private static final boolean PROPERTY = Boolean.getBoolean("vitrail.transferInPass");
+
+	private static final String ARM_FILE = "transfer-in-pass";
+
+	private static final long REPORT_NANOS = 10_000_000_000L;
+
+	private static final int CALLER_FRAMES = 5;
+
+	private static final StackWalker WALKER = StackWalker.getInstance();
+
+	private static final Map<String, int[]> COUNTS = new HashMap<>();
+
+	/** Null until the game directory can be resolved, which is not true on the first calls. */
+	private static Boolean armed;
+
+	private static boolean announced;
+
+	private static long lastReport;
+
+	private TransferProbe() {
+	}
+
+	/**
+	 * One call reaching the Vulkan encoder.
+	 *
+	 * @param call the encoder method, as the report names it
+	 * @param open the label of the pass open at that moment, or null when none is
+	 */
+	public static void seen(String call, Supplier<String> open) {
+		if (!armed()) {
+			return;
+		}
+
+		if (!announced) {
+			announced = true;
+			lastReport = System.nanoTime();
+			Vitrail.logger().warn("Transfer probe armed by vitrail/{}: a buffer or texture transfer, a "
+					+ "colour or depth clear or a pass opening recorded while a render pass is open is "
+					+ "named here", ARM_FILE);
+		}
+
+		if (open == null) {
+			return;
+		}
+
+		String caller = WALKER.walk(frames -> frames
+				.filter(frame -> outside(frame.getClassName()))
+				.limit(CALLER_FRAMES)
+				.map(frame -> simple(frame.getClassName()) + "." + frame.getMethodName())
+				.collect(Collectors.joining(" <- ")));
+		String key = call + " inside \"" + open.get() + "\" from " + caller;
+		int[] count = COUNTS.get(key);
+		if (count == null) {
+			count = new int[1];
+			COUNTS.put(key, count);
+			Vitrail.logger().warn("Transfer inside an open pass: {}", key);
+		}
+
+		count[0]++;
+
+		long now = System.nanoTime();
+		if (now - lastReport >= REPORT_NANOS) {
+			lastReport = now;
+			COUNTS.forEach((name, n) -> Vitrail.logger().info("Transfer inside an open pass, {} "
+					+ "times so far: {}", n[0], name));
+		}
+	}
+
+	private static boolean armed() {
+		if (PROPERTY) {
+			return true;
+		}
+
+		if (armed == null) {
+			Minecraft minecraft = Minecraft.getInstance();
+			if (minecraft == null || minecraft.gameDirectory == null) {
+				return false;
+			}
+
+			armed = Files.isRegularFile(minecraft.gameDirectory.toPath()
+					.resolve("vitrail").resolve(ARM_FILE));
+		}
+
+		return armed;
+	}
+
+	private static boolean outside(String className) {
+		return !className.startsWith("com.mojang.blaze3d.vulkan.VulkanCommandEncoder")
+				&& !className.startsWith("com.mojang.blaze3d.systems.CommandEncoder")
+				&& !className.startsWith("dev.vitrail.render.timing.TransferProbe")
+				&& !className.startsWith("java.");
+	}
+
+	private static String simple(String className) {
+		int dot = className.lastIndexOf('.');
+
+		return dot < 0 ? className : className.substring(dot + 1);
+	}
+}

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -79,6 +79,7 @@
 		"VulkanBindGroupLayoutMixin",
 		"access.VulkanCommandEncoderAccessor",
 		"VulkanCommandEncoderMixin",
+		"VulkanCommandEncoderTransferMixin",
 		"VulkanConstMixin",
 		"VulkanDeviceMixin",
 		"VulkanGpuTextureViewMixin",

--- a/docs/internals/entities.md
+++ b/docs/internals/entities.md
@@ -19,8 +19,9 @@ a **run** of draws and hand the pack every draw buffer it asked for.
 A run and not the group. One pass carries one set of attachments, so the run lasts as long as the
 draws that follow keep writing the same colour and depth images over the same area, whatever program
 they belong to: `GeometryHold` is what arbitrates that, and a different set of attachments, a
-different area, or anything that cannot be recorded inside a pass at all, which is a copy, a clear
-or a composite, is what ends it. Nothing is reordered to make runs longer, because the order the
+different area, or anything that cannot be recorded inside a pass at all, which is a copy, a clear,
+a composite, or a buffer or texture transfer arriving while nothing is drawing into the pass, is
+what ends it. Nothing is reordered to make runs longer, because the order the
 game walks its draws in is the order things overlap in. A run therefore outlives the group that
 started it, and the encoder still allows one pass at a time: a foreign `createRenderPass` ends the
 hold on its way in, which is what keeps a pass left standing from making the next thing the game

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -137,6 +137,14 @@ command buffer the frame submits once at its end. A pass left open by an early r
 exception path skips its barrier and stays open besides, so passes belong in try-with-resources
 without exception.
 
+**A transfer is refused inside a pass only by the encoder that opened that pass.**
+`GpuDevice.createCommandEncoder()` hands out a new `CommandEncoder` on every call over the one
+Vulkan encoder, and each instance checks only its own open pass, so a buffer or texture write asked
+for through any other instance is recorded straight into whatever pass is recording, which Vulkan
+forbids. A pass this engine keeps open across geometry is therefore ended before such a write
+whenever nothing is drawing into it, and a file `vitrail/transfer-in-pass` in the instance names
+every transfer that still lands inside a pass.
+
 The price still scales with the number of GPU stops rather than with what they read: each closed
 pass, each standalone clear, each copy. Folding a clear into a load-op, blitting a mip chain, and
 holding matching geometry in one pass are how this engine spends fewer of those stops. Note that


### PR DESCRIPTION
## What changes

The engine keeps one render pass open across consecutive geometry that writes the same images, and
ends it before anything that cannot be recorded inside a pass. A buffer or texture write was not on
that list. The game hands out a new command encoder on every call, and each one refuses a transfer
only inside a pass it opened itself, so a write asked for through another encoder went straight
into the pass being kept open. The hand's projection block and its vertex upload landed that way in
the pass of whichever family drew last, the translucent terrain among them. Vulkan forbids a
transfer inside a render pass; on a Mac it showed as rectangles of a lake with no surface, coming
and going as the view moved.

The kept pass now ends before a buffer or texture write whenever no family is drawing into it. A
separate commit adds `vitrail/transfer-in-pass` (or `-Dvitrail.transferInPass=true`), which names
the transfers, clears and pass openings recorded while a pass is open, with the pass and the caller.

## How it differs from the reference, and for what obstacle

It does not. The kept pass stands in for the framebuffer Iris leaves bound, and OpenGL has no
equivalent of a transfer inside a pass.

## What proves it

- `gradlew build` green.
- In game on a Mac mini M4 under MoltenVK, Complementary Unbound r5.8.1, a savanna lake seen from a
  hill, the camera held above the horizon then tilted down onto the lake by a datapack, identically
  on both jars. Captures taken at the same instants after the pack starts drawing, with the world
  loaded to the same point on both sides: without the change, the near lake has no surface and shows
  its bed while the probe names the hand's write inside the terrain pass; with it, the surface is
  there and the probe names nothing at all.
- The same probe on the jar without the change names writes inside the entity and particle passes
  frame after frame on every run, and none on the jar with it.

## What it leaves owing

- A transfer asked for while a family is still drawing into the kept pass still lands inside it;
  none was seen, and the probe would name one.
- The probe watches the encoder's transfers, colour and depth clears and pass openings, not a
  stencil clear.
- Ending the kept pass before those writes reopens a pass where one was held; the pass count per
  frame rises accordingly and was not measured.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
