### PR TITLE
fix(glsl): hide subgroup extensions from stages the device leaves out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,13 @@ what the next one holds.
   for the target its water is drawn into, where the beacon beam and the lightning would have been
   laid. The log says which.
 
+- **RenderPearl no longer stops on a Mac.** The pack shares its light lists between neighbouring
+  pixels wherever the shader compiler says the card can, and the compiler says so on every card.
+  Apple's graphics stack only allows that in some of the steps a program is made of, and not in
+  the one that places the terrain, so the terrain program was never built and the pack stopped.
+  The pack is now told what the card allows in each step, and takes its own road without it where
+  it is missing. A card that allows it everywhere draws exactly as before.
+
 - **A graphics card lost in the middle of a session now closes the game on the error that lost it.**
   When the card stopped answering, the engine caught the error at whichever step of the frame met it
   first, switched the pack or one of its parts off and went on drawing against a card that was gone,

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -1567,11 +1567,11 @@ public final class GlslTranslator {
 			if (token.directive().equals("extension")) {
 				this.strippedExtensions++;
 				String named = extensionNamed(index);
-				// Not hoisted where the device has not got it: the compiler would take the line
-				// and emit the vendor instruction, which is the one thing the device cannot run
-				// (VendorExtensions). The pack's own guard on the macro is hidden further down,
+				// Not hoisted where the device has not got it in this stage: the compiler would
+				// take the line and emit the instruction, which is the one thing the device cannot
+				// run (VendorExtensions). The pack's own guard on the macro is hidden further down,
 				// so its fallback is what compiles.
-				if (named != null && !VendorExtensions.absent(named)) {
+				if (named != null && !VendorExtensions.absent(named, this.stage)) {
 					this.extensions.add(named);
 				}
 			} else if (!token.directive().equals("version")) {
@@ -2074,8 +2074,8 @@ public final class GlslTranslator {
 	}
 
 	/**
-	 * Renames, in the pack's own preprocessor lines, the macro of every vendor extension the device
-	 * has not got, so that the compiler answers {@code defined} the way the device would.
+	 * Renames, in the pack's own preprocessor lines, the macro of every extension the device has not
+	 * got in this stage, so that the compiler answers {@code defined} the way the device would.
 	 * <p>
 	 * The reason is with {@link VendorExtensions}: the compiler defines the macro of every
 	 * extension it knows, and a pack gating a vendor instruction on that macro takes the branch on
@@ -2088,7 +2088,7 @@ public final class GlslTranslator {
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (token.directive() != null && token.kind() == Kind.IDENTIFIER
-					&& VendorExtensions.absent(token.text())) {
+					&& VendorExtensions.absent(token.text(), this.stage)) {
 				this.tokens.replace(index, VendorExtensions.hidden(token.text()));
 			}
 		}

--- a/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
@@ -378,8 +378,9 @@ public final class TranslationCache {
 		// the trig substitution and the shadow comparison both change what it emits and neither
 		// says so in the text it was handed.
 		feed(digest, GlslTranslator.emissionSwitches());
-		// And the device's answer on the vendor extensions, which decides which branch of a pack
-		// compiles: a card that has one of them translates differently from a card that has not.
+		// And the device's answer on the vendor extensions and on the stages it runs subgroup
+		// operations in, which decides which branch of a pack compiles: a card that has one of them
+		// translates differently from a card that has not.
 		feed(digest, VendorExtensions.key());
 
 		// The whole table, in its own order, which is fixed by the code that builds it. It carries

--- a/common/src/main/java/dev/vitrail/glsl/VendorExtensions.java
+++ b/common/src/main/java/dev/vitrail/glsl/VendorExtensions.java
@@ -1,7 +1,10 @@
 package dev.vitrail.glsl;
 
+import dev.vitrail.pack.model.ProgramStage;
+
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,6 +12,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * The vendor GLSL extensions the device does not have, so that a pack testing for one reads the
@@ -31,6 +35,15 @@ import java.util.function.Predicate;
  * absent. A translation is keyed on the answer ({@link #key}), so a cache written on one card is
  * not served to another.
  * <p>
+ * The subgroup extensions are answered the same way, but per stage, since a device may run
+ * subgroup operations in some stages and not in others. MoltenVK names the fragment, compute and
+ * tessellation control stages and leaves the vertex stage out, and SPIRV-Cross then refuses a
+ * vertex module using a subgroup builtin rather than convert it to Metal. RenderPearl gates its
+ * subgroup path on the compiler's macros, so its terrain vertex stage never converted on a Mac
+ * and the pack stopped, where hiding those macros lets it take its own fallback. The stages come
+ * from the device at creation ({@link #serveSubgroupStages}); until then, and off game, every stage
+ * has them, which is the compiler's answer and what this engine assumed before asking.
+ * <p>
  * Five extensions are answered absent on every device, and one of them is a divergence. {@code
  * GL_NV_gpu_shader5} has no Vulkan form at all, while an NVIDIA GL driver has it, so a pack
  * gating on it takes its fallback here where under Iris on a GeForce it takes the extension.
@@ -47,8 +60,15 @@ public final class VendorExtensions {
 	/** Each vendor GLSL extension with the device extension that implements it on Vulkan. */
 	private static final Map<String, String> DEVICE_EXTENSIONS = deviceExtensions();
 
+	/** The names of the subgroup extensions start with one of these, whatever operation they add. */
+	private static final List<String> SUBGROUP_PREFIXES =
+			List.of("GL_KHR_shader_subgroup_", "GL_EXT_shader_subgroup_extended_types_");
+
 	private static volatile Set<String> absent = Collections.unmodifiableSet(
 			new TreeSet<>(DEVICE_EXTENSIONS.keySet()));
+
+	private static volatile Set<ProgramStage> subgroupsAbsentIn =
+			Collections.unmodifiableSet(EnumSet.noneOf(ProgramStage.class));
 
 	private VendorExtensions() {
 	}
@@ -76,19 +96,57 @@ public final class VendorExtensions {
 		return enabled;
 	}
 
-	/** Whether a pack's {@code #extension} of this name asks for something the device lacks. */
-	static boolean absent(String glslExtension) {
-		return absent.contains(glslExtension);
+	/**
+	 * Records the stages the device runs subgroup operations in, asked once at the device's creation.
+	 *
+	 * @param supported the stages the device's subgroup properties name
+	 * @return the stages left out, for the log
+	 */
+	public static Set<ProgramStage> serveSubgroupStages(Set<ProgramStage> supported) {
+		Set<ProgramStage> lacking = EnumSet.allOf(ProgramStage.class);
+		lacking.removeAll(supported);
+		subgroupsAbsentIn = Collections.unmodifiableSet(lacking);
+
+		return subgroupsAbsentIn;
 	}
 
-	/** The absent names, joined, for a cache key. */
+	/**
+	 * Whether a pack's {@code #extension} of this name asks, in this stage, for something the device
+	 * lacks.
+	 */
+	static boolean absent(String glslExtension, ProgramStage stage) {
+		return absent.contains(glslExtension)
+				|| (subgroupsAbsentIn.contains(stage) && subgroup(glslExtension));
+	}
+
+	/**
+	 * The absent names, and the stages the subgroup extensions are absent from, joined, for a cache
+	 * key. A device running them in every stage keeps the key it had before stages were asked, since
+	 * it translates exactly as it did.
+	 */
 	public static String key() {
-		return String.join(",", absent);
+		String names = String.join(",", absent);
+		if (subgroupsAbsentIn.isEmpty()) {
+			return names;
+		}
+
+		return subgroupsAbsentIn.stream().map(Enum::name)
+				.collect(Collectors.joining(",", names + ";subgroups absent in ", ""));
 	}
 
 	/** The hidden spelling of a macro the compiler would define and the device would not answer for. */
 	static String hidden(String glslExtension) {
 		return "OF_ABSENT_" + glslExtension;
+	}
+
+	private static boolean subgroup(String glslExtension) {
+		for (String prefix : SUBGROUP_PREFIXES) {
+			if (glslExtension.startsWith(prefix)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private static Map<String, String> deviceExtensions() {

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
@@ -6,14 +6,19 @@ import com.mojang.blaze3d.vulkan.VulkanBackend;
 import com.mojang.blaze3d.vulkan.VulkanPhysicalDevice;
 import com.mojang.blaze3d.vulkan.init.VulkanFeature;
 import dev.vitrail.glsl.VendorExtensions;
+import dev.vitrail.pack.model.ProgramStage;
 import dev.vitrail.render.BufferBlending;
 import dev.vitrail.render.GeometryStage;
 import dev.vitrail.Vitrail;
 import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.VK10;
+import org.lwjgl.vulkan.VK11;
 import org.lwjgl.vulkan.VK12;
 import org.lwjgl.vulkan.VkDevice;
 import org.lwjgl.vulkan.VkPhysicalDeviceFeatures;
 import org.lwjgl.vulkan.VkPhysicalDeviceFeatures2;
+import org.lwjgl.vulkan.VkPhysicalDeviceProperties2;
+import org.lwjgl.vulkan.VkPhysicalDeviceSubgroupProperties;
 import org.lwjgl.vulkan.VkPhysicalDeviceVulkan11Features;
 import org.lwjgl.vulkan.VkPhysicalDeviceVulkan12Features;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,7 +27,9 @@ import org.spongepowered.asm.mixin.injection.At;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -139,6 +146,16 @@ public abstract class VulkanBackendMixin {
 			VulkanBackend.VK10_FEATURES_STRUCT, "geometryShader",
 			VkPhysicalDeviceFeatures.GEOMETRYSHADER);
 
+	// The Vulkan stage bit of each stage a pack ships, to read the stages a device names.
+	@Unique
+	private static final Map<ProgramStage, Integer> STAGE_BITS = Map.of(
+			ProgramStage.VERTEX, VK10.VK_SHADER_STAGE_VERTEX_BIT,
+			ProgramStage.FRAGMENT, VK10.VK_SHADER_STAGE_FRAGMENT_BIT,
+			ProgramStage.GEOMETRY, VK10.VK_SHADER_STAGE_GEOMETRY_BIT,
+			ProgramStage.COMPUTE, VK10.VK_SHADER_STAGE_COMPUTE_BIT,
+			ProgramStage.TESSELLATION_CONTROL, VK10.VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
+			ProgramStage.TESSELLATION_EVALUATION, VK10.VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT);
+
 	@Unique
 	private static final String VOXELS = "voxel lighting will not write";
 
@@ -181,6 +198,12 @@ public abstract class VulkanBackendMixin {
 		if (!vendor.isEmpty()) {
 			Vitrail.logger().info("Vulkan vendor extensions: {}", String.join(", ", vendor));
 		}
+		// And the stages the device runs subgroup operations in, which the compiler does not know
+		// either: MoltenVK leaves the vertex stage out, where SPIRV-Cross refuses a module using them.
+		Set<ProgramStage> noSubgroups = VendorExtensions.serveSubgroupStages(subgroupStages(physical));
+		if (!noSubgroups.isEmpty()) {
+			Vitrail.logger().info("Vulkan subgroup operations absent from stages: {}", noSubgroups);
+		}
 
 		enable(physical, features, SHADER_FLOAT16, enabled, NARROW);
 		enable(physical, features, SHADER_INT8, enabled, NARROW);
@@ -209,6 +232,27 @@ public abstract class VulkanBackendMixin {
 		enabled.add(feature.name());
 
 		return true;
+	}
+
+	@Unique
+	private static Set<ProgramStage> subgroupStages(VulkanPhysicalDevice physical) {
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			VkPhysicalDeviceSubgroupProperties subgroups =
+					VkPhysicalDeviceSubgroupProperties.calloc(stack).sType$Default();
+			VkPhysicalDeviceProperties2 properties =
+					VkPhysicalDeviceProperties2.calloc(stack).sType$Default().pNext(subgroups);
+			VK11.vkGetPhysicalDeviceProperties2(physical.vkPhysicalDevice(), properties);
+			int bits = subgroups.supportedStages();
+
+			Set<ProgramStage> stages = EnumSet.noneOf(ProgramStage.class);
+			for (Map.Entry<ProgramStage, Integer> stage : STAGE_BITS.entrySet()) {
+				if ((bits & stage.getValue()) != 0) {
+					stages.add(stage.getKey());
+				}
+			}
+
+			return stages;
+		}
 	}
 
 	@Unique


### PR DESCRIPTION
## What changes

The shader compiler defines the macro of every subgroup extension it knows. So a pack that gates its subgroup path on those macros takes that path in every stage, whatever the device supports.

MoltenVK runs subgroup operations only in the fragment, compute and tessellation control stages. SPIRV-Cross refuses a vertex module that uses a subgroup builtin (`Subgroup builtins are not available in this type of function.`). On a Mac, RenderPearl's terrain vertex stage therefore never converted to Metal, and the pack stopped.

The device's `VkPhysicalDeviceSubgroupProperties.supportedStages` is now read when the device is created. In a stage the device leaves out, the KHR subgroup and extended types extensions count as absent, the way a missing vendor extension already does: their `#extension` lines are not hoisted and their macros are hidden. The pack then takes its own fallback without subgroups.

The stages go into the translation cache key. A device that runs subgroups in every stage keeps exactly the translation and the key it had before, and so does a device that was never asked.

## How it differs from the reference, and for what obstacle

It does not. Iris runs on OpenGL and never meets MoltenVK's per stage subgroup support.

## What proves it

- `gradlew build` green, after the rebase.
- Before: on an M4 (MoltenVK 1.4.2), arena bench, one launch, RenderPearl 2.8.0-beta.4 stopped on `gbuffers_terrain_solid`.
- Off game: with only the pack's `SUBGROUP_ENABLED` define removed, the translated vertex stage converts to MSL, which confirms the cause.
- After, same place: the pack draws.

## What it leaves owing

- `supportedOperations` is not read. A device that runs subgroups in a stage but lacks one operation group still gets that group's macros.
- The extended types extensions do not look at the `shaderSubgroupExtendedTypes` feature.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
