### PR TITLE
fix(render): stop a pack that throws while it warms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,7 +268,8 @@ what the next one holds.
   needs many. The engine kept one size, and a shader asking for any other was silently handed the
   full one, so the estimate that decides how soft a shadow edge should be was made from the wrong
   picture. The copies are now made, once at the end of the pass that draws the map, and a shader
-  that names the size it wants gets that size.
+  that names the size it wants gets that size, unless it reads through the hardware comparison,
+  which always reads the full map.
 
   One pack of those at hand asks: iterationT, on the first of the map's two images, for the width
   of its soft shadows. A pack that says nothing keeps one size and pays for nothing. A shader that
@@ -289,8 +290,9 @@ what the next one holds.
   back a copy nothing ever filled: on screen it shows as a shadow that flickers between frames from
   a viewpoint that is not moving. Every other kind of read already named its copy for exactly that
   reason, and these did not, though they are the reads a pack makes most, the four tap shadow filter
-  of both Complementary packs among them. They name it now, and a shader that names a copy itself
-  still gets the one it named.
+  of both Complementary packs among them. They name it now, and the copy they name is always the
+  full map: a read through the comparison never reaches a smaller one, even where a shader asks
+  for it, which none of the packs at hand does.
 
 - **Smoke, flame and the other solid particles take the colour the pack meant them to.**
   The game draws its quad particles in two goes, the solid ones with the world and the
@@ -445,8 +447,10 @@ what the next one holds.
   for about half a minute, and then it put itself right. A pack of that kind keeps its light in
   volumes it fills a little at a time rather than writing whole, and it was handed those volumes
   still holding whatever had been in that memory, so its first frames spread that instead of light.
-  They are now emptied once, when they are made. Volumes far larger than any of these are left
-  alone, because emptying one of those at that moment is what took the display driver down once.
+  They are now emptied once, when they are made, up to a fixed amount of memory for all the volumes
+  made at the same moment; past it they are left as they come, a precaution kept since emptying at
+  that moment once coincided with the display driver going down. Photon at its two largest settings
+  for those volumes goes past it, and there a reload can still bring the one-colour world back.
 
 - **A setting compared against a number with a decimal point no longer switches a pass off.** Some
   packs write conditions like "if the motion blur is above 0.0" or "if the falloff equals 1", with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,13 @@ what the next one holds.
 
 ### Fixed
 
+- **A pack the graphics card will not build no longer closes the game.** When the card refused one
+  of a pack's programs while the pack was being prepared, which Apple's hardware does with a
+  program reading more textures at once than it has slots for, the error went all the way up and
+  the game closed on a crash report: on a Mac that was Reverie. The pack is now put away and the
+  world is drawn by the game, the way it is for a pack refused when it loads, and the settings
+  screen says an error stopped it.
+
 - **Water no longer loses whole patches of its surface on a Mac.** On Apple Silicon a lake could show
   its bed through rectangles where the surface was not drawn, coming and going as the view moved.
   The engine keeps one drawing pass open across the world's geometry when it can, and the hand

