### PR TITLE
fix(render): keep the seed and feature layer off integer targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,15 @@ what the next one holds.
 
 ### Fixed
 
+- **Noble no longer stops on a Mac.** Noble keeps packed whole numbers rather than a colour in the
+  first target its terrain writes, and the engine went on copying the game's own picture into that
+  target wherever the pack drew nothing, which a Mac refuses outright: the pack was put away as soon
+  as it started drawing. A pack that writes such numbers into its terrain target now gets no copy of
+  the game's picture there, so whatever the game still draws in the pack's place, a mob the pack has
+  no program for among it, is missing from the image rather than painted in flat. The same holds
+  for the target its water is drawn into, where the beacon beam and the lightning would have been
+  laid. The log says which.
+
 - **A graphics card lost in the middle of a session now closes the game on the error that lost it.**
   When the card stopped answering, the engine caught the error at whichever step of the frame met it
   first, switched the pack or one of its parts off and went on drawing against a card that was gone,

--- a/common/src/main/java/dev/vitrail/render/FeatureLayer.java
+++ b/common/src/main/java/dev/vitrail/render/FeatureLayer.java
@@ -178,7 +178,8 @@ final class FeatureLayer {
 	 *                    world's own translucents are about to blend, taken from the plan rather
 	 *                    than assumed
 	 * @param destination that target's format as the pack declared it, for the pipeline's own
-	 *                    colour state, the same rule the seed follows
+	 *                    colour state, the same rule the seed follows. Never an integer one, which the
+	 *                    caller keeps out for the seed's reason
 	 */
 	FeatureLayer(ChainPlan.Attachment into, GpuFormat destination) {
 		this.into = into;

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -407,8 +407,11 @@ public final class PackChain {
 		this.targets = new ColorTargets(chain.targets(), values.noiseResolution(),
 				values.noiseImage(), values.packImages(), values.storageImages(),
 				values.shadowResolution(), values.shadowColours(), values.shadowDepths());
+		// No seed at all into a target of integers, and asked here rather than of the compile, which
+		// on Metal throws instead of handing back a pipeline that is invalid. announceSeed says so.
 		this.seed = chain.chain().seed()
 				.filter(where -> this.targets.has(where.target()))
+				.filter(where -> !holdsIntegers(where.target()))
 				.map(where -> new SceneSeed(where, this.targets.format(where.target()),
 						seedExtras(chain, where)))
 				.orElse(null);
@@ -421,12 +424,9 @@ public final class PackChain {
 				.orElse(null);
 		// Composed where the world's own translucents are about to blend, so it needs that pass to
 		// exist: a pack serving no translucent geometry gets no layer, and the game's features stay
-		// where the game drew them.
-		this.features = chain.chain().geometry(TerrainPass.TRANSLUCENT)
-				.map(ChainPlan.Pass::attachments)
-				.filter(attachments -> !attachments.isEmpty())
-				.map(attachments -> attachments.get(0))
-				.filter(into -> this.targets.has(into.target()))
+		// where the game drew them. A target of integers gets none either, for the seed's reason.
+		this.features = featuresInto()
+				.filter(into -> !holdsIntegers(into.target()))
 				.map(into -> new FeatureLayer(into, this.targets.format(into.target())))
 				.orElse(null);
 		// Held rather than read: the terrain program is compiled against the chunk mesh format, and
@@ -490,6 +490,31 @@ public final class PackChain {
 		// Before the first frame allocates a target: the usage a compute needs is baked into the
 		// image at creation, and nothing can add it afterwards.
 		this.targets.storageTargets(this.compute.storageTargets());
+	}
+
+	/**
+	 * Where the feature layer would be composed: the first draw buffer of the translucent geometry
+	 * pass, provided the targets hold it. Asked by the constructor and again by the announce, which
+	 * has to tell a layer refused for its format from one that had nowhere to go.
+	 */
+	private Optional<ChainPlan.Attachment> featuresInto() {
+		return this.chain.chain().geometry(TerrainPass.TRANSLUCENT)
+				.map(ChainPlan.Pass::attachments)
+				.filter(attachments -> !attachments.isEmpty())
+				.map(attachments -> attachments.get(0))
+				.filter(into -> this.targets.has(into.target()));
+	}
+
+	/**
+	 * Whether a target of the pack holds integers, which the seed and the feature layer cannot write.
+	 * <p>
+	 * Both carry a colour through a {@code vec4} output, and there is no integer that means the
+	 * game's colour, so a {@code uvec4} would not help. Kept out rather than attempted, because a
+	 * float output on an integer attachment is not a pipeline that comes back invalid: Metal refuses
+	 * it by throwing from the compile, which put the whole pack away.
+	 */
+	private boolean holdsIntegers(int target) {
+		return this.chain.targets().directives().format(target).used().integer();
 	}
 
 	/**
@@ -3019,6 +3044,7 @@ public final class PackChain {
 		this.targets.notes().forEach(note -> Vitrail.logger().warn("{}", note));
 
 		announceSeed(seeding);
+		announceFeatures();
 		announceResting(seeding);
 
 		List<Integer> back = unfolded.swapBack();
@@ -3091,7 +3117,25 @@ public final class PackChain {
 		} else if (!this.seedEnabled) {
 			Vitrail.logger().info("The scene seed is off, {} holds its clear colour as well",
 					TargetName.canonical(where.get().target()));
+		} else if (this.seed == null && holdsIntegers(where.get().target())) {
+			Vitrail.logger().warn("{} writes {} first and it holds integers, so the scene seed is not "
+					+ "drawn: the game's frame is a colour and no integer stands for one. Whatever the "
+					+ "game still draws in the pack's place is missing from the picture",
+					where.get().from(), TargetName.canonical(where.get().target()));
 		}
+	}
+
+	private void announceFeatures() {
+		if (this.features != null) {
+			return;
+		}
+
+		featuresInto().filter(into -> holdsIntegers(into.target())).ifPresent(into ->
+				Vitrail.logger().warn("The world's translucents are drawn into {} first and it holds "
+						+ "integers, so the game's translucent features are not composed onto it: the "
+						+ "beacon beam, the lightning and anything else the pack does not draw stay on "
+						+ "the game's own target, which the pack's final draws over",
+						TargetName.canonical(into.target())));
 	}
 
 	private void announceResting(boolean seeding) {

--- a/common/src/main/java/dev/vitrail/render/SceneSeed.java
+++ b/common/src/main/java/dev/vitrail/render/SceneSeed.java
@@ -267,8 +267,8 @@ final class SceneSeed {
 	 * @param seed        which target the scene goes into and on which half, both taken from the
 	 *                    geometry program it stands in for rather than assumed
 	 * @param destination that target's format as the pack declared it. The caller is the one that
-	 *                    checks the target exists: a place that has nowhere to put the scene draws
-	 *                    no seed and says so, it does not refuse the pack
+	 *                    checks the target exists and holds no integers: a place that has nowhere to
+	 *                    put the scene draws no seed and says so, it does not refuse the pack
 	 * @param extras      the draw buffers of that program past the first that this may empty, in the
 	 *                    program's own order and with the ones it may not already left out. Empty
 	 *                    where there is nothing to empty, and then the seed is the one pass it was


### PR DESCRIPTION
## What changes

Noble writes packed integer data into its terrain target: `gbuffers_terrain` writes colortex1 through a `uvec4` output, and colortex1 is RGBA32_UINT. The scene seed copies the game's frame into the first draw buffer of the terrain program through a `vec4` output. On Apple hardware, Metal refuses a float output into an integer attachment by throwing from the compile, so the pack was put away and the world drew vanilla.

The seed is now not built into a target that holds integers, since no integer stands for the game's colour. The feature layer composes into the first draw buffer of the translucent pass the same way, and Noble's `gbuffers_water` leads with colortex1 too, so it gets the same check. Each skip writes one warning at load that names the target and says what goes missing: what the game still draws in the pack's place, and the game's translucent features.

## How it differs from the reference, and for what obstacle

It does not. Iris has neither a scene seed nor a feature layer.

## What proves it

- `gradlew build` green.
- In game on an M4 (MoltenVK 1.4.2), arena bench, one launch:
  - Before: Noble 1.9.7 stopped on `vitrail:pipeline/scene_seed`, "output of type float4 is not compatible with a MTLPixelFormatRGBA32Uint color attachment".
  - After: the pack draws its sky, clouds and terrain, and the log carries both warnings.
  - Against Windows at the same place, the picture is not the same yet: see below.

## What it leaves owing

On a pack whose terrain target holds integers, an opaque entity without a coverage mask falls back to the game's shader and is covered by the pack's final. The beacon beam and the lightning are covered the same way.

Noble's terrain reads pale on the Mac: sandy ground and dark trees, where Windows shows lit green grass at the same place. The seed only paints pixels the pack left uncovered, so this is most likely a separate Metal defect in how the packed integer gbuffer is written or read. It is not investigated here.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
