### PR TITLE
fix(glsl): split varyings declared through a storage macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,12 @@ what the next one holds.
   The pack is now told what the card allows in each step, and takes its own road without it where
   it is missing. A card that allows it everywhere draws exactly as before.
 
+- **I Like Vanilla's water no longer makes the pack stop on a Mac.** The pack names the values its
+  water hands from one shader to the next through a shorthand of its own, and the engine only
+  prepared such a value for the game when it was written out in full. One of them, a set of three
+  directions, therefore took the place of the value after it, which Apple's graphics refuse
+  outright, and the pack stopped. The shorthand is now read like the full spelling.
+
 - **A graphics card lost in the middle of a session now closes the game on the error that lost it.**
   When the card stopped answering, the engine caught the error at whichever step of the frame met it
   first, switched the pack or one of its parts off and went on drawing against a card that was gone,

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -714,7 +714,8 @@ public final class GlslTranslator {
 		}
 
 		this.tokens = new TokenStream(GlslLexer.lex(text));
-		this.splits = new VaryingSplit(this.tokens, unit, stage, this::fileScopeDeclaration);
+		this.splits = new VaryingSplit(this.tokens, unit, stage, this::fileScopeDeclaration,
+				this.macroAliases);
 		this.volumes = new VolumeFlattening(this.tokens, unit, volumes, this.packMacros,
 				this.macroAliases);
 	}
@@ -1317,6 +1318,32 @@ public final class GlslTranslator {
 		}
 
 		return Optional.ofNullable(target);