--- a/common/src/main/java/dev/vitrail/render/FaceShading.java
+++ b/common/src/main/java/dev/vitrail/render/FaceShading.java
@@ -89,8 +89,9 @@ public final class FaceShading {
 	 * The game's own brightness back.
 	 * <p>
 	 * Asked from the five places a chain or the terrain family stops, which is what covers every road
-	 * that ends with the game's shader drawing the chunks: {@code PackChain.stop} for the three
-	 * refusals at load, {@code PackChain.putAway} for the thirteen the frame can take,
+	 * that ends with the game's shader drawing the chunks: {@code PackChain.stop} for the refusals at
+	 * load and the errors the frame catches, {@code PackChain.putAway} for the stops the frame takes
+	 * for a reason of its own,
 	 * {@link TerrainDraw#wanted(boolean)} for every road that switches the family off, and the two
 	 * places {@link TerrainDraw} lowers that same field directly, one after a failed read and one
 	 * after a failed prepare. All of them leave

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -21,6 +21,7 @@ import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.buffers.Std140Builder;
@@ -169,8 +170,9 @@ public final class PackChain {
 		disabled = true;
 		// The mesh is not taken down here and the pass goes back to the game's own shader, which
 		// expects the game's per face brightness to be in the vertex colour. Said here rather than
-		// at each of the three roads into this method, so a fourth cannot forget it. This is the
-		// LOAD's road only; putAway is the frame's, and says the same thing for the same reason.
+		// at each road into this method, so a new one cannot forget it: the refusals of the load and
+		// the errors the frame catches. putAway, the frame's stop for a reason it names, says the
+		// same thing for the same reason.
 		FaceShading.none();
 	}
 
@@ -637,8 +639,8 @@ public final class PackChain {
 	 * chose that the device would not give, which no screen size changes and which the frame would
 	 * otherwise ask for again at every size the window passes through.
 	 * <p>
-	 * <strong>What this does NOT do is hand the colour targets back</strong>, where the two other
-	 * places that stop a pack mid-session do. The first reason cannot: it runs inside the chunk pass
+	 * <strong>What this does NOT do is hand the colour targets back</strong>, where most of the
+	 * frame's catches do after {@link #stop}. The first reason cannot: it runs inside the chunk pass
 	 * the renderer opened, and releasing a target there tears down what that pass is drawing into.
 	 * The second reaches this outside any pass and could, and does not, so that a pack put away is
 	 * one thing and not two; what it would hand back is what stood allocated when the device
@@ -654,9 +656,9 @@ public final class PackChain {
 		}
 
 		disabled = true;
-		// The frame's own road out, and the thirteen sites that reach it are why this is said here
-		// rather than beside each of them. The mesh stands and the game's shader takes the chunk
-		// passes back, so the per face brightness it reads out of the vertex colour has to be there.
+		// The frame's own road out for a reason it names. The mesh stands and the game's shader
+		// takes the chunk passes back, so the per face brightness it reads out of the vertex colour
+		// has to be there.
 		// Fired from inside a frame on purpose: allChanged raises a flag the next extract consumes
 		// rather than tearing sections down under the frame that asked.
 		FaceShading.none();
@@ -750,7 +752,7 @@ public final class PackChain {
 				chain.beginFrame();
 			}
 		} catch (RuntimeException e) {
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 			chain.release();
 		}
@@ -901,21 +903,35 @@ public final class PackChain {
 		}
 
 		long deadline = System.nanoTime() + WARM_BUDGET_NANOS;
-		do {
-			if (disabled) {
+		try {
+			do {
+				if (disabled) {
+					return;
+				}
+
+				if (chain.programs == null) {
+					chain.build(device);
+				}
+
+				if (!chain.prepare(device, main) || !chain.warm(device)) {
+					continue;
+				}
+
 				return;
-			}
-
-			if (chain.programs == null) {
-				chain.build(device);
-			}
-
-			if (!chain.prepare(device, main) || !chain.warm(device)) {
-				continue;
-			}
-
-			return;
-		} while (System.nanoTime() < deadline);
+			} while (System.nanoTime() < deadline);
+		} catch (GpuDeviceLossException e) {
+			// Not about this pack: the device is gone, and PackChoice rethrows it out of a release
+			// for the same reason.
+			throw e;
+		} catch (RuntimeException e) {
+			// A pipeline the driver will not build throws out of precompilePipeline rather than coming
+			// back invalid, which is what MoltenVK does with a stage Metal refuses, and nothing between
+			// here and the game loop caught it. The reference stops drawing the pack and draws the
+			// game's own picture on an exception while it builds its pipeline, and so does this.
+			stop();
+			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
+			chain.release();
+		}
 	}
 
 	/**
@@ -1275,7 +1291,7 @@ public final class PackChain {
 			// again would be measured against where the player stood in the one they left.
 			chain.voxelAnchored = false;
 		} catch (RuntimeException e) {
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 		}
 	}
@@ -1560,7 +1576,7 @@ public final class PackChain {
 		try {
 			chain.drawBegins(device);
 		} catch (RuntimeException e) {
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 			chain.release();
 		}
@@ -1593,7 +1609,7 @@ public final class PackChain {
 		try {
 			chain.drawPrepares(device);
 		} catch (RuntimeException e) {
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 			chain.release();
 		}
@@ -1627,7 +1643,7 @@ public final class PackChain {
 		try {
 			chain.drawEarly(device);
 		} catch (RuntimeException e) {
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 			chain.release();
 		}
@@ -1674,7 +1690,7 @@ public final class PackChain {
 			chain.targets.depth().takeDistantOpaque(device.createCommandEncoder(), device,
 					chain.quad(device), served, served.getWidth(0), served.getHeight(0));
 		} catch (RuntimeException e) {
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 			chain.release();
 		}
@@ -1774,7 +1790,7 @@ public final class PackChain {
 			chain.targets.depth().takePreHand(device.createCommandEncoder(), device, chain.quad(device),
 					main.getDepthTextureView(), main.width, main.height);
 		} catch (RuntimeException e) {
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 			chain.release();
 		}
@@ -1827,7 +1843,7 @@ public final class PackChain {
 						+ "rather than the far plane");
 			}
 		} catch (RuntimeException e) {
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 			chain.release();
 		}
@@ -1876,18 +1892,20 @@ public final class PackChain {
 		}
 
 		RenderTarget main = minecraft.gameRenderer.mainRenderTarget();
-		// The layer's own pipeline is compiled on the refused frames too, and deliberately before the
-		// question below rather than after it: it is one more pipeline the frame that finally draws
-		// would otherwise compile on top of the pack's last one.
-		if (main == null || !chain.features.prepare(device) || !chain.drawable()) {
-			return;
-		}
 
 		// Caught like every other entry point this bus calls. These two were the only ones without
 		// it, and they are the worst place to be missing one: an exception here reaches the game
 		// through an event handler and comes back on the very next frame, so what the player sees
-		// is not a pack that stopped drawing but a game that will not run.
+		// is not a pack that stopped drawing but a game that will not run. The layer's compile is
+		// inside it too, a pipeline the driver refuses throwing rather than coming back invalid.
 		try {
+			// The layer's own pipeline is compiled on the refused frames too, and deliberately
+			// before the question below rather than after it: it is one more pipeline the frame
+			// that finally draws would otherwise compile on top of the pack's last one.
+			if (main == null || !chain.features.prepare(device) || !chain.drawable()) {
+				return;
+			}
+
 			GpuTextureView layer = chain.features.open(device, main.width, main.height);
 			if (layer == null) {
 				return;
@@ -1902,7 +1920,7 @@ public final class PackChain {
 			RenderSystem.outputColorTextureOverride = null;
 			RenderSystem.outputDepthTextureOverride = null;
 			chain.redirected = false;
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 			chain.release();
 		}
@@ -1939,7 +1957,7 @@ public final class PackChain {
 		try {
 			chain.takeReadCopies(device);
 		} catch (RuntimeException e) {
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 			chain.release();
 		}
@@ -2012,7 +2030,7 @@ public final class PackChain {
 			chain.features.compose(device.createCommandEncoder(), chain.quad, view,
 					chain.targets.takeClear(view));
 		} catch (RuntimeException e) {
-			disabled = true;
+			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
 			chain.release();
 		}
@@ -2817,17 +2835,16 @@ public final class PackChain {
 	}
 
 	/**
-	 * Releases as well as latching, which the two other places that set {@code disabled} already
-	 * did and this one did not. A pack whose one bad program stops the chain kept every colour
-	 * target it had allocated for the rest of the session, ninety nine megabytes of them on BSL,
-	 * for an engine that had just decided to draw nothing.
+	 * Stops the pack and hands its targets back. Kept, they would stay allocated for the rest of
+	 * the session when one bad program stops the chain, ninety nine megabytes of them on BSL, for an
+	 * engine that has just decided to draw nothing.
 	 */
 	private boolean valid(CompiledRenderPipeline compiled, PackPass pass) {
 		if (compiled.isValid()) {
 			return true;
 		}
 
-		disabled = true;
+		stop();
 		Vitrail.logger().error("{} did not compile, nothing of this pack will be drawn", pass.path());
 		release();
 

--- a/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
+++ b/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
@@ -290,8 +290,9 @@ public final class ConfigEntry implements ConfigEntryPoint {
 	 * How many frames the shadow map is kept for after the one that drew it.
 	 * <p>
 	 * The pass that fills that map is the most expensive thing the engine does, and between two
-	 * frames of a player standing still nothing in it moves. What the frames cost is on casters that
-	 * MOVE: a mob, a boat, the player's own shadow keep the place they had when the map was drawn.
+	 * frames of a player standing still nothing in it moves. What the frames cost is on the GROUND: a
+	 * block placed or broken keeps the shadow it had when the map was drawn, while a mob, a boat and
+	 * the player's own shadow are drawn into the kept map again on every frame.
 	 * The slider stops at {@link ShadowAmortisation#MAX_FRAMES} because a walk finds the lag at
 	 * three, and a value nobody should choose is better left out of the selector than explained in
 	 * a tooltip.


### PR DESCRIPTION
## What changes

A pipeline the driver will not build throws out of `precompilePipeline` instead of coming back invalid, and the warm-up that compiles a pack's passes had no catch between it and the game loop. On Apple Silicon MoltenVK refuses one of Reverie's deferred programs, which reads more samplers than Metal has slots, and the game closed on a crash report. The warm-up now catches like the frame's other entry points and stops the pack, letting a device loss through the way a release already does, and the feature layer's own compile moves inside the catch its comment says covers it.

Every one of those catches now goes through `stop()` instead of setting the latch alone. Alone, it left the chunks meshed without the game's per face brightness while the game's own shader drew them, so a pack stopped by an error left every block face as bright as its top.

A second commit corrects three `Unreleased` changelog entries and a javadoc: a read through the hardware shadow comparison always reads the full map, whatever level it names; the emptying of storage volumes is bounded by a budget per allocation pass and not a size per volume, with its cause left open as the code leaves it; and moving casters are drawn into the kept shadow map on every frame.

## How it differs from the reference, and for what obstacle

It does not. Iris stops drawing the pack and falls back to vanilla on an exception while it builds its pipeline, `Iris.java:657-667` on `26.2`.

## What proves it

- `gradlew build` green on each of the two commits.
- In game on the Fabric bench, Photon on a flat test world, with a throw placed by hand inside the warm-up for one launch (not part of the branch): the game stays up, the per face brightness comes back into the chunk mesh with every section rebuilt, and the error is logged once with its stack.
- The crash being fixed is read from the Mac crash report: `VK_ERROR_INITIALIZATION_FAILED` out of `PackPass.compile`, reached from `PackChain.pumpWarmup`. The branch was not run on a Mac.
- The corrected entries are read against `ShadowCompare.java:216-217`, `StorageImages.java:72-96` and `ShadowAmortisation.java:37-40`.

## What it leaves owing

- Reverie still does not draw on a Mac: it is stopped rather than crashing.
- Pipelines compiled during a frame outside these catches still reach the game loop when the driver refuses one, the upscale's two in `RenderScale.endWorld` among them.
- A release that throws inside one of these catches still escapes it, as before.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
