### PR TITLE
fix(glsl): pack floats by integer arithmetic on MoltenVK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,13 @@ what the next one holds.
 
 ### Fixed
 
+- **Noble's surfaces are lit right on a Mac.** Noble keeps what each surface is made of, how
+  shiny it is, how much it glows and how much shade it gathers, as whole numbers packed out of its
+  colours, and Apple's graphics stored one of those numbers wrong and read them back wrong, so the
+  lit picture came out wrong wherever the pack drew. On a Mac those numbers are now packed and read
+  back by plain arithmetic the engine writes into the shader, which gives the numbers every other
+  card already got. Nothing changes on any other machine.
+
 - **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both
   mods reshape Sodium's texture filtering option, and Sodium refuses two of them, so a game set to
   OpenGL with both installed closed before the title screen. Vitrail now only touches that option

--- a/common/src/main/java/dev/vitrail/glsl/Emitter.java
+++ b/common/src/main/java/dev/vitrail/glsl/Emitter.java
@@ -41,6 +41,7 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 		Map<String, VolumeAtlas> readVolumes, Map<Integer, Output> packOutputs,
 		int maxFragmentOutput, Map<String, String> owedOutputs, VaryingSplit splits,
 		int gameTextureMatrix, int gameModelView, int softRewrites, int trigCalls, int hashCalls,
+		Set<String> packBuiltinCalls,
 		boolean mainWrapped, boolean depthEpilogue, boolean terrainPrologue,
 		boolean distantPrologue, boolean entityWrapped, boolean linesWrapped,
 		boolean alphaEpilogue, boolean covers,
@@ -293,6 +294,9 @@ record Emitter(ProgramStage stage, VertexInputs inputs, List<String> bound, Alph
 					+ " ofN ^= ofN >> 16u;"
 					+ " return float(ofN) * 2.3283064365386963e-10; }");
 		}
