### PR TITLE
feat: stand aside for Iris and copy only what is read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,10 @@ what the next one holds.
   corner, where Iris puts its own name on its screen, with the engine's news on the line under them
   when there is any, so a player with both mods installed can tell which screen is open.
 
+- **An empty pack folder offers both stores.** The pack screen with no pack in its folder had one
+  button, to CurseForge's shader search. It has two now, CurseForge and Modrinth, each asking before
+  it opens the page, since Vitrail is on both and a player finds packs where they found the mod.
+
 ### Fixed
 
 - **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,7 +281,10 @@ what the next one holds.
   line in the chat saying the picture is missing, nor answers Iris's reload key, which is also its
   own, with a red line of its own. After a startup that ended badly, the backend is kept as it was
   set rather than put back to Vulkan while Iris is installed, since Iris has already chosen its side
-  for that backend.
+  for that backend. Where Iris draws, its screen is the one that opens: Vitrail's page in the video
+  settings and NeoForge's Config button lead there, and Vitrail's key for the pack screen leaves the
+  press to Iris's own, which sits on the same I, so a pack picked is the pack drawn. On Vulkan, where
+  Vitrail draws, that I opens Vitrail's screen and not Iris's offer to switch to OpenGL over it.
 
 - **Reverie draws on a Mac.** Two of its passes read more textures at once than the sixteen a Mac
   takes when a pass is handed its textures one by one, which is how the game hands them over, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,10 @@ what the next one holds.
   in a different order, reallocating everything for the first frame and then again for the
   reading, and it does not any more. Nothing about the picture changes.
 
+- **The pack screen names itself at the bottom left.** Vitrail and its version sit in grey in the
+  corner, where Iris puts its own name on its screen, with the engine's news on the line under them
+  when there is any, so a player with both mods installed can tell which screen is open.
+
 ### Fixed
 
 - **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,9 +75,10 @@ what the next one holds.
   frames of a player standing still nothing in that map moves, so it is now kept and reused instead
   of drawn again, and the passes that sample it are handed the matrices of the map they actually
   have. Measured on a Mac mini M4 with Complementary Reimagined at its defaults, in a savanna beside
-  a village, in a window of 854x480 with a shadow distance of 32: 111 to 113 frames a second with
-  the map drawn every frame, 131 to 135 with it kept. Those figures belong to that window and that
-  distance, not to every setup.
+  a village, in a window of 854x480 with a shadow distance of 32: 116 frames a second with the map
+  drawn every frame, 133 with it kept. Those figures belong to that window and that distance, not
+  to every setup: on flat ground with little to draw into the map, putting the kept map back can
+  cost more than drawing it, and turning the setting off is then the faster choice.
 
   **It does nothing on a pack that voxelises into its shadow pass**, which Complementary Unbound and
   Photon do with their coloured lighting on. A pack whose shadow programs fill a volume the rest of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,9 +292,11 @@ what the next one holds.
 
 ### Fixed
 
-- **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both
-  mods reshape Sodium's texture filtering option, and Sodium refuses two of them, so a game set to
-  OpenGL with both installed closed before the title screen. Vitrail now only touches that option
+- **Iris and Vitrail installed together no longer close the game on OpenGL.** Both mods reshape
+  Sodium's texture filtering option, and Sodium refuses two of them, so a game set to OpenGL with
+  both installed closed before the title screen. Past it, joining a world with some packs closed the
+  game again, Reverie among them, because Vitrail still ran parts of its frame inside Iris's; it now
+  runs none of its frame on a backend it does not draw on. Vitrail now only touches that option
   where it draws the world itself and Iris does not, and where Iris draws it no longer puts a red
   line in the chat saying the picture is missing, nor answers Iris's reload key, which is also its
   own, with a red line of its own. After a startup that ended badly, the backend is kept as it was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,11 @@ what the next one holds.
   button, to CurseForge's shader search. It has two now, CurseForge and Modrinth, each asking before
   it opens the page, since Vitrail is on both and a player finds packs where they found the mod.
 
+- **The pack list is in the order Iris shows it.** A few packs colour their name with a formatting
+  code at the start of the file name, and the list sorted on the name as written, so those came
+  after the packs named in plain letters. The codes are left out of the sort now, as Iris does, and
+  two names that differ only in case keep Iris's order too.
+
 ### Fixed
 
 - **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,8 @@ what the next one holds.
   settings and NeoForge's Config button lead there, and Vitrail's key for the pack screen leaves the
   press to Iris's own, which sits on the same I, so a pack picked is the pack drawn. On Vulkan, where
   Vitrail draws, that I opens Vitrail's screen and not Iris's offer to switch to OpenGL over it.
+  And the F3 screen carries Iris's lines alone on OpenGL, Vitrail's staying off it there the way
+  Iris's stay off it on Vulkan.
 
 - **Reverie draws on a Mac.** Two of its passes read more textures at once than the sixteen a Mac
   takes when a pass is handed its textures one by one, which is how the game hands them over, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,14 @@ what the next one holds.
   after the packs named in plain letters. The codes are left out of the sort now, as Iris does, and
   two names that differ only in case keep Iris's order too.
 
+- **On OpenGL, Vitrail offers to switch to Vulkan.** Vitrail draws nothing on OpenGL, yet its pack
+  screen and its settings page still opened there, so a pack picked or a setting moved changed
+  nothing you could see. Its page in the video settings and NeoForge's Config button now open a
+  screen saying Vitrail cannot run on OpenGL, with a button that sets the game to Vulkan and closes
+  it, and one that goes back. Its settings page is no longer listed there, its keys and its lines on
+  the F3 screen do nothing and show nothing, and the game's own Graphics API setting is where it
+  always was. Beside Iris it is the same offer, the way Iris's own page offers OpenGL on Vulkan.
+
 ### Fixed
 
 - **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both
@@ -291,12 +299,9 @@ what the next one holds.
   line in the chat saying the picture is missing, nor answers Iris's reload key, which is also its
   own, with a red line of its own. After a startup that ended badly, the backend is kept as it was
   set rather than put back to Vulkan while Iris is installed, since Iris has already chosen its side
-  for that backend. Where Iris draws, its screen is the one that opens: Vitrail's page in the video
-  settings and NeoForge's Config button lead there, and Vitrail's key for the pack screen leaves the
-  press to Iris's own, which sits on the same I, so a pack picked is the pack drawn. On Vulkan, where
+  for that backend. Where Iris draws, Vitrail's key for the pack screen leaves the press to Iris's
+  own, which sits on the same I, so the I opens Iris's screen alone. On Vulkan, where
   Vitrail draws, that I opens Vitrail's screen and not Iris's offer to switch to OpenGL over it.
-  And the F3 screen carries Iris's lines alone on OpenGL, Vitrail's staying off it there the way
-  Iris's stay off it on Vulkan.
 
 - **Reverie draws on a Mac.** Two of its passes read more textures at once than the sixteen a Mac
   takes when a pass is handed its textures one by one, which is how the game hands them over, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,14 @@ what the next one holds.
   written and the whole program was turned away: on iterationT that took the terrain and the moon
   out of the picture entirely. Those programs now draw.
 
-  It needs a card that can run such a shader, which the desktop cards do and Apple's do not. Where
-  there is none the log names the program, and the world keeps the game's own shader for it rather
-  than drawing it with its middle missing.
+  It needs a card that can run such a shader, which the desktop cards do and Apple's do not. On a
+  card without one, a geometry stage that only passes each corner of a triangle on is folded into
+  the shader after it, which is what iterationT's terrain stage does, so its ground is drawn on a
+  Mac too. That stage also works out how fine a block's texture is from the whole triangle, and the
+  folded shader works the same size out for each pixel instead. Any other geometry stage is named in
+  the log on such a card, and the world keeps the game's own shader for that program rather than
+  drawing it with its middle missing: iterationT's sun and moon stay with the game on a Mac, its
+  stage telling the moon from the sun by a measure of the whole quad that no single pixel can see.
 
 - **A pack may now blend one of a pass's targets differently from the others.** A shader pack can
   ask for a blend function per target rather than one for the whole program, and the engine read
@@ -55,28 +60,30 @@ what the next one holds.
   as before and the whole-program function stands, which is the ground Iris refuses it on too.
 
 - **Temporal Fold, a new setting on the engine page.** A world drawn at a lower render scale loses
-  the thin things first, and those are what crawls as you move: distant leaves, fences, the far
-  edges of terrain. The upscale cannot put them back, because it only sees one frame. This blends
-  each frame with the ones before it, matching every pixel to where it stood a frame ago, so the
-  detail comes from the frames themselves and a low scale settles instead of shimmering.
+  the thin things first, and those are what crawls as you move. The upscale cannot put them back,
+  because it only sees one frame. This blends each frame with the ones before it, matching every
+  pixel to where it stood a frame ago, so detail one frame missed can come from the frames before
+  it.
 
   It is off until you turn it on, and the checkbox is greyed out at a render scale of 100 percent,
   where there is nothing to rebuild. It costs two more passes and three more images, about 40 MiB of
-  them at 1920x1080. Things that move on their own keep a faint trail, because the match is worked
-  out from the camera and not from what each object did.
+  them at 1920x1080. Things that move on their own can leave a faint trail, because the match is
+  worked out from the camera and not from what each object did.
 
 - **Shadow Reuse, a new setting on the engine page.** Filling the shadow map means walking the whole
   world a second time, for the sun, and it is the most expensive thing the frame does. Between two
   frames of a player standing still nothing in that map moves, so it is now kept and reused instead
   of drawn again, and the passes that sample it are handed the matrices of the map they actually
-  have. Measured at eye level in open terrain: 143 to 194 frames a second on Complementary Unbound,
-  157 to 190 on Photon.
+  have. Measured on a Mac mini M4 with Complementary Reimagined at its defaults, in a savanna beside
+  a village, in a window of 854x480 with a shadow distance of 32: 111 to 113 frames a second with
+  the map drawn every frame, 131 to 135 with it kept. Those figures belong to that window and that
+  distance, not to every setup.
 
-  **It does nothing on a pack that voxelises into its shadow pass**, which those two do at their
-  own default settings, coloured lighting being what turns it on. The measurements above were taken
-  with that switched off. A pack whose shadow programs fill a volume the rest of the frame reads has
-  to fill it every frame, so the engine refuses the reuse there and says so once in the log. What
-  is left is every pack that does not, and the same packs with coloured lighting off.
+  **It does nothing on a pack that voxelises into its shadow pass**, which Complementary Unbound and
+  Photon do with their coloured lighting on. A pack whose shadow programs fill a volume the rest of
+  the frame reads has to fill it every frame, so the engine refuses the reuse there and says so once
+  in the log. That is decided from the shadow programs as the pack's settings leave them, so what is
+  left is every pack that does not voxelise, and the same packs with coloured lighting off.
 
   What is kept is the ground alone. Everything that moves, a mob, a boat, your own shadow, is drawn
   into the kept map afresh on every frame, so none of it is ever late. The price is on the ground
@@ -87,242 +94,86 @@ what the next one holds.
 - **A pack that ships no `final` program now draws.** Some packs end their chain on their last
   composite and expect what it wrote to be the picture; they were refused outright, with nothing on
   screen. What the chain leaves in `colortex0` is now brought to the screen, which is what Iris
-  does with the same packs. I Like Vanilla and Pegasus were both refused for this alone.
+  does with the same packs. I Like Vanilla and Pegasus were both refused for it, and both now load.
+
+  Neither loaded in a released version, so nothing else they needed was ever visible either. I Like
+  Vanilla reads the screen under one of the game's texture names, which the entry on those names
+  covers, and on a Mac its water declares the values it hands on through a shorthand of its own,
+  now read like the full spelling, where one of them would otherwise take the place of the next and
+  Apple's graphics refuse it. Pegasus defines one of its settings twice under two values, which
+  refused every program of it; where the two cannot be told apart the later one now stands, as a
+  driver takes it, and where a use sits between them the pack is left exactly as it wrote it. Its
+  terrain, its water, its entities and its particles needed two things more. It builds its texture
+  reads out of shorthands of its own, and the name `texture` inside them was left as written while
+  the engine renamed it everywhere else, so those passes read a name nothing declared; the
+  shorthands are renamed with the rest now. And it compares settings against numbers with a decimal
+  point, "if the falloff equals 1" with the setting at 1.0, and those lines were read as whole
+  numbers and then refused. They are now reduced the way a driver reduces them.
 
 - **Compute passes are announced as a capability.** They have been running for a while, so a pack
   that says it cannot draw without them was being refused for something it would have got. Clarity
   and Noble now load.
 
-  Three more things stood between those two packs and their picture, and none of them was ever
-  visible in a released version, since neither pack loaded at all. Clarity spells the matrix that
-  places a texture under a plain name rather than the old fixed function one, and nothing here
-  answered that spelling, so every corner of the sun and of the moon was handed the same texture
-  coordinate and both came out as flat squares of a single colour; it also lost two passes to a
-  setting compared against a number with a decimal point, which the entry below describes. Noble
-  names, in the shader itself, the format of the image that shader writes to, and that word was
-  being dropped as the declaration was moved to where this backend wants it, so the pass never
-  built and nothing wrote its screen space reflections.
+  More stood between those two packs and their picture, and none of it was ever visible in a
+  released version, since neither pack loaded at all. Clarity spells the matrix that places a
+  texture under a plain name rather than the old fixed function one, and nothing here answered that
+  spelling, so every corner of the sun and of the moon was handed the same texture coordinate and
+  both came out flat; it also lost two compute programs to a setting
+  compared against a number with a decimal point, the same reading the Pegasus paragraph above
+  describes. Noble names, in the shader itself, the format of the image that shader writes to, and
+  that word was being dropped as the declaration was moved to where this backend wants it, so the
+  pass never built and nothing wrote its screen space reflections.
+
+  Noble keeps what each surface is made of as whole numbers packed out of its colours. Apple's
+  graphics store and read those numbers wrong, so on a Mac they are packed and read back by plain
+  arithmetic the engine writes into the shader, and the game's own picture is no longer copied into
+  a target holding such numbers, which a Mac refuses outright. On any machine, whatever the game
+  still draws in the pack's place, a mob the pack has no program for among it, is missing from the
+  targets its terrain and its water write rather than painted in flat, and the log says which.
 
 - **The pack is told what you are holding.** A shader recognises an item by the number the pack
   gives it in its own table, and nothing was looking your hands up in that table, so whatever you
   carried the pack was told you carried nothing it knew. What that drives on most packs is the
-  light in your hand: on Complementary a torch, a soul lantern and a froglight all cast the same
-  generic glow instead of their own colour, and a lava bucket cast none at all; on Pegasus the
-  light was white whichever torch you held. Both hands are read. The block you are aiming at and
-  the mount you are riding go through tables of the same kind and are read with them.
+  light in your hand, which now follows the item the pack's table names. Both hands are read. The
+  block you are aiming at and the mount you are riding go through tables of the same kind and are
+  read with them.
 
-  **And the off hand no longer answers for the main one on a pack that asked it not to.** A pack
-  says whether the brighter of your two hands is what the main one reports, which is how it worked
-  before the off hand had a light of its own, and that was being done whatever the pack said. Seven
-  of the eleven packs tested ask for it to stop: on those, a torch in the off hand was being
-  reported in both hands at once, so the pack lit the scene from the empty one beside it as well.
+- **A pack that says it cannot be drawn without the translucent entity program now loads.**
+  RenderPearl names that capability in its own file, the engine did not count the name among the
+  ones it serves, and the pack was turned away before any of its programs was read, with nothing of
+  it on screen. The capability itself was already there: a blending entity draw asks for the pack's
+  `gbuffers_entities_translucent` and a blending block entity for its `gbuffers_block_translucent`,
+  each falling back on the opaque file of its own family where the pack ships neither. The name is
+  now served, and announced as a define beside the others so that a pack testing for it reads the
+  truth. RenderPearl, which names compute shaders as well, now loads.
 
