### PR TITLE
docs: correct two unreleased changelog claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,8 @@ what the next one holds.
   What is kept is the ground alone. Everything that moves, a mob, a boat, your own shadow, is drawn
   into the kept map afresh on every frame, so none of it is ever late. The price is on the ground
   itself: a block you place or break casts the shadow it had for as many frames as the setting
-  keeps. One frame is what it ships at and is not visible in play; the slider goes to two and stops
-  there. Turning it off restores the previous behaviour exactly.
+  keeps. One frame is what it ships at, and the slider goes to two and stops there. Turning it off
+  restores the previous behaviour exactly.
 
 - **A pack that ships no `final` program now draws.** Some packs end their chain on their last
   composite and expect what it wrote to be the picture; they were refused outright, with nothing on
@@ -317,8 +317,9 @@ what the next one holds.
   those types, so the colour output declared under one stayed where the pack wrote it and a second
   output was laid on the same slot; it is declared under its ordinary width now, and the value
   written is the same. The programs asked the card for arithmetic the game never turns on, and a
-  program asking for what was not turned on is invalid: the engine now turns on every such feature
-  the card reports. The pack passes its values between the two stages in a block of its own, which
+  program asking for what was not turned on is invalid: the engine now turns on those the card
+  reports, all but the one for sixteen bit stage outputs, which the output declared under its
+  ordinary width no longer needs. The pack passes its values between the two stages in a block of its own, which
   the game counts as one value when it numbers them, so the value after the block landed inside it:
   the block's members are passed one by one now, at the cost of the packing the pack had chosen. And
   the pack asks whether the card has an AMD instruction before using it, a question the shader


### PR DESCRIPTION
## What changes

Two entries of the unreleased changelog said more than the code does.

The shadow reuse entry said one frame of reuse is not visible in play. No capture of the reuse in its current form shows that: the one frame bound is the value an earlier form of it was judged at. The entry now says what the setting ships at and stops there.

The half precision entry said the engine turns on every narrow arithmetic feature the card reports. One is left off, sixteen bit values passed between stages, which GeForce does not have and which the engine does without by declaring such an output under its ordinary width, as the same entry already says.

## How it differs from the reference, and for what obstacle

It does not. Text only.

## What proves it

- `fix(shadow): say what the kept map actually holds` names the one frame bound as inherited rather than measured.
- `VulkanBackendMixin.java:88` leaves `storageInputOutput16` out, with the reason.

## What it leaves owing

Nothing.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [ ] `gradlew build` green locally, after the rebase and not before it. Text only, left to CI.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
