### PR TITLE
fix(pack): read the compiler's macros before deciding a branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,15 @@ what the next one holds.
   the same light. A step past the allowance that runs as several batches is still refused, and the
   log says so. Every other card is left as it was.
 
+- **RenderPearl's water, particles and translucent blocks and mobs are drawn on a Mac.** The pack
+  lights them from light lists it only builds where the shader compiler can share values between
+  neighbouring pixels, and it asks the compiler whether it can. The engine answered that question
+  for itself before handing the shader over, answered no, and left out the part that holds the
+  lists, while the compiler answered yes and went looking for them: those four programs were
+  refused and drawn with the game's own shader instead. The engine now reads the compiler's answer,
+  step by step and less what the card cannot run, so a pack asking the compiler what it supports
+  gets the same answer at both ends.
+
 - **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both
   mods reshape Sodium's texture filtering option, and Sodium refuses two of them, so a game set to
   OpenGL with both installed closed before the title screen. Vitrail now only touches that option

--- a/common/src/main/java/dev/vitrail/glsl/CompilerMacros.java
+++ b/common/src/main/java/dev/vitrail/glsl/CompilerMacros.java
@@ -1,0 +1,134 @@
+package dev.vitrail.glsl;
+
+import dev.vitrail.pack.model.ProgramStage;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The macros the compiler defines before the first line of a translated stage, as a pack's
+ * conditionals get to see them.
+ * <p>
+ * glslang writes a preamble ahead of every shader it compiles ({@code TParseVersions::getPreamble}
+ * in {@code MachineIndependent/Versions.cpp}), one {@code #define} per extension it supports and a
+ * few more, and a pack tests them the way it tests a GL driver's: RenderPearl turns its subgroup
+ * lighting on where {@code GL_KHR_shader_subgroup_basic} is defined and includes the buffer that
+ * lighting reads under the same test. The include expander decides those tests before the compiler
+ * does, and with a table missing these names it dropped the include on a device where the compiler
+ * then took the branch.
+ * <p>
+ * <strong>The list is the shaderc the game ships, asked rather than read off glslang's
+ * source.</strong> The preamble depends on the version and profile of the header and on the stage,
+ * and every translated stage carries the same header ({@code #version 460 core}, {@link Emitter}),
+ * so what is left to vary is the stage. Asked by compiling, in each of the six stages, a unit
+ * testing every name the shaderc library carries in a define string, the answer is one set shared
+ * by all six, the same under either Vulkan target, plus the one macro naming the stage. It has to
+ * be asked through {@code shaderc_compile_into_spv}: the preprocessed text road preprocesses as a
+ * vertex stage whatever kind it is handed, and answers {@code GL_VERTEX_SHADER} in every stage. A
+ * newer shaderc can add a name, and asking it the same way is how this list is brought level.
+ * <p>
+ * The table for a stage leaves out what the translator hides from the compiler in that stage
+ * ({@link VendorExtensions#absent}), since the compiler then reads those names undefined.
+ */
+public final class CompilerMacros {
+
+	/** Defined to 1 in every stage. */
+	private static final List<String> PREAMBLE = List.of(
+			"GL_AMD_gcn_shader", "GL_AMD_gpu_shader_half_float",
+			"GL_AMD_gpu_shader_half_float_fetch", "GL_AMD_gpu_shader_int16",
+			"GL_AMD_shader_ballot", "GL_AMD_shader_explicit_vertex_parameter",
+			"GL_AMD_shader_fragment_mask", "GL_AMD_shader_image_load_store_lod",
+			"GL_AMD_shader_trinary_minmax", "GL_AMD_texture_gather_bias_lod",
+			"GL_ARB_compute_shader", "GL_ARB_conservative_depth", "GL_ARB_derivative_control",
+			"GL_ARB_draw_instanced", "GL_ARB_enhanced_layouts", "GL_ARB_explicit_attrib_location",
+			"GL_ARB_explicit_uniform_location", "GL_ARB_fragment_coord_conventions",
+			"GL_ARB_fragment_shader_interlock", "GL_ARB_gpu_shader5", "GL_ARB_gpu_shader_fp64",
+			"GL_ARB_gpu_shader_int64", "GL_ARB_post_depth_coverage", "GL_ARB_sample_shading",
+			"GL_ARB_separate_shader_objects", "GL_ARB_shader_atomic_counters",
+			"GL_ARB_shader_ballot", "GL_ARB_shader_bit_encoding", "GL_ARB_shader_draw_parameters",
+			"GL_ARB_shader_group_vote", "GL_ARB_shader_image_load_store",
+			"GL_ARB_shader_image_size", "GL_ARB_shader_stencil_export",
+			"GL_ARB_shader_storage_buffer_object", "GL_ARB_shader_texture_image_samples",
+			"GL_ARB_shader_texture_lod", "GL_ARB_shading_language_420pack",
+			"GL_ARB_shading_language_packing", "GL_ARB_sparse_texture2",
+			"GL_ARB_sparse_texture_clamp", "GL_ARB_tessellation_shader",
+			"GL_ARB_texture_cube_map_array", "GL_ARB_texture_gather", "GL_ARB_texture_multisample",
+			"GL_ARB_texture_query_lod", "GL_ARB_texture_rectangle", "GL_ARB_uniform_buffer_object",
+			"GL_ARB_vertex_attrib_64bit", "GL_ARB_viewport_array", "GL_EXT_bfloat16",
+			"GL_EXT_buffer_reference", "GL_EXT_buffer_reference2", "GL_EXT_buffer_reference_uvec2",
+			"GL_EXT_control_flow_attributes", "GL_EXT_control_flow_attributes2",
+			"GL_EXT_debug_printf", "GL_EXT_demote_to_helper_invocation", "GL_EXT_descriptor_heap",
+			"GL_EXT_device_group", "GL_EXT_float_e4m3", "GL_EXT_float_e5m2",
+			"GL_EXT_fragment_invocation_density", "GL_EXT_fragment_shader_barycentric",
+			"GL_EXT_fragment_shading_rate", "GL_EXT_integer_dot_product",
+			"GL_EXT_maximal_reconvergence", "GL_EXT_mesh_shader", "GL_EXT_multiview",
+			"GL_EXT_nontemporal_keyword", "GL_EXT_nonuniform_qualifier", "GL_EXT_null_initializer",
+			"GL_EXT_post_depth_coverage", "GL_EXT_ray_cull_mask",
+			"GL_EXT_ray_flags_primitive_culling", "GL_EXT_ray_query", "GL_EXT_ray_tracing",
+			"GL_EXT_ray_tracing_position_fetch", "GL_EXT_samplerless_texture_functions",
+			"GL_EXT_scalar_block_layout", "GL_EXT_shader_16bit_storage",
+			"GL_EXT_shader_64bit_indexing", "GL_EXT_shader_8bit_storage",
+			"GL_EXT_shader_atomic_float", "GL_EXT_shader_atomic_float2",
+			"GL_EXT_shader_atomic_int64", "GL_EXT_shader_explicit_arithmetic_types",
+			"GL_EXT_shader_explicit_arithmetic_types_float16",
+			"GL_EXT_shader_explicit_arithmetic_types_float32",
+			"GL_EXT_shader_explicit_arithmetic_types_float64",
+			"GL_EXT_shader_explicit_arithmetic_types_int16",
+			"GL_EXT_shader_explicit_arithmetic_types_int32",
+			"GL_EXT_shader_explicit_arithmetic_types_int64",
+			"GL_EXT_shader_explicit_arithmetic_types_int8", "GL_EXT_shader_image_int64",
+			"GL_EXT_shader_image_load_formatted", "GL_EXT_shader_integer_mix",
+			"GL_EXT_shader_invocation_reorder", "GL_EXT_shader_non_constant_global_initializers",
+			"GL_EXT_shader_quad_control", "GL_EXT_shader_realtime_clock",
+			"GL_EXT_shader_subgroup_extended_types_float16",
+			"GL_EXT_shader_subgroup_extended_types_int16",
+			"GL_EXT_shader_subgroup_extended_types_int64",
+			"GL_EXT_shader_subgroup_extended_types_int8", "GL_EXT_shared_memory_block",
+			"GL_EXT_spec_constant_composites", "GL_EXT_spirv_intrinsics",
+			"GL_EXT_subgroup_uniform_control_flow", "GL_EXT_terminate_invocation",
+			"GL_EXT_texture_array", "GL_EXT_texture_offset_non_const",
+			"GL_EXT_uniform_buffer_unsized_array", "GL_FRAGMENT_PRECISION_HIGH",
+			"GL_GOOGLE_cpp_style_line_directive", "GL_GOOGLE_include_directive",
+			"GL_INTEL_shader_integer_functions2", "GL_KHR_blend_equation_advanced",
+			"GL_KHR_cooperative_matrix", "GL_KHR_shader_subgroup_arithmetic",
+			"GL_KHR_shader_subgroup_ballot", "GL_KHR_shader_subgroup_basic",
+			"GL_KHR_shader_subgroup_clustered", "GL_KHR_shader_subgroup_quad",
+			"GL_KHR_shader_subgroup_shuffle", "GL_KHR_shader_subgroup_shuffle_relative",
+			"GL_KHR_shader_subgroup_vote", "GL_NV_compute_shader_derivatives",
+			"GL_NV_conservative_raster_underestimation", "GL_NV_cooperative_matrix",
+			"GL_NV_cooperative_matrix2", "GL_NV_fragment_shader_barycentric",
+			"GL_NV_geometry_shader_passthrough", "GL_NV_gpu_shader5",
+			"GL_NV_integer_cooperative_matrix", "GL_NV_mesh_shader", "GL_NV_ray_tracing",
+			"GL_NV_ray_tracing_motion_blur", "GL_NV_sample_mask_override_coverage",
+			"GL_NV_shader_atomic_int64", "GL_NV_shader_invocation_reorder",
+			"GL_NV_shader_sm_builtins", "GL_NV_shader_subgroup_partitioned",
+			"GL_NV_shader_texture_footprint", "GL_NV_shading_rate_image", "GL_NV_viewport_array2",
+			"GL_OVR_multiview", "GL_OVR_multiview2", "GL_QCOM_cooperative_matrix_conversion",
+			"GL_QCOM_image_processing", "GL_QCOM_image_processing2", "GL_QCOM_tile_shading",
+			"GL_core_profile");
+
+	private CompilerMacros() {
+	}
+
+	/**
+	 * Every macro the compiler has defined when it reads the first line of a stage, with its value,
+	 * less the ones hidden from it in that stage because the device lacks the extension there.
+	 */
+	public static Map<String, String> definedIn(ProgramStage stage) {
+		Map<String, String> defined = new LinkedHashMap<>();
+		for (String name : PREAMBLE) {
+			if (!VendorExtensions.absent(name, stage)) {
+				defined.put(name, "1");
+			}
+		}
+
+		// The Vulkan GLSL version the compiler targets, which it writes whatever the target's own
+		// version is.
+		defined.put("VULKAN", "100");
+		// glslang's names for the stages are the enum's, GL_FRAGMENT_SHADER for FRAGMENT.
+		defined.put("GL_" + stage.name() + "_SHADER", "1");
+
+		return defined;
+	}
+}

--- a/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/GlslTranslator.java
@@ -1577,13 +1577,14 @@ public final class GlslTranslator {
 	 * language wants them, and {@link #extensions} is what carries them there.
 	 * <p>
 	 * <strong>All the device has, and as {@code enable} rather than as the {@code require} the
-	 * pack wrote.</strong> Both halves are deliberate. A pack gates its extensions on macros this
-	 * engine's own {@code #if} evaluation cannot answer, since what defines them is the compiler
-	 * further down the road, so keeping only the live ones would keep none of the ones that
-	 * matter; and a name the compiler does not know is a warning under {@code enable} where
-	 * {@code require} is an error, which turns a pack asking for a vendor extension it will not
-	 * get into a pack that still compiles. What decides whether the pack's code USES an extension
-	 * is unchanged either way: its own macro test, answered by the compiler, which for a vendor
+	 * pack wrote.</strong> Both halves are deliberate. A pack gates its extensions on the
+	 * compiler's own macros, and whether a line is live is this engine's reading of the pack's
+	 * conditionals where the compiler's reading is the one that counts, so every extension named is
+	 * kept rather than only the live ones; and a name the compiler does not know is a warning under
+	 * {@code enable} where {@code require} is an error, which turns a pack asking for a vendor
+	 * extension it will not get into a pack that still compiles. What decides whether the pack's
+	 * code USES an extension is unchanged either way: its own macro test, answered by the compiler,
+	 * which for a vendor
 	 * extension the device has not got is given the device's answer to read
 	 * ({@link #hideAbsentExtensionMacros}, {@link VendorExtensions}).
 	 */
@@ -2111,8 +2112,8 @@ public final class GlslTranslator {
 	 * extension it knows, and a pack gating a vendor instruction on that macro takes the branch on
 	 * a card that cannot run the instruction. Under a GL driver the macro is only defined where the
 	 * card has the extension, which is the answer restored here. Every line is rewritten, live or
-	 * not, since the question is what the compiler will read; the engine's own evaluation already
-	 * answered undefined for a name it never defines, so the two agree afterwards.
+	 * not, since the question is what the compiler will read; the expander already read these names
+	 * as undefined in this stage ({@link CompilerMacros}), so the two agree afterwards.
 	 */
 	private void hideAbsentExtensionMacros() {
 		for (int index = 0; index < this.tokens.size(); index++) {

--- a/common/src/main/java/dev/vitrail/glsl/VendorExtensions.java
+++ b/common/src/main/java/dev/vitrail/glsl/VendorExtensions.java
@@ -35,6 +35,11 @@ import java.util.stream.Collectors;
  * absent. A translation is keyed on the answer ({@link #key}), so a cache written on one card is
  * not served to another.
  * <p>
+ * The expander reads a pack's conditionals with the same answer before the compiler does: the
+ * macros a stage starts with there ({@link CompilerMacros}) leave out every name {@link #absent}
+ * gives for that stage, so an include under such a test is followed exactly where the compiler
+ * takes the branch.
+ * <p>
  * The subgroup extensions are answered the same way, but per stage, since a device may run
  * subgroup operations in some stages and not in others. MoltenVK names the fragment, compute and
  * tessellation control stages and leaves the vertex stage out, and SPIRV-Cross then refuses a

--- a/common/src/main/java/dev/vitrail/pack/option/SettingSet.java
+++ b/common/src/main/java/dev/vitrail/pack/option/SettingSet.java
@@ -9,7 +9,8 @@ import java.util.Map;
  * <p>
  * Two tables of defines come out of this and they are deliberately not the same one.
  * {@code shaders.properties} is read with every setting already at its value, because it has to
- * be able to test them. A source file starts with only the engine's own symbols, and picks up
+ * be able to test them. A source file starts with only the engine's own symbols, beside the macros
+ * the compiler defines ahead of every stage ({@code IncludeExpander} adds those), and picks up
  * the pack's as it reads past their declarations, exactly as a preprocessor would: a file that
  * tests a setting above the line declaring it must see it undefined, because that is what the
  * compiler will see later.
@@ -161,9 +162,9 @@ public final class SettingSet {
 	}
 
 	/**
-	 * What a source file starts with, and it is the engine's own symbols alone. A choice is applied
-	 * where the pack declares it and nowhere else, so a name the pack declares nowhere is applied
-	 * nowhere.
+	 * What a source file starts with beside the compiler's own macros, and it is the engine's own
+	 * symbols alone. A choice is applied where the pack declares it and nowhere else, so a name the
+	 * pack declares nowhere is applied nowhere.
 	 * <p>
 	 * Such a name is dropped rather than written into the head of each unit, which is not what Iris
 	 * does either: {@code MutableOptionValues.addAll} walks the options the PACK declares and looks

--- a/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
+++ b/common/src/main/java/dev/vitrail/pack/source/IncludeExpander.java
@@ -1,6 +1,8 @@
 package dev.vitrail.pack.source;
 
+import dev.vitrail.glsl.CompilerMacros;
 import dev.vitrail.glsl.LoadClock;
+import dev.vitrail.pack.model.ProgramStage;
 import dev.vitrail.pack.option.OptionRewriter;
 import dev.vitrail.pack.option.SettingSet;
 
@@ -26,6 +28,12 @@ import java.util.regex.Pattern;
  * conditional. That makes the include graph a function of the settings rather than a property
  * of the pack, and it is why a unit has to be rebuilt when a setting changes rather than
  * patched.
+ * <p>
+ * A condition is decided on the names the compiler will have defined when it reads the line: the
+ * macros it writes ahead of the stage ({@link CompilerMacros}), the engine's own symbols, and the
+ * pack's defines as they are met. Leave the first out and an include under a test of a compiler
+ * macro is dropped where the compiler goes on to take the branch, and the code under it then names
+ * something nothing declared.
  * <p>
  * An include in a branch that is off becomes a comment rather than staying as it was. Keeping
  * it would leave a directive GLSL has no notion of sitting in the text, which is a gamble on
@@ -132,6 +140,9 @@ public final class IncludeExpander {
 	 * <p>
 	 * A unit that throws is not remembered, so whoever asks next reads the file again and meets the
 	 * same failure rather than a silence.
+	 * <p>
+	 * The device's answer on its extensions, which decides some of the compiler's macros, is not in
+	 * the memo's key: the device gives it once, at its creation, before any pack is read.
 	 */
 	public ExpandedUnit expand(Path entry) throws IOException {
 		String relative = this.source.rel(entry);
@@ -145,7 +156,7 @@ public final class IncludeExpander {
 		}
 
 		long began = System.nanoTime();
-		State state = new State(this.settings.unitDefines(), this.loose);
+		State state = new State(startingDefines(relative), this.loose);
 
 		expandFile(entry, 0, state);
 
@@ -157,6 +168,23 @@ public final class IncludeExpander {
 		}
 
 		return unit;
+	}
+
+	/**
+	 * What the compiler has defined before the first line of this entry, then the engine's symbols.
+	 * <p>
+	 * The stage is the one the entry's extension names, which is the stage the file is compiled as,
+	 * so no caller has to say it: the fragment entries a place is read for its directives start
+	 * with the table its fragment stage is compiled with. A file whose extension names no stage is
+	 * compiled as none and starts with the engine's symbols alone.
+	 */
+	private Map<String, String> startingDefines(String relative) {
+		Map<String, String> defines = new LinkedHashMap<>();
+		ProgramStage.ofFile(relative)
+				.ifPresent(stage -> defines.putAll(CompilerMacros.definedIn(stage)));
+		defines.putAll(this.settings.unitDefines());
+
+		return defines;
 	}
 
 	/** What this reader read for the pack across every unit expanded so far, ready for the log. */
@@ -629,8 +657,9 @@ public final class IncludeExpander {
 	 *             as a uniform in one branch and as an ordinary global in the other. Conditional
 	 *             lines themselves count as taken; they are directives, never declarations.
 	 * @param defines what the names of the unit stand for once the whole of it has been read: the
-	 *             engine's own symbols, then every {@code #define} the taken branches declare with
-	 *             the player's settings already applied to it, and none of the ones an
+	 *             macros the compiler defines for the entry's stage, the engine's own symbols, then
+	 *             every {@code #define} the taken branches declare with the player's settings
+	 *             already applied to it, and none of the ones an
 	 *             {@code #undef} took back. The text keeps the names as the pack wrote them,
 	 *             because the compiler substitutes them itself; a reader that has to know a value
 	 *             BEFORE anything is compiled, as the dispatch size of a compute program is, has

--- a/docs/internals/pack-loading.md
+++ b/docs/internals/pack-loading.md
@@ -164,9 +164,13 @@ setting, so every setting the index offers is present before the first line is r
 constant is the one that enters only while it is true, because an `#ifdef` on one declared false
 has to read false whatever text the declaration carries.
 
-The table a source file starts with carries **the engine's symbols and nothing else**. The pack's own
-defines enter as the expander walks past their declarations, in file order, exactly as a preprocessor
-would, and its constants never do: there is nothing in one for a preprocessor to test. A file that
+The table a source file starts with carries **the engine's symbols and the compiler's own macros, and
+nothing else**. The compiler defines one macro per extension it supports and one naming the stage
+before it reads a line, less the ones the translator hides in a stage the device lacks them in, so
+the expander starts from the table of the stage the entry's extension names, and a branch a pack
+gates on one of them is live exactly where the compiler takes it. The pack's own defines enter as
+the expander walks past their declarations, in file order, exactly as a preprocessor would, and its
+constants never do: there is nothing in one for a preprocessor to test. A file that
 tests a define above the line declaring it has to see it undefined, because that is what the compiler
 will see later.
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -25,6 +25,14 @@ condition, matches an include and tracks a define on the joined text. What it wr
 lines as they were, unless a setting rewrote the line: the compiler joins them again, and it joins
 once, so a joined line written out could end on a backslash the pack never meant as a continuation.
 
+**A condition reads the macros the compiler defines.** Before the first line of a stage the compiler
+defines a macro for every extension it supports, and one naming the stage, and packs gate code on
+them: RenderPearl turns its subgroup lighting on where `GL_KHR_shader_subgroup_basic` is defined
+and pulls in the buffer that lighting reads under the same test. The expander starts each entry
+from that table, for the stage the entry's extension names and without the extensions the device
+lacks in that stage, which the translator hides from the compiler as well. Read without it, that
+include is dropped while the compiler takes the branch and meets a name nothing declared.
+
 **Order at load matters.** The table of values that supplies a pack's defines has to be installed
 *before* the pack is read, because those symbols decide which branches compile. Read the pack first
 and it sees none of them. The same table is only meaningful once a world exists, so the reload path


### PR DESCRIPTION
## What changes

The include expander decides every `#if` of a pack before the compiler reads it, and drops the includes of a branch it reads as not taken, leaving the directive lines for the compiler. It decided on the engine's symbols and the pack's own defines, but not on the macros glslang defines ahead of every stage: one per extension it supports (`GL_KHR_shader_subgroup_basic`, `GL_EXT_shader_16bit_storage` and so on), `VULKAN`, and one naming the stage. A branch gated on one of them lost its includes wherever the compiler went on to take it.

RenderPearl gates its subgroup lighting that way (`prelude/compat.glsl`, `prog/lit_forward.fsh`). On a Mac, whose fragment stage runs subgroup operations, the compiler took the branch and met a light list buffer nothing declared, so `gbuffers_water`, `gbuffers_particles_translucent`, `gbuffers_entities_translucent` and `gbuffers_block_translucent` failed to compile and were drawn with the game's shader. On NVIDIA the pack's own `MC_GL_VENDOR_NVIDIA` fallback made both readings agree.

Each entry now starts from the compiler's macros for the stage its file extension names (`CompilerMacros`), less the extensions the translator already hides from the compiler in a stage the device lacks them in, then the engine's symbols.

## How it differs from the reference, and for what obstacle

It does not. Iris hands the pack's text to the GL driver, which answers those macros for itself; here an engine reads the conditionals first, and now reads them as the compiler will.

## What proves it

- `gradlew build` green, after the rebase.
- Off game: with the Mac's device answer, the fragment stage of those four programs fails to compile on `dev` and compiles on this branch; with an NVIDIA answer it compiles on both.
- Across the corpus (5980 units per answer): with an NVIDIA answer no translated or expanded text changes, only which lines count as live in Complementary Reimagined, Unbound and Outdated Unbound, Noble and RenderPearl. With the Mac answer, translated text changes only in RenderPearl's translucent fragment units, where the light list includes are now followed.
- Translated as a Windows NVIDIA machine, every translated file of the corpus and its SPIR-V is identical to `dev`, and so are the target and chain plans.
- On an M4 (MoltenVK 1.4.2), arena bench, back to back on `dev` and on this branch: RenderPearl logged seven compile failures on `dev` and none here, draws its water, particles, text and block entity passes itself, and keeps the same image otherwise. Complementary Reimagined r5.9 and BSL keep their image.

## What it leaves owing

- The macro list is the one the shaderc this game ships defines; a newer shaderc can add a name, which has to be asked of it again.
- `__VERSION__` is not modelled.
- The geometry fold still preprocesses a geometry stage through shaderc's preprocessed text road, which answers `GL_VERTEX_SHADER`.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