-### Changed
-
-- **The compiled shaders kept on disk are three times smaller.** Every one of them carried a copy
-  of the whole shader text and a marker in front of nearly every instruction, which is what a
-  driver would need to name a line inside a shader and which nothing else reads. Measured on
-  Complementary Unbound, one pack's compiled programs came to eighteen megabytes and now come to
-  six. What is stored is what is read back at every load, so there is less of everything to read,
-  check and hand to the driver, though no load came out measurably shorter on the machine this was
-  taken on. A compile error still names its line exactly as before.
-
-- **A pack read twice in one session is opened once.** Reading a pack means mounting its archive,
-  walking it for the settings it offers, parsing what it declares and pasting every shared header
-  into every file that includes one, and all of that was done again from nothing each time: at a
-  world join, at a portal, and every time you apply a setting. The engine now keeps the archive it
-  opened and reuses that reading wherever nothing it depends on has moved, which halves the work
-  the second reading of a session does. It is opened afresh the moment anything could have changed
-  it, a file edited on disk included, so a pack you are editing is still read as you left it.
-
-- **Reloading resources no longer rebuilds the pack.** Pressing F3 and T, or anything else that
-  reloads the game's resources, threw away every program the pack had compiled and built them all
-  again, with the world held back for about a second while it happened. A pack's programs come out
-  of its own archive, which a resource reload does not touch, so the ones being drawn with are kept
-  across it now and the reload costs the pack nothing. Programs left over from a pack that has been
-  replaced are still freed there, which is the one thing that ever frees them.
-
-- **Joining a world builds the pack once instead of twice.** The pack is read while the client
-  starts up, before any world has arrived, and joining one makes it read again against what that
-  world brings. That second reading used to come after the first had already built the whole
-  chain, so everything was compiled and then thrown away; the question of whether the world moved
-  is asked before the building starts now. Leaving a world and joining another paid the same bill
-  in a different order, reallocating everything for the first frame and then again for the
-  reading, and it does not any more. Nothing about the picture changes, and no wait came out
-  measurably shorter on the machine this was taken on, so it says work removed rather than time
-  gained.
-
-### Fixed
-
-- **Noble's surfaces are lit right on a Mac.** Noble keeps what each surface is made of, how
-  shiny it is, how much it glows and how much shade it gathers, as whole numbers packed out of its
-  colours, and Apple's graphics stored one of those numbers wrong and read them back wrong, so the
-  lit picture came out wrong wherever the pack drew. On a Mac those numbers are now packed and read
-  back by plain arithmetic the engine writes into the shader, which gives the numbers every other
-  card already got. Nothing changes on any other machine.
-
-- **Photon's sky light reaches the ground on a Mac.** Photon works out the light the sky casts in a
-  small step that runs on many threads of the graphics card at once, and those threads keep their
-  working numbers in memory they share. The step asks for more of that memory than Apple's graphics
-  allow, so it was never built, and everything the sky lights came out dark: the grass a dull olive
-  where any other card draws it bright green. On a Mac, such a step now keeps those numbers in an
-  ordinary buffer when it runs as one batch of threads, which is how Photon runs it, and works out
-  the same light. A step past the allowance that runs as several batches is still refused, and the
-  log says so. Every other card is left as it was.
-
-- **RenderPearl's water, particles and translucent blocks and mobs are drawn on a Mac.** The pack
-  lights them from light lists it only builds where the shader compiler can share values between
-  neighbouring pixels, and it asks the compiler whether it can. The engine answered that question
-  for itself before handing the shader over, answered no, and left out the part that holds the
-  lists, while the compiler answered yes and went looking for them: those four programs were
-  refused and drawn with the game's own shader instead. The engine now reads the compiler's answer,
-  step by step and less what the card cannot run, so a pack asking the compiler what it supports
-  gets the same answer at both ends.
-
-- **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both
-  mods reshape Sodium's texture filtering option, and Sodium refuses two of them, so a game set to
-  OpenGL with both installed closed before the title screen. Vitrail now only touches that option
-  where it draws the world itself and Iris does not, and where Iris draws it no longer puts a red
-  line in the chat saying the picture is missing, nor answers Iris's reload key, which is also its
-  own, with a red line of its own. After a startup that ended badly, the backend is kept as it was
-  set rather than put back to Vulkan while Iris is installed, since Iris has already chosen its side
-  for that backend.
-
-- **Noble no longer stops on a Mac.** Noble keeps packed whole numbers rather than a colour in the
-  first target its terrain writes, and the engine went on copying the game's own picture into that
-  target wherever the pack drew nothing, which a Mac refuses outright: the pack was put away as soon
-  as it started drawing. A pack that writes such numbers into its terrain target now gets no copy of
-  the game's picture there, so whatever the game still draws in the pack's place, a mob the pack has
-  no program for among it, is missing from the image rather than painted in flat. The same holds
-  for the target its water is drawn into, where the beacon beam and the lightning would have been
-  laid. The log says which.
-
-- **RenderPearl no longer stops on a Mac.** The pack shares its light lists between neighbouring
-  pixels wherever the shader compiler says the card can, and the compiler says so on every card.
-  Apple's graphics stack only allows that in some of the steps a program is made of, and not in
-  the one that places the terrain, so the terrain program was never built and the pack stopped.
-  The pack is now told what the card allows in each step, and takes its own road without it where
-  it is missing. A card that allows it everywhere draws exactly as before.
-
-- **I Like Vanilla's water no longer makes the pack stop on a Mac.** The pack names the values its
-  water hands from one shader to the next through a shorthand of its own, and the engine only
-  prepared such a value for the game when it was written out in full. One of them, a set of three
-  directions, therefore took the place of the value after it, which Apple's graphics refuse
-  outright, and the pack stopped. The shorthand is now read like the full spelling.
-
-- **Reverie no longer stops on a Mac.** Two of its passes read more textures at once than the
-  sixteen a Mac takes when a pass is handed its textures one by one, which is how the game hands
-  them over, so Apple's graphics card refused those passes and the engine put the pack away. On a
-  Mac whose card takes textures as one table, which every Apple Silicon Mac does, a pass reading
-  more than sixteen is now handed them that way. Every other pass, and every pass on any other
-  machine, is handed its textures as before.
-
-- **iterationT's ground is drawn on a Mac instead of black.** Apple's graphics have no geometry
-  stage, the third shader some packs put between the two every draw is built from, so on a Mac a
-  program shipping one was handed back to the game. On iterationT that was the terrain: the game
-  drew the blocks itself, the pack's lighting then found none of the surface it expected there, and
-  the whole ground came out black under a correct sky. A geometry stage that only passes each corner
-  of a triangle on is now folded into the shader after it on such a card, so the pack draws its
-  terrain. iterationT's geometry stage also works out how fine a block's texture is from the whole
-  triangle, and the folded shader works the same size out for each pixel instead. Its sun and moon
-  still fall back to the game on a Mac, that stage telling the moon from the sun by a measure of the
-  whole quad that no single pixel can see.
-
-- **A graphics card lost in the middle of a session now closes the game on the error that lost it.**
-  When the card stopped answering, the engine caught the error at whichever step of the frame met it
-  first, switched the pack or one of its parts off and went on drawing against a card that was gone,
-  until a later step crashed the game on a report about something else. That error now goes
-  straight through, so the crash report opens on the lost device itself.
-
-- **A pack the graphics card will not build no longer closes the game.** When the card refused one
-  of a pack's programs while the pack was being prepared, which Apple's hardware does with a
-  program reading more textures at once than it has slots for, the error went all the way up and
-  the game closed on a crash report: on a Mac that was Reverie. The pack is now put away and the
-  world is drawn by the game, the way it is for a pack refused when it loads, and the settings
-  screen says an error stopped it.
-
-- **Three more programs the graphics card will not build no longer close the game.** The render
-  scale's upscale, a pack's particle program rebuilt for particles another mod draws in a format of
-  its own, and the game's entity programs rebuilt when a pack starts drawing the entities or the
-  hand were all built in the middle of a frame with nothing to catch a refusal, so a card that
-  refused one closed the game. The render scale now falls back to a plain stretch, and turns itself
-  off when nothing builds; that other mod's particles are drawn through the pack's program as it
-  stands; and the entities and the hand go back to the game for the rest of the session. The log
-  says which.
-
-- **Water no longer loses whole patches of its surface on a Mac.** On Apple Silicon a lake could show
-  its bed through rectangles where the surface was not drawn, coming and going as the view moved.
-  The engine keeps one drawing pass open across the world's geometry when it can, and the hand
-  wrote its own data to the graphics card inside that pass right after the water had been drawn in
-  it, which Vulkan does not allow; on a Mac that write cost the water already drawn. The pass is now
-  closed before any such write, unless something is still drawing into it.
-
-- **Banners no longer flicker with light stripes on a Mac.** On Apple Silicon a banner could show
-  fine light stripes coming and going across its colour, plainest on the brown banners hanging in a
-  village seen from below. A banner is drawn twice at the same place, the cloth and then its colour
-  over it, by two different programs of the pack, and the Mac's shader compiler was free to round
-  each program's arithmetic its own way, so the colour could land a hair behind the cloth and be
-  hidden by it. Every vertex program of a pack now asks for its position to come out identical
-  wherever two programs compute it with the same code.
-
-- **The world stops being shaded twice, and the sides and undersides of blocks come back to the
-  brightness the pack drew them at.** The game tints a block face by which of the six directions it
-  faces, out of a small table each dimension carries: in the overworld full strength on top, half
-  underneath and two values between on the sides, which is what gives an unshaded world its relief.
-  A pack works its own lighting out of the direction each surface faces, so that tint left underneath
-  darkened everything the pack had already shaded, each face by its own fixed amount and an
-  underside by half. It showed most where a pack lights a surface the game leaves dark, the plainest
-  of those being a canopy seen from below. A pack that wants the old behaviour writes
-  `oldLighting=true`, which the engine reads now.
-
-- **Leaves, grass and the item in hand come back on a pack that tests its own transparency.** A
-  cutout draw needs the test that throws away the see-through parts of a texture, and the engine
-  used to write that test into the shader itself whatever the shader was, reading the fourth channel
-  of the first buffer the program fills. Filling that buffer the way shaders did before they could
-  name their own outputs came with the test built into the hardware, so a program written that way
-  is written expecting it. A program that names the buffer itself is not: it puts what it likes in
-  that channel, a light level as readily as a transparency, and does its own test with the threshold
-  the engine hands it. Testing the channel anyway threw away every leaf, every blade of grass and
-  the item in hand of RenderPearl, on a ground still carrying the shadow of a canopy that was not
-  being drawn. The test is now written only into the programs that expect it, which is where the
-  engine the packs are tuned against writes it too.
-
-- **A pack no longer brings the game down on a Mac over a name it chose.** Apple hardware has no
-  driver of its own for the interface this engine draws through, so a translation layer rewrites
-  every shader into Metal's language, which is C++, and it carries over the names a pack gave its
-  own functions and variables. A pack that had named something `bias`, `length_squared` or `new`
-  then collided with words that language already owns, and Apple's compiler refused the whole pass:
-  the game came down at the moment the world was drawn, on a pipeline it could not compile. BSL,
-  Bliss and Photon all died there, on the version out today as much as on this one. The engine now
-  drops the names of everything outside a shader never asks for, which is where a pack names its
-  own working parts, and BSL draws. The names of what a pack exposes stay, its uniforms and its
-  textures, because the engine binds those by name; none of the packs tried collides there.
-
-  Bliss and Photon got past that and stopped on a different Apple limit, the one below.
-
-- **A pack that declares more textures than a pass reads draws on a Mac.** Apple offers one pass
-  sixteen slots for the textures it reads, and numbers them off the whole list of textures the
-  engine hands that pass rather than off the ones its shaders touch. A pack usually declares every
-  texture it owns in one file all its programs include, so a pass reading thirteen of them was
-  handed a list of forty-eight and given slot numbers running past the sixteenth: Apple's compiler
-  refused it and the game came down as the world was drawn, on a pass wanting three fewer slots
-  than the hardware has. The engine now numbers a pass off the textures its two shader stages read
-  between them, which is the count that has to fit, so the numbering is dense and anything under
-  sixteen gets in. Bliss and Photon draw.
-
-  Reverie has two passes whose stages read seventeen and eighteen textures between them, more than
-  Apple's hardware holds however they are numbered, and those two stay refused. Everywhere else this
-  is invisible: the same textures are bound as before and the same ones are read, and what changes
-  is only which of them the pass is given a numbered slot for.
+  Much more stood between RenderPearl and its picture, and none of it was visible in a released
+  version, since the pack never loaded. It computes in sixteen and eight bit numbers: the line
+  enabling those types is kept instead of dropped, the card is asked for that arithmetic wherever it
+  reports it, a colour output declared under one of those types is declared under its ordinary
+  width, and the values the pack passes between its two stages in a block of its own are passed one
+  by one, at the cost of the packing it had chosen. Its shared vertex header narrows the block a
+  vertex stage writes its position through, which the language allows only ahead of any use of
+  that block, and pasting the headers in moved that line past one, so every vertex stage of the
+  pack was refused; the line is dropped now and the full block stands. It asks whether the card
+  has an AMD instruction,
+  which the shader compiler answered yes on every card and which takes the driver down on a
+  GeForce, and now gets the card's own answer. It tests its own transparency and keeps a light level
+  where a transparency usually sits, so the engine's own test is now written only into programs that
+  fill their first buffer the old way, which is where the reference writes it; otherwise it would
+  throw away every leaf, every blade of grass and the item in hand. On a Mac, the pack is told which
+  steps of a program the card lets share values between neighbouring pixels, the one placing the
+  terrain not among them, and what it includes is decided on the compiler's own answer, so its
+  water, particles and translucent blocks and mobs are lit by the pack there too. Its picture is
+  painted with compute shaders, which the entry of that name below covers.
 
 - **A pack that paints its picture with compute shaders draws it.** A few packs do their whole
   post-processing in compute programs rather than in full screen passes, and store the finished
   frame into a colour buffer of their own. The engine only ever opened a colour buffer for what a
   drawing program painted into or read from, so the buffer such a pack hands the screen was never
-  opened at all: the program holding the picture was dropped on every frame and what stayed on
-  screen was the flat colour the game had cleared it to. RenderPearl was a blue screen from end to
-  end for this. Those buffers are opened now, on the strength of the program that writes them,
-  which is what the engine packs are tuned against does.
+  opened at all and the program holding the picture was dropped on every frame. Those buffers are
+  opened now, on the strength of the program that writes them. RenderPearl paints its picture that
+  way.
 
   Two more things stood between that pack and its picture. It ships two of its lookup tables as
   plain blocks of numbers rather than pictures, and the engine read a block of numbers only where
@@ -333,17 +184,25 @@ what the next one holds.
   offset as well, the offset being how a pack samples the neighbourhood of a texel for a soft
   edge, and it is carried through rather than dropped.
 
-- **A pack asking for a hard shadow edge gets one.** A shader pack can say that its shadow map is
-  to be read without smoothing, and the engine listed those lines among the pack's settings and
-  then bound the map smoothed anyway, so a pack written for a hard, stepped shadow came out soft.
-  They are read now, on the full screen passes, the world's own programs and the compute passes
-  alike, so one map is read one way across a whole frame.
+- **A compute a pack ships for a step of the chain that draws nothing now runs.** It was left out
+  on the grounds that there was no pass to run it before; it is now dispatched on its own, at the
+  moment the program it hangs off would have run at, which is what Iris does with it: its family
+  says whether that falls before the world, before its translucents or after them, and its name says
+  where it lands among the passes drawn there. A pack reaches that state by shipping the compute and
+  no drawing program for the step, or by shipping one and switching it off itself, its switch never
+  naming the compute file. A pack may go further and build every one of its worlds out of such
+  computes with no full screen pass at all, and such a pack is drawn now as well: RenderPearl is
+  written that way. Noble computes the sun's illuminance and the sky's coefficients in one, and
+  everything that lights its world reads what that leaves behind.
 
-  A pack that says nothing is unchanged, its map staying smoothed, which is where both engines
-  start. One pack of those at hand does say something: Pegasus asks for its shadow map to be read
-  without smoothing, and now gets it, on a shadow test that steps hard enough for the change to sit
-  on the edge of a shadow rather than across it. The same request on the shadow's colour buffer
-  stays ignored, as it is by the engine packs are tuned against.
+- **A pack that calls the screen by one of the game's texture names draws its picture.** In a
+  full screen pass, OptiFine leaves the first colour target as the default texture, so a pack may
+  read the scene under a name that means something else in the world pass, `tex` and `texture` among
+  them. Those names read nothing here, so every pass of such a chain worked on black and what
+  reached the screen was black. They now read the screen, in the compute passes of those stages as
+  well, and a pack that lays a picture of its own over the first colour target has that picture read
+  instead, as it does under the reference. The log names them once per pass. I Like Vanilla reads
+  its screen that way throughout.
 
 - **A pack asking for a coarser copy of its shadow map gets one.** A shader pack can ask for the
   shadow map to be kept at several sizes at once, each half the one above it, and then read the
@@ -365,17 +224,162 @@ what the next one holds.
   interface always allowed and this one does not require, keeps a single size and says so in the
   log.
 
