### PR TITLE
fix(render): stop what a refused pipeline serves mid frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,15 @@ what the next one holds.
   world is drawn by the game, the way it is for a pack refused when it loads, and the settings
   screen says an error stopped it.
 
+- **Three more programs the graphics card will not build no longer close the game.** The render
+  scale's upscale, a pack's particle program rebuilt for particles another mod draws in a format of
+  its own, and the game's entity programs rebuilt when a pack starts drawing the entities or the
+  hand were all built in the middle of a frame with nothing to catch a refusal, so a card that
+  refused one closed the game. The render scale now falls back to a plain stretch, and turns itself
+  off when nothing builds; that other mod's particles are drawn through the pack's program as it
+  stands; and the entities and the hand go back to the game for the rest of the session. The log
+  says which.
+
 - **Water no longer loses whole patches of its surface on a Mac.** On Apple Silicon a lake could show
   its bed through rectangles where the surface was not drawn, coming and going as the view moved.
   The engine keeps one drawing pass open across the world's geometry when it can, and the hand

--- a/common/src/main/java/dev/vitrail/render/EntityMesh.java
+++ b/common/src/main/java/dev/vitrail/render/EntityMesh.java
@@ -4,6 +4,7 @@ import dev.vitrail.glsl.EntityVertex;
 import dev.vitrail.mixin.access.GpuDeviceAccessor;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
