### PR TITLE
build: reopen 0.11.0-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ publishing a jar named after one thing and built from another.
 Everything is a pre-release while the version stays under `1.0.0`. Nothing here is a promise about
 what the next one holds.
 
-## 0.11.0-beta
+## Unreleased
 
 ### Added
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.11.0-beta
+mod_version=0.11.0-dev
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

`dev` carries `0.11.0-beta` since #388, and that version was never tagged: more work has to land before it is. This puts `mod_version` back to `0.11.0-dev` and the changelog section back under `Unreleased`, so that the work lands under the right heading and the version commit can be the last one on `dev` again.

## How it differs from the reference, and for what obstacle

It does not. Nothing of the engine moves, only the version and one heading.

## What proves it

- `gradlew build` green.
- Two lines change, `gradle.properties` and the section heading of `CHANGELOG.md`.

## What it leaves owing

A fresh `release/0.11.0-beta` once the pending work is on `dev`.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [x] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.