-- **A shadow read through the hardware comparison names the copy it reads.** Where a pack asks the
-  card to compare shadow depths for it, which is how most of them read the map, the engine left the
-  choice of which copy of the map to read to the card, and a card works that out from how the
-  reading coordinate moves between neighbouring pixels. Inside a loop or a branch, where the pixels
-  beside one another may not be doing the same thing, that answer is undefined and the card may hand
-  back a copy nothing ever filled: on screen it shows as a shadow that flickers between frames from
-  a viewpoint that is not moving. Every other kind of read already named its copy for exactly that
-  reason, and these did not, though they are the reads a pack makes most, the four tap shadow filter
-  of both Complementary packs among them. They name it now, and the copy they name is always the
-  full map: a read through the comparison never reaches a smaller one, even where a shader asks
-  for it, which none of the packs at hand does.
+- **A pack asking for a hard shadow edge gets one.** A shader pack can say that its shadow map is
+  to be read without smoothing, and the engine listed those lines among the pack's settings and
+  then bound the map smoothed anyway. They are read now, on the full screen passes, the world's own
+  programs and the compute passes alike, so one map is read one way across a whole frame.
+
+  A pack that says nothing is unchanged, its map staying smoothed, which is where both engines
+  start. One pack of those at hand does say something: Pegasus, which loads for the first time in
+  this version, asks for its shadow map to be read without smoothing and gets it. The same request
+  on the shadow's colour buffer stays ignored, as it is by the engine packs are tuned against.
+
+### Changed
+
+- **The compiled shaders kept on disk are two to three times smaller.** Every one of them carried a
+  copy of the whole shader text and a marker in front of nearly every instruction, which is what a
+  driver would need to name a line inside a shader and which nothing else reads. What is stored is
+  what is read back at every load, so there is less of everything to read, check and hand to the
+  driver. A compile error still names its line exactly as before.
+
+- **A pack read twice in one session is opened once.** Reading a pack means mounting its archive,
+  walking it for the settings it offers, parsing what it declares and pasting every shared header
+  into every file that includes one, and all of that was done again from nothing each time: at a
+  world join, at a portal, and every time you apply a setting. The engine now keeps the archive it
+  opened and serves the next reading from it where the pack, its settings, its profile and the
+  values the engine defines for it are all as they were and its files carry the sizes and dates
+  they had. A setting you changed, or a world that moves those values, still has the pack read
+  afresh. Only that reading is spared: the pack's textures, its translation and its compiles go as
+  they did before. A file edited on disk changes its size or its date, so a pack you are editing is
+  still read as you left it.
+
+- **Reloading resources no longer rebuilds the pack.** Pressing F3 and T, or anything else that
+  reloads the game's resources, threw away every program the pack had compiled and built them all
+  again, with the world held back while it happened. A pack's programs come out of its own archive,
+  which a resource reload does not touch, so the ones being drawn with are kept across it now and
+  the reload costs the pack nothing. Programs left over from a pack that has been replaced are still
+  freed there, which is the one thing that ever frees them.
+
+- **Joining a world builds the pack once instead of twice.** The pack is read while the client
+  starts up, before any world has arrived, and joining one makes it read again against what that
+  world brings. That second reading used to come after the first had already built the whole
+  chain, so everything was compiled and then thrown away; the question of whether the world moved
+  is asked before the building starts now. Leaving a world and joining another paid the same bill
+  in a different order, reallocating everything for the first frame and then again for the
+  reading, and it does not any more. Nothing about the picture changes.
+
+### Fixed
+
+- **Iris and Vitrail installed together no longer close the game at startup on OpenGL.** Both
+  mods reshape Sodium's texture filtering option, and Sodium refuses two of them, so a game set to
+  OpenGL with both installed closed before the title screen. Vitrail now only touches that option
+  where it draws the world itself and Iris does not, and where Iris draws it no longer puts a red
+  line in the chat saying the picture is missing, nor answers Iris's reload key, which is also its
+  own, with a red line of its own. After a startup that ended badly, the backend is kept as it was
+  set rather than put back to Vulkan while Iris is installed, since Iris has already chosen its side
+  for that backend.
+
+- **Reverie draws on a Mac.** Two of its passes read more textures at once than the sixteen a Mac
+  takes when a pass is handed its textures one by one, which is how the game hands them over, so
+  Apple's graphics card refused those passes and the pack could not draw there. On a Mac whose card
+  takes textures as one table, which every Apple Silicon Mac does, a pass reading more than sixteen
+  is now handed them that way. Every other pass, and every pass on any other machine, is handed its
+  textures as before.
+
+- **A graphics card lost in the middle of a session now closes the game on the error that lost it.**
+  When the card stopped answering, the engine caught the error at whichever step of the frame met it
+  first, switched the pack or one of its parts off and went on drawing against a card that was gone,
+  until a later step crashed the game on a report about something else. That error now goes
+  straight through, so the crash report opens on the lost device itself.
+
+- **A pack the graphics card will not build no longer closes the game.** When the card refused one
+  of a pack's programs while the pack was being prepared, which Apple's hardware does with a
+  program reading more textures at once than it has slots for or naming something the way Metal
+  names its own, the error went all the way up and the game closed on a crash report: on a Mac
+  that was BSL, Bliss, Reverie and Photon on 0.10.0-beta, which all draw there now through the
+  entries on them. A pack the card still refuses is put away instead and the world is drawn by the
+  game, the way it is for a pack refused when it loads, and the settings screen says an error
+  stopped it.
+
+- **Three more programs the graphics card will not build no longer close the game.** The render
+  scale's upscale, a pack's particle program rebuilt for particles another mod draws in a format of
+  its own, and the game's entity programs rebuilt when a pack starts drawing the entities or the
+  hand were all built in the middle of a frame with nothing to catch a refusal, so a card that
+  refused one closed the game. The render scale now falls back to a plain stretch, and turns itself
+  off when nothing builds; that other mod's particles are drawn through the pack's program as it
+  stands; and the entities and the hand go back to the game for the rest of the session. The log
+  says which.
+
+- **Water no longer goes missing on a Mac.** The engine keeps one drawing pass open across the
+  world's geometry when it can, and the hand wrote its own data to the graphics card inside that
+  pass right after the water had been drawn in it, which Vulkan does not allow; on a Mac that write
+  cost the water already drawn. The pass is now closed before any such write, unless something is
+  still drawing into it.
+
+- **Banners no longer flicker with light stripes on a Mac.** On Apple Silicon a banner could show
+  fine light stripes coming and going across its colour, seen on the banners of a village with the
+  camera moving. A banner is drawn twice at the same place, the cloth and then its colour over it,
+  by two different programs of the pack, and the Mac's shader compiler was free to round each
+  program's arithmetic its own way, so the colour could land a hair behind the cloth and be hidden
+  by it. Every vertex program of a pack now asks for its position to come out identical
+  wherever two programs compute it with the same code.
+
+- **The world stops being shaded twice, and the sides and undersides of blocks come back to the
+  brightness the pack drew them at.** The game tints a block face by which of the six directions it
+  faces, out of a small table each dimension carries: in the overworld full strength on top, half
+  underneath and two values between on the sides, which is what gives an unshaded world its relief.
+  A pack works its own lighting out of the direction each surface faces, so that tint left underneath
+  darkened everything the pack had already shaded, each face by its own fixed amount and an
+  underside by half. It showed most where a pack lights a surface the game leaves dark, the plainest
+  of those being a canopy seen from below. A pack that wants the old behaviour writes
+  `oldLighting=true`, which the engine reads now.
+
+- **A pack no longer brings the game down on a Mac over a name it chose.** Apple hardware has no
+  driver of its own for the interface this engine draws through, so a translation layer rewrites
+  every shader into Metal's language, which is C++, and it carries over the names a pack gave its
+  own functions and variables. A pack that had named something `bias`, `length_squared` or `new`
+  then collided with words that language already owns, and Apple's compiler refused the whole pass:
+  the game came down while it warmed the pack's pipelines up, on one it could not compile. BSL,
+  Bliss and Photon all came down on a name of their own on 0.10.0-beta. The engine now drops the
+  names of everything outside a shader never asks for, which is where a pack names its own working
+  parts, and BSL draws.
+  The names of what a pack exposes stay, its uniforms and its textures, because the engine binds
+  those by name; none of the packs tried collides there. Bliss and Photon also needed the entry
+  below, and draw with it.
+
+- **A pack that declares more textures than a pass reads draws on a Mac.** Apple offers one pass
+  sixteen slots for the textures it reads, and numbers them off the whole list of textures the
+  engine hands that pass rather than off the ones its shaders touch. A pack usually declares every
+  texture it owns in one file all its programs include, so a pass reading thirteen of them was
+  handed a list of forty-eight and given slot numbers running past the sixteenth: Apple's compiler
+  refused it and the game came down while it warmed the pack's pipelines up, on a pass wanting
+  three fewer slots than the hardware has. The engine now numbers a pass off the textures its two
+  shader stages read between them, which is the count that has to fit, so the numbering is dense
+  and anything under sixteen gets in. Bliss and Photon draw.
+
+  Reverie has two passes whose stages read seventeen and eighteen textures between them, more than
+  sixteen slots hold however they are numbered, and those two are handed their textures as one table
+  instead, as the entry on Reverie says. Everywhere else this is invisible: the same textures are
+  bound as before and the same ones are read, and what changes is only which of them the pass is
+  given a numbered slot for.
+
+  Photon also works out the light its sky casts in a small step that runs on many threads of the
+  graphics card at once, and those threads share more working memory than Apple's graphics allow,
+  which leaves the step unbuilt and the sky lighting nothing. On a Mac, such a step now keeps those
+  numbers in an ordinary buffer when it runs as one batch of threads, which is how Photon runs it,
+  and works out the same light. A step past the allowance that runs as several batches is still
+  refused, and the log says so. Every other card is left as it was.
+
+- **A shadow read through the hardware comparison names the level it reads.** Where a pack asks
+  the card to compare shadow depths for it, which is how most of them read the map, the engine left
+  the level of detail to the card, and a card works that out from how the reading coordinate moves
+  between neighbouring pixels. Inside a loop or a branch, where the pixels beside one another may
+  not be doing the same thing, that answer is undefined, and a ceiling on the sampler is no guard:
+  the same ceiling on the other kinds of read was measured not to hold. Those reads already named
+  their level for exactly that reason, and these did not, though they are the reads a pack makes
+  most, the four tap shadow filter of both Complementary packs among them. They name it now, and
+  what they name is always the full map: a read through the comparison never reaches a smaller
+  copy, even where a shader asks for it, which none of the packs at hand does.
 
 - **Smoke, flame and the other solid particles take the colour the pack meant them to.**
   The game draws its quad particles in two goes, the solid ones with the world and the
@@ -400,30 +404,12 @@ what the next one holds.
   taken just ahead of the pass, which holds the world the pass wants to see behind itself, at
   the cost of two image copies a frame per such target.
 
-- **A pack written for half precision no longer takes the driver down with it.** RenderPearl
-  computes in sixteen and eight bit numbers, and five things stood between it and the screen, one of
-  which crashed the game the moment the pack's first program was built. The engine did not know
-  those types, so the colour output declared under one stayed where the pack wrote it and a second
-  output was laid on the same slot; it is declared under its ordinary width now, and the value
-  written is the same. The programs asked the card for arithmetic the game never turns on, and a
-  program asking for what was not turned on is invalid: the engine now turns on those the card
-  reports, all but the one for sixteen bit stage outputs, which the output declared under its
-  ordinary width no longer needs. The pack passes its values between the two stages in a block of its own, which
-  the game counts as one value when it numbers them, so the value after the block landed inside it:
-  the block's members are passed one by one now, at the cost of the packing the pack had chosen. And
-  the pack asks whether the card has an AMD instruction before using it, a question the shader
-  compiler answered yes on every card, and the instruction is what took the driver down on a
-  GeForce: the engine now answers it the way the card does, so the pack takes the road it wrote for
-  that card. The same pack tells the compiler it leaves the depth alone, and the engine's own code
-  wrote that depth above the pack's line, which the compiler refuses as a redeclaration after use:
-  the engine's code now comes after the pack's, where the reference puts its own.
-
-- **A pack that declares its own output where another of its branches wrote the old-style one loads
-  again.** Iteration keeps every one of its final passes in one file, one writing the old-style
-  output and the others declaring their own under the same number, and only one branch is ever
-  taken. The engine counted the branch nobody took, laid its own output on that number, and six of
-  the pack's passes were refused for two outputs on one slot. The pack's own declaration takes the
-  slot now.
+- **A pack that declares its own output where another of its branches wrote the old-style one
+  draws those passes.** Iteration keeps every one of its final passes in one file, one writing the
+  old-style output and the others declaring their own under the same number, and only one branch is
+  ever taken. The engine counted the branch nobody took, laid its own output on that number, and six
+  of the pack's passes were refused for two outputs on one slot. The pack's own declaration takes
+  the slot now.
 
 - **An effect a pack carries from one frame to the next no longer alternates between two images
   while the view moves.** The two halves of such a target were exchanged at the end of the frame
@@ -432,15 +418,14 @@ what the next one holds.
   pack was handed one image on one frame and the previous one on the next. It is steady standing
   still and shows as the view moves, so it reads as lighting that slides.
 
-- **A geometry program drawn before the water sees the world's depth again.** The terrain, the
-  mobs, the opaque particles and the held item are drawn before the frame takes its copy of the
-  opaque world, and those programs were handed an empty world where a pack asked for that copy,
-  so a shader that softens or fogs itself against the scene from one of them saw nothing in front
-  of it. They now read the copy as it stands, which at that point of the frame is the frame
-  before's, exactly what the reference hands them; the live depth stays out of reach there, being
-  the very image those programs draw into. Complementary Reimagined and Photon draw the same
-  picture as before: the one only reads that copy from its water, drawn after the take, and the
-  other reads it from its particles and glowing eyes without using it there.
+- **A geometry program drawn before the water sees the world's depth.** The terrain, the mobs, the
+  opaque particles and the held item are drawn before the frame takes its copy of the opaque world,
+  and those programs were handed the far plane where a pack asked for that copy, so a shader that
+  softens or fogs itself against the scene from one of them saw nothing in front of it. They now
+  read the copy as it stands, which at that point of the frame is the frame before's, exactly what
+  the reference hands them; the live depth stays out of reach there, being the very image those
+  programs draw into. Photon reads that copy from its opaque particles and its glowing eyes, and
+  Pegasus and E-LITE from their terrain, mobs, hand and particles.
 
 - **A greyscale picture a pack ships is read as the pack wrote it.** Every grey image came out
   lighter than the file, its darks lifted towards white, because the decoder converted the picture
@@ -460,53 +445,28 @@ what the next one holds.
   name stands for nothing the engine can read, the step still covers the whole screen and the log
   says which word it could not read.
 
-- **A pack that says it cannot be drawn without the translucent entity program now loads.**
-  RenderPearl names that capability in its own file, the engine did not count the name among the
-  ones it serves, and the pack was turned away before any of its programs was read, with nothing of
-  it on screen. The capability itself was already there: a blending entity draw asks for the pack's
-  `gbuffers_entities_translucent` and a blending block entity for its `gbuffers_block_translucent`,
-  each falling back on the opaque file of its own family where the pack ships neither. The name is
-  now served, and announced as a define beside the others so that a pack testing for it reads the
-  truth.
-
 - **The world is no longer painted over by the stage meant to run before it.** Some packs open the
   frame with a "prepare" stage, whose job is to fill a table the rest of the frame reads. It ran
   once the world was already drawn instead of ahead of it, so on a pack whose prepare fills the very
   image its terrain, its sky or its hand draws into, that table replaced all of them. On MakeUp
-  UltraFast and on E-LITE the ground vanished behind a pale blue field, the held item was not there
+  UltraFast and on E-LITE the ground vanished behind a pale field, the held item was not there
   and the sky stopped being the brightest thing on screen. The stage now runs at the head of the
   frame, where the world lands over it, and the begin stage that opens it runs ahead of the shadow
   map rather than behind it.
 
-- **A pack that calls the screen by one of the game's texture names draws its picture again.** In a
-  full screen pass, OptiFine leaves the first colour target as the default texture, so a pack may
-  read the scene under a name that means something else in the world pass, `tex` and `texture` among
-  them. Those names read nothing here, so every pass of such a chain worked on black and what
-  reached the screen was black. They now read the screen, in the compute passes of those stages as
-  well, and a pack that lays a picture of its own over the first colour target has that picture read
-  instead, as it does under the reference. The log names them once per pass. I Like Vanilla is the
-  pack this showed on, and it showed on the whole picture.
-
 - **Switching packs no longer leaves graphics memory behind on packs that use compute shaders.**
   A pack can attach a compute program to a step of its chain, and those programs kept their
   pipelines and their buffers when the pack was replaced, so every switch and every press of the
-  Reload Shaders key added to what was never given back. Long sessions spent trying packs out ended
-  with graphics memory that only closing the game freed. Photon, which builds its sky lighting in
-  such a compute, is among the packs this held on to.
+  Reload Shaders key added to what was never given back until the game closed. Photon builds its
+  sky lighting in such a compute, so every switch away from it left one behind.
 
-- **A compute a pack ships for a step of the chain that draws nothing now runs.** It was left out
-  on the grounds that there was no pass to run it before; it is now dispatched on its own, at the
-  moment the program it hangs off would have run at, which is what Iris does with it: its family
-  says whether that falls before the world, before its translucents or after them, and its name says
-  where it lands among the passes drawn there. A pack reaches that state by shipping the compute and
-  no drawing program for the step, or by shipping one and switching it off itself, its switch never
-  naming the compute file. A pack may go further and build every one of its worlds out of such
-  computes with no full screen pass at all, which used to stop its chain before the first frame:
-  RenderPearl is written that way. Noble computes the sun's illuminance and the sky's coefficients
-  in one and everything that lights its world reads what that leaves behind, so its diffuse
-  lighting, its shadows, its gbuffers and its fog all went dark at once.
+- **The off hand no longer answers for the main one on a pack that asked it not to.** A pack says
+  whether the brighter of your two hands is what the main one reports, which is how it worked
+  before the off hand had a light of its own, and that was being done whatever the pack said. Seven
+  of the eleven packs tested ask for it to stop: on those, a torch in the off hand was being
+  reported in both hands at once, so the pack lit the scene from the empty one beside it as well.
 
-- **E-LITE's clouds follow the hour of the day again.** A pack may declare a value of its own under
+- **E-LITE's clouds follow the hour of the day.** A pack may declare a value of its own under
   either of two keywords, and only one of them was reaching the shaders. E-LITE writes the hour of
   the day under the other one and its sky reads it, so it arrived as nought: the count of days was
   all the clock the cloud cover had left, and it changed in day-sized steps instead of drifting