@@ -115,6 +116,13 @@ public final class EntityMesh {
 	private static boolean said;
 
 	/**
+	 * Whether the device refused one of the game's entity pipelines at {@link #FORMAT}, which holds
+	 * for the rest of the session. The refusal is the device's answer to a fixed format, so every
+	 * later load that asks for the wider mesh would rebuild the world only to be refused again.
+	 */
+	private static boolean widerRefused;
+
+	/**
 	 * Whether a rebuild has already been asked for and not yet answered, so that one load asks for
 	 * one.
 	 * <p>
@@ -173,7 +181,7 @@ public final class EntityMesh {
 	 * come off it too and are already behind the entity switch.
 	 */
 	private static boolean asked() {
-		return EntityDraw.wanted() || HandDraw.wanted();
+		return !widerRefused && (EntityDraw.wanted() || HandDraw.wanted());
 	}
 
 	/**
@@ -272,8 +280,38 @@ public final class EntityMesh {
 			GpuDevice device = RenderSystem.getDevice();
 			if (((GpuDeviceAccessor) device).vitrail$backend() instanceof StalePipelines stale) {
 				List<RenderPipeline> dropped = stale.vitrail$dropEntityPipelines();
-				for (RenderPipeline pipeline : dropped) {
-					device.precompilePipeline(pipeline, null);
+				try {
+					for (RenderPipeline pipeline : dropped) {
+						device.precompilePipeline(pipeline, null);
+					}
+				} catch (GpuDeviceLossException e) {
+					throw e;
+				} catch (RuntimeException e) {
+					// A pipeline the driver refuses throws out of precompilePipeline rather than coming
+					// back invalid, and this runs inside Sodium's renderer setup, outside every catch
+					// of the frame. Going back to the game's own format is the game's own compile, and
+					// a refusal there is not this engine's to answer.
+					if (!asked) {
+						throw e;
+					}
+
+					// Going to the wider format, what was refused is the format, so the mesh stops
+					// carrying it. Whatever this loop already compiled at the wider format leaves the
+					// map again, so every entity pipeline of the game compiles at its own format at its
+					// next bind, and the pack's entities and hand stand down for the session, their
+					// programs reading a mesh that no longer carries. The order is what
+					// asks for no rebuild: the answer goes back first and the hand is taken down without
+					// asking, so the entity switch is the one question left and it finds agreement.
+					widerRefused = true;
+					carrying = false;
+					stale.vitrail$dropEntityPipelines();
+					HandDraw.stopped();
+					EntityDraw.wanted(false);
+					Vitrail.logger().error("An entity pipeline of the game did not compile at the "
+							+ "wider entity format, so no pack draws the entities or the hand for the "
+							+ "rest of this session", e);
+
+					return;
 				}
 
 				Vitrail.logger().info("{} entity pipelines of the game carried the previous "

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -24,6 +24,7 @@ import dev.vitrail.uniform.TextSink;
 import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.platform.CompareOp;
@@ -1121,13 +1122,28 @@ final class GeometryProgram {
 				return null;
 			}
 
-			if (!device.precompilePipeline(variant, this.source).isValid()) {
+			RuntimeException thrown = null;
+			boolean valid;
+			try {
+				valid = device.precompilePipeline(variant, this.source).isValid();
+			} catch (GpuDeviceLossException e) {
+				throw e;
+			} catch (RuntimeException e) {
+				// A stage the driver refuses throws out of precompilePipeline rather than coming back
+				// invalid, which is what MoltenVK does with one Metal will not build, and the caller
+				// is a pipeline being set on a pass, outside every catch of the frame. It is the same
+				// refusal, so it takes the same latch.
+				thrown = e;
+				valid = false;
+			}
+
+			if (!valid) {
 				// Latched like compile()'s refusal, and for its reason: retrying would pay shaderc
 				// every draw for the same answer, and the caller has a fallback to hand the draw to.
 				this.reshaped.put(layout, null);
 				Vitrail.logger().error("{} did not compile over a mesh layout brought by another "
 						+ "mod, so the {} pass draws that mesh through its own layout", this.path,
-						this.pass.name());
+						this.pass.name(), thrown);
 
 				return null;
 			}

--- a/common/src/main/java/dev/vitrail/render/RenderScale.java
+++ b/common/src/main/java/dev/vitrail/render/RenderScale.java
@@ -5,6 +5,7 @@ import dev.vitrail.mixin.access.RenderTargetAccessor;
 import dev.vitrail.settings.PackFile;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.buffers.GpuBuffer;
@@ -366,14 +367,26 @@ public final class RenderScale {
 				this.pipeline = build(this.fragment);
 			}
 
-			if (device.precompilePipeline(this.pipeline, SOURCE).isValid()) {
-				return this.pipeline;
+			try {
+				if (device.precompilePipeline(this.pipeline, SOURCE).isValid()) {
+					return this.pipeline;
+				}
+
+				Vitrail.logger().error("The {} pass of the render scale did not compile",
+						this.fragment.getPath());
+			} catch (GpuDeviceLossException e) {
+				throw e;
+			} catch (RuntimeException e) {
+				// A stage the driver refuses throws out of precompilePipeline rather than coming back
+				// invalid, which is what MoltenVK does with one Metal will not build, and endWorld
+				// runs outside every catch of the frame. The same latch as an invalid pipeline, so the
+				// fallback and the abandonment below it take over from here.
+				Vitrail.logger().error("The {} pass of the render scale did not compile",
+						this.fragment.getPath(), e);
 			}
 
 			this.refused = true;
 			this.pipeline = null;
-			Vitrail.logger().error("The {} pass of the render scale did not compile",
-					this.fragment.getPath());
 
 			return null;
 		}

--- a/common/src/main/java/dev/vitrail/render/TemporalAccumulation.java
+++ b/common/src/main/java/dev/vitrail/render/TemporalAccumulation.java
@@ -2,6 +2,7 @@ package dev.vitrail.render;
 
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.buffers.GpuBuffer;
@@ -416,15 +417,24 @@ public final class TemporalAccumulation {
 			this.pipeline = build();
 		}
 
-		if (device.precompilePipeline(this.pipeline, SOURCE).isValid()) {
-			return this.pipeline;
+		RuntimeException thrown = null;
+		try {
+			if (device.precompilePipeline(this.pipeline, SOURCE).isValid()) {
+				return this.pipeline;
+			}
+		} catch (GpuDeviceLossException e) {
+			throw e;
+		} catch (RuntimeException e) {
+			// A stage the driver refuses throws out of precompilePipeline rather than coming back
+			// invalid, and RenderScale.endWorld reaches this outside every catch of the frame.
+			thrown = e;
 		}
 
 		release();
 		this.refused = true;
 		this.pipeline = null;
 		Vitrail.logger().error("The temporal fold did not compile, so it stays off for this "
-				+ "session");
+				+ "session", thrown);
 
 		return null;
 	}


### PR DESCRIPTION
## What changes

On Apple hardware, a pipeline that Metal refuses to build makes `precompilePipeline` throw rather than return an invalid pipeline. Four compiles still ran outside any catch, so a refusal at any of them closed the game:

- the render scale's EASU, RCAS and bilinear passes;
- the temporal fold, reached from the same `endWorld`;
- a pack's particle program rebuilt over another mod's vertex layout (`GeometryProgram.reshape`);
- the game's entity pipelines, compiled again when the entity mesh widens (`EntityMesh.settle`).

Each site now treats the throw as the refusal it already handles, and rethrows `GpuDeviceLossException` first:

- The render scale falls back to its plain stretch, and is abandoned when nothing builds.
- The fold turns itself off.
- The reshape latches null, so the foreign draw goes through the program as built.
- The entity mesh stops carrying the wider format for the rest of the session. It drops the pipelines already compiled at that format, and hands the entities and the hand back to the game.

## How it differs from the reference, and for what obstacle

It does not. Iris builds its programs through OpenGL and never meets a pipeline that throws at build time.

## What proves it

- `gradlew build` green.
- In game: none of these four roads was exercised, because no pack on hand makes Metal refuse one of them.
- The road they copy is the warm-up stop. It was exercised on an M4 with Reverie Beta v0.9: Metal refused `deferred2`, the pack stopped, and the game stayed alive on the vanilla world.

## What it leaves owing

A refused compile still leaks the pipeline layout the game created before it threw. The entity latch bounds that to one per session, and the other sites latch after their first refusal.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