+	}
+
+	/**
+	 * The storage word a token stands for, {@code in} or {@code out}, or null where it is
+	 * neither.
+	 * <p>
+	 * A macro whose live replacement text is exactly one of the two is that word, since the
+	 * compiler never sees the macro. I Like Vanilla writes each varying once for both stages, as
+	 * {@code in_out mat3 tbn} with {@code in_out} defined to {@code in} under {@code FSH} and to
+	 * {@code out} otherwise. Read as the literal word alone, that matrix stays whole, its water
+	 * vertex stage numbers {@code fogAmount} onto a column of {@code tbn}, and Metal refuses two
+	 * outputs on one location outright.
+	 *
+	 * @param aliases the macros whose replacement text is one name, by macro, which is what the
+	 *                translator collects before any pass reads a storage word
+	 */
+	static String storageWord(Token token, Map<String, String> aliases) {
+		if (token.kind() != Kind.IDENTIFIER) {
+			return null;
+		}
+
+		String word = token.text().equals("in") || token.text().equals("out")
+				? token.text()
+				: aliases.getOrDefault(token.text(), "");
+
+		return word.equals("in") || word.equals("out") ? word : null;
 	}
 
 	/**
@@ -4341,13 +4368,14 @@ public final class GlslTranslator {
 				continue;
 			}
 
-			if (token.identifier("out")) {
+			String storage = storageWord(token, this.macroAliases);
+			if ("out".equals(storage)) {
 				FileScope declared = fileScopeDeclaration(index);
 				if (declared != null) {
 					this.declaredOutputs.addAll(declared.names());
 					this.declaredOutputScopes.add(declared);
 				}
-			} else if (token.identifier("in") && this.stage != ProgramStage.VERTEX) {
+			} else if ("in".equals(storage) && this.stage != ProgramStage.VERTEX) {
 				FileScope declared = fileScopeDeclaration(index);
 				if (declared != null) {
 					this.declaredInputs.add(declared);

--- a/common/src/main/java/dev/vitrail/glsl/VaryingSplit.java
+++ b/common/src/main/java/dev/vitrail/glsl/VaryingSplit.java
@@ -27,9 +27,10 @@ import java.util.regex.Pattern;
  * around its {@code main}. The three cases share the numbering they exist for, the shape of the
  * rewrite and the wrapper they are copied in, which is why they are one class and not three.
  * <p>
- * What it can see is the token list, the unit's own liveness, the stage, and one reader handed to
- * it: a declaration at file scope is {@link GlslTranslator}'s to recognise, and reading one a
- * second way here would be a second answer to drift from the first.
+ * What it can see is the token list, the unit's own liveness, the stage, the macros that spell
+ * another name, and one reader handed to it: a declaration at file scope is
+ * {@link GlslTranslator}'s to recognise, and so is a storage word, and reading either a second way
+ * here would be a second answer to drift from the first.
  */
 final class VaryingSplit {
 
@@ -65,6 +66,13 @@ final class VaryingSplit {
 	private final Declarations declarations;
 
 	/**
+	 * The translator's macros whose replacement text is one name, filled before {@link #split}
+	 * runs, so that a varying declared through a macro standing for {@code in} or {@code out} is
+	 * split like one written with the word.
+	 */
+	private final Map<String, String> macroAliases;
+
+	/**
 	 * Matrix varyings rewritten as one vector per column, so {@code createFromSpirv} can number
 	 * them without overlap. Empty when the stage declared none.
 	 */
@@ -83,11 +91,12 @@ final class VaryingSplit {
 	private final List<SplitArray> arrays = new ArrayList<>();
 
 	VaryingSplit(TokenStream tokens, ExpandedUnit unit, ProgramStage stage,
-			Declarations declarations) {
+			Declarations declarations, Map<String, String> macroAliases) {
 		this.tokens = tokens;
 		this.unit = unit;
 		this.stage = stage;
 		this.declarations = declarations;
+		this.macroAliases = macroAliases;
 	}
 
 	/**
@@ -277,12 +286,12 @@ final class VaryingSplit {
 				continue;
 			}
 
-			boolean input = token.identifier("in");
-			boolean output = token.identifier("out");
-			if (!input && !output) {
+			String storage = GlslTranslator.storageWord(token, this.macroAliases);
+			if (storage == null) {
 				continue;
 			}
 
+			boolean input = storage.equals("in");
 			if (input && this.stage == ProgramStage.VERTEX) {
 				continue;
 			}
@@ -403,12 +412,12 @@ final class VaryingSplit {
 				continue;
 			}
 
-			boolean input = token.identifier("in");
-			boolean output = token.identifier("out");
-			if (!input && !output) {
+			String storage = GlslTranslator.storageWord(token, this.macroAliases);
+			if (storage == null) {
 				continue;
 			}
 
+			boolean input = storage.equals("in");
 			if (input && this.stage == ProgramStage.VERTEX) {
 				continue;
 			}
@@ -596,11 +605,12 @@ final class VaryingSplit {
 			return;
 		}
 
+		String wanted = output ? "out" : "in";
 		int[] lines = this.tokens.lineNumbers();
 		for (int index = 0; index < this.tokens.size(); index++) {
 			Token token = this.tokens.get(index);
 			if (token.directive() != null || !this.unit.isLive(lines[index])
-					|| !token.identifier(output ? "out" : "in")) {
+					|| !wanted.equals(GlslTranslator.storageWord(token, this.macroAliases))) {
 				continue;
 			}
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -241,7 +241,10 @@ handed three varyings draws the lake as the reference does. A plain array varyin
 over several locations too, and it is split the same way, one varying per element: Photon's
 sky harmonics reach its deferred shading as nine `vec3` in one array, with two varyings declared
 after them. Only a single dimension sized by a number the pack wrote out is taken; a size behind
-a constant expression stays with the declaration.
+a constant expression stays with the declaration. All three read the storage word through a macro
+whose live replacement is exactly `in` or `out`, since I Like Vanilla declares each varying once
+for both stages as `in_out`, defined to one or the other by stage: read as the literal word alone,
+its water's `tbn` stays whole, and Metal refuses the two outputs that then share a location.
 
 A consequence for measurement, and it is sharper than it looks: **a per-unit check cannot see this
 class of defect at all**, because it never pairs a vertex stage with its fragment stage. Neither


### PR DESCRIPTION
## What changes

The game numbers a stage's outputs by their rank, so a varying spanning several locations (a matrix, a struct, an array) overlaps the next one. `VaryingSplit` answers that by rewriting each such varying into one varying per location. But it, and `collectVaryings`, recognised a varying only when its storage word was written literally as `in` or `out`.

I Like Vanilla declares each varying once for both stages as `in_out mat3 tbn`, with `in_out` a macro defined to `in` or `out` depending on the stage. The matrix therefore stayed whole, and `fogAmount` landed on a column of `tbn`. Metal refuses two vertex outputs on one location (`invalid return type 'main0_out' for vertex function`), so the pack stopped on a Mac.

A macro whose live replacement text is exactly `in` or `out` now reads as that word. The translator collects these macros before either pass runs, so no new parsing is added. Both stages split `tbn` into the same three columns.

## How it differs from the reference, and for what obstacle

It does not. Iris links by name on OpenGL and never numbers varyings by rank.

## What proves it

- `gradlew build` green, after the rebase.
- The off game translation harness ran over the bench's 28 packs, before and after. Translated text changed only in I Like Vanilla: the `gbuffers_water` stages, and `composite21`, whose `mat2 cornerDepths` is now split too.
- Before: on an M4 (MoltenVK 1.4.2), arena bench, one launch, the pack stopped on `gbuffers_water`.
- After, same place: it draws.

## What it leaves owing

- A macro standing for another macro that means `in` or `out` is not followed.
- The other literal storage word matches (`out gl_PerVertex`, interface blocks, fragment outputs, vertex attributes) share the blind spot in principle; none of them affects a corpus pack.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
