### PR TITLE
fix(render): let a lost device through the frame's catches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,12 @@ what the next one holds.
 
 ### Fixed
 
+- **A graphics card lost in the middle of a session now closes the game on the error that lost it.**
+  When the card stopped answering, the engine caught the error at whichever step of the frame met it
+  first, switched the pack or one of its parts off and went on drawing against a card that was gone,
+  until a later step crashed the game on a report about something else. That error now goes
+  straight through, so the crash report opens on the lost device itself.
+
 - **A pack the graphics card will not build no longer closes the game.** When the card refused one
   of a pack's programs while the pack was being prepared, which Apple's hardware does with a
   program reading more textures at once than it has slots for, the error went all the way up and

--- a/common/src/main/java/dev/vitrail/dh/DhLods.java
+++ b/common/src/main/java/dev/vitrail/dh/DhLods.java
@@ -5,6 +5,7 @@ import dev.vitrail.render.DistantMesh;
 import dev.vitrail.render.timing.PassTimings;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.buffers.GpuBuffer;
 
 import java.lang.invoke.MethodHandle;
@@ -568,6 +569,8 @@ public final class DhLods {
 					if (DistantDraw.draw(opaque, sections)) {
 						return null;
 					}
+				} catch (GpuDeviceLossException e) {
+					throw e;
 				} catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
 					usable = false;
 					// Handed back for good and not merely stopped: this proxy stands in front of DH's

--- a/common/src/main/java/dev/vitrail/render/CenterDepth.java
+++ b/common/src/main/java/dev/vitrail/render/CenterDepth.java
@@ -3,6 +3,7 @@ package dev.vitrail.render;
 import dev.vitrail.uniform.Smoothed;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.buffers.GpuBuffer;
