### PR TITLE
fix(render): move oversized compute shared memory on MoltenVK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,15 @@ what the next one holds.
   back by plain arithmetic the engine writes into the shader, which gives the numbers every other
   card already got. Nothing changes on any other machine.
 
+- **Photon's sky light reaches the ground on a Mac.** Photon works out the light the sky casts in a
+  small step that runs on many threads of the graphics card at once, and those threads keep their
+  working numbers in memory they share. The step asks for more of that memory than Apple's graphics
+  allow, so it was never built, and everything the sky lights came out dark: the grass a dull olive
+  where any other card draws it bright green. On a Mac, such a step now keeps those numbers in an
+  ordinary buffer when it runs as one batch of threads, which is how Photon runs it, and works out
+  the same light. A step past the allowance that runs as several batches is still refused, and the
+  log says so. Every other card is left as it was.
+
 - **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both
   mods reshape Sodium's texture filtering option, and Sodium refuses two of them, so a game set to
   OpenGL with both installed closed before the title screen. Vitrail now only touches that option

--- a/common/src/main/java/dev/vitrail/glsl/SharedMemory.java
+++ b/common/src/main/java/dev/vitrail/glsl/SharedMemory.java
@@ -1,0 +1,396 @@
+package dev.vitrail.glsl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Moves the shared variables of a compute stage into a storage buffer, for a Metal kernel that
+ * could not hold them in threadgroup memory.
+ * <p>
+ * <strong>What goes wrong without it.</strong> SPIRV-Cross declares a GLSL {@code shared} variable,
+ * workgroup storage in SPIR-V, as {@code threadgroup} memory of the Metal kernel, and Metal refuses a
+ * kernel holding more than 32768 bytes of it as the pipeline is built:
+ * {@code Threadgroup memory size (36864) exceeds the maximum threadgroup memory allowed (32768)}.
+ * That is Photon's sky light, {@code shared vec3 shared_memory[256][9]} at sixteen bytes a
+ * {@code float3}, and without it everything the sky lights renders dark. Vulkan reports no such
+ * limit, so the figure is the one Metal's refusal names and not an answer asked of the device.
+ * <p>
+ * <strong>Why a buffer is the same memory, and when it is not.</strong> A shared variable is one
+ * copy for the invocations of one local work group, and a buffer is one copy for every invocation of
+ * the dispatch. The two agree when the dispatch is a single work group, which the caller asks before
+ * using the text. A shared variable starts undefined, and what the last dispatch left in the buffer
+ * is one reading of that.
+ * <p>
+ * <strong>The barriers have to name the buffer.</strong> SPIRV-Cross writes {@code barrier()} as
+ * {@code threadgroup_barrier(mem_flags::mem_threadgroup)} whatever memory the stage touches, and that
+ * flag orders writes to threadgroup memory and to nothing else, so a reduction reading what the other
+ * invocations wrote into a buffer would race. The moved text therefore puts
+ * {@code memoryBarrierBuffer()} in front of every {@code barrier()}, which SPIRV-Cross writes as
+ * {@code mem_device} below MSL 3.2 and as an {@code atomic_thread_fence} over device memory from
+ * 3.2, and declares the block {@code coherent}, which 3.2 receives as {@code coherent device}, the
+ * qualifier that fence is written against.
+ * <p>
+ * Off until {@code VulkanBackendMixin} says the driver is MoltenVK, which is what the harness gets.
+ */
+public final class SharedMemory {
+
+	/** What a Metal kernel may hold in threadgroup memory, as its refusal names it. */
+	public static final long THREADGROUP_BYTES = 32768L;
+
+	/** The block the moved variables are declared in, and the name the dispatch binds a buffer to. */
+	public static final String BLOCK = "OfSharedMemory";
+
+	/**
+	 * Written after the version line, so that every barrier of the stage names the buffer. One
+	 * expression and not two statements: {@code if (x) barrier();} would otherwise fence the buffer
+	 * in the branch and wait for every thread outside it.
+	 */
+	private static final String BARRIER = "#define barrier() (memoryBarrierBuffer(), barrier())";
+
+	private static final Pattern WORD = Pattern.compile("\\bshared\\b");
+
+	private static final Pattern TOKEN = Pattern.compile("[A-Za-z_]\\w*|\\d+[uU]?|\\S");
+
+	private static final Pattern NAME = Pattern.compile("[A-Za-z_]\\w*");
+
+	private static final Pattern COUNT = Pattern.compile("(\\d+)[uU]?");
+
+	private static final Pattern VERSION = Pattern.compile("(?m)^[ \\t]*#[ \\t]*version\\b.*$");
+
+	/** What a shared declaration may carry beside the word, none of which changes its layout. */
+	private static final Set<String> QUALIFIERS = Set.of("shared", "highp", "mediump", "lowp", "precise");
+
+	private static final Map<String, Layout> TYPES = types();
+
+	private static volatile boolean moltenVk;
+
+	private SharedMemory() {
+	}
+
+	/**
+	 * What was read of a stage's shared declarations.
+	 *
+	 * @param threadgroupBytes what they take as Metal threadgroup memory, laid out as SPIRV-Cross
+	 *                         lays them out, or -1 when one of them could not be sized
+	 * @param bufferBytes      what the block holding them takes under std430
+	 * @param moved            the stage with them moved into that block, or null when they fit
+	 * @param unread           the declaration that could not be sized, or null
+	 */
+	public record Reading(long threadgroupBytes, long bufferBytes, String moved, String unread) {
+
+		/** Whether Metal refuses that much threadgroup memory. */
+		public boolean over() {
+			return this.threadgroupBytes > THREADGROUP_BYTES;
+		}
+	}
+
+	/** Set once by {@code VulkanBackendMixin}, at device creation. */
+	public static void serve(boolean moltenVkDriver) {
+		moltenVk = moltenVkDriver;
+	}
+
+	/** Whether the driver is MoltenVK, the one driver whose threadgroup memory is capped. */
+	public static boolean moltenVk() {
+		return moltenVk;
+	}
+
+	/** Whether the text says {@code shared} at all, asked before paying for a preprocessing. */
+	public static boolean mentioned(String text) {
+		return WORD.matcher(text).find();
+	}
+
+	/**
+	 * Sizes the shared declarations of a preprocessed compute stage and, past what Metal allows,
+	 * moves them into one buffer block.
+	 * <p>
+	 * Preprocessed because the text a translation hands out still carries every {@code #if} of the
+	 * pack and its macros: a declaration in a dead branch would be counted, and an array sized by a
+	 * setting could not be. Only what shaderc would compile is left here. Only declarations of
+	 * scalars, vectors and matrices of floats and integers, and arrays of them counted in literals,
+	 * are sized; anything else is named unread and the stage is left as it stands.
+	 */
+	public static Reading read(String preprocessed) {
+		String scanned = withoutDirectives(preprocessed);
+		List<int[]> spans = new ArrayList<>();
+		StringBuilder members = new StringBuilder();
+		long threadgroup = 0L;
+		long offset = 0L;
+		long widest = 4L;
+		int depth = 0;
+		int start = 0;
+		for (int i = 0; i < scanned.length(); i++) {
+			char c = scanned.charAt(i);
+			if (c == '{') {
+				depth++;
+				continue;
+			}
+
+			if (c == '}') {
+				depth = Math.max(0, depth - 1);
+				if (depth == 0) {
+					start = i + 1;
+				}
+
+				continue;
+			}
+
+			if (c != ';' || depth != 0) {
+				continue;
+			}
+
+			String statement = scanned.substring(start, i);
+			int from = start + (statement.length() - statement.stripLeading().length());
+			start = i + 1;
+			List<String> tokens = tokens(statement);
+			if (!declaresShared(tokens)) {
+				continue;
+			}
+
+			Declaration declaration = declaration(tokens);
+			// A directive inside the statement would be lost with the span it sits in.
+			if (declaration == null || preprocessed.substring(from, i).indexOf('#') >= 0) {
+				return new Reading(-1L, 0L, null, statement.strip());
+			}
+
+			Layout layout = declaration.layout();
+			for (long count : declaration.counts()) {
+				long metal = layout.stride() * Math.max(1L, count);
+				threadgroup += metal;
+				offset = aligned(offset, layout.align()) + (count == 0L ? layout.size() : metal);
+				widest = Math.max(widest, layout.align());
+			}
+
+			members.append(declaration.member()).append(' ');
+			spans.add(new int[] {from, i + 1});
+		}
+
+		long bytes = aligned(offset, widest);
+		if (threadgroup <= THREADGROUP_BYTES) {
+			return new Reading(threadgroup, bytes, null, null);
+		}
+
+		return new Reading(threadgroup, bytes, moved(preprocessed, spans, members.toString()), null);
+	}
+
+	/** The first declaration becomes the block, the others blanks, and the barrier is redefined. */
+	private static String moved(String preprocessed, List<int[]> spans, String members) {
+		StringBuilder text = new StringBuilder(preprocessed.length() + 256);
+		int copied = 0;
+		for (int k = 0; k < spans.size(); k++) {
+			int[] span = spans.get(k);
+			text.append(preprocessed, copied, span[0]);
+			text.append(k == 0
+					? "layout(std430) coherent buffer " + BLOCK + " { " + members + "};"
+					: blank(preprocessed.substring(span[0], span[1])));
+			copied = span[1];
+		}
+
+		text.append(preprocessed, copied, preprocessed.length());
+		Matcher version = VERSION.matcher(text);
+		if (version.find()) {
+			text.insert(version.end(), "\n" + BARRIER);
+		} else {
+			text.insert(0, BARRIER + "\n");
+		}
+
+		return text.toString();
+	}
+
+	private record Layout(long size, long align, long stride) {
+	}
+
+	/** @param counts each declarator's element count, or 0 for one that is not an array */
+	private record Declaration(String member, Layout layout, List<Long> counts) {
+	}
+
+	/**
+	 * The std430 size and alignment of each type, and the stride of an array of it, which is also
+	 * what Metal gives one of them: a {@code float3} takes sixteen bytes there as a {@code vec3}
+	 * element does here, and a matrix is its columns.
+	 */
+	private static Map<String, Layout> types() {
+		Map<String, Layout> table = new HashMap<>();
+		for (String scalar : List.of("float", "int", "uint")) {
+			table.put(scalar, new Layout(4L, 4L, 4L));
+		}
+
+		for (int n = 2; n <= 4; n++) {
+			long align = n == 2 ? 8L : 16L;
+			for (String prefix : List.of("vec", "ivec", "uvec")) {
+				table.put(prefix + n, new Layout(4L * n, align, align));
+			}
+
+			for (int rows = 2; rows <= 4; rows++) {
+				long column = rows == 2 ? 8L : 16L;
+				Layout matrix = new Layout(n * column, column, n * column);
+				table.put("mat" + n + "x" + rows, matrix);
+				if (rows == n) {
+					table.put("mat" + n, matrix);
+				}
+			}
+		}
+
+		return Map.copyOf(table);
+	}
+
+	private static boolean declaresShared(List<String> tokens) {
+		int parentheses = 0;
+		for (String token : tokens) {
+			if ("(".equals(token)) {
+				parentheses++;
+			} else if (")".equals(token)) {
+				parentheses--;
+			} else if (parentheses == 0 && "shared".equals(token)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** One declaration read, or null for anything other than a sizable type and literal counts. */
+	private static Declaration declaration(List<String> tokens) {
+		int at = 0;
+		while (at < tokens.size() && QUALIFIERS.contains(tokens.get(at))) {
+			at++;
+		}
+
+		Layout layout = at < tokens.size() ? TYPES.get(tokens.get(at)) : null;
+		if (layout == null) {
+			return null;
+		}
+
+		at++;
+		List<Long> counts = new ArrayList<>();
+		try {
+			long typeCount = 0L;
+			while (at < tokens.size() && "[".equals(tokens.get(at))) {
+				long[] dimension = dimension(tokens, at);
+				if (dimension == null) {
+					return null;
+				}
+
+				typeCount = Math.multiplyExact(Math.max(1L, typeCount), dimension[0]);
+				at = (int) dimension[1];
+			}
+
+			while (true) {
+				if (at >= tokens.size() || !NAME.matcher(tokens.get(at)).matches()
+						|| TYPES.containsKey(tokens.get(at)) || QUALIFIERS.contains(tokens.get(at))) {
+					return null;
+				}
+
+				at++;
+				long count = typeCount;
+				while (at < tokens.size() && "[".equals(tokens.get(at))) {
+					long[] dimension = dimension(tokens, at);
+					if (dimension == null) {
+						return null;
+					}
+
+					count = Math.multiplyExact(Math.max(1L, count), dimension[0]);
+					at = (int) dimension[1];
+				}
+
+				counts.add(count);
+				if (at == tokens.size()) {
+					break;
+				}
+
+				if (!",".equals(tokens.get(at))) {
+					return null;
+				}
+
+				at++;
+			}
+		} catch (ArithmeticException wide) {
+			return null;
+		}
+
+		List<String> member = new ArrayList<>();
+		for (String token : tokens) {
+			if (!"shared".equals(token)) {
+				member.add(token);
+			}
+		}
+
+		return new Declaration(String.join(" ", member) + ";", layout, List.copyOf(counts));
+	}
+
+	/**
+	 * The count of the bracket opening at that token and the token past its close, or null for
+	 * anything but a literal or a product of literals. I Like Vanilla writes its floodfill cache as
+	 * {@code [10 * 10 * 10]}, which the preprocessor leaves as it is.
+	 */
+	private static long[] dimension(List<String> tokens, int at) {
+		long product = 1L;
+		int next = at + 1;
+		while (next < tokens.size()) {
+			Matcher count = COUNT.matcher(tokens.get(next));
+			if (!count.matches()) {
+				return null;
+			}
+
+			try {
+				product = Math.multiplyExact(product, Long.parseLong(count.group(1)));
+			} catch (NumberFormatException wide) {
+				return null;
+			}
+
+			next++;
+			if (next < tokens.size() && "]".equals(tokens.get(next))) {
+				return product > 0L ? new long[] {product, next + 1L} : null;
+			}
+
+			if (next >= tokens.size() || !"*".equals(tokens.get(next))) {
+				return null;
+			}
+
+			next++;
+		}
+
+		return null;
+	}
+
+	private static List<String> tokens(String statement) {
+		List<String> tokens = new ArrayList<>();
+		Matcher matcher = TOKEN.matcher(statement);
+		while (matcher.find()) {
+			tokens.add(matcher.group());
+		}
+
+		return tokens;
+	}
+
+	/** The text with each directive line blanked, lengths and line breaks kept. */
+	private static String withoutDirectives(String text) {
+		StringBuilder scanned = new StringBuilder(text.length());
+		for (String line : text.split("\n", -1)) {
+			if (scanned.length() > 0) {
+				scanned.append('\n');
+			}
+
+			scanned.append(line.stripLeading().startsWith("#") ? " ".repeat(line.length()) : line);
+		}
+
+		return scanned.toString();
+	}
+
+	private static String blank(String text) {
+		StringBuilder blank = new StringBuilder(text.length());
+		for (int i = 0; i < text.length(); i++) {
+			blank.append(text.charAt(i) == '\n' ? '\n' : ' ');
+		}
+
+		return blank.toString();
+	}
+
+	private static long aligned(long offset, long align) {
+		return (offset + align - 1L) / align * align;
+	}
+}

--- a/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
+++ b/common/src/main/java/dev/vitrail/mixin/VulkanBackendMixin.java
@@ -5,6 +5,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.vulkan.VulkanBackend;
 import com.mojang.blaze3d.vulkan.VulkanPhysicalDevice;
 import com.mojang.blaze3d.vulkan.init.VulkanFeature;
+import dev.vitrail.glsl.SharedMemory;
 import dev.vitrail.glsl.VendorExtensions;
 import dev.vitrail.pack.model.ProgramStage;
 import dev.vitrail.render.BufferBlending;
@@ -202,6 +203,8 @@ public abstract class VulkanBackendMixin {
 				physical.vkPhysicalDeviceProperties().limits().maxPerStageDescriptorSamplers(),
 				moltenVk ? tableSamplers(physical) : 0);
 		VendorExtensions.serveMoltenVk(moltenVk);
+		// And Metal's cap on the threadgroup memory of a compute, which Vulkan has no limit to name.
+		SharedMemory.serve(moltenVk);
 		// The vendor extensions a pack may gate a vendor instruction on, answered by the device
 		// and not by the compiler, which defines the macro of every one it knows; the ones the
 		// device has are enabled on it here, since a module using one needs it enabled.

--- a/common/src/main/java/dev/vitrail/render/PackCompute.java
+++ b/common/src/main/java/dev/vitrail/render/PackCompute.java
@@ -3,6 +3,7 @@ package dev.vitrail.render;
 import dev.vitrail.cache.ModuleCache;
 import dev.vitrail.glsl.LoadClock;
 import dev.vitrail.glsl.PackProgram;
+import dev.vitrail.glsl.SharedMemory;
 import dev.vitrail.glsl.TranslatedUnit;
 import dev.vitrail.mixin.access.CommandEncoderAccessor;
 import dev.vitrail.mixin.access.GpuDeviceAccessor;
@@ -44,13 +45,17 @@ import com.mojang.blaze3d.vulkan.VulkanUtils;
 import com.mojang.blaze3d.vulkan.glsl.IntermediaryShaderModule;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MappableRingBuffer;
+import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.util.shaderc.Shaderc;
+import org.lwjgl.util.vma.Vma;
+import org.lwjgl.util.vma.VmaAllocationCreateInfo;
 import org.lwjgl.vulkan.KHRPushDescriptor;
 import org.lwjgl.vulkan.KHRSynchronization2;
 import org.lwjgl.vulkan.VK12;
 import org.lwjgl.vulkan.VK13;
+import org.lwjgl.vulkan.VkBufferCreateInfo;
 import org.lwjgl.vulkan.VkCommandBuffer;
 import org.lwjgl.vulkan.VkComputePipelineCreateInfo;
 import org.lwjgl.vulkan.VkDependencyInfo;
@@ -66,6 +71,7 @@ import org.lwjgl.vulkan.VkWriteDescriptorSet;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -512,9 +518,10 @@ final class PackCompute implements AutoCloseable {
 	 * Frees every pass this load built: the shadow computes, the ones hanging off a full screen
 	 * pass, and the ones dispatched at the moment of a program this place draws no pass for.
 	 * <p>
-	 * A pass holds a shader module, a descriptor set layout, a pipeline layout, a pipeline and a
-	 * ring of uniform buffers. {@link Pass#destroy} queues the module, both layouts and the
-	 * pipeline on {@link GpuRecording#destroyLater}, and {@link Pass#close} queues the ring there
+	 * A pass holds a shader module, a descriptor set layout, a pipeline layout, a pipeline, a ring
+	 * of uniform buffers, and on MoltenVK the buffer its shared variables were moved into when it
+	 * has one. {@link Pass#destroy} queues the module, both layouts, the pipeline and that buffer
+	 * on {@link GpuRecording#destroyLater}, and {@link Pass#close} queues the ring there
 	 * as well rather than closing it where it stands, since this is not a quiet moment: every
 	 * error path of a frame calls {@link PackChain#release} in the middle of one, after the chain
 	 * has dispatched these computes, so a pass is closed while frames that still name its objects
@@ -738,6 +745,14 @@ final class PackCompute implements AutoCloseable {
 		private List<VulkanBindGroupLayout.Entry> entries = List.of();
 		private boolean compiled;
 
+		/**
+		 * The std430 size of the block {@link SharedMemory} moved this compute's shared variables
+		 * into, or 0 where they keep their threadgroup memory, which is everywhere but MoltenVK.
+		 */
+		private long sharedBytes;
+		private long sharedBuffer;
+		private long sharedAllocation;
+
 		private Pass(PackProgram.Compute compute, UniformCatalog catalog, int load, String path,
 				String program) {
 			this.compute = compute;
@@ -818,7 +833,7 @@ final class PackCompute implements AutoCloseable {
 			// One state for the key and the patch, as the game's compiler road takes it.
 			RawLocals.begin();
 			try {
-				String source = unit.text();
+				String source = sharedMemory(unit.text());
 				String key = ModuleCache.keyOf(source, MODULE_CACHE_STAGE);
 				module = ModuleCache.lookup(key, this.label);
 				ByteBuffer spirv = null;
@@ -876,6 +891,7 @@ final class PackCompute implements AutoCloseable {
 			try (MemoryStack stack = MemoryStack.stackPush()) {
 				createLayout(vulkan, stack);
 				createPipeline(vulkan, stack);
+				createSharedBuffer(vulkan, stack);
 			} catch (GpuDeviceLossException e) {
 				throw e;
 			} catch (RuntimeException e) {
@@ -889,23 +905,65 @@ final class PackCompute implements AutoCloseable {
 			}
 		}
 
+		/**
+		 * The text to compile: the translation as it stands, or on MoltenVK the same with its shared
+		 * variables moved into a storage buffer, where Metal would refuse the threadgroup memory they
+		 * take. {@link SharedMemory} says why the buffer is the same memory and what the move does to
+		 * the barriers.
+		 * <p>
+		 * Only for a pack count of one work group on every axis, which is what makes one buffer the
+		 * memory every invocation of the dispatch shares: the count a pack writes is dispatched as
+		 * written, and a count off the screen is as many groups as the window asks for. Anything else
+		 * keeps its threadgroup memory, and the log says why Metal will refuse it. The translation
+		 * itself is not touched, so its store holds one answer for every driver, and the module store
+		 * is keyed on the text returned here, which differs wherever the move was made.
+		 */
+		private String sharedMemory(String translated) {
+			if (!SharedMemory.moltenVk() || !SharedMemory.mentioned(translated)) {
+				return translated;
+			}
+
+			String preprocessed = preprocess(translated);
+			if (preprocessed == null) {
+				return translated;
+			}
+
+			SharedMemory.Reading reading = SharedMemory.read(preprocessed);
+			if (reading.unread() != null) {
+				Vitrail.logger().warn("compute {} declares shared memory this engine cannot size, "
+						+ "{}, so it keeps its threadgroup memory on Metal", this.path, reading.unread());
+				return translated;
+			}
+
+			if (!reading.over()) {
+				return translated;
+			}
+
+			if (this.compute.groupsX() != 1 || this.compute.groupsY() != 1
+					|| this.compute.groupsZ() != 1) {
+				Vitrail.logger().warn("compute {} asks Metal for {} bytes of threadgroup memory, past "
+						+ "the {} it allows, and does not dispatch a single work group, where one buffer "
+						+ "would not be the memory each group has of its own, so Metal refuses it",
+						this.path, reading.threadgroupBytes(), SharedMemory.THREADGROUP_BYTES);
+				return translated;
+			}
+
+			this.sharedBytes = reading.bufferBytes();
+			Vitrail.logger().info("compute {} asks Metal for {} bytes of threadgroup memory, past the "
+					+ "{} it allows, so its shared variables are served from a storage buffer of {} bytes",
+					this.path, reading.threadgroupBytes(), SharedMemory.THREADGROUP_BYTES,
+					this.sharedBytes);
+			return reading.moved();
+		}
+
 		private static ByteBuffer compileSpirv(String source) {
 			long compiler = Shaderc.shaderc_compiler_initialize();
-			long options = Shaderc.shaderc_compile_options_initialize();
+			long options = compileOptions();
 			ByteBuffer sourceBuffer = MemoryUtil.memUTF8(source, false);
 			ByteBuffer filename = MemoryUtil.memUTF8("shadowcomp.csh");
 			ByteBuffer entry = MemoryUtil.memUTF8("main");
 			long result = 0L;
 			try {
-				Shaderc.shaderc_compile_options_set_target_env(options, 0, SHADERC_VULKAN_1_2);
-				Shaderc.shaderc_compile_options_set_auto_bind_uniforms(options, true);
-				Shaderc.shaderc_compile_options_set_auto_map_locations(options, true);
-				Shaderc.shaderc_compile_options_set_generate_debug_info(options);
-				// Performance, and for the LAYOUT before speed: the pack's common include
-				// declares samplers a compute never reads, an unoptimised module keeps them,
-				// and reflection then demands a binding for every one. Optimised, the dead
-				// declarations fall out and the entries are the names the shader touches.
-				Shaderc.shaderc_compile_options_set_optimization_level(options, 2);
 				result = Shaderc.shaderc_compile_into_spv(compiler, sourceBuffer, SHADERC_COMPUTE,
 						filename, entry, options);
 				int status = Shaderc.shaderc_result_get_compilation_status(result);
@@ -932,6 +990,88 @@ final class PackCompute implements AutoCloseable {
 			}
 		}
 
+		/** The options a compute is compiled and preprocessed at, released by the caller. */
+		private static long compileOptions() {
+			long options = Shaderc.shaderc_compile_options_initialize();
+			Shaderc.shaderc_compile_options_set_target_env(options, 0, SHADERC_VULKAN_1_2);
+			Shaderc.shaderc_compile_options_set_auto_bind_uniforms(options, true);
+			Shaderc.shaderc_compile_options_set_auto_map_locations(options, true);
+			Shaderc.shaderc_compile_options_set_generate_debug_info(options);
+			// Performance, and for the LAYOUT before speed: the pack's common include declares
+			// samplers a compute never reads, an unoptimised module keeps them, and reflection then
+			// demands a binding for every one. Optimised, the dead declarations fall out and the
+			// entries are the names the shader touches.
+			Shaderc.shaderc_compile_options_set_optimization_level(options, 2);
+			return options;
+		}
+
+		/**
+		 * The text through shaderc's preprocessor alone, at the options it is compiled at, or null
+		 * where it does not preprocess, which the compile after it then says.
+		 */
+		private static String preprocess(String source) {
+			long compiler = Shaderc.shaderc_compiler_initialize();
+			long options = compileOptions();
+			ByteBuffer sourceBuffer = MemoryUtil.memUTF8(source, false);
+			ByteBuffer filename = MemoryUtil.memUTF8("shadowcomp.csh");
+			ByteBuffer entry = MemoryUtil.memUTF8("main");
+			long result = 0L;
+			try {
+				result = Shaderc.shaderc_compile_into_preprocessed_text(compiler, sourceBuffer,
+						SHADERC_COMPUTE, filename, entry, options);
+				if (result == 0L) {
+					return null;
+				}
+
+				ByteBuffer bytes = Shaderc.shaderc_result_get_bytes(result);
+				if (Shaderc.shaderc_result_get_compilation_status(result) != 0 || bytes == null) {
+					return null;
+				}
+
+				return StandardCharsets.UTF_8.decode(bytes).toString();
+			} finally {
+				if (result != 0L) {
+					Shaderc.shaderc_result_release(result);
+				}
+
+				MemoryUtil.memFree(entry);
+				MemoryUtil.memFree(filename);
+				MemoryUtil.memFree(sourceBuffer);
+				Shaderc.shaderc_compile_options_release(options);
+				Shaderc.shaderc_compiler_release(compiler);
+			}
+		}
+
+		/**
+		 * The buffer a moved stage's shared variables live in, allocated the way the pack's own
+		 * storage buffers are. Left unfilled: a shared variable starts undefined.
+		 */
+		private void createSharedBuffer(VulkanDevice vulkan, MemoryStack stack) {
+			if (this.sharedBytes <= 0L) {
+				return;
+			}
+
+			VkBufferCreateInfo bufferInfo = VkBufferCreateInfo.calloc(stack).sType$Default();
+			bufferInfo.size(this.sharedBytes);
+			bufferInfo.usage(VK12.VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
+			bufferInfo.sharingMode(VK12.VK_SHARING_MODE_EXCLUSIVE);
+			VmaAllocationCreateInfo allocationInfo = VmaAllocationCreateInfo.calloc(stack);
+			allocationInfo.usage(8);
+			LongBuffer bufferPtr = stack.callocLong(1);
+			PointerBuffer allocationPtr = stack.callocPointer(1);
+			VulkanUtils.crashIfFailure(vulkan,
+					Vma.vmaCreateBuffer(vulkan.vma(), bufferInfo, allocationInfo, bufferPtr,
+							allocationPtr, null),
+					"compute shared memory");
+			this.sharedBuffer = bufferPtr.get(0);
+			this.sharedAllocation = allocationPtr.get(0);
+		}
+
+		/** Whether that entry is the block the shared variables were moved into. */
+		private boolean servesShared(String name) {
+			return this.sharedBytes > 0L && SharedMemory.BLOCK.equals(name);
+		}
+
 		private void createLayout(VulkanDevice vulkan, MemoryStack stack) {
 			int count = Math.max(1, this.entries.size());
 			VkDescriptorSetLayoutBinding.Buffer bindings =
@@ -943,7 +1083,7 @@ final class PackCompute implements AutoCloseable {
 						|| COLOUR_IMAGE.matcher(entry.name()).matches();
 				int type;
 				if (entry.type() == VulkanBindGroupLayout.VulkanBindGroupEntryType.UNIFORM_BUFFER) {
-					type = StorageBuffers.named(entry.name())
+					type = StorageBuffers.named(entry.name()) || servesShared(entry.name())
 							? VK12.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
 							: VK12.VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
 				} else {
@@ -1025,6 +1165,16 @@ final class PackCompute implements AutoCloseable {
 				write.dstArrayElement(0);
 				write.descriptorCount(1);
 				if (entry.type() == VulkanBindGroupLayout.VulkanBindGroupEntryType.UNIFORM_BUFFER) {
+					if (servesShared(entry.name())) {
+						VkDescriptorBufferInfo.Buffer bufferInfo = VkDescriptorBufferInfo.calloc(1, stack);
+						bufferInfo.buffer(this.sharedBuffer);
+						bufferInfo.offset(0L);
+						bufferInfo.range(this.sharedBytes);
+						write.descriptorType(VK12.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+						write.pBufferInfo(bufferInfo);
+						continue;
+					}
+
 					if (StorageBuffers.named(entry.name())) {
 						StorageBuffers.Bound bound = StorageBuffers.bound(entry.name());
 						if (bound == null) {
@@ -1274,11 +1424,19 @@ final class PackCompute implements AutoCloseable {
 			long pipelineLayout = this.pipelineLayout;
 			long setLayout = this.setLayout;
 			long shaderModule = this.shaderModule;
+			long sharedBuffer = this.sharedBuffer;
+			long sharedAllocation = this.sharedAllocation;
 			this.pipeline = 0L;
 			this.pipelineLayout = 0L;
 			this.setLayout = 0L;
 			this.shaderModule = 0L;
+			this.sharedBuffer = 0L;
+			this.sharedAllocation = 0L;
 			GpuRecording.destroyLater(() -> {
+				if (sharedBuffer != 0L) {
+					Vma.vmaDestroyBuffer(vulkan.vma(), sharedBuffer, sharedAllocation);
+				}
+
 				if (pipeline != 0L) {
 					VK12.vkDestroyPipeline(vulkan.vkDevice(), pipeline, null);
 				}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -125,6 +125,14 @@ refused. A pass the card refuses stops the pack:
 the world goes back to the game's own look and the settings screen says an error stopped it, which
 is what the reference does with a pack that fails the same way.
 
+**On a Mac, a compute step that shares more memory between its threads than Metal allows is given a
+buffer instead.** Metal lets the threads of one compute step share 32768 bytes, and Photon's sky
+light asks for 36864, so the step was refused and the ground the sky lights came out dark. Where
+the step runs as a single group of threads, which is how Photon runs it, that memory is now a buffer
+and the step computes the same light. A step past the limit that runs as several groups is still
+refused, and the log names it. How is in
+[the game's graphics API](internals/game-graphics-api.md#compute-and-storage-images-the-facade-vs-the-backend).
+
 **A full-screen pass that fails to compile takes the whole pack with it**, and the log names the
 program. One shape of that was a `const` whose initialiser Vulkan will not take as a constant,
 which OpenGL drivers accepted as merely immutable; that spelling is now rewritten, see

--- a/docs/internals/game-graphics-api.md
+++ b/docs/internals/game-graphics-api.md
@@ -292,6 +292,23 @@ Which programs it serves, including the pack's own switch deciding whether it se
 and why the shadow moment rather than beside the shadow map that feeds it, is answered where the
 pack's chain is.
 
+**On MoltenVK, a compute's shared variables can be moved into a storage buffer.** SPIRV-Cross
+declares a GLSL `shared` variable as `threadgroup` memory of the Metal kernel, and Metal refuses a
+kernel holding more than 32768 bytes of it as the pipeline is built: Photon's
+`shared vec3 shared_memory[256][9]`, sixteen bytes a `float3`, is refused as 36864. Vulkan reports
+no such limit, so the figure is Metal's own message. `PackCompute` preprocesses a stage that says
+`shared`, `glsl/SharedMemory` sizes its live declarations the way SPIRV-Cross lays them out, and past
+the limit the stage is compiled with them declared in one `std430` block instead, which the pass
+allocates through VMA and binds for its dispatch. The body is left as it was. Two conditions make
+that the same memory. The pack's own count has to be one work group on every axis, since a shared
+variable is one copy per group and a buffer one copy for the whole dispatch; any other stage keeps
+its threadgroup memory and the log says Metal will refuse it. And the barriers have to name the
+buffer: SPIRV-Cross writes `barrier()` as `threadgroup_barrier(mem_flags::mem_threadgroup)`, which
+orders writes to threadgroup memory only, so the moved text puts `memoryBarrierBuffer()` in front of
+each one, `mem_device` below MSL 3.2 and a fence over device memory from 3.2, and declares the block
+`coherent`. The translation is the same on every driver; the module store is keyed on the text
+compiled, which differs where the move was made.
+
 ## Small things that cost a lot to rediscover
 
 - **The shared sampler cache hands out shared objects.** Never close one; the cache owns it.


### PR DESCRIPTION
## What changes

SPIRV-Cross declares a GLSL `shared` variable of a compute stage as `threadgroup` memory of the Metal kernel, and Metal refuses a kernel holding more than 32768 bytes of it when MoltenVK builds the pipeline: `Threadgroup memory size (36864) exceeds the maximum threadgroup memory allowed (32768)`. Photon's sky light pass, `world0/deferred4_a`, reduces 256 samples of 9 spherical harmonic bands in `shared vec3 shared_memory[256][9]`, sixteen bytes a `float3` on Metal. The pipeline was never built on a Mac, the sky light never reached its image, and the ground rendered dark olive where other drivers draw it green.

On MoltenVK, a compute stage whose live `shared` declarations pass that size, and whose pack count is one work group on every axis, is now compiled from its preprocessed text with those declarations in one `layout(std430) coherent buffer` block, which the pass allocates, binds at dispatch and frees with the pass. One work group is what makes one buffer the same memory as the shared variables of that group; any other stage over the limit keeps its threadgroup memory and the log says why Metal refuses it.

SPIRV-Cross writes a bare `barrier()` as `threadgroup_barrier(mem_threadgroup)`, which does not order writes to a buffer, so the moved text defines `barrier()` as `(memoryBarrierBuffer(), barrier())`: the barrier then fences device memory (`mem_device`, or an `atomic_thread_fence` over the `coherent device` buffer from MSL 3.2). The variables keep their types, and the reduction its order and its arithmetic; only where the memory lives changes.

Every other driver, and every stage under the limit, compiles the translation exactly as before.

## How it differs from the reference, and for what obstacle

It does not change what a pack computes. Iris runs the stage on the GL driver's compute shaders, where shared memory has the driver's own limit; here the stage goes through SPIRV-Cross to a Metal kernel, whose threadgroup memory cap is the obstacle.

## What proves it

- `gradlew build` green.
- Off game: with the MoltenVK answer, Photon's `world0/deferred4_a` sizes at 36864 bytes and is moved; the moved text compiles with shaderc, the block reflects at 36864 bytes, equal to the allocation, and its MSL at 3.0 and 3.2 holds no threadgroup variable. With the answer off, the translated text of all 130 compute stages of the corpus is byte-identical to `dev`. No other compute stage of the corpus passes the limit; the largest is I Like Vanilla's floodfill cache at 16000 bytes.
- On an M4 (MoltenVK 1.4.2), arena bench, one launch each: the log reads that `world0/deferred4_a` is served from a storage buffer of 36864 bytes, no pipeline fails, and Photon's ground is green under white clouds. I Like Vanilla and Complementary Reimagined r5.9 keep their image.

## What it leaves owing

- The 32768 byte figure is the one Metal's refusal names; no MoltenVK or Metal document read here states it.
- A stage over the limit that dispatches more than one work group is still refused on Metal.
- Only scalar, vector and matrix declarations with literal array counts are sized; any other shared declaration keeps its threadgroup memory, and the log names it.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
