### PR TITLE
fix(render): bind a set where MoltenVK cannot push every sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,13 @@ what the next one holds.
   directions, therefore took the place of the value after it, which Apple's graphics refuse
   outright, and the pack stopped. The shorthand is now read like the full spelling.
 
+- **Reverie no longer stops on a Mac.** Two of its passes read more textures at once than the
+  sixteen a Mac takes when a pass is handed its textures one by one, which is how the game hands
+  them over, so Apple's graphics card refused those passes and the engine put the pack away. On a
+  Mac whose card takes textures as one table, which every Apple Silicon Mac does, a pass reading
+  more than sixteen is now handed them that way. Every other pass, and every pass on any other
+  machine, is handed its textures as before.
+
 - **A graphics card lost in the middle of a session now closes the game on the error that lost it.**
   When the card stopped answering, the engine caught the error at whichever step of the frame met it
   first, switched the pack or one of its parts off and went on drawing against a card that was gone,

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
@@ -9,6 +9,7 @@ import dev.vitrail.glsl.VendorExtensions;
 import dev.vitrail.pack.model.ProgramStage;
 import dev.vitrail.render.BufferBlending;
 import dev.vitrail.render.GeometryStage;
+import dev.vitrail.render.WideSamplerSets;
 import dev.vitrail.Vitrail;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.vulkan.VK10;
@@ -21,6 +22,7 @@ import org.lwjgl.vulkan.VkPhysicalDeviceProperties2;
 import org.lwjgl.vulkan.VkPhysicalDeviceSubgroupProperties;
 import org.lwjgl.vulkan.VkPhysicalDeviceVulkan11Features;
 import org.lwjgl.vulkan.VkPhysicalDeviceVulkan12Features;
+import org.lwjgl.vulkan.VkPhysicalDeviceVulkan12Properties;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -191,6 +193,13 @@ public abstract class VulkanBackendMixin {
 		enable(physical, features, WRITE_WITHOUT_FORMAT, enabled, VOXELS);
 		BufferBlending.serve(enable(physical, features, INDEPENDENT_BLEND, enabled, PER_BUFFER));
 		GeometryStage.serve(enable(physical, features, GEOMETRY_SHADER, enabled, GEOMETRY));
+		// Not a feature, but asked of the same device at the same moment: the physical device is
+		// closed once the game's own device has read what it keeps of it.
+		boolean moltenVk =
+				physical.vkPhysicalDeviceDriverProperties().driverID() == VK12.VK_DRIVER_ID_MOLTENVK;
+		WideSamplerSets.serve(moltenVk,
+				physical.vkPhysicalDeviceProperties().limits().maxPerStageDescriptorSamplers(),
+				moltenVk ? tableSamplers(physical) : 0);
 		// The vendor extensions a pack may gate a vendor instruction on, answered by the device
 		// and not by the compiler, which defines the macro of every one it knows; the ones the
 		// device has are enabled on it here, since a module using one needs it enabled.
@@ -252,6 +261,20 @@ public abstract class VulkanBackendMixin {
 			}
 
 			return stages;
+		}
+	}
+
+	// The samplers one stage of an allocated set may read, which MoltenVK raises past the pushed
+	// sixteen only while it binds sets through tier 2 argument buffers.
+	@Unique
+	private static int tableSamplers(VulkanPhysicalDevice physical) {
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			VkPhysicalDeviceVulkan12Properties vulkan12 =
+					VkPhysicalDeviceVulkan12Properties.calloc(stack).sType$Default();
+			VkPhysicalDeviceProperties2 properties =
+					VkPhysicalDeviceProperties2.calloc(stack).sType$Default().pNext(vulkan12);
+			VK11.vkGetPhysicalDeviceProperties2(physical.vkPhysicalDevice(), properties);
+			return vulkan12.maxPerStageDescriptorUpdateAfterBindSamplers();
 		}
 	}
 

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBindGroupLayoutMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBindGroupLayoutMixin.java
@@ -2,17 +2,24 @@ package dev.vitrail.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
 import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout.Entry;
 import dev.vitrail.pack.texture.CustomImages;
 import dev.vitrail.render.GeometryStage;
+import dev.vitrail.render.WideSamplerSets;
 import dev.vitrail.render.storage.StorageBuffers;
 import dev.vitrail.render.storage.StorageImages;
+import org.lwjgl.vulkan.VK12;
+import org.lwjgl.vulkan.VkAllocationCallbacks;
 import org.lwjgl.vulkan.VkDescriptorSetLayoutBinding;
+import org.lwjgl.vulkan.VkDescriptorSetLayoutCreateInfo;
+import org.lwjgl.vulkan.VkDevice;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
+import java.nio.LongBuffer;
 import java.util.List;
 
 /**
@@ -22,6 +29,8 @@ import java.util.List;
  * The Java enum has no storage-image or storage-buffer arm, so the layout would otherwise write
  * a combined image sampler (type 1) for {@code voxel_img} and a uniform buffer (type 6) for
  * {@code blockDataBuffer}. Complementary writes both with {@code imageStore} / SSBO stores.
+ * <p>
+ * And takes the push flag off the layout MoltenVK could not push, for {@link WideSamplerSets}.
  */
 @Mixin(VulkanBindGroupLayout.class)
 public abstract class VulkanBindGroupLayoutMixin {
@@ -80,5 +89,29 @@ public abstract class VulkanBindGroupLayoutMixin {
 			Operation<VkDescriptorSetLayoutBinding> original) {
 		return original.call(binding,
 				GeometryStage.buildingHere() ? flags | GeometryStage.STAGE_BIT : flags);
+	}
+
+	/**
+	 * Takes the push flag off a layout MoltenVK could not push, and records which road the handle
+	 * that comes back takes, which is what {@code VulkanRenderPassMixin} asks at every draw.
+	 * <p>
+	 * At the driver call rather than at the flag the game writes, because both rewrites above have
+	 * run by then: the count is taken over the types and the stages the layout really carries.
+	 */
+	@WrapOperation(method = "create", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/VK12;vkCreateDescriptorSetLayout("
+							+ "Lorg/lwjgl/vulkan/VkDevice;Lorg/lwjgl/vulkan/VkDescriptorSetLayoutCreateInfo;"
+							+ "Lorg/lwjgl/vulkan/VkAllocationCallbacks;Ljava/nio/LongBuffer;)I"))
+	private static int vitrail$allocatedSets(VkDevice device, VkDescriptorSetLayoutCreateInfo info,
+			VkAllocationCallbacks allocator, LongBuffer handle, Operation<Integer> original,
+			@Local(argsOnly = true) String name) {
+		boolean allocated = WideSamplerSets.dropPush(info, name);
+		int result = original.call(device, info, allocator, handle);
+		if (result == VK12.VK_SUCCESS) {
+			WideSamplerSets.created(handle.get(0), allocated);
+		}
+
+		return result;
 	}
 }