@@ -520,7 +480,7 @@ what the next one holds.
   that was never written. They are now named for what they are, and a pack gets the same nought under
   Iris.
 
-- **A pack's quality profile is named again instead of reading "Custom".** A profile can list a
+- **A pack's quality profile is named instead of reading "Custom".** A profile can list a
   setting the pack does not actually have, and one such name was enough to stop the profile from
   ever being recognised: the shader screen and the F3 overlay both fell back to "Custom" on a pack
   nobody had touched, and the profile buttons could never land on a name. Photon is the pack this
@@ -536,27 +496,10 @@ what the next one holds.
   that moment once coincided with the display driver going down. Photon at its two largest settings
   for those volumes goes past it, and there a reload can still bring the one-colour world back.
 
-- **A setting compared against a number with a decimal point no longer switches a pass off.** Some
-  packs write conditions like "if the motion blur is above 0.0" or "if the falloff equals 1", with
-  the setting itself holding 0.5 or 1.0. Those were read as whole numbers, so a half became nought
-  and the branch was decided the wrong way, and the line was then refused outright besides. Pegasus
-  was losing its terrain, its water, its entities and its particles to one of them.
-
-- **The extensions a pack asks for are no longer dropped.** A pack using half precision types
-  guarded them on the extension being available and shipped a fallback for when it is not; the line
-  that enables the extension was thrown away while everything around it stayed, so neither road
-  worked and every one of that pack's programs failed on a type the compiler had never been told
-  about. RenderPearl went from nothing at all to most of its programs.
-
-- **A pack defining the same setting twice no longer loses every program.** Drivers take the later
-  definition and warn; this refused the whole file. Where the two cannot be told apart the later one
-  now stands, and where a use sits between them the pack is left exactly as it wrote it. Pegasus was
-  losing all of its programs to one duplicated line.
-
-- **RedHat's shadows, E-LITE's entities and hand, and the vertex stages of core-profile packs.**
-  Three separate names a pack may write that this engine either had no answer for or answered
-  twice, each of which cost the passes that read them: the picture kept the game's own shader there
-  and the pack's effect was missing on those surfaces alone.
+- **RedHat's shadows, and E-LITE's entities and hand.** Two separate names a pack may write that
+  this engine either had no answer for or answered twice, each of which cost the passes that read
+  them: the picture kept the game's own shader there and the pack's effect was missing on those
+  surfaces alone.
 
 ## 0.10.0-beta
 

--- a/NOTICE
+++ b/NOTICE
@@ -900,7 +900,8 @@ GNU Lesser General Public License version 3
   common/src/main/java/dev/vitrail/screen/SettingsScreen.java is
   net.irisshaders.iris.gui.screen.ShaderPackScreen: the two views and the switch that applies on the
   way between them, the three buttons of the bottom row and the two above it, the eye and F1, the
-  notification line, the comment panel with its splitting on sentences, the queue of what must be drawn
+  notification line, the name and version in grey at the bottom left with the line that pushes them up
+  one, the comment panel with its splitting on sentences, the queue of what must be drawn
   after every row, the two fades and the blur they gate, and the files dropped on either view.
   The blur has a second half, and it is Iris's too:
   common/src/main/java/dev/vitrail/mixin/GameRendererBlurMixin.java is

--- a/NOTICE
+++ b/NOTICE
@@ -909,9 +909,16 @@ GNU Lesser General Public License version 3
   passes to GlobalSettingsUniform down to what the screen's own fade has reached. Asking for the blur
   is a yes or a no, so without this half the fade fades nothing.
   common/src/main/java/dev/vitrail/screen/SettingsKey.java carries iris.keybind.reload, on R as Iris
-  binds it, with both of the lines Iris says in the chat afterwards, Iris.java:184 and Iris.java:191. The key that opens
-  the settings screen is on I and is NOT Iris's, which binds that screen to O, Iris.java:787; the two
-  it binds that have no counterpart here are toggleShaders on K and an unbound wireframe.
+  binds it, with both of the lines Iris says in the chat afterwards, Iris.java:187 and Iris.java:194,
+  and iris.keybind.shaderPackSelection, on I as Iris binds it, Iris.java:811 and 813; the two it
+  binds that have no counterpart here are toggleShaders on K and an unbound wireframe. Where Iris
+  draws, beside it on OpenGL, the reload stands aside for Iris's own, and the screen key too while
+  bound to the same key as Iris's, which the same press reaches, and the page of Sodium's video settings and NeoForge's Config button open
+  Iris's own screen instead, common/src/main/java/dev/vitrail/screen/PackScreens.java, through the
+  entry point Iris publishes for other mods, IrisApi.openMainIrisScreenObj, IrisApi.java:83. Where
+  Iris does not draw, the press of the I both bind is taken from Iris's mapping at the start of the
+  tick, before Iris asks it at the end, VKOnly_InitKeys.java:27, so the screen Iris opens there,
+  IrisVKOnly.java:24, does not open over this one.
   common/src/main/java/dev/vitrail/ScreenText.java keeps the English of these screens word
   for word wherever Iris has a string for the same thing, so that a player who has configured a
   pack before reads the words they already know; what Iris has no string for is this project's

--- a/NOTICE
+++ b/NOTICE
@@ -919,14 +919,18 @@ GNU Lesser General Public License version 3
   common/src/main/java/dev/vitrail/screen/SettingsKey.java carries iris.keybind.reload, on R as Iris
   binds it, with both of the lines Iris says in the chat afterwards, Iris.java:187 and Iris.java:194,
   and iris.keybind.shaderPackSelection, on I as Iris binds it, Iris.java:811 and 813; the two it
-  binds that have no counterpart here are toggleShaders on K and an unbound wireframe. Where Iris
-  draws, beside it on OpenGL, the reload stands aside for Iris's own, and the screen key too while
-  bound to the same key as Iris's, which the same press reaches, and the page of Sodium's video settings and NeoForge's Config button open
-  Iris's own screen instead, common/src/main/java/dev/vitrail/screen/PackScreens.java, through the
-  entry point Iris publishes for other mods, IrisApi.openMainIrisScreenObj, IrisApi.java:83. Where
-  Iris does not draw, the press of the I both bind is taken from Iris's mapping at the start of the
-  tick, before Iris asks it at the end, VKOnly_InitKeys.java:27, so the screen Iris opens there,
-  IrisVKOnly.java:24, does not open over this one.
+  binds that have no counterpart here are toggleShaders on K and an unbound wireframe. On a backend
+  this engine does not draw on both keys do nothing and Iris's mapping is left alone, so beside Iris
+  each press is Iris's own. On Vulkan, the press of the I both bind is taken from Iris's mapping at
+  the start of the tick, before Iris asks it at the end, VKOnly_InitKeys.java:27, so the screen Iris
+  opens there, IrisVKOnly.java:24, does not open over this one.
+  common/src/main/java/dev/vitrail/screen/BackendPlaceholder.java transcribes
+  net.irisshaders.iris.compat.sodium.config.ShaderPackScreenPlaceholder mirrored for the other
+  backend: its title, its message with OpenGL and Vulkan swapped, its two buttons and their bounds,
+  and the closing sequence of its switch, which sets Vulkan here where Iris sets OpenGL. The pages
+  PackScreens stands behind open it on any backend this engine does not draw on, and the settings
+  page of Sodium's video settings is left out there, Iris drawing there or not, both as
+  net.irisshaders.iris.compat.sodium.config.IrisConfig does on Vulkan.
   common/src/main/java/dev/vitrail/ScreenText.java keeps the English of these screens word
   for word wherever Iris has a string for the same thing, so that a player who has configured a
   pack before reads the words they already know; what Iris has no string for is this project's

--- a/NOTICE
+++ b/NOTICE
@@ -461,7 +461,10 @@ GNU Lesser General Public License version 3
   game's F3 registry, an entry registered as the registry's class initializer returns, a display
   status written only while the entry has none so that the player's own choice stands, and the
   wording of the version, shaderpack and shaders-disabled lines. What is said when a pack is not
-  drawn is this project's own, following how its loader keeps the three reasons apart.
+  drawn is this project's own, following how its loader keeps the three reasons apart. Iris's lines
+  show only off Vulkan, net.irisshaders.iris.mixin.IrisMixinPlugin applying the registering mixin
+  there alone, and this entry says nothing on a backend other than Vulkan, the same line held from
+  the other side.
 
   common/src/main/java/dev/vitrail/glsl/LegacyGlsl.java reproduces what Iris puts in place of the
   fixed function vertex inputs of a full screen pass, in CompositeTransformer lines 47 to 71: the

--- a/NOTICE
+++ b/NOTICE
@@ -868,6 +868,10 @@ GNU Lesser General Public License version 3
   itself, where Iris looks the row up by an index it was built with: that index counts the rows and
   not the packs, so it already counts the toggle above them and would count wrong the day another row
   joins it.
+  common/src/main/java/dev/vitrail/pack/load/PackLoader.java lists the packs in the order of
+  net.irisshaders.iris.shaderpack.discovery.ShaderpackDirectoryManager: by name with each section sign
+  and the character after it left out, ignoring case and then by the exact name. Its debug mode, which
+  puts folders above archives, is not carried, this engine having no such mode.
 
   Three things in this group are not transcriptions. Iris enables blending by hand before each blit
   through com.mojang.blaze3d.opengl.GlStateManager, which is the OpenGL backend's own state machine

--- a/NOTICE
+++ b/NOTICE
@@ -852,7 +852,8 @@ GNU Lesser General Public License version 3
   net.irisshaders.iris.gui.element.ShaderPackSelectionList: the row at the top switching shaders on
   and off, one row per pack with the yellow the applied one is drawn in and the grey every one takes
   while shaders are off, the bold on the row under the mouse, the line saying a pack can be dropped
-  in, the entry offering somewhere to get one when the folder is empty, the folder watched through a
+  in, the entry offering somewhere to get one when the folder is empty (Iris's opens Modrinth, and
+  a second one here opens CurseForge), the folder watched through a
   WatchService rather than polled, the row geometry down to the two pixel nudge, and the swallowing of
   Up on the first row. Its comment about why clicking a pack switches shaders on is reproduced with
   the behaviour, being the record of a real confusion. Its EnableShadersButtonElement is not carried:

