### PR TITLE
build: open 0.12.0-dev

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.configuration-cache=false
 
 group_id=dev.vitrail
 mod_id=vitrail
-mod_version=0.11.0-beta
+mod_version=0.12.0-dev
 java_version=25
 
 # Toolchain. neoform_version is the bare game, which both the common module and the Fabric one


### PR DESCRIPTION
## What changes

`mod_version` in `gradle.properties` leaves 0.11.0-beta, which has just been tagged and published, and
takes 0.12.0-dev. Nothing built from here on names a version that is already out: the jar, the line the
engine logs at load, the settings screen and the F3 line all say 0.12.0-dev, and a build off a topic
branch says it with that branch's name after it.

The suffix comes off again on the `release/` branch that cuts the next version, and no `-dev`
version is ever tagged: the release workflow accepts three numbers followed by `-alpha`, `-beta` or
nothing, and would refuse this one.

## How it differs from the reference, and for what obstacle

It does not. This branch changes one line of `gradle.properties` and reaches no engine code at all.

## What proves it

- The branch is `dev`'s tip plus that one line, and the repository's own `build` check runs on it
  here.

## What it leaves owing

Nothing. What lands next is whatever was waiting for the release to go out.

---

- [x] Rebased onto `dev`, so the merge is a fast-forward.
- [ ] `gradlew build` green locally, after the rebase and not before it.
- [x] `CHANGELOG.md` carries an entry under `Unreleased`, or this changes nothing a player sees.
- [x] Every place that states a fact this branch changed now states the new one. A fact is cited
      in more places than it lives in: javadoc, `docs/`, `README.md`, and the lines the engine
      prints at load.