### PR TITLE
fix(glsl): declare the vertex position invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,14 @@ what the next one holds.
   it, which Vulkan does not allow; on a Mac that write cost the water already drawn. The pass is now
   closed before any such write, unless something is still drawing into it.
 
+- **Banners no longer flicker with light stripes on a Mac.** On Apple Silicon a banner could show
+  fine light stripes coming and going across its colour, plainest on the brown banners hanging in a
+  village seen from below. A banner is drawn twice at the same place, the cloth and then its colour
+  over it, by two different programs of the pack, and the Mac's shader compiler was free to round
+  each program's arithmetic its own way, so the colour could land a hair behind the cloth and be
+  hidden by it. Every vertex program of a pack now asks for its position to come out identical
+  wherever two programs compute it with the same code.
+
 - **The world stops being shaded twice, and the sides and undersides of blocks come back to the
   brightness the pack drew them at.** The game tints a block face by which of the six directions it
   faces, out of a small table each dimension carries: in the overworld full strength on top, half

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -163,6 +163,16 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 					}
 				}
 			}
+
+			// Two programs of a pack that place the same vertex with the same code have to land it at
+			// the same depth to the last bit: a banner's pattern is tested GREATER_THAN_OR_EQUAL
+			// against the depth its base wrote through another program. MoltenVK compiles with fast
+			// math unless a stage says otherwise, and Metal is then free to fold each program's
+			// arithmetic its own way; on an M4 the pattern lost that test in hatched patches across a
+			// village's banners, and with this line it does not. SPIRV-Cross reports the qualifier as
+			// position invariance and MoltenVK compiles the stage with preserveInvariance, which
+			// every vertex stage now pays, the shadow and full screen ones included.
+			lines.add("invariant gl_Position;");
 		}
 
 		// The four taps a hardware comparison blends, for the lookups the road decision sent here:

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -179,6 +179,17 @@ declare all outputs in the header from zero with no gaps, and name each once in 
 from a function called as the first statement of main, so rank equals location and the game's
 rewrite becomes the identity.
 
+Every vertex stage also declares `invariant gl_Position`. Two programs of one pack often place the
+same vertex with the same code and are expected to land it at the same depth to the last bit: a
+banner's colour is drawn over its cloth by another program, with a test that passes only at an
+equal or nearer depth. MoltenVK compiles with fast math unless a stage says otherwise, which leaves
+Metal free to fold each program's arithmetic its own way, and on Apple Silicon the colour lost that
+test in hatched patches until the qualifier was there. SPIRV-Cross reports it as position
+invariance, and MoltenVK compiles the stage with `preserveInvariance`, which every vertex stage
+pays. The qualifier only holds where the two programs spell the computation the same: a pack whose
+programs place a vertex by different code is not covered, nor a draw the game still makes with its
+own shader.
+
 ## The unit of translation is the program, not the file
 
 This is the correction that mattered most, and it applies twice.


### PR DESCRIPTION
## What changes

Every vertex stage the translator writes now declares `invariant gl_Position`. On a Mac, banners showed fine light stripes coming and going across their colour, plainest on the plain brown banners of a village. A banner is drawn twice at one place, the cloth by the pack's block program and the colour over it by its translucent one, which passes only at an equal or nearer depth. Both compute the position with the same code from the same values, but MoltenVK compiles with fast math, so Metal was free to fold each program's arithmetic its own way and the colour lost its depth test in patches. With the qualifier, SPIRV-Cross reports the stage as position invariant and MoltenVK compiles it with `preserveInvariance`.

## How it differs from the reference, and for what obstacle

It does not change what a pack is given. Iris runs on OpenGL and never meets MoltenVK's fast math; the qualifier asks the compiler for what the pack already assumes.

## What proves it

- `gradlew build` green.
- The out-of-game Metal harness over the corpus: the same units reach SPIR-V as before the change, and the MSL backend refuses none.
- In game on a Mac mini M4 under MoltenVK, Photon, a wall of wall banners a thousand blocks from the origin, the camera sweeping twenty degrees: without the change, six of twelve captures show light hatched patches on the banners; with it, none of twelve. The same wall turned to a morning sun: every one of twelve captures without the change shows patches, several covering half a banner, and none of twelve with it.
- On a GeForce RTX 4060 under Vulkan, the same scene at the origin and a thousand blocks out shows no stripes in twenty four captures, without the change.

## What it leaves owing

- A draw the game still makes with its own shader over pack geometry at an equal depth is not covered: only translated stages carry the qualifier.
- `preserveInvariance` asks Metal for more conservative vertex code on every stage. Measured on the M4 with Photon on a pinned superflat, the two jars alternated three times each: the middle frame stays within the runs' own spread, around 14.4 ms either way, so no cost shows there; a heavier scene was not tried.
- A GeForce was not tried in game with the change.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