--- a/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderSetsMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanCommandEncoderSetsMixin.java
@@ -1,0 +1,75 @@
+package dev.vitrail.mixin;
+
+import dev.vitrail.render.DescriptorSetPools;
+import dev.vitrail.render.WideSamplerSets;
+
+import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import org.lwjgl.vulkan.VkWriteDescriptorSet;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Owns the descriptor pools {@link WideSamplerSets} allocates from and turns them over on the
+ * encoder's own beat: reset with the command pool of the same submit slot, destroyed with the
+ * encoder, which the device destroys before itself.
+ * <p>
+ * Made on the first set asked for, so a device that never creates such a layout, which is every
+ * device but MoltenVK under a pack past its sampler slots, never makes a pool.
+ */
+@Mixin(VulkanCommandEncoder.class)
+public abstract class VulkanCommandEncoderSetsMixin implements WideSamplerSets.SetAllocator {
+
+	@Shadow
+	@Final
+	private VulkanDevice device;
+
+	@Shadow
+	private long currentSubmitIndex;
+
+	@Unique
+	private DescriptorSetPools vitrail$setPools;
+
+	@Override
+	public long vitrail$allocateSet(long setLayout, VkWriteDescriptorSet.Buffer writes) {
+		if (this.vitrail$setPools == null) {
+			this.vitrail$setPools = new DescriptorSetPools(this.device,
+					VulkanCommandEncoder.MAX_SUBMITS_IN_FLIGHT);
+		}
+
+		return this.vitrail$setPools.allocate(vitrail$slot(), setLayout, writes);
+	}
+
+	/**
+	 * At the game's reset of the command pool of the slot about to record, which it reaches only
+	 * once the submission that last recorded in that slot is done, and after the index has moved on
+	 * to that slot.
+	 */
+	@Inject(method = "submit", require = 1,
+			at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vulkan/VulkanCommandPool;reset()V"))
+	private void vitrail$resetSets(CallbackInfo callback) {
+		if (this.vitrail$setPools != null) {
+			this.vitrail$setPools.reset(vitrail$slot());
+		}
+	}
+
+	/** At the tail, past the wait for idle, and before the device destroys itself. */
+	@Inject(method = "destroy", at = @At("TAIL"), require = 1)
+	private void vitrail$destroySets(CallbackInfo callback) {
+		if (this.vitrail$setPools != null) {
+			this.vitrail$setPools.destroy();
+			this.vitrail$setPools = null;
+		}
+	}
+
+	/** The slot recording now, picked the way {@code currentCommandPool} picks its pool. */
+	@Unique
+	private int vitrail$slot() {
+		return (int) (this.currentSubmitIndex % VulkanCommandEncoder.MAX_SUBMITS_IN_FLIGHT);
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanRenderPassMixin.java
@@ -4,15 +4,19 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.vulkan.VulkanBindGroupLayout;
+import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
 import com.mojang.blaze3d.vulkan.VulkanRenderPass;
 import com.mojang.blaze3d.vulkan.VulkanRenderPipeline;
 import dev.vitrail.render.PushedDescriptor;
 import dev.vitrail.render.ShadowCompare;
+import dev.vitrail.render.WideSamplerSets;
 import dev.vitrail.render.storage.StorageBuffers;
 import dev.vitrail.render.storage.StorageImages;
+import org.lwjgl.vulkan.VkCommandBuffer;
 import org.lwjgl.vulkan.VkDescriptorBufferInfo;
 import org.lwjgl.vulkan.VkDescriptorImageInfo;
 import org.lwjgl.vulkan.VkWriteDescriptorSet;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -32,12 +36,19 @@ import java.util.Set;
  * on {@code blockDataBuffer}. The comparison is the same shape of gap: no {@code GpuSampler}
  * describes one, so {@link ShadowCompare} makes it in Vulkan's own terms and this walk puts its
  * handle under the names the pipeline registered when it was built.
+ * <p>
+ * And binds those same writes as an allocated set where the layout is one MoltenVK could not push,
+ * for {@link WideSamplerSets}.
  */
 @Mixin(VulkanRenderPass.class)
 public abstract class VulkanRenderPassMixin {
 
 	@Shadow
 	protected VulkanRenderPipeline pipeline;
+
+	@Shadow
+	@Final
+	private VulkanCommandEncoder encoder;
 
 	/** The pipeline the set below answers for, so that the set is asked once per pipeline. */
 	@Unique
@@ -139,6 +150,27 @@ public abstract class VulkanRenderPassMixin {
 		}
 
 		return original.call(set, type);
+	}
+
+	/**
+	 * Allocates and binds a set carrying the writes the push was handed, the rewrites above
+	 * included, where the pipeline's layout was created without the push flag. Every other draw,
+	 * which on any machine but a Mac under such a pack is every draw, pushes as the game does.
+	 */
+	@WrapOperation(method = "pushDescriptors", require = 1,
+			at = @At(value = "INVOKE",
+					target = "Lorg/lwjgl/vulkan/KHRPushDescriptor;vkCmdPushDescriptorSetKHR("
+							+ "Lorg/lwjgl/vulkan/VkCommandBuffer;IJI"
+							+ "Lorg/lwjgl/vulkan/VkWriteDescriptorSet$Buffer;)V"))
+	private void vitrail$pushOrBind(VkCommandBuffer commands, int bindPoint, long layout, int set,
+			VkWriteDescriptorSet.Buffer writes, Operation<Void> original) {
+		long setLayout = this.pipeline == null ? 0L : this.pipeline.layout().handle();
+		if (WideSamplerSets.allocated(setLayout)) {
+			WideSamplerSets.bind(this.encoder, commands, bindPoint, layout, set, setLayout, writes);
+			return;
+		}
+
+		original.call(commands, bindPoint, layout, set, writes);
 	}
 
 	@Unique

--- a/common/src/main/java/dev/vitrail/render/DescriptorSetPools.java
+++ b/common/src/main/java/dev/vitrail/render/DescriptorSetPools.java
@@ -1,0 +1,165 @@
+package dev.vitrail.render;
+
+import com.mojang.blaze3d.vulkan.VulkanDevice;
+import com.mojang.blaze3d.vulkan.VulkanUtils;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.VK10;
+import org.lwjgl.vulkan.VK11;
+import org.lwjgl.vulkan.VkDescriptorPoolCreateInfo;
+import org.lwjgl.vulkan.VkDescriptorPoolSize;
+import org.lwjgl.vulkan.VkDescriptorSetAllocateInfo;
+import org.lwjgl.vulkan.VkWriteDescriptorSet;
+
+import java.nio.LongBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The descriptor pools {@link WideSamplerSets} allocates from, one list of them per submit slot of
+ * the game's command encoder.
+ * <p>
+ * <strong>Why the slot.</strong> A set named by a recorded command buffer has to stay valid until
+ * the GPU is done with that buffer, and the game keeps two submissions in flight
+ * ({@code VulkanCommandEncoder.MAX_SUBMITS_IN_FLIGHT}). It already answers that for the command
+ * buffers themselves: two command pools, the one recording picked by the submit index modulo two,
+ * each reset in {@code submit} right after waiting on the submission that last recorded into it
+ * ({@code VulkanCommandEncoder:205-210}). These pools follow the same slot and are reset at that
+ * same call, so a set is never handed back while a buffer binding it can still run, and never kept
+ * past the buffer either. The encoder's destruction queue turns on that beat too, which is what
+ * frees a texel buffer view a write names at the moment the set naming it goes.
+ * <p>
+ * <strong>Why a list.</strong> How many sets a frame binds is not known up front: one per draw
+ * whose descriptors changed, on every pipeline of such a layout. A pool that runs out is left for
+ * the rest of its slot's turn and the next one is used, created when there is none, sized off the
+ * set that did not fit. A reset keeps every pool, so once a pack has drawn a frame or two each slot
+ * owns what a frame takes and creates nothing more.
+ * <p>
+ * Render thread only, which is where every draw and dispatch is recorded.
+ */
+public final class DescriptorSetPools {
+
+	/** Sets one pool holds; each descriptor type gets this many times what the set that opened it needs. */
+	private static final int SETS_PER_POOL = 64;
+
+	/** Every core descriptor type is below this, the input attachment being the last at ten. */
+	private static final int TYPES = VK10.VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT + 1;
+
+	private final VulkanDevice device;
+
+	private final List<List<Long>> slots = new ArrayList<>();
+
+	/** Per slot, the pool the next allocation tries first; the ones before it ran out this turn. */
+	private final int[] cursors;
+
+	/**
+	 * @param slots how many submit slots the encoder turns over, one list of pools each
+	 */
+	public DescriptorSetPools(VulkanDevice device, int slots) {
+		this.device = device;
+		this.cursors = new int[slots];
+		for (int i = 0; i < slots; i++) {
+			this.slots.add(new ArrayList<>());
+		}
+	}
+
+	/**
+	 * A set of that layout from the pools of the slot, unwritten.
+	 *
+	 * @param writes the writes the set is about to be given, which size a pool created for it
+	 */
+	public long allocate(int slot, long setLayout, VkWriteDescriptorSet.Buffer writes) {
+		List<Long> pools = this.slots.get(slot);
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			LongBuffer set = stack.callocLong(1);
+			VkDescriptorSetAllocateInfo info = VkDescriptorSetAllocateInfo.calloc(stack)
+					.sType$Default()
+					.pSetLayouts(stack.longs(setLayout));
+			while (true) {
+				boolean fresh = this.cursors[slot] == pools.size();
+				if (fresh) {
+					pools.add(create(writes));
+				}
+
+				info.descriptorPool(pools.get(this.cursors[slot]));
+				int result = VK10.vkAllocateDescriptorSets(this.device.vkDevice(), info, set);
+				if (result == VK10.VK_SUCCESS) {
+					return set.get(0);
+				}
+
+				// Only a full pool is moved past, and never one just sized off this very set: a pool
+				// that refuses the set it was made for would otherwise be followed by another, forever.
+				boolean full = result == VK11.VK_ERROR_OUT_OF_POOL_MEMORY
+						|| result == VK10.VK_ERROR_FRAGMENTED_POOL;
+				if (!full || fresh) {
+					String message = "Can't allocate a descriptor set";
+					VulkanUtils.crashIfFailure(this.device, result, message);
+					throw new IllegalStateException(VulkanUtils.resultToString(result) + ": " + message);
+				}
+
+				this.cursors[slot]++;
+			}
+		}
+	}
+
+	/** Hands every set of the slot back, once the submission that last recorded in it is done. */
+	public void reset(int slot) {
+		for (long pool : this.slots.get(slot)) {
+			VK10.vkResetDescriptorPool(this.device.vkDevice(), pool, 0);
+		}
+
+		this.cursors[slot] = 0;
+	}
+
+	/** Destroys every pool, once the device has gone idle and before it is destroyed. */
+	public void destroy() {
+		for (int slot = 0; slot < this.slots.size(); slot++) {
+			for (long pool : this.slots.get(slot)) {
+				VK10.vkDestroyDescriptorPool(this.device.vkDevice(), pool, null);
+			}
+
+			this.slots.get(slot).clear();
+			this.cursors[slot] = 0;
+		}
+	}
+
+	/** A pool for {@link #SETS_PER_POOL} sets carrying the descriptors those writes carry. */
+	private long create(VkWriteDescriptorSet.Buffer writes) {
+		int[] counts = new int[TYPES];
+		int kinds = 0;
+		for (int i = writes.position(); i < writes.limit(); i++) {
+			VkWriteDescriptorSet write = writes.get(i);
+			int type = write.descriptorType();
+			if (type < 0 || type >= TYPES) {
+				throw new IllegalStateException("No pool size for descriptor type " + type);
+			}
+
+			if (counts[type] == 0) {
+				kinds++;
+			}
+
+			counts[type] += write.descriptorCount();
+		}
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			VkDescriptorPoolSize.Buffer sizes = VkDescriptorPoolSize.calloc(kinds, stack);
+			int at = 0;
+			for (int type = 0; type < TYPES; type++) {
+				if (counts[type] > 0) {
+					sizes.get(at).type(type).descriptorCount(counts[type] * SETS_PER_POOL);
+					at++;
+				}
+			}
+
+			VkDescriptorPoolCreateInfo info = VkDescriptorPoolCreateInfo.calloc(stack)
+					.sType$Default()
+					.maxSets(SETS_PER_POOL)
+					.pPoolSizes(sizes);
+			LongBuffer pool = stack.callocLong(1);
+			VulkanUtils.crashIfFailure(this.device,
+					VK10.vkCreateDescriptorPool(this.device.vkDevice(), info, null, pool),
+					"Can't create a descriptor pool");
+
+			return pool.get(0);
+		}
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -405,19 +405,21 @@ final class PackCompute implements AutoCloseable {
 		// underneath would leave that object to close a pass the encoder no longer has.
 		GeometryHold.flush(() -> "the compute dispatch at " + program);
 		GpuRecording.endPass(encoder);
-		VkCommandBuffer commands = commands(encoder);
+		VulkanCommandEncoder recorder = recorder(encoder);
 		VulkanDevice vulkan = vulkan(device);
-		if (commands == null || vulkan == null) {
+		if (recorder == null || vulkan == null) {
 			return;
 		}
 
+		VkCommandBuffer commands = ((VulkanCommandEncoderAccessor) recorder).vitrail$commandBuffer();
 		try (MemoryStack stack = MemoryStack.stackPush()) {
 			beforeChainCompute(commands, stack);
 		}
 
 		for (Pass pass : attached) {
 			try {
-				pass.dispatch(vulkan, commands, values, targets, width, height, step, depth, distant);
+				pass.dispatch(vulkan, recorder, commands, values, targets, width, height, step, depth,
+						distant);
 			} catch (GpuDeviceLossException e) {
 				throw e;
 			} catch (RuntimeException e) {
@@ -456,12 +458,13 @@ final class PackCompute implements AutoCloseable {
 		// encoder no longer has, which is a crash at the next flush and not here.
 		GeometryHold.flush(() -> "the shadow compute dispatch");
 		GpuRecording.endPass(encoder);
-		VkCommandBuffer commands = commands(encoder);
+		VulkanCommandEncoder recorder = recorder(encoder);
 		VulkanDevice vulkan = vulkan(device);
-		if (commands == null || vulkan == null) {
+		if (recorder == null || vulkan == null) {
 			return;
 		}
 
+		VkCommandBuffer commands = ((VulkanCommandEncoderAccessor) recorder).vitrail$commandBuffer();
 		values.convention(ClipSpace.FORWARD);
 		values.modelView(null, null);
 		values.projection(null);
@@ -484,7 +487,7 @@ final class PackCompute implements AutoCloseable {
 		int height = main == null ? 0 : main.height;
 		for (Pass pass : this.passes) {
 			try {
-				pass.dispatch(vulkan, commands, values, targets, width, height, null, null, null);
+				pass.dispatch(vulkan, recorder, commands, values, targets, width, height, null, null, null);
 			} catch (GpuDeviceLossException e) {
 				throw e;
 			} catch (RuntimeException e) {
@@ -528,9 +531,9 @@ final class PackCompute implements AutoCloseable {
 		this.alone.values().forEach(list -> list.forEach(Pass::close));
 	}
 
-	private static VkCommandBuffer commands(CommandEncoder encoder) {
+	private static VulkanCommandEncoder recorder(CommandEncoder encoder) {
 		return ((CommandEncoderAccessor) encoder).vitrail$backend() instanceof VulkanCommandEncoder vulkan
-				? ((VulkanCommandEncoderAccessor) vulkan).vitrail$commandBuffer()
+				? vulkan
 				: null;
 	}
 
@@ -728,6 +731,8 @@ final class PackCompute implements AutoCloseable {
 		private MappableRingBuffer block;
 		private long shaderModule;
 		private long setLayout;
+		/** Whether the set layout lost its push flag to {@link WideSamplerSets}. */
+		private boolean allocatedSets;
 		private long pipelineLayout;
 		private long pipeline;
 		private List<VulkanBindGroupLayout.Entry> entries = List.of();
@@ -754,10 +759,11 @@ final class PackCompute implements AutoCloseable {
 		 *                then reads the far plane, and the two copies read what they last held,
 		 *                as they do for a pass drawn before the copy is taken
 		 * @param distant the far terrain's depth on the same terms
+		 * @param recorder the encoder {@code commands} belongs to, whose slot an allocated set lives in
 		 */
-		private void dispatch(VulkanDevice vulkan, VkCommandBuffer commands, PackValues values,
-				ColorTargets targets, int width, int height, TargetSchedule.Bound step,
-				GpuTextureView depth, GpuTextureView distant) {
+		private void dispatch(VulkanDevice vulkan, VulkanCommandEncoder recorder,
+				VkCommandBuffer commands, PackValues values, ColorTargets targets, int width,
+				int height, TargetSchedule.Bound step, GpuTextureView depth, GpuTextureView distant) {
 			if (!this.compiled) {
 				compile(vulkan);
 			}
@@ -770,7 +776,7 @@ final class PackCompute implements AutoCloseable {
 			try (MemoryStack stack = MemoryStack.stackPush()) {
 				VulkanCommandEncoder.memoryBarrier(commands, stack);
 				VK12.vkCmdBindPipeline(commands, VK12.VK_PIPELINE_BIND_POINT_COMPUTE, this.pipeline);
-				pushDescriptors(commands, stack, targets, step, depth, distant);
+				pushDescriptors(recorder, commands, stack, targets, step, depth, distant);
 				// The screen and not the shadow map: Iris sizes a shadow composite's compute off
 				// the main render target, ShadowCompositeRenderer.java:213-214, and the resolution
 				// of the shadow map is what it sizes the shadow GEOMETRY computes off instead,
@@ -953,6 +959,7 @@ final class PackCompute implements AutoCloseable {
 					.sType$Default()
 					.flags(1)
 					.pBindings(bindings);
+			this.allocatedSets = WideSamplerSets.dropPush(layoutInfo, this.label);
 			LongBuffer layoutPtr = stack.callocLong(1);
 			VulkanUtils.crashIfFailure(vulkan,
 					VK12.vkCreateDescriptorSetLayout(vulkan.vkDevice(), layoutInfo, null, layoutPtr),
@@ -1003,9 +1010,9 @@ final class PackCompute implements AutoCloseable {
 			}
 		}
 
-		private void pushDescriptors(VkCommandBuffer commands, MemoryStack stack,
-				ColorTargets targets, TargetSchedule.Bound step, GpuTextureView depth,
-				GpuTextureView distant) {
+		private void pushDescriptors(VulkanCommandEncoder recorder, VkCommandBuffer commands,
+				MemoryStack stack, ColorTargets targets, TargetSchedule.Bound step,
+				GpuTextureView depth, GpuTextureView distant) {
 			if (this.entries.isEmpty()) {
 				return;
 			}
@@ -1166,6 +1173,12 @@ final class PackCompute implements AutoCloseable {
 						? VK12.VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
 						: VK12.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
 				write.pImageInfo(imageInfo);
+			}
+
+			if (this.allocatedSets) {
+				WideSamplerSets.bind(recorder, commands, VK12.VK_PIPELINE_BIND_POINT_COMPUTE,
+						this.pipelineLayout, 0, this.setLayout, writes);
+				return;
 			}
 
 			KHRPushDescriptor.vkCmdPushDescriptorSetKHR(commands,

--- a/common/src/main/java/dev/vitrail/render/SamplerReach.java
+++ b/common/src/main/java/dev/vitrail/render/SamplerReach.java
@@ -27,8 +27,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * number is a name and nothing more, and the numbering can be as sparse as it likes. On Apple it is
  * not: MoltenVK hands each descriptor of a set a Metal slot counted off its place among the
  * descriptors of its own kind, and Metal has sixteen sampler slots. So a stage that reads thirteen
- * samplers out of a layout carrying forty-eight is given indices running past sixteen and the
- * pipeline is refused, for a shader wanting three slots fewer than the hardware has.
+ * samplers out of a layout carrying forty-eight is given indices running past sixteen, which a
+ * pushed set cannot reach: the layout then needs {@link WideSamplerSets} and an argument buffer,
+ * for a shader wanting three slots fewer than the hardware has.
  * <p>
  * <strong>Why the list held more than the shader reads.</strong> A pack's programs are a handful of
  * files over a shared include, and that include declares every sampler any of them might want. The
@@ -126,11 +127,12 @@ public final class SamplerReach {
 			// initialiser refuses long before anything compiles, but the invoke can still throw,
 			// and thrown from here it would come out of the compiler's own method and take every
 			// pack on the machine down rather than cost one layout its density. Said at WARN,
-			// because a load that lost this quietly is a load whose Apple refusals come back with
-			// nothing in the log to explain them.
+			// because a load that lost this quietly is a load that binds allocated sets on Apple
+			// hardware, or is refused there, with nothing in the log to explain why.
 			Vitrail.logger().warn("Could not read a module's sampler names, so its layout keeps a "
-					+ "binding for every declared sampler: a pack over Metal's sixteen slots is "
-					+ "refused on Apple hardware again", e);
+					+ "binding for every declared sampler: on Apple hardware a stage numbered past "
+					+ "Metal's sixteen slots needs an allocated set, and is refused where no argument "
+					+ "buffer takes it", e);
 
 			return;
 		}
@@ -157,7 +159,9 @@ public final class SamplerReach {
 			Vitrail.logger().warn("Every DECLARED sampler given a binding, asked for by "
 					+ "-Dvitrail.declaredSamplers ({} modules built this load, none walked): a pack "
 					+ "whose shared include declares more samplers than a stage reads is numbered "
-					+ "past Metal's sixteen slots and refused on Apple hardware", compiled);
+					+ "past Metal's sixteen slots, which on Apple hardware takes an allocated set or is "
+					+ "refused",
+					compiled);
 
 			return;
 		}

--- a/common/src/main/java/dev/vitrail/render/WideSamplerSets.java
+++ b/common/src/main/java/dev/vitrail/render/WideSamplerSets.java
@@ -1,0 +1,225 @@
+package dev.vitrail.render;
+
+import dev.vitrail.Vitrail;
+
+import com.mojang.blaze3d.vulkan.VulkanCommandEncoder;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.VK10;
+import org.lwjgl.vulkan.VkCommandBuffer;
+import org.lwjgl.vulkan.VkDescriptorSetLayoutBinding;
+import org.lwjgl.vulkan.VkDescriptorSetLayoutCreateInfo;
+import org.lwjgl.vulkan.VkWriteDescriptorSet;
+
+import java.nio.IntBuffer;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Allocates and binds the descriptor set of a layout MoltenVK could not push, rather than pushing
+ * it.
+ * <p>
+ * <strong>What goes wrong without it.</strong> The game creates every set layout with the push
+ * descriptor flag ({@code VulkanBindGroupLayout:34}) and hands every draw its descriptors through
+ * {@code vkCmdPushDescriptorSetKHR} ({@code VulkanRenderPass:412}). MoltenVK never gives a push
+ * layout a Metal argument buffer, so each combined image sampler takes a {@code [[sampler(n)]]}
+ * slot of its own, and Metal has sixteen. A stage reading more is refused as Metal builds it,
+ * {@code 'sampler' attribute parameter is out of bounds: must be between 0 and 15}, which on
+ * Reverie is {@code deferred2} and took the whole pack down on a Mac. MoltenVK goes on reporting
+ * sixteen as {@code maxPerStageDescriptorSamplers}, and that report is the line drawn here.
+ * <p>
+ * <strong>Where a set without the flag is really given an argument buffer.</strong> Not everywhere:
+ * MoltenVK binds every set slot by slot when its argument buffers are turned off
+ * ({@code MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=0}) or below macOS 11, and on a GPU without native
+ * texture swizzle it does so for any layout holding a combined image sampler. What it reports
+ * instead is {@code maxPerStageDescriptorUpdateAfterBindSamplers}, which it raises past sixteen
+ * only while it binds sets through tier 2 argument buffers. Every tier 2 GPU is of Metal's Mac 2 or
+ * Apple family, which MoltenVK gives native swizzle, so on a device reporting more there a layout
+ * of samplers created without the flag does get its argument buffer. That second report is the
+ * other line: a layout past it stays pushed, where Metal refuses it as before, rather than being
+ * allocated for nothing.
+ * <p>
+ * <strong>Narrowed on purpose.</strong> Only a layout on MoltenVK whose widest stage lies between
+ * those two reports loses the flag. Every other layout, and every layout on every other driver, is
+ * pushed exactly as the game pushes it: an allocated set costs an update and a pool slot on every
+ * bind, where a push is what the game was measured with.
+ * <p>
+ * <strong>Where the set lives</strong> is {@link DescriptorSetPools}, whose javadoc says why its
+ * lifetime is the encoder's submit slot.
+ * <p>
+ * Off until {@code VulkanBackendMixin} says what the device is, which is what the harness gets.
+ */
+public final class WideSamplerSets {
+
+	/**
+	 * {@code VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_SET_BIT_KHR}, the one flag taken off and
+	 * the one the game sets on every layout it creates. Written out, this LWJGL carrying no constant
+	 * for it.
+	 */
+	private static final int PUSH = 1;
+
+	/** The stages a pack's layout can name, each counted on its own as MoltenVK counts them. */
+	private static final int[] STAGES = {
+			VK10.VK_SHADER_STAGE_VERTEX_BIT,
+			VK10.VK_SHADER_STAGE_GEOMETRY_BIT,
+			VK10.VK_SHADER_STAGE_FRAGMENT_BIT,
+			VK10.VK_SHADER_STAGE_COMPUTE_BIT,
+	};
+
+	/**
+	 * The handles of the layouts created without the flag. By handle because that is all a draw has
+	 * in hand, and the game's layout record is built only after the driver returned it.
+	 */
+	private static final Set<Long> ALLOCATED = ConcurrentHashMap.newKeySet();
+
+	/** The layout names already said, so that a pack built again does not say them again. */
+	private static final Set<String> SAID = ConcurrentHashMap.newKeySet();
+
+	private static volatile boolean moltenVk;
+
+	private static volatile int perStageSamplers = Integer.MAX_VALUE;
+
+	private static volatile int tableSamplers;
+
+	/** Whether any layout ever lost the flag, so that a draw on any other machine asks nothing more. */
+	private static volatile boolean any;
+
+	private WideSamplerSets() {
+	}
+
+	/**
+	 * Set once by {@code VulkanBackendMixin}, at device creation and before any layout is created.
+	 *
+	 * @param moltenVkDriver      whether the device's driver is MoltenVK
+	 * @param maxPerStageSamplers what the device reports as {@code maxPerStageDescriptorSamplers}
+	 * @param maxTableSamplers    what it reports as {@code maxPerStageDescriptorUpdateAfterBindSamplers}
+	 */
+	public static void serve(boolean moltenVkDriver, int maxPerStageSamplers, int maxTableSamplers) {
+		perStageSamplers = maxPerStageSamplers;
+		tableSamplers = maxTableSamplers;
+		moltenVk = moltenVkDriver;
+	}
+
+	/**
+	 * Takes the push flag off a layout about to be created when MoltenVK could not push it and would
+	 * bind it through an argument buffer instead.
+	 * <p>
+	 * Read off the bindings as they go to the driver, so a storage image a rewrite already turned
+	 * into one is not counted as a sampler, and the stage flags counted are the ones the layout
+	 * really carries.
+	 *
+	 * @param info the create info, whose flags are rewritten in place
+	 * @param name what the layout is for, said once in the log
+	 * @return whether the flag was taken off, which is what {@link #created} is then handed
+	 */
+	public static boolean dropPush(VkDescriptorSetLayoutCreateInfo info, String name) {
+		if (!moltenVk || (info.flags() & PUSH) == 0) {
+			return false;
+		}
+
+		int widest = widestStage(info.pBindings());
+		if (widest <= perStageSamplers) {
+			return false;
+		}
+
+		if (widest > tableSamplers) {
+			if (SAID.add(name)) {
+				Vitrail.logger().warn("{} reads {} samplers in one stage, past the {} MoltenVK can push, "
+						+ "and this device binds sets through no argument buffer taking more, so it stays "
+						+ "pushed and Metal refuses it", name, widest, perStageSamplers);
+			}
+
+			return false;
+		}
+
+		info.flags(info.flags() & ~PUSH);
+		if (SAID.add(name)) {
+			Vitrail.logger().info("{} reads {} samplers in one stage, past the {} MoltenVK can push, so "
+					+ "its descriptor set is allocated and bound through an argument buffer", name, widest,
+					perStageSamplers);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Records which road the layout just created takes.
+	 * <p>
+	 * A pushed layout is taken OUT of the set rather than simply left out of it: a handle under
+	 * MoltenVK is an address, and one freed with a pipeline can come back for the next layout
+	 * created, which must not inherit the road of the one that held it before.
+	 */
+	public static void created(long handle, boolean allocated) {
+		if (allocated) {
+			ALLOCATED.add(handle);
+			any = true;
+		} else if (any) {
+			ALLOCATED.remove(handle);
+		}
+	}
+
+	/** Whether that layout was created without the push flag, and a draw must bind a set for it. */
+	public static boolean allocated(long setLayout) {
+		return any && ALLOCATED.contains(setLayout);
+	}
+
+	/**
+	 * Allocates a set of that layout from the encoder's current slot, writes into it exactly the
+	 * descriptors the push would have carried, and binds it where the push would have put them.
+	 * <p>
+	 * A failure to allocate throws out of here the way the game's own push throws on a missing
+	 * sampler, a lost device as {@code GpuDeviceLossException}, so the draw or dispatch is not made
+	 * and the catch around it decides, rather than the call going ahead with nothing bound.
+	 *
+	 * @param writes the writes the push was handed, every one aimed at the new set before the update
+	 */
+	public static void bind(VulkanCommandEncoder encoder, VkCommandBuffer commands, int bindPoint,
+			long pipelineLayout, int set, long setLayout, VkWriteDescriptorSet.Buffer writes) {
+		long allocated = ((SetAllocator) encoder).vitrail$allocateSet(setLayout, writes);
+		for (int i = writes.position(); i < writes.limit(); i++) {
+			writes.get(i).dstSet(allocated);
+		}
+
+		VK10.vkUpdateDescriptorSets(commands.getDevice(), writes, null);
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			VK10.vkCmdBindDescriptorSets(commands, bindPoint, pipelineLayout, set,
+					stack.longs(allocated), (IntBuffer) null);
+		}
+	}
+
+	/** The most combined image samplers any one stage of those bindings holds. */
+	private static int widestStage(VkDescriptorSetLayoutBinding.Buffer bindings) {
+		if (bindings == null) {
+			return 0;
+		}
+
+		int widest = 0;
+		for (int stage : STAGES) {
+			int held = 0;
+			for (int i = bindings.position(); i < bindings.limit(); i++) {
+				VkDescriptorSetLayoutBinding binding = bindings.get(i);
+				if (binding.descriptorType() == VK10.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
+						&& (binding.stageFlags() & stage) != 0) {
+					held += binding.descriptorCount();
+				}
+			}
+
+			widest = Math.max(widest, held);
+		}
+
+		return widest;
+	}
+
+	/**
+	 * Implemented on the game's command encoder, which owns the submit slots a set's lifetime
+	 * follows. Duck typed onto it for the same reason {@link MipmapCommands} is.
+	 */
+	public interface SetAllocator {
+
+		/**
+		 * A set of that layout, unwritten, from the pools of the slot recording now.
+		 *
+		 * @param writes the writes the set will be given, which size a pool created for it
+		 */
+		long vitrail$allocateSet(long setLayout, VkWriteDescriptorSet.Buffer writes);
+	}
+}

--- a/common/src/main/resources/vitrail.mixins.json
+++ b/common/src/main/resources/vitrail.mixins.json
@@ -79,6 +79,7 @@
 		"VulkanBindGroupLayoutMixin",
 		"access.VulkanCommandEncoderAccessor",
 		"VulkanCommandEncoderMixin",
+		"VulkanCommandEncoderSetsMixin",
 		"VulkanCommandEncoderTransferMixin",
 		"VulkanConstMixin",
 		"VulkanDeviceMixin",

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -110,18 +110,20 @@ Iris refuses a required flag only when the name is unknown to it or the hardware
 it, and it has built every one of the ones Reverie asks for: some outright, some wherever the
 driver supports them.
 
-**On a Mac, a pass that reads more than sixteen textures at once takes the pack with it.** Apple
-gives one pass sixteen slots for the textures it reads, and no setting or numbering raises that. The
-engine numbers a pass off the textures its two shader stages actually read between them, which is as
-tight as the numbering can be made, so what is left over that line is a genuine count rather than an
-accounting artefact. Two of Reverie's passes read seventeen and eighteen textures between their
-stages, so on Apple hardware they are refused, with Apple's own message in the log:
-`'sampler' attribute parameter is out of bounds: must be between 0 and 15`. The engine then stops
-drawing the pack, the world goes back to the game's own look and the settings screen says an error
-stopped it, which is what the reference does with a pack that fails the same way. The same two
-passes draw on a desktop card, the cap being Apple's. What would lift it is Metal's argument
-buffers, a stage handed one table of resources instead of one slot each, and nothing here asks for
-that today. Every other pack measured on a Mac draws.
+**On a Mac, a pass that reads more than sixteen textures at once is handed them as one table.**
+Apple gives one pass sixteen slots for textures handed over one at a time, which is how the game
+hands over every texture. The engine numbers a pass off the textures its two shader stages actually
+read between them, which is as tight as the numbering can be made, so a pass over that line
+genuinely reads more: two of Reverie's passes read seventeen and eighteen between their stages, and
+Apple refused them with `'sampler' attribute parameter is out of bounds: must be between 0 and 15`.
+A pass past that count is given its textures through a Metal argument buffer, one table a stage
+reads far more than sixteen textures out of, while every other pass, and every pass on any other
+machine, is handed them the way the game hands them. Such a table needs macOS 11 and a graphics card
+in Apple's second tier of argument buffers, which every Apple Silicon Mac is: on an older Mac, or
+with MoltenVK's argument buffers turned off, the pass is still handed its textures one by one and
+refused. A pass the card refuses stops the pack:
+the world goes back to the game's own look and the settings screen says an error stopped it, which
+is what the reference does with a pack that fails the same way.
 
 **A full-screen pass that fails to compile takes the whole pack with it**, and the log names the
 program. One shape of that was a `const` whose initialiser Vulkan will not take as a constant,

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -226,9 +226,11 @@ the hardware has.
 `render/SamplerReach` closes that: it drops from a module's reflected sampler list every sampled
 image the entry point does not reach, so the layout is dense and a program under sixteen fits. Over
 a program's two stages TOGETHER, since one layout serves both. A program whose stages read more than
-sixteen between them is still refused there, and that is Metal's own cap, the same one Iris
-documented for macOS. The translator still writes sampled names first in the header, which no longer
-decides the cap and is described where it lives.
+sixteen between them is past Metal's cap for a pushed set, the same one Iris documented for macOS,
+and that is where `render/WideSamplerSets` steps in: on MoltenVK, when the device binds sets through
+tier 2 argument buffers, it creates that one layout without the push flag, which MoltenVK answers
+with a Metal argument buffer, and each draw allocates and binds the set instead of pushing it. The translator still writes sampled names first in the header,
+which no longer decides the cap and is described where it lives.
 
 The asymmetry does not extend to the draw. A sampler that is declared and used, but not bound when
 the draw happens, throws, so the layout can be generous while the binding cannot be sloppy.


### PR DESCRIPTION
## What changes

The game creates every descriptor set layout with the push descriptor flag, and binds each draw with `vkCmdPushDescriptorSet`. MoltenVK never uses Metal argument buffers for a push layout: each combined image sampler takes its own `[[sampler(n)]]` slot, and Metal caps those at 16 per stage. Reverie's `deferred2` reads more than 16, so Metal refused the fragment stage (`'sampler' attribute parameter is out of bounds: must be between 0 and 15`) and the pack stopped.

On MoltenVK only, a layout whose one stage holds more combined image samplers than the device's `maxPerStageDescriptorSamplers`, and no more than its `maxPerStageDescriptorUpdateAfterBindSamplers`, is now created without the push flag. Where the game would push descriptors for it, in the render pass and in the pack's compute dispatch, a set is allocated instead, written with the same infos and bound with `vkCmdBindDescriptorSets`. MoltenVK then routes the samplers through an argument buffer.

The second limit is the gate because MoltenVK does not give every non-push layout an argument buffer: not with `MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=0`, not below macOS 11, and not for a sampler layout on a GPU without native swizzle. It raises that limit past 16 only while it binds sets through tier 2 argument buffers, and every tier 2 GPU has native swizzle. A layout past it stays pushed and is refused as before, with a warning naming it.

The sets come from pools kept per submit slot. A slot's pools are reset when the game resets that slot's command pool, after it has waited for the submission that recorded into it. All pools are destroyed with the command encoder.

Every other layout, and every layout on any other driver, is pushed exactly as before.

## How it differs from the reference, and for what obstacle

It does not. Iris runs on OpenGL, where the texture unit limit is the driver's and no descriptor sets exist.

## What proves it

- `gradlew build` green, after the rebase.
- Before, on an M4 (MoltenVK 1.4.2), arena bench, one launch: Reverie Beta v0.9 stopped on `vitrail:pipeline/pack/2/world0/deferred2` with the sampler bound error above.
- After, same place: the pack draws. Complementary Reimagined r5.9 and Photon 1.3b, launched the same way, draw as before.
- The gate on the second limit came after that launch, and was run on the M4 again before merging.

## What it leaves owing

- The per stage count follows each binding's stage flags. That MoltenVK 1.4.2 counts the same way was not checked separately.
- Moving to the next pool relies on `VK_ERROR_OUT_OF_POOL_MEMORY` when one runs out, which no run exercised.
- Sets are allocated per draw on those layouts and not cached.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