--- a/common/src/main/java/dev/vitrail/HostReport.java
+++ b/common/src/main/java/dev/vitrail/HostReport.java
@@ -204,8 +204,8 @@ public final class HostReport {
 
 	/**
 	 * Said as an error rather than a warning because the pack a player asks for is not drawn at all,
-	 * and that is the engine's doing: {@code PackChoice.load} reads whichever one is named, publishes
-	 * it to the settings screen and stops there. It stops because of what the passes drew when they were let run on the
+	 * and that is the engine's doing: {@code PackChoice.load} finds whichever one is named and stops
+	 * before reading it. It stops because of what the passes drew when they were let run on the
 	 * other backend, the symptom this repository has seen there: a picture both credible and wrong,
 	 * the programs having been translated against Vulkan's depth and clip conventions. Credible and
 	 * wrong reads as a pack fault, which is worse than a picture the game draws alone, so nothing is
@@ -229,8 +229,8 @@ public final class HostReport {
 		}
 
 		Vitrail.logger().error("This game is running the {} backend and {}'s programs are translated "
-				+ "for {} alone. The mod loads, a pack it is asked for is read and shown in its "
-				+ "settings screen, and nothing of it is drawn: the game keeps its own image. Set "
+				+ "for {} alone. The mod loads, and a pack it is asked for is neither read nor drawn: "
+				+ "the game keeps its own image. Set "
 				+ "Graphics API to \"Prefer Vulkan (Experimental)\" under Options, Video Settings, "
 				+ "and restart. If it was already set there, either a launch argument forced this "
 				+ "backend, which the game says higher up, or the Vulkan boot failed and the game "

--- a/common/src/main/java/dev/vitrail/ScreenText.java
+++ b/common/src/main/java/dev/vitrail/ScreenText.java
@@ -227,6 +227,16 @@ public final class ScreenText {
 	public static final String GRAPHICS_API_OPENGL = "options.graphicsApi.opengl";
 
 	/**
+	 * What the pages leading to the pack screen open instead on a backend this engine does not draw
+	 * on, with its two buttons. Iris's words with the two backends swapped,
+	 * {@code ShaderPackScreenPlaceholder.java:30}, 19 and 38, since Iris makes the same offer the other
+	 * way round.
+	 */
+	public static final String BACKEND_PLACEHOLDER = "options.vitrail.backend_placeholder";
+	public static final String BACKEND_SWITCH = "options.vitrail.backend_switch";
+	public static final String BACKEND_RETURN = "options.vitrail.backend_return";
+
+	/**
 	 * The words beside the pulsing mark for as long as a pack compiles, through the held world
 	 * and the background compiles alike. Short on purpose: they stand next to a sixteen-pixel
 	 * icon, not on a line of their own.

--- a/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
+++ b/common/src/main/java/dev/vitrail/glsl/ProgramTranslator.java
@@ -65,6 +65,11 @@ public final class ProgramTranslator {
 	 *                    Names a stage actually samples come first, so their bindings stay inside
 	 *                    Metal's sixteen sampler slots; unused declarations follow rather than
 	 *                    pushing a used name onto slot 17
+	 * @param sampled     the names any stage reads outside their declaration. Read off the text
+	 *                    with every {@code #if} still standing, so it can hold a name only a branch
+	 *                    the compiler drops reads, or one declared again where it is not taken for
+	 *                    a declaration; it errs toward holding a name, which costs a copy and never
+	 *                    a wrong read
 	 * @param synthesized vertex inputs the mesh has not got, answered with a constant, by name and
 	 *                    with the type the pack declared them under. Empty for every pass drawn over
 	 *                    a quad, which is every pass this engine drew before milestone six
@@ -76,7 +81,7 @@ public final class ProgramTranslator {
 	 */
 	public record TranslatedProgram(Map<ProgramStage, TranslatedUnit> stages,
 			List<TranslatedUnit.Uniform> uniforms, List<TranslatedUnit.Uniform> samplers,
-			Map<String, String> synthesized, VertexInputs inputs) {
+			Set<String> sampled, Map<String, String> synthesized, VertexInputs inputs) {
 	}
 
 	/**
@@ -304,8 +309,13 @@ public final class ProgramTranslator {
 			stage.samplers().forEach(sampler -> samplers.putIfAbsent(sampler.name(), sampler));
 		}
 
+		Set<String> sampled = new LinkedHashSet<>();
+		for (GlslTranslator.Stage stage : prepared.values()) {
+			sampled.addAll(stage.sampled());
+		}
+
 		List<TranslatedUnit.Uniform> block = fixedFunctionFirst(uniforms);
-		List<TranslatedUnit.Uniform> bound = sampledFirst(samplers, prepared);
+		List<TranslatedUnit.Uniform> bound = sampledFirst(samplers, sampled);
 		Set<String> elements = clashingElements(prepared, inputs);
 
 		Map<ProgramStage, TranslatedUnit> translated = new LinkedHashMap<>();
@@ -315,8 +325,8 @@ public final class ProgramTranslator {
 			translated.put(stage, prepare.render(block, bound, varyings, shadowed));
 		});
 
-		return new TranslatedProgram(Map.copyOf(translated), block, bound, Map.copyOf(synthesized),
-				inputs);
+		return new TranslatedProgram(Map.copyOf(translated), block, bound, Set.copyOf(sampled),
+				Map.copyOf(synthesized), inputs);
 	}
 
 	/**
@@ -500,13 +510,7 @@ public final class ProgramTranslator {
 	 * twice, and {@code -Dvitrail.declaredSamplers}.
 	 */
 	private static List<TranslatedUnit.Uniform> sampledFirst(
-			Map<String, TranslatedUnit.Uniform> samplers,
-			Map<ProgramStage, GlslTranslator.Stage> prepared) {
-		Set<String> sampled = new LinkedHashSet<>();
-		for (GlslTranslator.Stage stage : prepared.values()) {
-			sampled.addAll(stage.sampled());
-		}
-
+			Map<String, TranslatedUnit.Uniform> samplers, Set<String> sampled) {
 		List<TranslatedUnit.Uniform> bound = new ArrayList<>();
 		for (TranslatedUnit.Uniform sampler : samplers.values()) {
 			if (sampled.contains(sampler.name())) {

--- a/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
+++ b/common/src/main/java/dev/vitrail/glsl/TranslatedProgramCodec.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A translated program written down and read back, byte for byte the same object either way.
@@ -19,9 +20,9 @@ import java.util.Map;
  * It exists so that {@link TranslationCache} can keep a translation between two loads. Everything a
  * {@link ProgramTranslator.TranslatedProgram} carries is written: the text of each stage, the notes
  * the translation took on the way, the uniform block in the order that IS its layout, the samplers
- * in the order they bind, and the names the translator synthesised. Leaving one of them out would
- * not fail: it would hand back a program that draws with a block laid out differently from the one
- * the engine fills, which is a wrong picture and not a crash.
+ * in the order they bind, the names the stages sample, and the names the translator synthesised.
+ * Leaving one of them out would not fail: it would hand back a program that draws with a block laid
+ * out differently from the one the engine fills, which is a wrong picture and not a crash.
  * <p>
  * <strong>Every string is written behind its length in bytes</strong> rather than through
  * {@code writeUTF}, whose count is a short: a translated composite runs to tens of thousands of
@@ -33,7 +34,7 @@ import java.util.Map;
 final class TranslatedProgramCodec {
 
 	/** Bumped by hand when the layout changes. It is part of the key, so old blobs go unread. */
-	static final String FORMAT = "vitrail-translation-5";
+	static final String FORMAT = "vitrail-translation-6";
 
 	private TranslatedProgramCodec() {
 	}
@@ -52,6 +53,7 @@ final class TranslatedProgramCodec {
 
 			uniforms(out, program.uniforms());
 			uniforms(out, program.samplers());
+			names(out, List.copyOf(program.sampled()));
 
 			out.writeInt(program.synthesized().size());
 			for (Map.Entry<String, String> made : program.synthesized().entrySet()) {
@@ -85,6 +87,7 @@ final class TranslatedProgramCodec {
 
 			List<TranslatedUnit.Uniform> uniforms = uniforms(in);
 			List<TranslatedUnit.Uniform> samplers = uniforms(in);
+			Set<String> sampled = Set.copyOf(names(in));
 
 			Map<String, String> synthesized = new LinkedHashMap<>();
 			for (int left = in.readInt(); left > 0; left--) {
@@ -92,7 +95,7 @@ final class TranslatedProgramCodec {
 			}
 
 			return new ProgramTranslator.TranslatedProgram(Map.copyOf(stages), uniforms, samplers,
-					Map.copyOf(synthesized), inputs);
+					sampled, Map.copyOf(synthesized), inputs);
 		} catch (IllegalArgumentException | NullPointerException e) {
 			// A stage name no enum has, or a null where the format promised a string. Both are a
 			// damaged blob and neither is worth its own catch upstream.

--- a/common/src/main/java/dev/vitrail/mixin/sodium/MixinSodiumWorldRendererInit.java
+++ b/common/src/main/java/dev/vitrail/mixin/sodium/MixinSodiumWorldRendererInit.java
@@ -1,5 +1,6 @@
 package dev.vitrail.mixin.sodium;
 
+import dev.vitrail.HostReport;
 import dev.vitrail.render.EntityMesh;
 import dev.vitrail.sodium.TerrainMesh;
 
@@ -46,6 +47,12 @@ public abstract class MixinSodiumWorldRendererInit {
 
 	@Inject(method = "initRenderer", at = @At("HEAD"), require = 1)
 	private void vitrail$settle(CallbackInfo callback) {
+		// Off Vulkan no pack is loaded and both meshes stay the game's and Sodium's, so there is
+		// nothing to settle and nothing to say about it.
+		if (HostReport.otherBackend()) {
+			return;
+		}
+
 		TerrainMesh.settle();
 		EntityMesh.settle();
 	}

--- a/common/src/main/java/dev/vitrail/pack/load/PackLoader.java
+++ b/common/src/main/java/dev/vitrail/pack/load/PackLoader.java
@@ -32,6 +32,10 @@ public final class PackLoader {
 
 	public static final String DIRECTORY_NAME = "shaderpacks";
 
+	/** Iris's order for pack names, case ignored first and the exact name breaking a tie. */
+	private static final Comparator<String> BY_NAME =
+			String.CASE_INSENSITIVE_ORDER.thenComparing(Comparator.naturalOrder());
+
 	private PackLoader() {
 	}
 
@@ -107,8 +111,13 @@ public final class PackLoader {
 	}
 
 	/**
-	 * Every pack in the directory, in name order. A directory and a zip are both candidates; a
-	 * zip that turns out not to be a pack fails when it is opened, not here.
+	 * Every pack in the directory, in the order Iris lists them. A directory and a zip are both
+	 * candidates; a zip that turns out not to be a pack fails when it is opened, not here.
+	 * <p>
+	 * Iris sorts on the name with its formatting codes left out, ignoring case and then by the exact
+	 * name ({@code ShaderpackDirectoryManager.java:78-107}), so a pack whose name opens on a colour
+	 * code sits among the others rather than after every pack named in plain letters. Its debug mode, which puts folders
+	 * above archives, has no counterpart here.
 	 */
 	public static List<Path> candidates(Path gameDirectory) throws IOException {
 		Path directory = directory(gameDirectory);
@@ -118,10 +127,28 @@ public final class PackLoader {
 
 		try (Stream<Path> entries = Files.list(directory)) {
 			List<Path> found = new ArrayList<>(entries.filter(PackLoader::looksLikeAPack).toList());
-			found.sort(Comparator.comparing(path -> path.getFileName().toString().toLowerCase(Locale.ROOT)));
+			found.sort(Comparator.comparing(path -> withoutFormatting(path.getFileName().toString()),
+					BY_NAME));
 
 			return List.copyOf(found);
 		}
+	}
+
+	/**
+	 * A name with each section sign and the character after it left out, Iris's
+	 * {@code ShaderpackDirectoryManager.java:24-39}: a few packs colour their name that way.
+	 */
+	private static String withoutFormatting(String name) {
+		StringBuilder kept = new StringBuilder(name.length());
+		for (int i = 0; i < name.length(); i++) {
+			if (name.charAt(i) == '§') {
+				i++;
+			} else {
+				kept.append(name.charAt(i));
+			}
+		}
+
+		return kept.toString();
 	}
 
 	/**

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -110,6 +110,15 @@ public final class EngineStages {
 	}
 
 	/**
+	 * At the start of every client tick, before anything of the tick has asked a key. Only the key
+	 * this mod shares with Iris is served here, whose press has to be taken before Iris asks for it
+	 * at the end of the same tick ({@link SettingsKey#beforeTick}).
+	 */
+	public static void clientTickStart() {
+		SettingsKey.beforeTick();
+	}
+
+	/**
 	 * At the end of every client tick, in a world or out of one. The one moment of the engine that
 	 * is not a point of the frame, and it is listed here for the same reason the others are: what
 	 * is asked once a tick has to be the same list on both loaders, and each of them reaches it

--- a/common/src/main/java/dev/vitrail/platform/EngineStages.java
+++ b/common/src/main/java/dev/vitrail/platform/EngineStages.java
@@ -35,6 +35,12 @@ import net.minecraft.world.phys.Vec3;
  * Nothing here is a frame's worth of work in itself. Each method is the short ordered list of what
  * belongs at one point of the frame, and every line of it says why it is at that point rather than
  * the next.
+ * <p>
+ * <strong>On a backend this engine does not draw on, every stage of the level frame returns at
+ * once.</strong> No pack is loaded there, so none of them has anything to do, and beside Iris the
+ * level render is Iris's: the material maps, the depth copies and the entity windows would each
+ * reach into it for nothing. The pack screen, the keys and the F3 lines stand aside on the same
+ * question.
  */
 public final class EngineStages {
 
@@ -146,6 +152,10 @@ public final class EngineStages {
 	 * and the last lines below have nothing to do with the two arguments.
 	 */
 	public static void frameGraphSetup(Matrix4fc modelView, Vec3 cameraPosition) {
+		if (HostReport.otherBackend()) {
+			return;
+		}
+
 		// First, and before the shadow question below can send this line home: the graph is being
 		// BUILT here and not executed, so it is the first point of a level frame where no render pass
 		// is open. That is what the material maps of a plain texture need, and it is the reason they
@@ -198,6 +208,10 @@ public final class EngineStages {
 	 * entities are served in opens.
 	 */
 	public static void afterOpaqueBlocks() {
+		if (HostReport.otherBackend()) {
+			return;
+		}
+
 		// Opens the one window the entities are served in. It has to be a window, because the
 		// screen is drawn by the same feature renderers, with the same pipelines and into the same
 		// target, out of a submit storage GameRenderer hands them after the level: nothing about one
@@ -225,6 +239,10 @@ public final class EngineStages {
 	 * the water is thrown away in its entirety.
 	 */
 	public static void afterOpaqueFeatures() {
+		if (HostReport.otherBackend()) {
+			return;
+		}
+
 		// First, and before anything of this engine draws: everything after this point is either the
 		// world's translucents or, once the level returns, the screen.
 		EntityDraw.opaqueFeatures(false);
@@ -259,6 +277,10 @@ public final class EngineStages {
 	 * vanish.
 	 */
 	public static void afterTranslucentFeatures() {
+		if (HostReport.otherBackend()) {
+			return;
+		}
+
 		// First, and before the layer is composed: closing the window closes any pass a group left
 		// open, and composing opens one of its own where the encoder allows only one at a time.
 		EntityDraw.translucentFeatures(false);
@@ -273,6 +295,10 @@ public final class EngineStages {
 	 * any render pass the game has open.
 	 */
 	public static void afterLevel() {
+		if (HostReport.otherBackend()) {
+			return;
+		}
+
 		// The hand's blending half, before the chain and never after it: what it draws has to be in
 		// the picture the composites read, and this stage is the last moment it can be. Iris draws it
 		// at the same place, at the head of the call that ends its level render and so ahead of its

--- a/common/src/main/java/dev/vitrail/render/GeometryProgram.java
+++ b/common/src/main/java/dev/vitrail/render/GeometryProgram.java
@@ -67,7 +67,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -503,11 +502,12 @@ final class GeometryProgram {
 	private boolean discarded;
 
 	/**
-	 * The attachments of this pass some sampler of the program also reads, on the same half.
-	 * Served a copy taken before the world's translucents on a pass drawn after the deferred
-	 * stage, and one pixel on any other; {@link TargetCopies} says why the two differ.
+	 * The attachments of this pass some sampler of the program also names, on the same half, each
+	 * with whether it is served a copy taken before the world's translucents. Only a name the
+	 * program samples on a pass drawn after the deferred stage is; every other one is served one
+	 * pixel, and {@link TargetCopies} says why the two passes differ.
 	 */
-	private final Set<ChainPlan.Attachment> readWhileWritten;
+	private final Map<ChainPlan.Attachment, Boolean> readWhileWritten;
 
 	/** Reused while a descriptor is built: Sodium asks for one per region, not once a frame. */
 	private final List<GpuTextureView> attachedViews = new ArrayList<>();
@@ -2243,71 +2243,96 @@ final class GeometryProgram {
 	}
 
 	/**
-	 * Which of this pass's attachments some sampler of the program reads on the same half,
-	 * settled once: both lists are the plan's and neither moves while the pack is loaded. Said in
-	 * the log here, once per program, because the answer decides what the draw reads.
+	 * Which of this pass's attachments some sampler of the program names on the same half, and
+	 * whether each is served the copy, settled once: both lists are the plan's and neither moves
+	 * while the pack is loaded. Said in the log here, once per program, because the answer decides
+	 * what the draw reads.
 	 * <p>
 	 * A pass drawn after the deferred stage asks for the copy {@link TargetCopies} takes ahead of
-	 * it, which is the picture the reference's framebuffer holds when it is read there. A pass drawn before it keeps the one pixel: what stands in the target at that
-	 * moment is the frame's clear or the pass's own siblings at work, and no copy taken at one
-	 * moment stands in for either. So does a read of the first four targets on any pass, which
-	 * the reference binds to no geometry program at all ({@link TargetCopies#FIRST_SAMPLED}).
+	 * it, which is the picture the reference's framebuffer holds when it is read there. A pass drawn
+	 * before it keeps the one pixel: what stands in the target at that moment is the frame's clear
+	 * or the pass's own siblings at work, and no copy taken at one moment stands in for either. So
+	 * does a read of the first four targets on any pass, which the reference binds to no geometry
+	 * program at all ({@link TargetCopies#FIRST_SAMPLED}).
+	 * <p>
+	 * Only a name the program's stages sample asks for the copy. A pack's shared header declares
+	 * targets most of its programs never read, Complementary's colortex4, colortex6 and colortex12
+	 * among them, and each one asked is copied at full size twice a frame. A name that is only
+	 * declared is still answered with the one pixel and never with the target: a layout can carry
+	 * every declared name, {@code -Dvitrail.declaredSamplers} puts them all back, and one image
+	 * cannot be an attachment and a texture of one pass. Sampled is read off the text with every
+	 * {@code #if} standing, so a read in a branch the compiler drops still asks.
 	 */
-	private Set<ChainPlan.Attachment> readWhileWritten(ColorTargets targets) {
-		Set<ChainPlan.Attachment> collided = new HashSet<>();
+	private Map<ChainPlan.Attachment, Boolean> readWhileWritten(ColorTargets targets) {
+		Set<String> sampled = this.loaded.program().sampled();
+		Map<ChainPlan.Attachment, Boolean> collided = new HashMap<>();
 		for (ChainPlan.Attachment attachment : this.extra) {
+			if (collided.containsKey(attachment)) {
+				continue;
+			}
+
+			boolean named = false;
+			boolean read = false;
 			for (Sampled one : this.bound) {
 				SamplerPlan.Binding binding = one.binding;
-				if (binding.kind() != SamplerPlan.Kind.COLORTEX
-						|| binding.index() != attachment.target()
-						|| binding.side() != attachment.side()
-						|| !collided.add(attachment)) {
-					continue;
+				if (binding.kind() == SamplerPlan.Kind.COLORTEX
+						&& binding.index() == attachment.target()
+						&& binding.side() == attachment.side()) {
+					// Two names can answer one target, gaux1 and colortex4, and a read of either counts.
+					named = true;
+					read |= sampled.contains(one.name);
 				}
+			}
 
-				boolean copied = this.pass.afterDeferred()
-						&& attachment.target() >= TargetCopies.FIRST_SAMPLED;
-				if (copied) {
-					targets.copies().ask(attachment.target(), attachment.side());
-				}
+			if (!named) {
+				continue;
+			}
 
-				// Once per program path: the entity family builds one of these per element it serves.
-				if (!targets.copies().firstMention(this.path, attachment.target(), attachment.side())) {
-					continue;
-				}
+			boolean copied = read && this.pass.afterDeferred()
+					&& attachment.target() >= TargetCopies.FIRST_SAMPLED;
+			collided.put(attachment, copied);
+			if (copied) {
+				targets.copies().ask(attachment.target(), attachment.side());
+			}
 
-				if (copied) {
-					Vitrail.logger().info("{} reads {} on the half it writes, so it is served a copy "
-							+ "taken ahead of the pass, which is what the target holds when the "
-							+ "reference reads it there", this.path,
-							TargetName.canonical(attachment.target()));
-				} else if (attachment.target() < TargetCopies.FIRST_SAMPLED) {
-					Vitrail.logger().warn("{} reads {} on the half it writes, so it is answered with "
-							+ "one pixel: one image cannot be both an attachment and a texture of one "
-							+ "pass, and the reference binds none of the first four targets to a "
-							+ "geometry program", this.path, TargetName.canonical(attachment.target()));
-				} else {
-					Vitrail.logger().warn("{} reads {} on the half it writes, so it is answered with "
-							+ "one pixel: one image cannot be both an attachment and a texture of one "
-							+ "pass, and a pass drawn before the deferred stage has no picture a copy "
-							+ "could stand in for", this.path, TargetName.canonical(attachment.target()));
-				}
+			// A name only declared draws the same whatever answers it, so it is not worth a line.
+			// Once per program path: the entity family builds one of these per element it serves.
+			if (!read
+					|| !targets.copies().firstMention(this.path, attachment.target(), attachment.side())) {
+				continue;
+			}
+
+			if (copied) {
+				Vitrail.logger().info("{} reads {} on the half it writes, so it is served a copy "
+						+ "taken ahead of the pass, which is what the target holds when the "
+						+ "reference reads it there", this.path,
+						TargetName.canonical(attachment.target()));
+			} else if (attachment.target() < TargetCopies.FIRST_SAMPLED) {
+				Vitrail.logger().warn("{} reads {} on the half it writes, so it is answered with "
+						+ "one pixel: one image cannot be both an attachment and a texture of one "
+						+ "pass, and the reference binds none of the first four targets to a "
+						+ "geometry program", this.path, TargetName.canonical(attachment.target()));
+			} else {
+				Vitrail.logger().warn("{} reads {} on the half it writes, so it is answered with "
+						+ "one pixel: one image cannot be both an attachment and a texture of one "
+						+ "pass, and a pass drawn before the deferred stage has no picture a copy "
+						+ "could stand in for", this.path, TargetName.canonical(attachment.target()));
 			}
 		}
 
-		return Set.copyOf(collided);
+		return Map.copyOf(collided);
 	}
 
-	/** Whether this name reads a target this pass writes, whatever it is answered with. */
+	/** Whether this name answers a target this pass writes, whatever it is answered with. */
 	private boolean collides(SamplerPlan.Binding binding) {
-		return binding.kind() == SamplerPlan.Kind.COLORTEX && this.readWhileWritten.contains(
+		return binding.kind() == SamplerPlan.Kind.COLORTEX && this.readWhileWritten.containsKey(
 				new ChainPlan.Attachment(binding.index(), binding.side()));
 	}
 
 	/** Whether this name is answered with the copy rather than with the target itself. */
 	private boolean copied(SamplerPlan.Binding binding) {
-		return this.pass.afterDeferred() && binding.index() >= TargetCopies.FIRST_SAMPLED
-				&& collides(binding);
+		return binding.kind() == SamplerPlan.Kind.COLORTEX && this.readWhileWritten.getOrDefault(
+				new ChainPlan.Attachment(binding.index(), binding.side()), false);
 	}
 
 	/**
@@ -2321,7 +2346,8 @@ final class GeometryProgram {
 	 * same pass, and no copy taken at one moment stands in for a target the pass's own siblings
 	 * are filling, so the read is refused rather than left to mean whatever the driver decides
 	 * that frame; and so is a read of the first four targets, which the reference binds to no
-	 * geometry program. {@link #readWhileWritten} said which at the load.
+	 * geometry program, and a name the program declares on a target it writes and never samples.
+	 * {@link #readWhileWritten} said which at the load.
 	 */
 	private GpuTextureView colortex(SamplerPlan.Binding binding) {
 		if (collides(binding)) {

--- a/common/src/main/java/dev/vitrail/render/PackChain.java
+++ b/common/src/main/java/dev/vitrail/render/PackChain.java
@@ -16,6 +16,7 @@ import dev.vitrail.pack.target.TargetSchedule;
 import dev.vitrail.pack.texture.CustomImages;
 import dev.vitrail.render.storage.StorageImages;
 import dev.vitrail.render.timing.PassTimings;
+import dev.vitrail.HostReport;
 import dev.vitrail.ScreenText;
 import dev.vitrail.uniform.ClipSpace;
 import dev.vitrail.uniform.WorldState;
@@ -734,6 +735,12 @@ public final class PackChain {
 	 *         frame nothing
 	 */
 	public static boolean beforeLevel() {
+		// Off Vulkan nothing is loaded for the world to move under, and the road is not named either:
+		// beside Iris that line would be about a pack Iris is the one drawing.
+		if (HostReport.otherBackend()) {
+			return false;
+		}
+
 		sayBeforeLevelRoad();
 
 		return RELOAD_BEFORE_LEVEL

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -261,26 +261,16 @@ public final class PackChoice {
 				return;
 			}
 
-			SettingsLayers.Resolved settings = open(gameDirectory, pack);
-
-			Map<String, OptionValue> chosen = new LinkedHashMap<>(settings.chosen());
-			// Reserved keys rather than options: no pack declares a setting under any of these
-			// names, and each names something this mod does rather than a value the pack has. The
-			// fourth, profile, never reaches here: the settings layer takes it out and carries it
-			// apart, because it is the side that writes it back into the pack's own file.
-			EngineOptions.Read engine = EngineOptions.take(chosen);
-			packsFirst = engine.packsFirst();
-			PackChain.chainWanted(engine.chain());
-
-			// Read and shown, and not drawn. On a backend this engine is not written for, the pack
-			// is published to the screen above so that it can be picked and configured ahead of the
-			// restart that will draw it, and every switch below stays down so that nothing of it
-			// reaches a mesh or a frame: the programs are translated against Vulkan's depth and
-			// clip conventions, and what they drew when let run elsewhere was a picture credible
-			// and wrong, which reads as a pack fault. The game's own image is the better answer.
+			// Chosen, and neither read, drawn nor offered for picking. On a backend this engine is not
+			// written for, its pages open the offer to switch to Vulkan instead (PackScreens) and its
+			// keys do nothing (SettingsKey), so nothing asks for the pack's settings, and every switch
+			// here stays down so that nothing of the pack reaches a mesh or a frame: the programs are
+			// translated against Vulkan's depth and clip conventions, and what they drew when let run
+			// elsewhere was a picture credible and wrong, which reads as a pack fault. The game's own
+			// image is the better answer. Asked before the pack is opened rather than after it, so
+			// that beside Iris the log carries no reading of a pack Iris is not the one drawing.
 			// HostReport says it once in the log at startup and, unless Iris draws there, once in chat
-			// on entering a world; what this road adds is the screen's bottom line, through
-			// lastError, and nothing else.
+			// on entering a world; lastError is kept all the same, for whatever asks it next.
 			if (HostReport.otherBackend()) {
 				TerrainDraw.wanted(false);
 				EntityDraw.wanted(false);
@@ -291,6 +281,17 @@ public final class PackChoice {
 				OpenedPack.forgetKept();
 				return;
 			}
+
+			SettingsLayers.Resolved settings = open(gameDirectory, pack);
+
+			Map<String, OptionValue> chosen = new LinkedHashMap<>(settings.chosen());
+			// Reserved keys rather than options: no pack declares a setting under any of these
+			// names, and each names something this mod does rather than a value the pack has. The
+			// fourth, profile, never reaches here: the settings layer takes it out and carries it
+			// apart, because it is the side that writes it back into the pack's own file.
+			EngineOptions.Read engine = EngineOptions.take(chosen);
+			packsFirst = engine.packsFirst();
+			PackChain.chainWanted(engine.chain());
 
 			TerrainDraw.wanted(engine.terrain());
 			TerrainDraw.shadowWanted(engine.shadow());

--- a/common/src/main/java/dev/vitrail/render/PackChoice.java
+++ b/common/src/main/java/dev/vitrail/render/PackChoice.java
@@ -664,7 +664,9 @@ public final class PackChoice {
 	 * The whole name is tried before the fragment. Two packs of a folder can have one name inside
 	 * the other, a version next to the version it replaces being the ordinary way that happens, and
 	 * on a fragment the shorter one would answer for both: the settings screen writes the whole
-	 * name for that reason and would otherwise be unable to reach the longer one at all.
+	 * name for that reason and would otherwise be unable to reach the longer one at all. For the same
+	 * reason the name as written is tried before the same name in another case: a case sensitive disk
+	 * can hold both, and whichever sorted first would otherwise answer for the other.
 	 *
 	 * @param asked what {@code pack.txt} says, read by the caller: the folder is searched here and
 	 *              the file is not, so that the one road out of a load that never searches a folder
@@ -674,6 +676,12 @@ public final class PackChoice {
 	private static Optional<Path> choose(List<Path> packs, PackFile asked) {
 		if (!asked.wantsPack()) {
 			return Optional.empty();
+		}
+
+		for (Path pack : packs) {
+			if (pack.getFileName().toString().equals(asked.name())) {
+				return Optional.of(pack);
+			}
 		}
 
 		String wanted = asked.name().toLowerCase(Locale.ROOT);

--- a/common/src/main/java/dev/vitrail/render/ShadowAmortisation.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowAmortisation.java
@@ -142,6 +142,12 @@ public final class ShadowAmortisation {
 
 	private static boolean missedLastPlan;
 
+	/** Whether a map drawn this frame is to be kept for a later frame, settled at the head of it. */
+	private static boolean keepThisFrame;
+
+	/** Whether the map last drawn was kept, which is the only map a later frame may put back. */
+	private static boolean keptAtLastDraw;
+
 	private static boolean saidRefused;
 
 	private static int countedFrames;
@@ -209,7 +215,11 @@ public final class ShadowAmortisation {
 			countedDraws = 0;
 		}
 
-		drawThisFrame = !seeded || asked <= 0 || !amortisable
+		keepThisFrame = asked > 0 && amortisable;
+		// A map that was not kept when it was drawn is not in the store, and the store may hold an
+		// older one from before the reuse was switched off: the first frame after switching it on
+		// draws and keeps, so a put back only ever follows a kept draw.
+		drawThisFrame = !seeded || asked <= 0 || !amortisable || !keptAtLastDraw
 				|| sinceDraw >= asked
 				|| anchorCamera.distance(camera) >= MOVE_BLOCKS
 				|| Math.abs(shadowAngle - anchorAngle) >= ANGLE_TURNS;
@@ -266,6 +276,16 @@ public final class ShadowAmortisation {
 		sinceDraw = 0;
 		seeded = true;
 		drewSinceBegin = true;
+		keptAtLastDraw = keepThisFrame;
+	}
+
+	/**
+	 * Whether the map drawn this frame is to be kept, which the stage asks before it copies it: only
+	 * where the reuse is asked for and the pack allows it. Everywhere else every frame draws its own
+	 * map and a copy of it would never be read. Nought is then the engine as it was, copy included.
+	 */
+	public static boolean keepsDrawnMap() {
+		return keepThisFrame;
 	}
 
 	/**
@@ -283,6 +303,7 @@ public final class ShadowAmortisation {
 		drawThisFrame = true;
 		drewLastFrame = true;
 		drewSinceBegin = false;
+		keptAtLastDraw = false;
 		saidRefused = false;
 	}
 

--- a/common/src/main/java/dev/vitrail/render/ShadowTargets.java
+++ b/common/src/main/java/dev/vitrail/render/ShadowTargets.java
@@ -737,11 +737,6 @@ final class ShadowTargets {
 		return this.kept && !this.broken;
 	}
 
-	/** Drops the store, at a resize and wherever the images behind it stop being the map's. */
-	void forgetKept() {
-		this.kept = false;
-	}
-
 	private GpuTexture store(String name, GpuFormat format) {
 		return RenderSystem.getDevice().createTexture(() -> name,
 				GpuTexture.USAGE_COPY_DST | GpuTexture.USAGE_COPY_SRC, format,

--- a/common/src/main/java/dev/vitrail/render/TargetCopies.java
+++ b/common/src/main/java/dev/vitrail/render/TargetCopies.java
@@ -102,8 +102,9 @@ final class TargetCopies {
 
 	/**
 	 * Says that a geometry program drawn after the deferred stage samples this target on the half
-	 * it writes. Asked at the program's construction, which is before any frame; a key asked once
-	 * a frame is running is served from the next {@link #ensure} on.
+	 * it writes. A name the program only declares, as a shared header declares every target, does
+	 * not ask. Asked at the program's construction, which is before any frame; a key asked once a
+	 * frame is running is served from the next {@link #ensure} on.
 	 */
 	void ask(int target, TargetSchedule.Side side) {
 		synchronized (this) {

--- a/common/src/main/java/dev/vitrail/screen/BackendPlaceholder.java
+++ b/common/src/main/java/dev/vitrail/screen/BackendPlaceholder.java
@@ -1,0 +1,89 @@
+package dev.vitrail.screen;
+
+import dev.vitrail.ScreenText;
+import dev.vitrail.Vitrail;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.PreferredGraphicsApi;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.TextAlignment;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.MultiLineLabel;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.network.chat.Component;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * What a door to the pack screen opens on a backend this engine does not draw on: a sentence saying
+ * so, a button that switches the game to Vulkan and closes it, and one that goes back.
+ * <p>
+ * It is the reference's screen for the same situation the other way round, which Iris opens on
+ * Vulkan in place of its pack screen ({@code IrisConfig.java:50-51}, {@code IrisVKOnly.java:24}).
+ * The layout, the words with the two backends swapped and what the switch does are
+ * {@code ShaderPackScreenPlaceholder.java}'s, line for line.
+ * <p>
+ * The switch closes the game rather than leaving that to the player, because the backend is chosen
+ * once, in the {@code Minecraft} constructor, and the saved option does nothing before the next
+ * start. The integrated server is halted and the world left through the game's saving screen first,
+ * {@code ShaderPackScreenPlaceholder.java:48-53}.
+ */
+public final class BackendPlaceholder extends Screen {
+
+	private final @Nullable Screen parent;
+
+	private @Nullable MultiLineLabel message;
+
+	public BackendPlaceholder(@Nullable Screen parent) {
+		super(Component.literal(Vitrail.MOD_NAME));
+		this.parent = parent;
+	}
+
+	@Override
+	protected void init() {
+		super.init();
+		MultiLineLabel label = MultiLineLabel.create(this.font,
+				Component.translatable(ScreenText.BACKEND_PLACEHOLDER), this.width - 50);
+		this.message = label;
+		int textSize = (label.getLineCount() + 1) * 9;
+
+		this.addRenderableWidget(Button.builder(Component.translatable(ScreenText.BACKEND_SWITCH),
+						_ -> switchToVulkan())
+				.bounds(this.width / 2 - 155, 100 + textSize, 150, 20)
+				.build());
+		this.addRenderableWidget(Button.builder(Component.translatable(ScreenText.BACKEND_RETURN),
+						_ -> onClose())
+				.bounds(this.width / 2 - 155 + 160, 100 + textSize, 150, 20)
+				.build());
+	}
+
+	private void switchToVulkan() {
+		Minecraft minecraft = Minecraft.getInstance();
+		minecraft.options.preferredGraphicsBackend().set(PreferredGraphicsApi.VULKAN);
+		minecraft.options.save();
+
+		IntegratedServer server = minecraft.getSingleplayerServer();
+		if (minecraft.isLocalServer() && server != null) {
+			server.halt(true);
+		}
+
+		minecraft.disconnectWithSavingScreen();
+		minecraft.stop();
+	}
+
+	@Override
+	public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float a) {
+		super.extractRenderState(graphics, mouseX, mouseY, a);
+		graphics.centeredText(this.font, this.title, this.width / 2, 50, -1);
+
+		MultiLineLabel label = this.message;
+		if (label != null) {
+			label.visitLines(TextAlignment.CENTER, this.width / 2, 70, 9, graphics.textRenderer());
+		}
+	}
+
+	@Override
+	public void onClose() {
+		Minecraft.getInstance().gui.setScreen(this.parent);
+	}
+}

--- a/common/src/main/java/dev/vitrail/screen/PackList.java
+++ b/common/src/main/java/dev/vitrail/screen/PackList.java
@@ -73,14 +73,16 @@ public final class PackList extends AbstractSelectionList<PackList.BaseEntry> {
 	private static final float FAINTEST = 0.01F;
 
 	/**
-	 * Where a pack comes from when the folder is empty. Iris sends people to Modrinth from here,
-	 * which is a store this mod is not on, so the address is the CurseForge search instead. It asks
-	 * for the shader class and nothing else: the same search filtered on a game version answers
-	 * with the packs whose author has uploaded a file tagged for it, which is close to none of them
-	 * in the weeks after a game release, exactly when somebody arrives here with an empty folder.
+	 * Where a pack comes from when the folder is empty, one row for each store this mod is published
+	 * on, since nothing here knows which of the two a player came through. Modrinth's is the page Iris
+	 * sends people to from the same place, {@code ShaderPackSelectionList.java:58}. CurseForge's asks
+	 * for the shader class and nothing else: the same search filtered on a game version answers with
+	 * the packs whose author has uploaded a file tagged for it, which is close to none of them in the
+	 * weeks after a game release, exactly when somebody arrives here with an empty folder.
 	 */
-	private static final String PACK_SITE =
+	private static final String CURSEFORGE_PACKS =
 			"https://www.curseforge.com/minecraft/search?class=shaders";
+	private static final String MODRINTH_PACKS = "https://modrinth.com/shaders";
 
 	private static final int ROW_HEIGHT = 20;
 
@@ -280,7 +282,10 @@ public final class PackList extends AbstractSelectionList<PackList.BaseEntry> {
 		this.toggleRow.packsPresent = !packs.isEmpty();
 		if (packs.isEmpty()) {
 			// Untranslated, as Iris leaves its own: the address it opens is in English either way.
-			addEntry(new PinnedEntry(Component.literal("Download Shaders"), this::openPackSite));
+			addEntry(new PinnedEntry(Component.literal("Download Shaders from CurseForge"),
+					() -> openPackSite(CURSEFORGE_PACKS)));
+			addEntry(new PinnedEntry(Component.literal("Download Shaders from Modrinth"),
+					() -> openPackSite(MODRINTH_PACKS)));
 		}
 
 		PackEntry selected = null;
@@ -341,17 +346,17 @@ public final class PackList extends AbstractSelectionList<PackList.BaseEntry> {
 	/**
 	 * Somewhere to get a pack, through the game's own "do you want to open this link" screen so that
 	 * nothing is opened without being asked for and the address is shown before it is followed. Iris
-	 * offers a page of its own from the same place.
+	 * offers Modrinth's from the same place.
 	 */
-	private void openPackSite() {
+	private void openPackSite(String address) {
 		Screen here = this.minecraft.gui.screen();
 		this.minecraft.gui.setScreen(new ConfirmLinkScreen(followed -> {
 			if (followed) {
-				Util.getPlatform().openUri(PACK_SITE);
+				Util.getPlatform().openUri(address);
 			}
 
 			this.minecraft.gui.setScreen(here);
-		}, PACK_SITE, true));
+		}, address, true));
 	}
 
 	/** Every row of this list, whatever it draws. */

--- a/common/src/main/java/dev/vitrail/screen/PackScreens.java
+++ b/common/src/main/java/dev/vitrail/screen/PackScreens.java
@@ -1,63 +1,36 @@
 package dev.vitrail.screen;
 
 import dev.vitrail.HostReport;
-import dev.vitrail.IrisBeside;
-import dev.vitrail.Vitrail;
 
 import net.minecraft.client.gui.screens.Screen;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Which pack screen a door of this mod opens: this engine's own, or Iris's in a session where Iris
- * draws.
+ * Which screen a door of this mod to the packs opens: this engine's own on Vulkan, and an offer to
+ * switch to Vulkan on any other backend, Iris beside it or not.
  * <p>
- * Beside Iris on OpenGL the picture is Iris's, and so is the pack: Iris reads its own choice and its
- * own settings, and this engine draws nothing on that backend. This engine's screen would list the
- * same folder and write its own files, so a pack picked there would change nothing on screen while the
- * one Iris draws stayed where it was. The page of Sodium's video settings and the Config button of
- * NeoForge's mod list therefore lead to Iris's screen in that session, and so does the key, which
- * stands aside while it shares Iris's own ({@link SettingsKey}). The way in is the one Iris publishes for other mods,
- * {@code IrisApi.openMainIrisScreenObj} at {@code IrisApi.java:83}, called by name because Iris is
- * nowhere on this mod's compile path.
+ * Off Vulkan this engine draws nothing, so a pack picked or a setting moved on its screen would change
+ * nothing on screen, and beside Iris would write files Iris never reads while the pack Iris draws
+ * stayed where it was. The page of Sodium's video settings and the Config button of NeoForge's mod
+ * list therefore open {@link BackendPlaceholder} there. That is Iris's own answer the other way round:
+ * on Vulkan its Sodium page opens the same offer in place of its pack screen,
+ * {@code IrisConfig.java:50-51}. The keys open nothing off Vulkan ({@link SettingsKey}).
  * <p>
- * The device is asked as well as the options, as the Sodium page does before its overlay: a launch
- * argument forcing Vulkan over a file that asks for OpenGL leaves Iris hooked for OpenGL and this
- * engine drawing, and this engine's screen is then the one that changes the picture.
+ * The device is asked rather than the options: a launch argument forcing Vulkan over a file that asks
+ * for OpenGL leaves Iris hooked for OpenGL and this engine drawing, and this engine's screen is then
+ * the one that changes the picture.
  */
 public final class PackScreens {
-
-	private static final String IRIS_API = "net.irisshaders.iris.api.v0.IrisApi";
 
 	private PackScreens() {
 	}
 
-	/**
-	 * The screen to open over {@code parent}. Should Iris's entry point not answer, which a later Iris
-	 * could cause by moving it, this engine's screen opens rather than nothing, and the log says why.
-	 */
+	/** The screen to open over {@code parent}. */
 	public static Screen open(@Nullable Screen parent) {
-		if (irisDraws()) {
-			try {
-				Class<?> api = Class.forName(IRIS_API, true, PackScreens.class.getClassLoader());
-				Object instance = api.getMethod("getInstance").invoke(null);
-				Object screen = api.getMethod("openMainIrisScreenObj", Object.class).invoke(instance, parent);
-				if (screen instanceof Screen irisScreen) {
-					return irisScreen;
-				}
-
-				Vitrail.logger().warn("Iris draws this session but its pack screen entry point answered {}, "
-						+ "so Vitrail's screen opens instead", screen);
-			} catch (ReflectiveOperationException | LinkageError e) {
-				Vitrail.logger().warn("Iris draws this session but its pack screen could not be opened, "
-						+ "so Vitrail's screen opens instead", e);
-			}
+		if (HostReport.otherBackend()) {
+			return new BackendPlaceholder(parent);
 		}
 
 		return new SettingsScreen(parent);
-	}
-
-	/** Whether Iris draws this session, by the options it read at startup and on the device it hooked. */
-	static boolean irisDraws() {
-		return IrisBeside.draws() && HostReport.otherBackend();
 	}
 }

--- a/common/src/main/java/dev/vitrail/screen/PackScreens.java
+++ b/common/src/main/java/dev/vitrail/screen/PackScreens.java
@@ -1,0 +1,63 @@
+package dev.vitrail.screen;
+
+import dev.vitrail.HostReport;
+import dev.vitrail.IrisBeside;
+import dev.vitrail.Vitrail;
+
+import net.minecraft.client.gui.screens.Screen;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Which pack screen a door of this mod opens: this engine's own, or Iris's in a session where Iris
+ * draws.
+ * <p>
+ * Beside Iris on OpenGL the picture is Iris's, and so is the pack: Iris reads its own choice and its
+ * own settings, and this engine draws nothing on that backend. This engine's screen would list the
+ * same folder and write its own files, so a pack picked there would change nothing on screen while the
+ * one Iris draws stayed where it was. The page of Sodium's video settings and the Config button of
+ * NeoForge's mod list therefore lead to Iris's screen in that session, and so does the key, which
+ * stands aside while it shares Iris's own ({@link SettingsKey}). The way in is the one Iris publishes for other mods,
+ * {@code IrisApi.openMainIrisScreenObj} at {@code IrisApi.java:83}, called by name because Iris is
+ * nowhere on this mod's compile path.
+ * <p>
+ * The device is asked as well as the options, as the Sodium page does before its overlay: a launch
+ * argument forcing Vulkan over a file that asks for OpenGL leaves Iris hooked for OpenGL and this
+ * engine drawing, and this engine's screen is then the one that changes the picture.
+ */
+public final class PackScreens {
+
+	private static final String IRIS_API = "net.irisshaders.iris.api.v0.IrisApi";
+
+	private PackScreens() {
+	}
+
+	/**
+	 * The screen to open over {@code parent}. Should Iris's entry point not answer, which a later Iris
+	 * could cause by moving it, this engine's screen opens rather than nothing, and the log says why.
+	 */
+	public static Screen open(@Nullable Screen parent) {
+		if (irisDraws()) {
+			try {
+				Class<?> api = Class.forName(IRIS_API, true, PackScreens.class.getClassLoader());
+				Object instance = api.getMethod("getInstance").invoke(null);
+				Object screen = api.getMethod("openMainIrisScreenObj", Object.class).invoke(instance, parent);
+				if (screen instanceof Screen irisScreen) {
+					return irisScreen;
+				}
+
+				Vitrail.logger().warn("Iris draws this session but its pack screen entry point answered {}, "
+						+ "so Vitrail's screen opens instead", screen);
+			} catch (ReflectiveOperationException | LinkageError e) {
+				Vitrail.logger().warn("Iris draws this session but its pack screen could not be opened, "
+						+ "so Vitrail's screen opens instead", e);
+			}
+		}
+
+		return new SettingsScreen(parent);
+	}
+
+	/** Whether Iris draws this session, by the options it read at startup and on the device it hooked. */
+	static boolean irisDraws() {
+		return IrisBeside.draws() && HostReport.otherBackend();
+	}
+}

--- a/common/src/main/java/dev/vitrail/screen/SettingsKey.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsKey.java
@@ -12,24 +12,29 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.Identifier;
+import org.jspecify.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
 import java.nio.file.Path;
 
 /**
- * The two keys this mod binds: R reads the pack again, I opens the settings screen.
+ * The two keys this mod binds: R reads the pack again, I opens the pack screen.
  * <p>
- * R is Iris's own, {@code iris.keybind.reload} at {@code Iris.java:785}, so a player who has
- * configured a pack before will try it first and find it. I is NOT: Iris opens its screen on O,
- * {@code Iris.java:787}. Nothing forced that, it is simply the key this mod was given before anyone
- * read which one the reference used, and it is written down here rather than quietly presented as
- * parity.
+ * Both are Iris's own, {@code iris.keybind.reload} and {@code iris.keybind.shaderPackSelection} at
+ * {@code Iris.java:811} and {@code 813}, so a player who has configured a pack before will try them
+ * first and find them. The game hands a press to every mapping bound to its key, so beside Iris one
+ * press reaches both mods, and only one of them may answer it. Where Iris draws, the reload stands
+ * aside, Iris's answering only with its debug options on ({@code Iris.java:181}), and so does this
+ * screen's key while it shares Iris's. Where Iris does not draw, on Vulkan, Iris binds I to a screen
+ * saying it cannot run there ({@code IrisVKOnly.java:17}), and the press is taken from Iris's mapping
+ * before Iris asks it ({@link #beforeTick}). A player who moved either key gets each screen on its
+ * own.
  * <p>
- * The mappings and what a press does are here; registering them and asking them once a tick is each
+ * The mappings and what a press does are here; registering them and asking them on the tick is each
  * loader's own business, because those are the two things they do differently. Asking on a tick
  * rather than on a key event is deliberate and is the same on both: the game only feeds key mappings
  * while no screen is open, so the shortcut cannot open a second copy of this screen over the first,
- * and it costs two booleans a tick.
+ * and it costs two booleans a tick, and one lookup more beside Iris.
  * <p>
  * That last point is also why the screen keeps a reload button of its own. From an open screen these
  * keys are not fed at all, so the key alone would leave the one place where a pack is being worked on
@@ -46,14 +51,37 @@ public final class SettingsKey {
 	public static final KeyMapping RELOAD =
 			new KeyMapping(ScreenText.RELOAD_PACK, GLFW.GLFW_KEY_R, CATEGORY);
 
+	/** Iris's mapping for its pack screen, by the name it registers under on both backends. */
+	private static final String IRIS_SCREEN_KEY = "iris.keybind.shaderPackSelection";
+
 	private SettingsKey() {
+	}
+
+	/**
+	 * Takes the press of the key this mod shares with Iris from Iris's mapping, where Iris does not
+	 * draw. Called before anything of the tick has asked a key, because Iris asks its own at the end
+	 * of the tick ({@code VKOnly_InitKeys.java:27}) and would open its screen over this one.
+	 */
+	public static void beforeTick() {
+		if (!IrisBeside.installed() || PackScreens.irisDraws()) {
+			return;
+		}
+
+		KeyMapping iris = sharedIrisKey();
+		if (iris != null) {
+			drain(iris);
+		}
 	}
 
 	/** Acts on whichever of the two was pressed since the last tick, and does nothing otherwise. */
 	public static void poll() {
 		if (drain(OPEN)) {
-			Minecraft minecraft = Minecraft.getInstance();
-			minecraft.gui.setScreen(new SettingsScreen(minecraft.gui.screen()));
+			// Where Iris draws and the key is shared, the same press reached Iris's mapping, which opens
+			// Iris's screen: opening it here as well would lay a second over it.
+			if (!PackScreens.irisDraws() || sharedIrisKey() == null) {
+				Minecraft minecraft = Minecraft.getInstance();
+				minecraft.gui.setScreen(PackScreens.open(minecraft.gui.screen()));
+			}
 
 			return;
 		}
@@ -61,6 +89,13 @@ public final class SettingsKey {
 		if (drain(RELOAD)) {
 			reload();
 		}
+	}
+
+	/** Iris's mapping for its pack screen where it is bound to the same key as {@link #OPEN}, or null. */
+	private static @Nullable KeyMapping sharedIrisKey() {
+		KeyMapping iris = KeyMapping.get(IRIS_SCREEN_KEY);
+
+		return iris != null && iris.same(OPEN) ? iris : null;
 	}
 
 	/**
@@ -93,7 +128,7 @@ public final class SettingsKey {
 	 * The failure is asked for rather than caught, because catching is not where it lands: reading a
 	 * pack puts what went wrong where the screen's own bottom line reads it instead of throwing, and
 	 * the load's own catch is what makes that so. So a press that read nothing is told apart by asking
-	 * that same question. Iris says both lines too, {@code Iris.java:184} and {@code Iris.java:191},
+	 * that same question. Iris says both lines too, {@code Iris.java:187} and {@code Iris.java:194},
 	 * off a catch rather than off a question because throwing is what its own reload does.
 	 * <p>
 	 * <b>A reading that read nothing because the named pack is gone answers as a failure.</b> Warned

--- a/common/src/main/java/dev/vitrail/screen/SettingsKey.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsKey.java
@@ -1,5 +1,6 @@
 package dev.vitrail.screen;
 
+import dev.vitrail.HostReport;
 import dev.vitrail.IrisBeside;
 import dev.vitrail.render.PackChoice;
 import dev.vitrail.ScreenText;
@@ -23,12 +24,12 @@ import java.nio.file.Path;
  * Both are Iris's own, {@code iris.keybind.reload} and {@code iris.keybind.shaderPackSelection} at
  * {@code Iris.java:811} and {@code 813}, so a player who has configured a pack before will try them
  * first and find them. The game hands a press to every mapping bound to its key, so beside Iris one
- * press reaches both mods, and only one of them may answer it. Where Iris draws, the reload stands
- * aside, Iris's answering only with its debug options on ({@code Iris.java:181}), and so does this
- * screen's key while it shares Iris's. Where Iris does not draw, on Vulkan, Iris binds I to a screen
- * saying it cannot run there ({@code IrisVKOnly.java:17}), and the press is taken from Iris's mapping
- * before Iris asks it ({@link #beforeTick}). A player who moved either key gets each screen on its
- * own.
+ * press reaches both mods, and only one of them may answer it. Off Vulkan this engine draws nothing and
+ * both keys do nothing, which beside Iris on OpenGL leaves each press to Iris's own, its reload
+ * answering only with its debug options on ({@code Iris.java:181}). Where Iris does not draw, on
+ * Vulkan, Iris binds I to a screen saying it cannot run there ({@code IrisVKOnly.java:17}), and the
+ * press is taken from Iris's mapping before Iris asks it ({@link #beforeTick}). A player who moved
+ * either key on Vulkan gets each screen on its own.
  * <p>
  * The mappings and what a press does are here; registering them and asking them on the tick is each
  * loader's own business, because those are the two things they do differently. Asking on a tick
@@ -58,12 +59,13 @@ public final class SettingsKey {
 	}
 
 	/**
-	 * Takes the press of the key this mod shares with Iris from Iris's mapping, where Iris does not
-	 * draw. Called before anything of the tick has asked a key, because Iris asks its own at the end
-	 * of the tick ({@code VKOnly_InitKeys.java:27}) and would open its screen over this one.
+	 * Takes the press of the key this mod shares with Iris from Iris's mapping, on Vulkan where this
+	 * engine draws. Called before anything of the tick has asked a key, because Iris asks its own at
+	 * the end of the tick ({@code VKOnly_InitKeys.java:27}) and would open its screen over this one.
+	 * Off Vulkan Iris's mapping is left alone, whichever of Iris's two faces a fallback left it with.
 	 */
 	public static void beforeTick() {
-		if (!IrisBeside.installed() || PackScreens.irisDraws()) {
+		if (!IrisBeside.installed() || HostReport.otherBackend()) {
 			return;
 		}
 
@@ -73,15 +75,20 @@ public final class SettingsKey {
 		}
 	}
 
-	/** Acts on whichever of the two was pressed since the last tick, and does nothing otherwise. */
+	/**
+	 * Acts on whichever of the two was pressed since the last tick, and does nothing otherwise. Off
+	 * Vulkan the presses are only emptied, so that none of them waits to be answered on a later tick.
+	 */
 	public static void poll() {
+		if (HostReport.otherBackend()) {
+			drain(OPEN);
+			drain(RELOAD);
+			return;
+		}
+
 		if (drain(OPEN)) {
-			// Where Iris draws and the key is shared, the same press reached Iris's mapping, which opens
-			// Iris's screen: opening it here as well would lay a second over it.
-			if (!PackScreens.irisDraws() || sharedIrisKey() == null) {
-				Minecraft minecraft = Minecraft.getInstance();
-				minecraft.gui.setScreen(PackScreens.open(minecraft.gui.screen()));
-			}
+			Minecraft minecraft = Minecraft.getInstance();
+			minecraft.gui.setScreen(PackScreens.open(minecraft.gui.screen()));
 
 			return;
 		}
@@ -139,13 +146,6 @@ public final class SettingsKey {
 	 * it.
 	 */
 	private static void reload() {
-		// Where Iris draws this session the key is Iris's: it reloads its own pack on the same R, and
-		// this engine, which draws nothing on that backend, would only answer the press with a red
-		// line saying the pack is not drawn.
-		if (IrisBeside.draws()) {
-			return;
-		}
-
 		Path directory = PackChoice.session()
 				.map(PackSession::gameDirectory)
 				.orElseGet(() -> Vitrail.platform().gameDirectory());

--- a/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
+++ b/common/src/main/java/dev/vitrail/screen/SettingsScreen.java
@@ -64,9 +64,9 @@ import java.util.stream.Stream;
  * the world behind can be looked at while a setting is judged, and Escape brings them back. This is
  * what makes the screen usable for the one thing it is for.
  * <p>
- * <b>Three facts this engine has and Iris does not</b> are drawn where Iris draws its own name, at the
- * bottom left: a load that failed, how many settings {@code vitrail/options.txt} is holding down, and
- * how many passes this backend could not build. Nothing else on the screen reaches the player with
+ * <b>The bottom left carries the name and version, as Iris's does, and under them three facts this
+ * engine has and Iris does not</b>: a load that failed, how many settings {@code vitrail/options.txt}
+ * is holding down, and how many passes this backend could not build. Nothing else on the screen reaches the player with
  * them, and the log is not where anyone looks.
  */
 public final class SettingsScreen extends Screen implements PackHost, ScreenHost {
@@ -118,6 +118,9 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 			.withStyle(ChatFormatting.GRAY, ChatFormatting.ITALIC);
 
 	private final @Nullable Screen parent;
+
+	/** The mod's name and version in grey, Iris's own line, {@code ShaderPackScreen.java:119} and 125. */
+	private final Component nameLine;
 
 	/**
 	 * The pages walked through to get here, so that going back follows the way in rather than a tree
@@ -176,6 +179,8 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 	public SettingsScreen(@Nullable Screen parent) {
 		super(Component.translatable(ScreenText.PACKS_TITLE));
 		this.parent = parent;
+		this.nameLine = Component.literal(Vitrail.MOD_NAME + " " + Vitrail.platform().modVersion())
+				.withStyle(ChatFormatting.GRAY);
 		adopt(PackChoice.session().orElse(null));
 		// Whatever the file says when there is no pack: the other view would be an empty page, and the
 		// list is where one is picked.
@@ -360,16 +365,21 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 			drawComment(graphics);
 		}
 
-		// After every list entry, and before the engine's own line, which nothing may cover.
+		// After every list entry, and before the lines at the bottom left, which nothing may cover.
 		for (Runnable draw : this.topLayer) {
 			draw.run();
 		}
 
 		this.topLayer.clear();
 
+		// Iris's arrangement, ShaderPackScreen.java:218-226: the name and version on the bottom line,
+		// pushed up one by whatever has to be said under them.
 		Component note = engineNote();
-		if (!note.getString().isEmpty()) {
+		if (note.getString().isEmpty()) {
+			graphics.text(this.font, this.nameLine, 2, this.height - 10, WHITE);
+		} else {
 			graphics.text(this.font, note, 2, this.height - 10, WHITE);
+			graphics.text(this.font, this.nameLine, 2, this.height - 20, WHITE);
 		}
 	}
 
@@ -404,9 +414,9 @@ public final class SettingsScreen extends Screen implements PackHost, ScreenHost
 	}
 
 	/**
-	 * The one line at the bottom left, which is where Iris draws its own name and version. Ours carries
-	 * the engine's news instead, worst first: a load that failed, then what is being held down from
-	 * outside, then what could not be built.
+	 * The line under the name at the bottom left, where Iris says it runs in a development environment
+	 * or is out of date. Ours carries the engine's news, worst first: a load that failed, then what is
+	 * being held down from outside, then what could not be built, and nothing when there is none.
 	 */
 	private Component engineNote() {
 		String failed = this.error == null ? PackChoice.lastError().orElse(null) : this.error;

--- a/common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java
+++ b/common/src/main/java/dev/vitrail/screen/VitrailDebugEntry.java
@@ -1,5 +1,6 @@
 package dev.vitrail.screen;
 
+import dev.vitrail.HostReport;
 import dev.vitrail.Vitrail;
 import dev.vitrail.render.PackChain;
 import dev.vitrail.render.PackChoice;
@@ -29,6 +30,12 @@ import org.jspecify.annotations.Nullable;
  * pack that was refused would send the reader to the settings screen when the log is where the
  * answer is.
  * <p>
+ * Nothing is said on a backend this engine does not draw on, which is where Iris draws when it is
+ * installed. Iris shows its own lines only off Vulkan, its mixin plugin applying the mixin that
+ * registers them there alone ({@code mixin/IrisMixinPlugin.java:71-73},
+ * {@code mixin/MixinDebugEntries.java:23}), so each engine's lines stand where that engine draws.
+ * Before the device exists the backend has no name and the lines show.
+ * <p>
  * Registration is {@code DebugScreenEntriesMixin}'s, and the line showing without a hand's turn of
  * F3 configuration is {@code DebugScreenEntryListMixin}'s; this class only says the words. All
  * three follow Iris's own construction on the same vanilla seams.
@@ -54,6 +61,10 @@ public final class VitrailDebugEntry implements DebugScreenEntry {
 	@Override
 	public void display(DebugScreenDisplayer displayer, @Nullable Level level,
 			@Nullable LevelChunk clientChunk, @Nullable LevelChunk serverChunk) {
+		if (HostReport.otherBackend()) {
+			return;
+		}
+
 		displayer.addToGroup(GROUP, PREFIX + "Version: " + Vitrail.platform().modVersion());
 		PackChain.compilingWords().ifPresent(words ->
 				displayer.addToGroup(GROUP, PREFIX + words.getString()));

--- a/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
+++ b/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
@@ -8,7 +8,7 @@ import dev.vitrail.render.ShadowAmortisation;
 import dev.vitrail.render.StartupGuard;
 import dev.vitrail.render.TemporalAccumulation;
 import dev.vitrail.render.TerrainDraw;
-import dev.vitrail.screen.SettingsScreen;
+import dev.vitrail.screen.PackScreens;
 import dev.vitrail.ScreenText;
 import dev.vitrail.settings.GraphicsApiChoice;
 import dev.vitrail.settings.PackFile;
@@ -39,7 +39,8 @@ import java.util.Set;
  * <p>
  * This is the same entry the reference takes, {@code IrisConfig} in its own tree, and by the same
  * public API rather than by reaching into Sodium: one page under the mod's own name, which opens
- * this screen with the video settings as the screen to come back to, and a second page for the
+ * the pack screen with the video settings as the screen to come back to, Iris's where Iris draws
+ * ({@link PackScreens}), and a second page for the
  * settings that are this engine's own rather than a pack's. That second page is thin on purpose:
  * almost everything this engine has to offer is the pack's and lives on the pack's pages, and only
  * what a player sets over every pack belongs here. The one thing registered that is not a page is an
@@ -117,7 +118,7 @@ public final class ConfigEntry implements ConfigEntryPoint {
 				.addPage(builder.createExternalPage()
 						.setName(Component.translatable(ScreenText.PACKS_TITLE))
 						.setScreenConsumer(parent ->
-								Minecraft.getInstance().gui.setScreen(new SettingsScreen(parent))))
+								Minecraft.getInstance().gui.setScreen(PackScreens.open(parent))))
 				.addPage(builder.createOptionPage()
 						.setName(Component.translatable(ScreenText.PAGE_TITLE))
 						.addOptionGroup(builder.createOptionGroup()

--- a/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
+++ b/common/src/main/java/dev/vitrail/sodium/ConfigEntry.java
@@ -39,9 +39,9 @@ import java.util.Set;
  * <p>
  * This is the same entry the reference takes, {@code IrisConfig} in its own tree, and by the same
  * public API rather than by reaching into Sodium: one page under the mod's own name, which opens
- * the pack screen with the video settings as the screen to come back to, Iris's where Iris draws
- * ({@link PackScreens}), and a second page for the
- * settings that are this engine's own rather than a pack's. That second page is thin on purpose:
+ * the pack screen with the video settings as the screen to come back to, and an offer to switch to
+ * Vulkan on any other backend, Iris beside it or not ({@link PackScreens}), and, on Vulkan alone, a
+ * second page for the settings that are this engine's own rather than a pack's. That second page is thin on purpose:
  * almost everything this engine has to offer is the pack's and lives on the pack's pages, and only
  * what a player sets over every pack belongs here. The one thing registered that is not a page is an
  * overlay over an option of Sodium's own, whose reason is written where it is registered.
@@ -118,17 +118,24 @@ public final class ConfigEntry implements ConfigEntryPoint {
 				.addPage(builder.createExternalPage()
 						.setName(Component.translatable(ScreenText.PACKS_TITLE))
 						.setScreenConsumer(parent ->
-								Minecraft.getInstance().gui.setScreen(PackScreens.open(parent))))
-				.addPage(builder.createOptionPage()
-						.setName(Component.translatable(ScreenText.PAGE_TITLE))
-						.addOptionGroup(builder.createOptionGroup()
-								.addOption(shadowDistance(builder))
-								.addOption(shadowMapScale(builder))
-								.addOption(renderScale(builder))
-								.addOption(temporalFold(builder))
-								.addOption(shadowAmortisation(builder))
-								.addOption(graphicsApi(builder))
-								.addOption(moduleCacheCeiling(builder))));
+								Minecraft.getInstance().gui.setScreen(PackScreens.open(parent))));
+
+		// Left out where this engine draws nothing, as Iris leaves its own out on the backend it does
+		// not draw on, IrisConfig.java:54-55. The game's own Graphics API setting stays in the video
+		// settings, and the rescue choice below is only read after a startup that crashed, so nothing
+		// here is needed to get back to Vulkan. The device is up by this walk.
+		if (!HostReport.otherBackend()) {
+			options.addPage(builder.createOptionPage()
+					.setName(Component.translatable(ScreenText.PAGE_TITLE))
+					.addOptionGroup(builder.createOptionGroup()
+							.addOption(shadowDistance(builder))
+							.addOption(shadowMapScale(builder))
+							.addOption(renderScale(builder))
+							.addOption(temporalFold(builder))
+							.addOption(shadowAmortisation(builder))
+							.addOption(graphicsApi(builder))
+							.addOption(moduleCacheCeiling(builder))));
+		}
 
 		// Only on the backend this engine draws on. Anywhere else the pack draws nothing, so RGSS
 		// keeps working and there is nothing to narrow. And never where Iris draws, which registers

--- a/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
+++ b/common/src/main/java/dev/vitrail/sodium/ShadowTerrain.java
@@ -363,9 +363,13 @@ public final class ShadowTerrain {
 
 		// The store is taken HERE and nowhere else: with the opaque world in the map and before the
 		// first thing that moves goes into it. A store taken later would carry a mob, and every
-		// frame restoring it would paint that mob's old place back under the new one.
+		// frame restoring it would paint that mob's old place back under the new one. Taken only where
+		// a later frame may put it back: with the reuse off the copy is the whole map and its colours
+		// on every frame, read by nobody, and it cost the M4 about eight per cent of its frames.
 		if (drawTerrain && casters.terrain()) {
-			TerrainDraw.keepShadowMap();
+			if (ShadowAmortisation.keepsDrawnMap()) {
+				TerrainDraw.keepShadowMap();
+			}
 			ShadowAmortisation.drawn();
 		}
 

--- a/common/src/main/resources/assets/vitrail/lang/en_us.json
+++ b/common/src/main/resources/assets/vitrail/lang/en_us.json
@@ -66,6 +66,9 @@
 	"options.vitrail.pack_reloaded": "Shaders Reloaded!",
 	"options.vitrail.reload_failed": "Failed to reload shaders! Reason: %s",
 	"options.vitrail.other_backend": "Vitrail draws nothing on %s: its shaders run on Vulkan only. Set %s to \"%s\" under Options, Video Settings, and restart the game.",
+	"options.vitrail.backend_placeholder": "Vitrail cannot run when using OpenGL. Would you like to switch to Vulkan?\nThis will close your game.",
+	"options.vitrail.backend_switch": "Switch",
+	"options.vitrail.backend_return": "Return",
 	"overlay.vitrail.compiling": "Compiling shaders...",
 	"overlay.vitrail.compiled": "Shaders compiled!",
 	"key.category.vitrail.keybinds": "Vitrail"

--- a/common/src/main/resources/assets/vitrail/lang/fr_fr.json
+++ b/common/src/main/resources/assets/vitrail/lang/fr_fr.json
@@ -66,6 +66,9 @@
 	"options.vitrail.pack_reloaded": "Shaders rechargés !",
 	"options.vitrail.reload_failed": "Échec lors du rechargement des shaders ! Raison : %s",
 	"options.vitrail.other_backend": "Vitrail ne dessine rien sur %s : ses shaders ne tournent que sur Vulkan. Réglez %s sur \"%s\" dans Options, Paramètres vidéo, puis redémarrez le jeu.",
+	"options.vitrail.backend_placeholder": "Vitrail ne peut pas fonctionner avec OpenGL. Voulez-vous passer à Vulkan ?\nCela fermera votre jeu.",
+	"options.vitrail.backend_switch": "Changer",
+	"options.vitrail.backend_return": "Retour",
 	"overlay.vitrail.compiling": "Compilation des shaders...",
 	"overlay.vitrail.compiled": "Shaders compilés !",
 	"key.category.vitrail.keybinds": "Vitrail"

--- a/docs/settings-screen.md
+++ b/docs/settings-screen.md
@@ -15,6 +15,10 @@ the key bound in the game's controls (`I` by default), or from wherever else you
 options. A second key, `R`, reads the pack again from disk without opening anything, which is what
 makes editing a shader by hand and seeing the result a two second loop.
 
+On a backend other than Vulkan the engine draws nothing, so its page in the video settings opens an
+offer to switch to Vulkan, which closes the game, Iris installed or not. Its two keys do nothing
+there, and its own page of settings is not listed in the video settings.
+
 ## Two views, one screen
 
 The screen holds two views and swaps between them with the button above the bottom row. Tab does the

--- a/fabric/src/main/java/dev/vitrail/fabric/FabricKey.java
+++ b/fabric/src/main/java/dev/vitrail/fabric/FabricKey.java
@@ -11,7 +11,7 @@ import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
  * <p>
  * This is the only place in the mod that needs Fabric API at all, and it takes two of its modules
  * because the bare game offers neither of the two things a key needs: the mapping has to be appended
- * to an array the options own, and it has to be asked once a tick. Both are exactly what those
+ * to an array the options own, and it has to be asked at both ends of a tick. Both are exactly what those
  * modules do, so writing a mixin for either would be reimplementing them. The tick carries the
  * engine's whole tick stage rather than the key alone, since this is the module that reaches it.
  * <p>
@@ -26,6 +26,7 @@ final class FabricKey {
 	static void register() {
 		KeyMappingHelper.registerKeyMapping(SettingsKey.OPEN);
 		KeyMappingHelper.registerKeyMapping(SettingsKey.RELOAD);
+		ClientTickEvents.START_CLIENT_TICK.register(_ -> EngineStages.clientTickStart());
 		ClientTickEvents.END_CLIENT_TICK.register(_ -> EngineStages.clientTick());
 	}
 }

--- a/neoforge/src/main/java/dev/vitrail/neoforge/VitrailKeys.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/VitrailKeys.java
@@ -7,7 +7,7 @@ import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 
 /**
  * Registers {@link SettingsKey}, on the mod bus because that is the bus the event is posted on.
- * Asking it once a tick is the tick stage's business, reached from {@code VitrailNeoForge}.
+ * Asking it at both ends of a tick is the tick stage's business, reached from {@code VitrailNeoForge}.
  */
 public final class VitrailKeys {
 

--- a/neoforge/src/main/java/dev/vitrail/neoforge/VitrailNeoForge.java
+++ b/neoforge/src/main/java/dev/vitrail/neoforge/VitrailNeoForge.java
@@ -2,7 +2,7 @@ package dev.vitrail.neoforge;
 
 import dev.vitrail.platform.EngineStages;
 import dev.vitrail.render.pbr.PbrAtlases;
-import dev.vitrail.screen.SettingsScreen;
+import dev.vitrail.screen.PackScreens;
 import dev.vitrail.Vitrail;
 
 import net.minecraft.client.renderer.texture.TextureAtlas;
@@ -37,7 +37,7 @@ public final class VitrailNeoForge {
 		// pause menu. A two argument lambda rather than a supplier, which is the overload it
 		// would otherwise pick.
 		container.registerExtensionPoint(IConfigScreenFactory.class,
-				(_, modListScreen) -> new SettingsScreen(modListScreen));
+				(_, modListScreen) -> PackScreens.open(modListScreen));
 
 		VitrailKeys.register(modBus);
 
@@ -50,6 +50,7 @@ public final class VitrailNeoForge {
 
 		modBus.addListener(FMLClientSetupEvent.class, _ -> EngineStages.clientSetup());
 
+		NeoForge.EVENT_BUS.addListener(ClientTickEvent.Pre.class, _ -> EngineStages.clientTickStart());
 		NeoForge.EVENT_BUS.addListener(ClientTickEvent.Post.class, _ -> EngineStages.clientTick());
 
 		// Posted at the end of TextureAtlas.upload, once per atlas and once per resource reload,


### PR DESCRIPTION
## What changes

On any backend Vitrail does not draw on, Iris beside it or not, it now stands aside whole: no F3 lines, no keys, no settings page, and none of its level frame stages, its reload before the level or its mesh settle, which until now still ran inside the level render there, Iris's included. Its page in Sodium's video settings and NeoForge's Config button open an offer to switch to Vulkan, as Iris does on Vulkan. On Vulkan, Iris's OpenGL prompt no longer opens over Vitrail's screen on the I both bind. The pack screen names itself and its version at the bottom left, an empty pack folder offers CurseForge and Modrinth, the pack list follows Iris's order, formatting codes left out, and `pack.txt` is matched as written before another case. Shadow Reuse copied the shadow map aside on every frame it drew, the setting off included, and a colour target was copied ahead of a pass for any program declaring its sampler; both copies are now made only where they are read, most of what an Apple M4 lost against 0.10.0-beta.

## How it differs from the reference, and for what obstacle

It does not, bar one point. The key is Iris's I (`Iris.java:813`), the name line `ShaderPackScreen.java:119`, `:125` and `:218-226`, the order `ShaderpackDirectoryManager.java:24-39` and `:78-107`, the switch offer `ShaderPackScreenPlaceholder.java` mirrored with the settings page left out as `IrisConfig.java:50-55` does, the F3 lines `IrisMixinPlugin.java:71-73`. Iris's empty folder offers Modrinth alone; a second entry opens CurseForge, where Vitrail ships too.

## What proves it

- `gradlew build` green.
- Apple M4, the whole corpus, three launches a pack alternated against 0.10.0-beta: from 4 % above to 7 % below on the packs both draw (5 to 14 % below before the copy fixes), and the packs 0.10.0-beta crashed on or left bare are drawn.
- Windows, the whole corpus hot swapped on the Fabric bench against the build before the two copy changes: frame rates and captures within the spread two sweeps of one jar show, bar E-LITE's motion blur.
- In game beside Iris 1.11.2 on OpenGL: I opens Iris alone, no Vitrail F3 line or settings page, and Vitrail's entry offers Vulkan and restarts there. On Vulkan: I opens Vitrail's screen, the version and Iris's order show, and an empty folder offers both stores.
- In game beside Iris 1.11.2 on OpenGL with Reverie, joining a server: the game closed natively right after Vitrail's reload line before the stages stood aside, and with them standing aside it loads and draws, with no line of Vitrail's past startup.

## What it leaves owing

At the end of a frame each flipped target is copied back to its main side, as Iris does, including a target nothing reads again; MakeUp pays three such copies and stays 7 % under 0.10.0-beta on the M4. Sparing them needs the samplers of every stage read in pass order.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
