### PR TITLE
fix: stand aside for Iris where it draws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,15 @@ what the next one holds.
 
 ### Fixed
 
+- **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both
+  mods reshape Sodium's texture filtering option, and Sodium refuses two of them, so a game set to
+  OpenGL with both installed closed before the title screen. Vitrail now only touches that option
+  where it draws the world itself and Iris does not, and where Iris draws it no longer puts a red
+  line in the chat saying the picture is missing, nor answers Iris's reload key, which is also its
+  own, with a red line of its own. After a startup that ended badly, the backend is kept as it was
+  set rather than put back to Vulkan while Iris is installed, since Iris has already chosen its side
+  for that backend.
+
 - **Noble no longer stops on a Mac.** Noble keeps packed whole numbers rather than a colour in the
   first target its terrain writes, and the engine went on copying the game's own picture into that
   target wherever the pack drew nothing, which a Mac refuses outright: the pack was put away as soon

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,10 +42,12 @@ to Sodium. For a CurseForge instance that is:
 <instances>/<instance name>/mods/
 ```
 
-Remove any other shader engine from that folder first. Iris and Vitrail both want
-to own the frame, and there is no reason to have both. An older Vitrail goes too:
-the per-loader `vitrail-neoforge-*` and `vitrail-fabric-*` jars carry the same
-mod as the merged one, and a loader that finds it twice refuses to start.
+Iris can stay in that folder. The two share an instance by the graphics backend
+the game runs on: on Vulkan Vitrail draws and Iris stands aside, on OpenGL Iris
+draws and Vitrail stands aside, so switching the backend in the video settings and
+restarting the game switches engines. An older Vitrail has to go, though: the per-loader
+`vitrail-neoforge-*` and `vitrail-fabric-*` jars carry the same mod as the merged
+one, and a loader that finds it twice refuses to start.
 
 Shader packs go into the `shaderpacks/` folder at the root of the instance, the
 same folder OptiFine and Iris use, zipped or unpacked. Two files of the mod's own

--- a/common/src/main/java/dev/vitrail/HostReport.java
+++ b/common/src/main/java/dev/vitrail/HostReport.java
@@ -172,6 +172,14 @@ public final class HostReport {
 			return;
 		}
 
+		// Iris drawing this session means a player who picked it, and a red line saying the picture
+		// is missing would be false for them. Asked of what Iris chose at startup rather than of
+		// Iris being there: after a Vulkan boot that fell back, Iris draws nothing and the line is
+		// owed.
+		if (IrisBeside.draws()) {
+			return;
+		}
+
 		minecraft.gui.hud.getChat().addClientSystemMessage(Component.translatable(
 				ScreenText.OTHER_BACKEND, backend(), Component.translatable(ScreenText.GRAPHICS_API),
 				Component.translatable(ScreenText.GRAPHICS_API_VULKAN))
@@ -202,9 +210,21 @@ public final class HostReport {
 	 * the programs having been translated against Vulkan's depth and clip conventions. Credible and
 	 * wrong reads as a pack fault, which is worse than a picture the game draws alone, so nothing is
 	 * drawn and the line says why.
+	 * <p>
+	 * Where Iris draws this session the same backend is information rather than an error: the
+	 * picture is not missing, it is the other engine's.
 	 */
 	private static void sayBackend() {
 		if (!otherBackend()) {
+			return;
+		}
+
+		if (IrisBeside.draws()) {
+			Vitrail.logger().info("This game is running the {} backend with Iris installed, so Iris "
+					+ "draws the packs and {} stands aside. Set Graphics API to \"Prefer Vulkan "
+					+ "(Experimental)\" under Options, Video Settings, and restart to draw them with {} "
+					+ "instead", backend(), Vitrail.MOD_NAME, Vitrail.MOD_NAME);
+
 			return;
 		}
 

--- a/common/src/main/java/dev/vitrail/IrisBeside.java
+++ b/common/src/main/java/dev/vitrail/IrisBeside.java
@@ -1,0 +1,83 @@
+package dev.vitrail;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
+import net.minecraft.client.PreferredGraphicsApi;
+
+/**
+ * Iris in the same instance, and which of the two engines draws this session.
+ * <p>
+ * <strong>Iris picks its side once, before the game is built</strong>, off the
+ * {@code preferredGraphicsBackend} line of {@code options.txt}: a line asking for Vulkan takes its
+ * Vulkan-only hooks and draws nothing, anything else takes its OpenGL hooks and draws there
+ * ({@code IrisMixinPlugin.java:54} and {@code 72-73}). What this engine does beside it follows that
+ * read and not the device. The two part company after a Vulkan boot that failed and fell back to
+ * OpenGL, where the file still asks for Vulkan and Iris draws nothing, and under a launch argument
+ * that forces a backend: asked of the device, both engines would register the same overlay of
+ * Sodium's filtering option, which Sodium refuses at startup, or neither would say why the picture
+ * is missing.
+ * <p>
+ * The line is taken from the options as the game has just loaded them, at the one read of this mod
+ * that runs that early ({@code StartupGuard}), which is the same file Iris read and before anything
+ * has written the backend back. A later question reads that answer.
+ */
+public final class IrisBeside {
+
+	/**
+	 * A class of Iris's own, looked for as a resource: the first question comes from inside the
+	 * game's constructor, before this mod is constructed and before any loader platform exists to
+	 * ask by mod id.
+	 */
+	private static final String MARKER = "net/irisshaders/iris/Iris.class";
+
+	private static volatile Boolean installed;
+
+	/** Whether the options the game loaded asked for Vulkan, or null until they have been seen. */
+	private static volatile Boolean askedVulkan;
+
+	private IrisBeside() {
+	}
+
+	/** Whether Iris is in this instance at all, whichever backend it took. */
+	public static boolean installed() {
+		Boolean known = installed;
+		if (known == null) {
+			known = IrisBeside.class.getClassLoader().getResource(MARKER) != null;
+			installed = known;
+		}
+
+		return known;
+	}
+
+	/**
+	 * Remembers what the options asked for as the game loaded them. Only the first call counts: what
+	 * Iris read is the file as it stood at startup, whatever is written into the options afterwards.
+	 *
+	 * @param options the game's options, loaded and not yet touched by anything of this mod
+	 */
+	public static void loaded(Options options) {
+		if (askedVulkan == null) {
+			askedVulkan = options.preferredGraphicsBackend().get() == PreferredGraphicsApi.VULKAN;
+		}
+	}
+
+	/**
+	 * Whether Iris draws this session: installed, and started on options that did not ask for
+	 * Vulkan. Where the startup read was never seen, the game's options stand in for it, which is
+	 * the same answer unless the player moved the setting during the session.
+	 */
+	public static boolean draws() {
+		if (!installed()) {
+			return false;
+		}
+
+		Boolean asked = askedVulkan;
+		if (asked == null) {
+			Minecraft minecraft = Minecraft.getInstance();
+			asked = minecraft != null
+					&& minecraft.options.preferredGraphicsBackend().get() == PreferredGraphicsApi.VULKAN;
+		}
+
+		return !asked;
+	}
+}

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -278,8 +278,9 @@ public final class PackChoice {
 			// reaches a mesh or a frame: the programs are translated against Vulkan's depth and
 			// clip conventions, and what they drew when let run elsewhere was a picture credible
 			// and wrong, which reads as a pack fault. The game's own image is the better answer.
-			// HostReport says it once in the log at startup and once in chat on entering a world;
-			// what this road adds is the screen's bottom line, through lastError, and nothing else.
+			// HostReport says it once in the log at startup and, unless Iris draws there, once in chat
+			// on entering a world; what this road adds is the screen's bottom line, through
+			// lastError, and nothing else.
 			if (HostReport.otherBackend()) {
 				TerrainDraw.wanted(false);
 				EntityDraw.wanted(false);

--- a/common/src/main/java/dev/vitrail/render/StartupGuard.java
+++ b/common/src/main/java/dev/vitrail/render/StartupGuard.java
@@ -1,5 +1,6 @@
 package dev.vitrail.render;
 
+import dev.vitrail.IrisBeside;
 import dev.vitrail.settings.GraphicsApiChoice;
 import dev.vitrail.Vitrail;
 
@@ -41,13 +42,16 @@ public final class StartupGuard {
 
 	/**
 	 * Answers the game's question about the last startup, having first put the API back where the
-	 * player asked for it to be.
+	 * player asked for it to be, except beside Iris, which has already chosen its side.
 	 *
 	 * @param options the game's options, already loaded, and the only thing that exists this early
 	 * @param cleanly what the field really holds
 	 * @return what the game should believe, which decides both resets it is about to consider
 	 */
 	public static boolean startedCleanly(Options options, boolean cleanly) {
+		// Before anything below can move the backend: Iris read the same file before the game was
+		// built, and which engine draws this session follows that value and nothing written after it.
+		IrisBeside.loaded(options);
 		if (cleanly) {
 			return true;
 		}
@@ -55,6 +59,21 @@ public final class StartupGuard {
 		GraphicsApiChoice asked = asked();
 		if (asked == GraphicsApiChoice.GAME) {
 			return false;
+		}
+
+		// Beside Iris the backend is not this mod's to move. Iris took its hooks for the backend the
+		// file names before the game was built, so putting the API back to Vulkan here would leave
+		// Iris hooked for OpenGL on a Vulkan device. Kept as the file has it, and the resets are
+		// still refused, for the reason below. A player who chose the game's own rescue still has it,
+		// above: that one is theirs to take whatever it does to Iris.
+		if (IrisBeside.installed()) {
+			Vitrail.logger().warn("The last startup ended badly. The game was about to reset the "
+					+ "graphics API and the fullscreen mode; both are kept as they were, {}, and the API "
+					+ "is not put back to Vulkan because Iris is installed and has already chosen its "
+					+ "hooks for this backend",
+					options.preferredGraphicsBackend().get().getSerializedName());
+
+			return true;
 		}
 
 		PreferredGraphicsApi wanted = asked == GraphicsApiChoice.OPENGL

--- a/common/src/main/java/dev/vitrail/screen/SettingsKey.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsKey.java
@@ -1,5 +1,6 @@
 package dev.vitrail.screen;
 
+import dev.vitrail.IrisBeside;
 import dev.vitrail.render.PackChoice;
 import dev.vitrail.ScreenText;
 import dev.vitrail.settings.PackSession;
@@ -103,6 +104,13 @@ public final class SettingsKey {
 	 * it.
 	 */
 	private static void reload() {
+		// Where Iris draws this session the key is Iris's: it reloads its own pack on the same R, and
+		// this engine, which draws nothing on that backend, would only answer the press with a red
+		// line saying the pack is not drawn.
+		if (IrisBeside.draws()) {
+			return;
+		}
+
 		Path directory = PackChoice.session()
 				.map(PackSession::gameDirectory)
 				.orElseGet(() -> Vitrail.platform().gameDirectory());

--- a/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
+++ b/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
@@ -1,6 +1,8 @@
 package dev.vitrail.sodium;
 
 import dev.vitrail.cache.ModuleCache;
+import dev.vitrail.HostReport;
+import dev.vitrail.IrisBeside;
 import dev.vitrail.render.PackChoice;
 import dev.vitrail.render.ShadowAmortisation;
 import dev.vitrail.render.StartupGuard;
@@ -17,6 +19,7 @@ import net.caffeinemc.mods.sodium.api.config.ConfigState;
 import net.caffeinemc.mods.sodium.api.config.option.OptionImpact;
 import net.caffeinemc.mods.sodium.api.config.option.Range;
 import net.caffeinemc.mods.sodium.api.config.structure.ConfigBuilder;
+import net.caffeinemc.mods.sodium.api.config.structure.ModOptionsBuilder;
 import net.caffeinemc.mods.sodium.api.config.structure.OptionBuilder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.TextureFilteringMethod;
@@ -106,7 +109,7 @@ public final class ConfigEntry implements ConfigEntryPoint {
 
 	@Override
 	public void registerConfigLate(ConfigBuilder builder) {
-		builder.registerOwnModOptions()
+		ModOptionsBuilder options = builder.registerOwnModOptions()
 				// Not tinted: this icon is the mod's own, in colour, where Sodium's screen is drawn
 				// for the monochrome ones it can paint in the theme colour.
 				.setNonTintedIcon(ICON)
@@ -124,37 +127,47 @@ public final class ConfigEntry implements ConfigEntryPoint {
 								.addOption(temporalFold(builder))
 								.addOption(shadowAmortisation(builder))
 								.addOption(graphicsApi(builder))
-								.addOption(moduleCacheCeiling(builder))))
-				// RGSS is shader code, written into the game's own terrain shader and into Sodium's,
-				// so it is worth nothing while the pack's terrain program is the one drawing: the
-				// player moves the selector and the image does not move. ANISOTROPIC keeps working,
-				// because it is a sampler and an atlas seam fix rather than a shader, and this engine
-				// takes both as it finds them. The reference registers this same overlay over the
-				// same two values, IrisConfig.java:78.
-				//
-				// What differs is the question asked, and only because this engine can answer a
-				// narrower one. The reference asks whether a pack is loaded, IrisConfig.java:87,
-				// which for it is the same thing: a loaded pack there always takes the terrain over.
-				// Here the pack's terrain program can be off on its own while the rest of the chain
-				// draws, either because the engine options refuse it or because reading it threw, and
-				// then Sodium's own shader draws the world and RGSS works again. So the question is
-				// whether that program draws, which is what TerrainDraw.asked answers.
-				//
-				// Asked through UPDATE_ON_REBUILD rather than read once, so the list follows a pack
-				// loaded or dropped while the game is up rather than the state the screen was first
-				// built under.
-				//
-				// A stored RGSS survives the narrowing, and that is not something this overlay can
-				// change from here. Sodium answers a value its allowed set no longer holds with the
-				// option's default (EnumOption.validateValue), and its default for this option is
-				// RGSS itself (SodiumConfigBuilder.java:511), so the fall back lands on the value it
-				// was meant to replace: the selector opens on a name outside the set it offers, and
-				// the player cannot cycle back to it once they have moved off.
-				.registerOptionOverlay(FILTERING,
-						builder.createEnumOption(FILTERING, TextureFilteringMethod.class)
-								.setAllowedValuesProvider(
-										state -> TerrainDraw.asked() ? WITHOUT_RGSS : EVERY_METHOD,
-										ConfigState.UPDATE_ON_REBUILD));
+								.addOption(moduleCacheCeiling(builder))));
+
+		// Only on the backend this engine draws on. Anywhere else the pack draws nothing, so RGSS
+		// keeps working and there is nothing to narrow. And never where Iris draws, which registers
+		// its own overlay of this option in exactly that case (IrisConfig.java:40 and 54): Sodium
+		// refuses two overlays of one option, so a game on OpenGL with both mods installed closed at
+		// startup on the settings it could not build. Iris decides from options.txt and this engine
+		// from the device, and IrisBeside says where those two part company, which is why both
+		// questions are asked. The device is up by this walk.
+		if (HostReport.otherBackend() || IrisBeside.draws()) {
+			return;
+		}
+
+		// RGSS is shader code, written into the game's own terrain shader and into Sodium's, so it
+		// is worth nothing while the pack's terrain program is the one drawing: the player moves the
+		// selector and the image does not move. ANISOTROPIC keeps working, because it is a sampler
+		// and an atlas seam fix rather than a shader, and this engine takes both as it finds them.
+		// The reference registers this same overlay over the same two values, IrisConfig.java:58.
+		//
+		// What differs is the question asked, and only because this engine can answer a narrower
+		// one. The reference asks whether a pack is loaded, IrisConfig.java:74, which for it is the
+		// same thing: a loaded pack there always takes the terrain over. Here the pack's terrain
+		// program can be off on its own while the rest of the chain draws, either because the engine
+		// options refuse it or because reading it threw, and then Sodium's own shader draws the world
+		// and RGSS works again. So the question is whether that program draws, which is what
+		// TerrainDraw.asked answers.
+		//
+		// Asked through UPDATE_ON_REBUILD rather than read once, so the list follows a pack loaded or
+		// dropped while the game is up rather than the state the screen was first built under.
+		//
+		// A stored RGSS survives the narrowing, and that is not something this overlay can change
+		// from here. Sodium answers a value its allowed set no longer holds with the option's default
+		// (EnumOption.validateValue), and its default for this option is RGSS itself
+		// (SodiumConfigBuilder.java:511), so the fall back lands on the value it was meant to replace:
+		// the selector opens on a name outside the set it offers, and the player cannot cycle back to
+		// it once they have moved off.
+		options.registerOptionOverlay(FILTERING,
+				builder.createEnumOption(FILTERING, TextureFilteringMethod.class)
+						.setAllowedValuesProvider(
+								state -> TerrainDraw.asked() ? WITHOUT_RGSS : EVERY_METHOD,
+								ConfigState.UPDATE_ON_REBUILD));
 	}
 
 	/**
@@ -339,7 +352,7 @@ public final class ConfigEntry implements ConfigEntryPoint {
 	 * own and the cheapest thing a player can trade for frames.
 	 * <p>
 	 * It is the reference's option, built the same way and over the same range,
-	 * {@code compat/sodium/config/IrisConfig.java:54-76}: zero to thirty-two, thirty-two by default,
+	 * {@code compat/sodium/config/IrisConfig.java:163-194}: zero to thirty-two, thirty-two by default,
 	 * greyed out while the pack forces a distance of its own, and shown as the pack's number then
 	 * rather than as the player's. What the two numbers mean and which of them wins is
 	 * {@code PackValues.shadowRenderDistance}, and the conversion into blocks lives there too.
@@ -377,7 +390,7 @@ public final class ConfigEntry implements ConfigEntryPoint {
 				// Sodium refuses to build an option without one, at the loading screen and not at
 				// compile time. It has nothing left to do here: the binding above writes pack.txt
 				// as it is moved, where the reference's binding only moves a field and its handler
-				// saves the whole config file afterwards, IrisConfig.java:67.
+				// saves the whole config file afterwards, IrisConfig.java:192.
 				.setStorageHandler(() -> {})
 				.setImpact(OptionImpact.HIGH);
 	}


### PR DESCRIPTION
## What changes

With Iris and Vitrail in one instance, a game set to OpenGL closed at startup: both register an overlay over Sodium's texture filtering option, and Sodium refuses two overlays of one option ("Multiple overlays for option 'sodium:quality.filtering_mode'! Sources: iris and vitrail"). On Vulkan the pair already worked, Iris taking only its Vulkan-only hooks.

The two now share an instance, each on its own backend. Iris picks its side once, before the game is built, off the backend `options.txt` names; the new `IrisBeside` takes that same value as the game loads its options, and every decision beside Iris follows it rather than the device, which a Vulkan boot that fell back can put on the other backend:

- the filtering overlay is registered only where this engine draws and Iris does not;
- where Iris draws, the backend line is information in the log instead of an error, the red chat line is not said, and R, which both mods bind to reload, is left to Iris;
- after a startup that ended badly, `StartupGuard` no longer puts Vulkan back while Iris is installed, which would leave Iris hooked for OpenGL on a Vulkan device; a player who chose the game's own rescue still gets it.

`INSTALL.md` no longer asks for Iris to be removed, and the `IrisConfig` citations in `ConfigEntry` are re-anchored on the reference's current lines.

## How it differs from the reference, and for what obstacle

It does not change what a pack draws. Beside Iris it follows Iris's own decision, `IrisMixinPlugin.java:54` and `72-73`, and the overlay Iris registers where it draws, `IrisConfig.java:40` and `54`.

## What proves it

- `gradlew build` green.
- Fabric, Iris 1.11.2, Sodium 0.9.1, BSL. Before: OpenGL crashed at startup on the overlay. After: OpenGL starts, Iris builds its pipeline for the overworld, the log carries the information line and the chat nothing; Vulkan starts and this engine draws BSL with its full screen passes; OpenGL after a startup marked unclean keeps OpenGL, logs why, and Iris draws.
- NeoForge 26.2.0.64, Iris 1.11.2, Sodium 0.9.1, BSL: OpenGL starts with Iris building its pipeline, Vulkan draws BSL.

## What it leaves owing

- The I key opens this mod's settings, and on Vulkan Iris keeps I for its own screen offering to switch to OpenGL; what a press opens with both installed is not checked.
- This mod's settings screen still opens on OpenGL beside Iris, and its bottom line says the pack is not drawn there and asks for Vulkan, which reads as a fault while Iris is drawing it.
- Chloride's live graphics API swap is not covered: Iris refuses it from OpenGL, and this engine surviving a device rebuilt in place is unchecked.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one.