@@ -302,6 +303,8 @@ final class CenterDepth {
 			// is still being read for.
 			this.factor = new MappableRingBuffer(() -> LABEL,
 					GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, BLOCK_BYTES);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			release();
 			this.refused = true;

--- a/common/src/main/java/dev/vitrail/render/CloudDraw.java
+++ b/common/src/main/java/dev/vitrail/render/CloudDraw.java
@@ -9,6 +9,7 @@ import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.model.TargetSize;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderPass;
@@ -215,6 +216,8 @@ public final class CloudDraw extends FamilyDraw {
 
 		try {
 			return draw.prepare(device, fancy);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			wanted = false;
 			Vitrail.logger().error("Vitrail stopped drawing the clouds after an error", e);

--- a/common/src/main/java/dev/vitrail/render/ColorTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ColorTargets.java
@@ -18,6 +18,7 @@ import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.NoiseTexture;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.GpuDevice;
@@ -494,6 +495,8 @@ final class ColorTargets {
 			// filled by the frame before anything reads it, so it is never owed a clear. A refusal
 			// there is the copy's own to keep, one target at a time, and takes nothing else down.
 			this.copies.ensure(this::target);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			this.broken = true;
 			this.brokenWidth = screenWidth;
@@ -1152,6 +1155,8 @@ final class ColorTargets {
 				this.packSurfaces.put(image, new TargetSurface(
 						"Vitrail " + image.texture().sampler(), image.format(), false, image.width(),
 						image.height()));
+			} catch (GpuDeviceLossException e) {
+				throw e;
 			} catch (RuntimeException e) {
 				note(image.texture().sampler() + " could not be allocated at " + image.width() + "x"
 						+ image.height() + ", so it reads one black pixel: " + e.getMessage());

--- a/common/src/main/java/dev/vitrail/render/DistantDraw.java
+++ b/common/src/main/java/dev/vitrail/render/DistantDraw.java
@@ -13,6 +13,7 @@ import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.model.TargetSize;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.IndexType;
 import com.mojang.blaze3d.PrimitiveTopology;
@@ -454,6 +455,8 @@ public final class DistantDraw extends FamilyDraw {
 
 		try {
 			return draw.record(device, minecraft, ELEMENTS.get(key(!opaque, false)), sections);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			// Latched, like every other family the game calls back into: the alternative is one stack
 			// trace a frame for a failure that will not mend itself. What is lost by stopping is only
@@ -506,6 +509,8 @@ public final class DistantDraw extends FamilyDraw {
 		try {
 			draw.recordShadow(device, ELEMENTS.get(key(water, true)),
 					water ? draw.shadowWater : draw.shadowOpaque, camera);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			// Latched on its own, and the picture keeps going: what stops here is the far terrain's
 			// entry into the map, so the LOD is lit by what the pack computes from its own depth,
@@ -585,6 +590,8 @@ public final class DistantDraw extends FamilyDraw {
 			// which hands the far terrain back to that mod for the rest of the pack rather than
 			// costing the occlusion alone.
 			this.seeded = seed(device, main, this.owner.quad(device));
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			this.seedBroken = true;
 			Vitrail.logger().error("Vitrail stopped seeding the world's depth under the far terrain's "

--- a/common/src/main/java/dev/vitrail/render/EntityDraw.java
+++ b/common/src/main/java/dev/vitrail/render/EntityDraw.java
@@ -16,6 +16,7 @@ import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.model.TargetSize;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.systems.CommandEncoder;
@@ -1812,6 +1813,8 @@ public final class EntityDraw extends FamilyDraw {
 
 		try {
 			return draw.record(device, element, prepared, info);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			// Said before the pass is closed and not after: closing one the failure left in a bad
 			// state can throw in its turn, and the second throw would carry away the only line that

--- a/common/src/main/java/dev/vitrail/render/FeatureLayer.java
+++ b/common/src/main/java/dev/vitrail/render/FeatureLayer.java
@@ -4,6 +4,7 @@ import dev.vitrail.pack.target.ChainPlan;
 import dev.vitrail.pack.model.TargetName;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.buffers.GpuBuffer;
@@ -237,6 +238,8 @@ final class FeatureLayer {
 				// No depth of its own: the redirected draws test against the game's depth, which
 				// the override for depth keeps pointing at, so entities still hide behind walls.
 				this.layer = new TextureTarget("Vitrail features", width, height, false, FORMAT);
+			} catch (GpuDeviceLossException e) {
+				throw e;
 			} catch (RuntimeException e) {
 				this.broken = true;
 				this.brokenWidth = width;

--- a/common/src/main/java/dev/vitrail/render/GlyphIntensity.java
+++ b/common/src/main/java/dev/vitrail/render/GlyphIntensity.java
@@ -2,6 +2,7 @@ package dev.vitrail.render;
 
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -104,6 +105,8 @@ public final class GlyphIntensity {
 		GpuTextureView made;
 		try {
 			made = device.createTextureView(texture, sheet.baseMipLevel(), sheet.mipLevels());
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			Vitrail.logger().error("Could not build a swizzled view of the font sheet "
 					+ texture.getLabel() + ", so the pack reads it with one channel and draws its "

--- a/common/src/main/java/dev/vitrail/render/HandDraw.java
+++ b/common/src/main/java/dev/vitrail/render/HandDraw.java
@@ -2,6 +2,7 @@ package dev.vitrail.render;
 
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.ProjectionType;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -351,6 +352,8 @@ public final class HandDraw {
 		if (instance == null && !failed) {
 			try {
 				instance = new HandDraw(Minecraft.getInstance());
+			} catch (GpuDeviceLossException e) {
+				throw e;
 			} catch (RuntimeException e) {
 				failed = true;
 				Vitrail.logger().error("Vitrail could not build the renderer it draws the hand with, "

--- a/common/src/main/java/dev/vitrail/render/MotionVectors.java
+++ b/common/src/main/java/dev/vitrail/render/MotionVectors.java
@@ -4,6 +4,7 @@ import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.WorldState;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.buffers.GpuBuffer;
@@ -336,6 +337,8 @@ final class MotionVectors {
 			try {
 				this.block = new MappableRingBuffer(() -> LABEL,
 						GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, BLOCK_BYTES);
+			} catch (GpuDeviceLossException e) {
+				throw e;
 			} catch (RuntimeException e) {
 				this.broken = true;
 				this.brokenWidth = width;
@@ -361,6 +364,8 @@ final class MotionVectors {
 			}
 
 			this.vectors = new TargetSurface(LABEL, FORMAT, false, width, height);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			this.broken = true;
 			this.brokenWidth = width;

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -751,6 +751,8 @@ public final class PackChain {
 				// of it: closeFrame turns them below, drawn or not.
 				chain.beginFrame();
 			}
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
@@ -1290,6 +1292,8 @@ public final class PackChain {
 			// NOT replaced on the way out, so nothing else would ever reset it, and a world joined
 			// again would be measured against where the player stood in the one they left.
 			chain.voxelAnchored = false;
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
@@ -1575,6 +1579,8 @@ public final class PackChain {
 
 		try {
 			chain.drawBegins(device);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
@@ -1608,6 +1614,8 @@ public final class PackChain {
 
 		try {
 			chain.drawPrepares(device);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
@@ -1642,6 +1650,8 @@ public final class PackChain {
 
 		try {
 			chain.drawEarly(device);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
@@ -1689,6 +1699,8 @@ public final class PackChain {
 		try {
 			chain.targets.depth().takeDistantOpaque(device.createCommandEncoder(), device,
 					chain.quad(device), served, served.getWidth(0), served.getHeight(0));
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
@@ -1789,6 +1801,8 @@ public final class PackChain {
 		try {
 			chain.targets.depth().takePreHand(device.createCommandEncoder(), device, chain.quad(device),
 					main.getDepthTextureView(), main.width, main.height);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
@@ -1842,6 +1856,8 @@ public final class PackChain {
 						+ "always-on-top features, so what this pack reads as depthtex0 is the world "
 						+ "rather than the far plane");
 			}
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
@@ -1914,6 +1930,8 @@ public final class PackChain {
 			RenderSystem.outputColorTextureOverride = layer;
 			RenderSystem.outputDepthTextureOverride = main.getDepthTextureView();
 			chain.redirected = true;
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			// The overrides are cleared on the way out rather than left half set: one standing past
 			// this point swallows every later feature draw of the frame.
@@ -1956,6 +1974,8 @@ public final class PackChain {
 
 		try {
 			chain.takeReadCopies(device);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);
@@ -2029,6 +2049,8 @@ public final class PackChain {
 			// the layer would sit on stale texels and be erased with them at the deferred flush.
 			chain.features.compose(device.createCommandEncoder(), chain.quad, view,
 					chain.targets.takeClear(view));
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			stop();
 			Vitrail.logger().error("Vitrail stopped drawing this pack after an error", e);

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -518,6 +518,8 @@ public final class PackChoice {
 			if (!engine.weather()) {
 				EngineOptions.announceWeatherOff(gameDirectory);
 			}
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (IOException | RuntimeException e) {
 			PackChain.stop();
 			lastError = "Could not prepare this pack: " + e;
@@ -1112,7 +1114,7 @@ public final class PackChoice {
 				// (VulkanUtils.crashIfFailure) and catches it in no place at all, which is what
 				// makes it the end of the session rather than the end of a release: the load below
 				// would allocate its targets against a device that is gone. Rethrown as it stands,
-				// so the report names the driver rather than a line about video memory.
+				// so the report opens on the lost device rather than on a line about video memory.
 				throw e;
 			} catch (RuntimeException e) {
 				// Said here rather than left to whatever comes next, and said once: the chain is

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -23,6 +23,7 @@ import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.UniformCatalog;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.buffers.Std140Builder;
@@ -417,6 +418,8 @@ final class PackCompute implements AutoCloseable {
 		for (Pass pass : attached) {
 			try {
 				pass.dispatch(vulkan, commands, values, targets, width, height, step, depth, distant);
+			} catch (GpuDeviceLossException e) {
+				throw e;
 			} catch (RuntimeException e) {
 				if (pass.failed.add(e.toString())) {
 					Vitrail.logger().warn("compute {} failed: {}", pass.path, e.toString());
@@ -482,6 +485,8 @@ final class PackCompute implements AutoCloseable {
 		for (Pass pass : this.passes) {
 			try {
 				pass.dispatch(vulkan, commands, values, targets, width, height, null, null, null);
+			} catch (GpuDeviceLossException e) {
+				throw e;
 			} catch (RuntimeException e) {
 				if (pass.failed.add(e.toString())) {
 					Vitrail.logger().warn("shadow compute {} failed: {}", pass.path, e.toString());
@@ -846,6 +851,8 @@ final class PackCompute implements AutoCloseable {
 								+ "past the {} a device commonly allows at once", this.path,
 								this.entries.size(), PUSH_DESCRIPTORS);
 					}
+				} catch (GpuDeviceLossException e) {
+					throw e;
 				} catch (Exception e) {
 					Vitrail.logger().warn("compute {} SPIR-V failed: {}", this.path,
 							e.toString());
@@ -863,6 +870,8 @@ final class PackCompute implements AutoCloseable {
 			try (MemoryStack stack = MemoryStack.stackPush()) {
 				createLayout(vulkan, stack);
 				createPipeline(vulkan, stack);
+			} catch (GpuDeviceLossException e) {
+				throw e;
 			} catch (RuntimeException e) {
 				destroy(vulkan);
 				Vitrail.logger().warn("compute {} pipeline failed: {}", this.path, e.toString());

--- a/common/src/main/java/dev/vitrail/render/PackDepth.java
+++ b/common/src/main/java/dev/vitrail/render/PackDepth.java
@@ -3,6 +3,7 @@ package dev.vitrail.render;
 import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.buffers.GpuBuffer;
@@ -725,6 +726,8 @@ final class PackDepth {
 					width, height);
 			this.scene = new TargetSurface("Vitrail depth with the translucents", FORMAT, false,
 					width, height);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			this.broken = true;
 			this.brokenWidth = width;
@@ -775,6 +778,8 @@ final class PackDepth {
 			this.preHand = close(this.preHand);
 			this.preHand =
 					new TargetSurface("Vitrail depth before the hand", FORMAT, false, width, height);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			this.preHandBroken = true;
 			this.preHand = close(this.preHand);
@@ -840,6 +845,8 @@ final class PackDepth {
 					FORMAT, false, width, height);
 			this.distantScene = new TargetSurface("Vitrail far terrain depth with its water",
 					FORMAT, false, width, height);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			this.distantBroken = true;
 			this.distantBrokenWidth = width;

--- a/common/src/main/java/dev/vitrail/render/ParticleDraw.java
+++ b/common/src/main/java/dev/vitrail/render/ParticleDraw.java
@@ -11,6 +11,7 @@ import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.model.TargetSize;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderPass;
@@ -260,6 +261,8 @@ public final class ParticleDraw extends FamilyDraw {
 
 		try {
 			return draw.prepare(device, ELEMENTS.get(translucent), colour, depth);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			wanted = false;
 			Vitrail.logger().error("Vitrail stopped drawing the particles after an error", e);

--- a/common/src/main/java/dev/vitrail/render/RenderScale.java
+++ b/common/src/main/java/dev/vitrail/render/RenderScale.java
@@ -5,6 +5,7 @@ import dev.vitrail.mixin.access.RenderTargetAccessor;
 import dev.vitrail.settings.PackFile;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.buffers.GpuBuffer;
@@ -709,6 +710,8 @@ public final class RenderScale {
 			} else if (upscaled.width() != outWidth || upscaled.height() != outHeight) {
 				upscaled.resize(outWidth, outHeight);
 			}
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			refusedAtSize = true;
 			refusedWidth = width;

--- a/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowGeometry.java
@@ -3,6 +3,7 @@ package dev.vitrail.render;
 import dev.vitrail.pack.source.ShadowCasters;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
@@ -366,6 +367,8 @@ public final class ShadowGeometry {
 			buffers = owned;
 
 			return true;
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			if (owned != null) {
 				owned.close();

--- a/common/src/main/java/dev/vitrail/render/ShadowTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowTargets.java
@@ -4,6 +4,7 @@ import dev.vitrail.pack.target.PackDirectives;
 import dev.vitrail.pack.target.TargetDirectives;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.RenderPass;
@@ -420,6 +421,8 @@ final class ShadowTargets {
 				+ "with {}", this.resolution, this.resolution, describe());
 
 			return true;
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			this.broken = true;
 			// The images go with the refusal, so that a map allocated and not emptied is never the

--- a/common/src/main/java/dev/vitrail/render/SkyDraw.java
+++ b/common/src/main/java/dev/vitrail/render/SkyDraw.java
@@ -9,6 +9,7 @@ import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.model.TargetSize;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
@@ -307,6 +308,8 @@ public final class SkyDraw extends FamilyDraw {
 
 		try {
 			return draw.prepare(device, element, modelView, colour);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			wanted = false;
 			Vitrail.logger().error("Vitrail stopped drawing the sky after an error", e);

--- a/common/src/main/java/dev/vitrail/render/TargetCopies.java
+++ b/common/src/main/java/dev/vitrail/render/TargetCopies.java
@@ -4,6 +4,7 @@ import dev.vitrail.pack.model.TargetName;
 import dev.vitrail.pack.target.TargetSchedule;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.textures.GpuTextureView;
 
@@ -164,6 +165,8 @@ final class TargetCopies {
 				} else {
 					copy.resize(target.width(), target.height());
 				}
+			} catch (GpuDeviceLossException e) {
+				throw e;
 			} catch (RuntimeException e) {
 				this.refused.add(key);
 				TargetSurface failed = this.copies.remove(key);

--- a/common/src/main/java/dev/vitrail/render/TemporalAccumulation.java
+++ b/common/src/main/java/dev/vitrail/render/TemporalAccumulation.java
@@ -2,6 +2,7 @@ package dev.vitrail.render;
 
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.buffers.GpuBuffer;
@@ -395,6 +396,8 @@ public final class TemporalAccumulation {
 					height);
 			this.block = new MappableRingBuffer(() -> LABEL,
 					GpuBuffer.USAGE_UNIFORM | GpuBuffer.USAGE_MAP_WRITE, BLOCK_BYTES);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			release();
 			this.refused = true;

--- a/common/src/main/java/dev/vitrail/render/TerrainDraw.java
+++ b/common/src/main/java/dev/vitrail/render/TerrainDraw.java
@@ -9,6 +9,7 @@ import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.render.timing.PassTimings;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderPass;
@@ -361,6 +362,8 @@ public final class TerrainDraw {
 
 		try {
 			self.targets.shadow().clear(device.createCommandEncoder());
+		} catch (GpuDeviceLossException lost) {
+			throw lost;
 		} catch (RuntimeException second) {
 			// Not rethrown: this is the handler the bus called, and the error above is the one worth
 			// reading. A pass left open by whatever threw there is enough to refuse a clear, so the
@@ -689,6 +692,8 @@ public final class TerrainDraw {
 
 					return false;
 				}
+			} catch (GpuDeviceLossException e) {
+				throw e;
 			} catch (RuntimeException e) {
 				shadowWanted = false;
 				Vitrail.logger().error("Vitrail stopped drawing the shadow map after an error in "
@@ -872,6 +877,8 @@ public final class TerrainDraw {
 
 		try {
 			return draw.prepare(drawn, format, atlas);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			wanted = false;
 			// The same as at the read above: the mesh is about to be drawn by the game's shader.

--- a/common/src/main/java/dev/vitrail/render/WeatherDraw.java
+++ b/common/src/main/java/dev/vitrail/render/WeatherDraw.java
@@ -11,6 +11,7 @@ import dev.vitrail.pack.target.TargetPlan;
 import dev.vitrail.pack.model.TargetSize;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderPass;
@@ -276,6 +277,8 @@ public final class WeatherDraw extends FamilyDraw {
 
 		try {
 			return draw.prepare(device, element, colour, depth);
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			wanted = false;
 			Vitrail.logger().error("Vitrail stopped drawing the weather after an error", e);

--- a/common/src/main/java/dev/vitrail/render/pbr/PbrAtlases.java
+++ b/common/src/main/java/dev/vitrail/render/pbr/PbrAtlases.java
@@ -4,6 +4,7 @@ import dev.vitrail.pack.option.EngineDefines;
 import dev.vitrail.render.PackDefines;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.textures.GpuTexture;
 import com.mojang.blaze3d.textures.GpuTextureView;
 import net.minecraft.client.Minecraft;
@@ -120,6 +121,8 @@ public final class PbrAtlases {
 			if (read != null) {
 				ATLASES.put(atlas, read);
 			}
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			// Named and swallowed. Every one of these images is an improvement on a flat texel and
 			// none of them is owed: a pack that cannot get one still draws, and taking the world

--- a/common/src/main/java/dev/vitrail/render/pbr/PbrTextures.java
+++ b/common/src/main/java/dev/vitrail/render/pbr/PbrTextures.java
@@ -3,6 +3,7 @@ package dev.vitrail.render.pbr;
 import dev.vitrail.mixin.access.TextureManagerAccessor;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.GpuFormat;
 import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.systems.GpuDevice;
@@ -185,6 +186,8 @@ public final class PbrTextures {
 			for (PbrMap map : PbrMap.values()) {
 				read(built, map, beside(name, map), resources);
 			}
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			// Named and swallowed, the same answer PbrAtlases gives for the same reason: an image
 			// beside a texture is an improvement on a flat texel and none of them is owed, so a

--- a/common/src/main/java/dev/vitrail/render/storage/StorageImages.java
+++ b/common/src/main/java/dev/vitrail/render/storage/StorageImages.java
@@ -9,6 +9,7 @@ import dev.vitrail.pack.model.TargetFormat;
 import dev.vitrail.render.StalePipelines;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.systems.CommandEncoder;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.GpuDeviceBackend;
@@ -236,6 +237,8 @@ public final class StorageImages implements AutoCloseable {
 							: image.clear() && image.depth() > 1
 									? ", left on the frame that filled it"
 									: "");
+				} catch (GpuDeviceLossException e) {
+					throw e;
 				} catch (RuntimeException e) {
 					this.refusedForGood = true;
 					throw refused(image, e);
@@ -269,6 +272,8 @@ public final class StorageImages implements AutoCloseable {
 					this.allocated.add(Allocated.create(vulkan, image, width, height, 1, false));
 					Vitrail.logger().info("storage image {} at {}x{}", image.describe(), width,
 							height);
+				} catch (GpuDeviceLossException e) {
+					throw e;
 				} catch (RuntimeException e) {
 					throw refused(image, e);
 				}
@@ -788,6 +793,8 @@ public final class StorageImages implements AutoCloseable {
 								"storage image scratch " + declared.name());
 						allocated.scratch = imagePtr.get(0);
 						allocated.scratchAllocation = allocationPtr.get(0);
+					} catch (GpuDeviceLossException e) {
+						throw e;
 					} catch (RuntimeException e) {
 						Vitrail.logger().warn("storage image {} keeps a frame of lag, its scratch "
 								+ "could not be allocated: {}", declared.name(), e.toString());

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -13,6 +13,7 @@ import dev.vitrail.render.TerrainDraw;
 import dev.vitrail.render.timing.RingTimings;
 import dev.vitrail.Vitrail;
 
+import com.mojang.blaze3d.GpuDeviceLossException;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuSampler;
@@ -149,6 +150,8 @@ public final class ShadowTerrain {
 	public static void draw() {
 		try {
 			walk();
+		} catch (GpuDeviceLossException e) {
+			throw e;
 		} catch (RuntimeException e) {
 			TerrainDraw.shadowStageFailed(e);
 		}


### PR DESCRIPTION
## What changes

The game's Vulkan backend raises `GpuDeviceLossException` when a call comes back `VK_ERROR_DEVICE_LOST` and catches it nowhere, so a lost graphics card is meant to end the session. That exception is a `RuntimeException`, and the engine's catches around its device work took it like any other failure: they stopped the pack or switched a family off (terrain, shadow map, sky, clouds, weather, particles, entities, the hand, far terrain, compute, storage images and the rest), logged that drawing stopped after an error, and the frame went on against a device that was gone until a later call crashed the game on a report that opened on some other error.

Every catch whose try body can reach the device now rethrows a device loss ahead of its own handling, the idiom `PackChain.pumpWarmup` and the release in `PackChoice` already used. Catches around parsing, translation, disk caches, settings files and file dialogs are unchanged. The comment at the release no longer claims the report names the driver: every crash report lists the device, and what changes is which error the report opens on.

## How it differs from the reference, and for what obstacle

It does not.

## What proves it

- `gradlew build` green, clean and without the build cache.
- Every broad catch of the three source trees listed and classified by whether its try body reaches the device, then checked mechanically for the guard.
- In game, Fabric, Complementary Unbound r5.9: a probe build raised a device loss inside the sky's prepare for one launch. The game closed on a crash report opening on `GpuDeviceLossException` at `SkyDraw.element`, through `SkyRenderer.renderSkyDisc` up to `Minecraft.run`, where that catch used to log that the sky stopped and carry on. The probe is not in this branch.

## What it leaves owing

A loss on a loading road that may run off the render thread (NeoForge's client setup reaching `PackChoice.load`) becomes a loading error rather than a render frame crash, and one met while a resource reload stitches the material atlases goes through the game's own reload handling. A loss inside a pooled compile task of the family warm-up is still only logged by its future. The pipeline compiles in `RenderScale.Pass.get`, `ParticleDraw.pipeline` and `EntityMesh.settle` are guarded by a separate change.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
