### PR TITLE
build: raise the version to 0.11.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## Unreleased
+## 0.11.0-beta
 
 ### Added
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.11.0-dev
+mod_version=0.11.0-beta
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

Raises `mod_version` to `0.11.0-beta` and names the `Unreleased` section of the changelog after it. Nothing else.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

- `build` on this head.

## What it leaves owing

The tag that publishes is pushed separately. Anything that lands on `dev` after this needs a fresh bump on top before tagging.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [ ] `gradlew build` green locally, after the rebase and not before it. Two lines, left to CI.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