+
+		// Only the helpers a call was sent to, which happens on MoltenVK alone. See PackBuiltins.
+		lines.addAll(PackBuiltins.definitions(this.packBuiltinCalls));
 
 		// Only where a lookup was moved. A stage carrying the declaration and never reading it, which
 		// is most of them, has its declaration flattened and owes no helper.

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -595,6 +595,9 @@ public final class GlslTranslator {
 	/** Goldberg hash idioms rewritten onto {@link #HASH} instead of through a sine. */
 	private int hashCalls;
 
+	/** The float packing builtins this unit's calls were sent to {@link PackBuiltins} from. */
+	private final Set<String> packBuiltinCalls = new HashSet<>();
+
 	/**
 	 * Reads of {@code gl_TextureMatrix[0]} sent to the game's own per draw block instead of to the
 	 * uniform block this engine writes.
@@ -2333,6 +2336,17 @@ public final class GlslTranslator {
 					this.trigCalls++;
 					continue;
 				}
+			}
+
+			// The same two exclusions, and on MoltenVK alone: PackBuiltins says what Metal does with
+			// these calls. Above the directive guard like the sine, a call in a #define body being
+			// code the preprocessor pastes into the program.
+			String packed = PackBuiltins.helper(name);
+			if (packed != null && VendorExtensions.moltenVk() && this.tokens.callOpener(index) >= 0
+					&& !this.declaredNames.contains(name)) {
+				this.tokens.replace(index, packed);
+				this.packBuiltinCalls.add(name);
+				continue;
 			}
 
 			// Above the guard below, and it is the one rewrite that belongs there. The body of a
@@ -5575,8 +5589,8 @@ public final class GlslTranslator {
 				this.volumes.read(), this.packOutputs, this.maxFragmentOutput, this.owedOutputs,
 				this.splits, this.gameTextureMatrix,
 				this.gameModelView, this.softRewrites, this.trigCalls, this.hashCalls,
-				this.mainWrapped, this.depthEpilogue, this.terrainPrologue, this.distantPrologue,
-				this.entityWrapped, this.linesWrapped, this.alphaEpilogue, this.covers,
+				this.packBuiltinCalls, this.mainWrapped, this.depthEpilogue, this.terrainPrologue,
+				this.distantPrologue, this.entityWrapped, this.linesWrapped, this.alphaEpilogue, this.covers,
 				wrapsFragment(), this.ordered, this.namesFragDepth, this.makesOverlayColour);
 	}
 

--- a/common/src/main/java/dev/vitrail/glsl/PackBuiltins.java
+++ b/common/src/main/java/dev/vitrail/glsl/PackBuiltins.java
@@ -1,0 +1,112 @@
+package dev.vitrail.glsl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The GLSL functions that pack floats into whole numbers and back, written out in integer
+ * arithmetic for a MoltenVK device, so that Apple's compiler never sees its own pack builtins.
+ * <p>
+ * <strong>What it costs a pack to keep them there.</strong> Noble writes its material into an
+ * unsigned target as two {@code packUnorm4x8} words and a {@code packUnorm2x16}, one statement
+ * each, and reads the two words back with {@code unpackUnorm4x8}. MoltenVK's SPIRV-Cross renders
+ * those calls correctly, each on its own vector, and on an M4 through MoltenVK 1.4.2 the first
+ * word still reached the target holding the float bits of its vector's first component, the
+ * second word right. A pack changed so that one function packs a single distinct vector lands the
+ * first word right, and so does packing it by shifts; the decode is hit the same way, the image
+ * staying wrong with the pack fixed and the unpack left standing. The same stages draw right on
+ * NVIDIA. So on MoltenVK every call to one of the eight goes to a helper of this translation's
+ * own, and every other driver keeps the builtins, its text byte for byte what it was.
+ * <p>
+ * <strong>The helpers are the definitions of GLSL 4.60, section 8.4.</strong> A unorm pack clamps
+ * to nought to one and a snorm pack to minus one to one, scales by 255, 65535, 127 or 32767,
+ * rounds, and lays the first component in the least significant bits, a snorm component as its
+ * two's complement; an unpack divides by the same figure, and a snorm unpack clamps the quotient
+ * back to minus one to one. The rounding is {@code round}, the function the definition itself is
+ * written with, which SPIRV-Cross hands Metal as its own {@code round}. Adding a half before a
+ * truncation would not be the same function: it takes the last float below a half up, and a
+ * negative half the other way. The two roundings can only part on an exact half, one half times
+ * 255 for instance, where the language leaves the direction to the implementation. The quotient of
+ * an unpack is one fp32 division, which is what the builtin computes too. The argument is a
+ * parameter, so it is evaluated once whatever expression the pack wrote.
+ * <p>
+ * A signed component goes from a byte to an integer by flipping its top bit and taking the
+ * midpoint off, which is two's complement read as arithmetic and needs neither a sign-extending
+ * shift nor a comparison.
+ */
+final class PackBuiltins {
+
+	/** Each builtin with the helper a call to it becomes, in the order the helpers are written. */
+	private static final Map<String, String> HELPERS = helpers();
+
+	private PackBuiltins() {
+	}
+
+	/** The helper a call to this builtin becomes, or null where the name is not one of the eight. */
+	static String helper(String builtin) {
+		return HELPERS.get(builtin);
+	}
+
+	/**
+	 * The definitions of the helpers the named builtins became, one line each, in a fixed order
+	 * whatever order the calls were met in.
+	 */
+	static List<String> definitions(Set<String> called) {
+		List<String> lines = new ArrayList<>();
+		for (String builtin : HELPERS.keySet()) {
+			if (called.contains(builtin)) {
+				lines.add(definition(builtin));
+			}
+		}
+
+		return lines;
+	}
+
+	private static String definition(String builtin) {
+		String name = HELPERS.get(builtin);
+		return switch (builtin) {
+			case "packUnorm4x8" -> "uint " + name + "(vec4 ofV) {"
+					+ " uvec4 ofB = uvec4(round(clamp(ofV, 0.0, 1.0) * 255.0));"
+					+ " return ofB.x | (ofB.y << 8u) | (ofB.z << 16u) | (ofB.w << 24u); }";
+			case "unpackUnorm4x8" -> "vec4 " + name + "(uint ofP) {"
+					+ " return vec4(uvec4(ofP, ofP >> 8u, ofP >> 16u, ofP >> 24u) & 255u) / 255.0; }";
+			case "packUnorm2x16" -> "uint " + name + "(vec2 ofV) {"
+					+ " uvec2 ofB = uvec2(round(clamp(ofV, 0.0, 1.0) * 65535.0));"
+					+ " return ofB.x | (ofB.y << 16u); }";
+			case "unpackUnorm2x16" -> "vec2 " + name + "(uint ofP) {"
+					+ " return vec2(uvec2(ofP, ofP >> 16u) & 65535u) / 65535.0; }";
+			case "packSnorm4x8" -> "uint " + name + "(vec4 ofV) {"
+					+ " uvec4 ofB = uvec4(ivec4(round(clamp(ofV, -1.0, 1.0) * 127.0))) & 255u;"
+					+ " return ofB.x | (ofB.y << 8u) | (ofB.z << 16u) | (ofB.w << 24u); }";
+			case "unpackSnorm4x8" -> "vec4 " + name + "(uint ofP) {"
+					+ " ivec4 ofB = ivec4((uvec4(ofP, ofP >> 8u, ofP >> 16u, ofP >> 24u) & 255u)"
+					+ " ^ 128u) - 128;"
+					+ " return clamp(vec4(ofB) / 127.0, -1.0, 1.0); }";
+			case "packSnorm2x16" -> "uint " + name + "(vec2 ofV) {"
+					+ " uvec2 ofB = uvec2(ivec2(round(clamp(ofV, -1.0, 1.0) * 32767.0))) & 65535u;"
+					+ " return ofB.x | (ofB.y << 16u); }";
+			case "unpackSnorm2x16" -> "vec2 " + name + "(uint ofP) {"
+					+ " ivec2 ofB = ivec2((uvec2(ofP, ofP >> 16u) & 65535u) ^ 32768u) - 32768;"
+					+ " return clamp(vec2(ofB) / 32767.0, -1.0, 1.0); }";
+			default -> throw new IllegalArgumentException(builtin);
+		};
+	}
+
+	private static Map<String, String> helpers() {
+		Map<String, String> table = new LinkedHashMap<>();
+		table.put("packUnorm4x8", "ofPackUnorm4x8");
+		table.put("unpackUnorm4x8", "ofUnpackUnorm4x8");
+		table.put("packUnorm2x16", "ofPackUnorm2x16");
+		table.put("unpackUnorm2x16", "ofUnpackUnorm2x16");
+		table.put("packSnorm4x8", "ofPackSnorm4x8");
+		table.put("unpackSnorm4x8", "ofUnpackSnorm4x8");
+		table.put("packSnorm2x16", "ofPackSnorm2x16");
+		table.put("unpackSnorm2x16", "ofUnpackSnorm2x16");
+
+		return Collections.unmodifiableMap(table);
+	}
+}

--- a/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslationCache.java
@@ -378,9 +378,10 @@ public final class TranslationCache {
 		// the trig substitution and the shadow comparison both change what it emits and neither
 		// says so in the text it was handed.
 		feed(digest, GlslTranslator.emissionSwitches());
-		// And the device's answer on the vendor extensions and on the stages it runs subgroup
-		// operations in, which decides which branch of a pack compiles: a card that has one of them
-		// translates differently from a card that has not.
+		// And the device's answer on the vendor extensions, on the stages it runs subgroup
+		// operations in and on whether its driver is MoltenVK, which decide which branch of a pack
+		// compiles and what a float packing call becomes: a card that has one of them translates
+		// differently from a card that has not.
 		feed(digest, VendorExtensions.key());
 
 		// The whole table, in its own order, which is fixed by the code that builds it. It carries

--- a/common/src/main/java/dev/vitrail/glsl/VendorExtensions.java
+++ b/common/src/main/java/dev/vitrail/glsl/VendorExtensions.java
@@ -44,6 +44,11 @@ import java.util.stream.Collectors;
  * from the device at creation ({@link #serveSubgroupStages}); until then, and off game, every stage
  * has them, which is the compiler's answer and what this engine assumed before asking.
  * <p>
+ * Whether the driver is MoltenVK is answered here too ({@link #serveMoltenVk}), since that decides
+ * what the translation writes for a pack's float packing calls, {@link PackBuiltins} saying why.
+ * Until it has answered, and off game, the answer is no, and a device that says no keeps the key it
+ * had before the question was asked.
+ * <p>
  * Five extensions are answered absent on every device, and one of them is a divergence. {@code
  * GL_NV_gpu_shader5} has no Vulkan form at all, while an NVIDIA GL driver has it, so a pack
  * gating on it takes its fallback here where under Iris on a GeForce it takes the extension.
@@ -69,6 +74,8 @@ public final class VendorExtensions {
 
 	private static volatile Set<ProgramStage> subgroupsAbsentIn =
 			Collections.unmodifiableSet(EnumSet.noneOf(ProgramStage.class));
+
+	private static volatile boolean moltenVk;
 
 	private VendorExtensions() {
 	}
@@ -120,18 +127,32 @@ public final class VendorExtensions {
 	}
 
 	/**
-	 * The absent names, and the stages the subgroup extensions are absent from, joined, for a cache
-	 * key. A device running them in every stage keeps the key it had before stages were asked, since
-	 * it translates exactly as it did.
+	 * Records whether the driver is MoltenVK, asked once at the device's creation.
+	 *
+	 * @param moltenVkDriver whether the device's driver is MoltenVK
+	 */
+	public static void serveMoltenVk(boolean moltenVkDriver) {
+		moltenVk = moltenVkDriver;
+	}
+
+	/** Whether a pack's float packing calls go to {@link PackBuiltins} rather than to the driver. */
+	static boolean moltenVk() {
+		return moltenVk;
+	}
+
+	/**
+	 * The absent names, the stages the subgroup extensions are absent from and whether the driver is
+	 * MoltenVK, joined, for a cache key. A device running them in every stage keeps the key it had
+	 * before stages were asked, and a driver other than MoltenVK the key it had before the driver
+	 * was, since each translates exactly as it did.
 	 */
 	public static String key() {
 		String names = String.join(",", absent);
-		if (subgroupsAbsentIn.isEmpty()) {
-			return names;
-		}
-
-		return subgroupsAbsentIn.stream().map(Enum::name)
+		String stages = subgroupsAbsentIn.isEmpty() ? names : subgroupsAbsentIn.stream()
+				.map(Enum::name)
 				.collect(Collectors.joining(",", names + ";subgroups absent in ", ""));
+
+		return moltenVk ? stages + ";MoltenVK" : stages;
 	}
 
 	/** The hidden spelling of a macro the compiler would define and the device would not answer for. */

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
@@ -201,6 +201,7 @@ public abstract class VulkanBackendMixin {
 		WideSamplerSets.serve(moltenVk,
 				physical.vkPhysicalDeviceProperties().limits().maxPerStageDescriptorSamplers(),
 				moltenVk ? tableSamplers(physical) : 0);
+		VendorExtensions.serveMoltenVk(moltenVk);
 		// The vendor extensions a pack may gate a vendor instruction on, answered by the device
 		// and not by the compiler, which defines the macro of every one it knows; the ones the
 		// device has are enabled on it here, since a module using one needs it enabled.

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -89,6 +89,16 @@ a builtin introduced after the version the pack targets, and the error does not 
 it complains about overload precision qualifiers. Renaming is triggered only on names the pack
 actually defines, so lengthening the reserved list costs nothing.
 
+**On MoltenVK, the float packing builtins are written out in arithmetic.** A call to
+`packUnorm4x8`, `packUnorm2x16`, `packSnorm4x8`, `packSnorm2x16` or one of their four unpacks
+becomes a call to a helper of the translation's own, which does in integer arithmetic what GLSL
+defines the builtin to do, rounding included. Noble packs its material into two `packUnorm4x8`
+words, and on Apple Silicon the first word reached the target holding the bits of a float rather
+than the packed value, the second one right and the decode wrong the same way, where the same stages
+draw right on NVIDIA. Every other driver keeps the builtins, and a unit that declares or defines one
+of those names for itself keeps its own. Whether the driver is MoltenVK is part of the translation
+cache's key, so a translation kept on disk is never served to the other kind of device.
+
 **Depth reads are converted, and not by the translator.** The game renders in reversed Z; packs
 expect the legacy convention. The translated text does carry depth conversion, at three fixed sites:
 the built-in fragment depth, a write to the built-in output depth, and the clip depth in the vertex


### PR DESCRIPTION
## What changes

On Apple Silicon through MoltenVK, a shader stage that calls `packUnorm4x8` on two different vectors gets a wrong first word: Noble writes its material into an unsigned integer target as `packUnorm4x8(ao, emission, F0, subsurface)` then `packUnorm4x8(albedo, roughness)`, and the first word reached the target as `0x3F800000` on every pixel. The Metal source SPIRV-Cross emits for both calls is correct; packing that word by explicit shifts, or packing only one distinct vector in the stage, lands it right. The decode through `unpackUnorm4x8` is hit the same way. Noble read an F0 of one half everywhere, so the direct sun specular washed its grass beige and its canopies grey.

On a MoltenVK device, calls to the eight float packing builtins (`packUnorm4x8`, `unpackUnorm4x8`, `packUnorm2x16`, `unpackUnorm2x16` and their snorm twins) are now rewritten into calls to helpers written in integer arithmetic to the GLSL 4.60 definitions (section 8.4), so Metal never sees its pack builtins. Only the helpers a stage calls are written into it. Every other driver keeps the builtins, and whether the driver is MoltenVK is part of the translation cache key.

## How it differs from the reference, and for what obstacle

It does not change what a pack computes. Iris hands these builtins to the GL driver; here the GLSL goes through SPIR-V and SPIRV-Cross to Metal, whose compiler is what loses the word. The helpers use `round`, the function the definition is written with, so they can only part from a driver's builtin on an exact half, where the language leaves the direction to the implementation.

## What proves it

- `gradlew build` green.
- Off game: every Noble program translated with the MoltenVK answer compiles with shaderc and carries none of the eight builtins; with the answer off, every translated text is byte-identical to `dev`. Across the whole corpus translated as an NVIDIA machine, every translated file and its SPIR-V is identical to `dev`.
- The helpers against the builtins in a compute stage on SwiftShader, over every byte and 16-bit word for the unpacks and every rounding threshold of all four scales with both signs for the packs: no difference.
- On an M4 (MoltenVK 1.4.2), arena bench, one launch each: Noble's grass and canopies are green again. Complementary Reimagined r5.9, Bliss and Pegasus, which also use these builtins, keep their image and frame rate.

## What it leaves owing

- A pack that declares or defines one of the eight names, even in a branch that is not compiled, or reaches one through a macro alias such as `#define PACK packUnorm4x8`, keeps the builtin on MoltenVK. No pack of the corpus does either.
- A `const` whose initialiser calls one of the eight becomes a function call on MoltenVK. The one such line in the corpus is a local constant in RenderPearl's Voxy path.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
